### PR TITLE
Remove code for TS < 3.7 compat, deprecate custom Omit

### DIFF
--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { INavPage, LoadingComponent } from '@fluentui/react-docsite-components/lib/index2';
 import { ControlsAreaPage } from '../../../pages/Controls/ControlsAreaPage';
 import { IPageJson } from '@fluentui/react-internal/lib/common/DocPage.types';
-import { Omit } from '@fluentui/react/lib/Utilities';
 
 export type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
 

--- a/change/@fluentui-foundation-legacy-2020-10-30-14-33-59-ts37.json
+++ b/change/@fluentui-foundation-legacy-2020-10-30-14-33-59-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add deprecation note to readme",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T21:33:58.998Z"
+}

--- a/change/@fluentui-merge-styles-2020-10-30-10-36-31-ts37.json
+++ b/change/@fluentui-merge-styles-2020-10-30-10-36-31-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Deprecate Omit and Diff helpers in favor of versions provided by TS",
+  "packageName": "@fluentui/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T17:35:59.467Z"
+}

--- a/change/@fluentui-monaco-editor-2020-10-30-10-36-31-ts37.json
+++ b/change/@fluentui-monaco-editor-2020-10-30-10-36-31-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove code for TS < 3.7 compat",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T17:36:05.975Z"
+}

--- a/change/@fluentui-react-2020-10-30-10-36-31-ts37.json
+++ b/change/@fluentui-react-2020-10-30-10-36-31-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove references to custom Omit helper",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T17:36:31.976Z"
+}

--- a/change/@fluentui-react-experiments-2020-10-30-10-36-31-ts37.json
+++ b/change/@fluentui-react-experiments-2020-10-30-10-36-31-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove references to custom Omit helper",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T17:36:21.712Z"
+}

--- a/change/@fluentui-react-internal-2020-10-30-10-36-31-ts37.json
+++ b/change/@fluentui-react-internal-2020-10-30-10-36-31-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove references to custom Omit helper",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T17:36:26.737Z"
+}

--- a/change/@fluentui-utilities-2020-10-30-16-42-42-ts37.json
+++ b/change/@fluentui-utilities-2020-10-30-16-42-42-ts37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove TS < 3.7 compat code",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T23:42:42.876Z"
+}

--- a/packages/foundation-legacy/README.md
+++ b/packages/foundation-legacy/README.md
@@ -1,12 +1,3 @@
 # @fluentui/foundation-legacy
 
-**Foundation for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
-
-This library is deprecated and Fluent UI React components are no longer built on top of the patterns and utilities from this package.
-
-To import the foundation:
-
-```js
-import { createStatelessComponent, createComponent } from '@fluentui/foundation-legacy';
-```
+This library is deprecated. New [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) components are no longer built on top of the patterns and utilities from this package.

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -476,7 +476,7 @@ export type ObjectOnly<TArg> = TArg extends {} ? TArg : {};
 
 // Warning: (ae-forgotten-export) The symbol "Diff" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
 // @public
@@ -506,7 +506,7 @@ export class Stylesheet {
 
 // Warnings were encountered during analysis:
 //
-// lib/IStyleSet.d.ts:50:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
+// lib/IStyleSet.d.ts:53:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -1,12 +1,16 @@
 import { IStyle } from './IStyle';
 import { IStyleFunctionOrObject, IStyleFunction } from './IStyleFunction';
 
+/**
+ * @deprecated Use `Exclude` provided by TypeScript instead.
+ */
 export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } &
   { [P in U]: never } & { [x: string]: never })[T];
 
 /**
- * {@docCategory Omit}
+ * @deprecated Use the version provided by TypeScript instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
 /**
@@ -24,6 +28,7 @@ export type __MapToFunctionType<T> = Extract<T, Function> extends never
  * property.
  */
 export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = { [key: string]: any }> = {
+  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
@@ -33,6 +38,7 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = { [key: string]: 
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any> };
@@ -43,6 +49,7 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
 export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {
   subComponentStyles: {

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -8,6 +8,7 @@ export { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 
 export { DeepPartial } from './DeepPartial';
 
+// eslint-disable-next-line deprecation/deprecation
 export { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, Omit } from './IStyleSet';
 
 export { ICSSRule, IFontFace, IFontWeight, IRawFontStyle, IRawStyleBase } from './IRawStyleBase';

--- a/packages/monaco-editor/monaco-typescript.d.ts
+++ b/packages/monaco-editor/monaco-typescript.d.ts
@@ -2,6 +2,7 @@
 // 1. Open <root>/node_modules/monaco-typescript/release/esm
 // 2. Merge .d.ts files into this file (unfortunately a manual process right now)
 // 3. Resolve any type mismatch issues (likely caused by mismatches between our TS version and Monaco's)
+/* eslint-disable */
 
 // merged imports from all files
 import * as ts from 'typescript';
@@ -14,8 +15,6 @@ import Position = monaco.Position;
 import Range = monaco.Range;
 import Thenable = monaco.Thenable;
 import Uri = monaco.Uri;
-// temporarily using this Omit to prevent TS compatibility breaks
-import { Omit } from '@fluentui/utilities';
 
 // convenience re-export
 export type EmitOutput = ts.EmitOutput;
@@ -40,8 +39,7 @@ export declare class DiagnosticsAdapter extends Adapter {
   private _tsDiagnosticCategoryToMarkerSeverity;
 }
 export declare class SuggestAdapter extends Adapter implements monaco.languages.CompletionItemProvider {
-  // changed from getter syntax
-  readonly triggerCharacters: string[];
+  get triggerCharacters(): string[];
   provideCompletionItems(model: monaco.editor.ITextModel, position: Position, _context: monaco.languages.CompletionContext, token: CancellationToken): Promise<monaco.languages.CompletionList | undefined>;
   resolveCompletionItem(model: monaco.editor.ITextModel, _position: Position, item: monaco.languages.CompletionItem, token: CancellationToken): Promise<monaco.languages.CompletionItem>;
   private static convertKind;
@@ -103,14 +101,11 @@ export declare class FormatAdapter extends FormatHelper implements monaco.langua
   provideDocumentRangeFormattingEdits(model: monaco.editor.ITextModel, range: Range, options: monaco.languages.FormattingOptions, token: CancellationToken): Promise<monaco.languages.TextEdit[] | undefined>;
 }
 export declare class FormatOnTypeAdapter extends FormatHelper implements monaco.languages.OnTypeFormattingEditProvider {
-// changed from getter syntax
-  readonly autoFormatTriggerCharacters: string[];
+  get autoFormatTriggerCharacters(): string[];
   provideOnTypeFormattingEdits(model: monaco.editor.ITextModel, position: Position, ch: string, options: monaco.languages.FormattingOptions, token: CancellationToken): Promise<monaco.languages.TextEdit[] | undefined>;
 }
 export declare class CodeActionAdaptor extends FormatHelper implements monaco.languages.CodeActionProvider {
-  provideCodeActions(model: monaco.editor.ITextModel, range: Range, context: monaco.languages.CodeActionContext, token: CancellationToken): Promise<monaco.languages.CodeActionList>;
-  // Original:
-  // provideCodeActions(model: monaco.editor.ITextModel, range: Range, context: monaco.languages.CodeActionContext, token: CancellationToken): Promise<monaco.languages.CodeActionList | undefined>;
+  provideCodeActions(model: monaco.editor.ITextModel, range: Range, context: monaco.languages.CodeActionContext, token: CancellationToken): Promise<monaco.languages.CodeActionList | undefined>;
   private _tsCodeFixActionToMonacoCodeAction;
 }
 export declare class RenameAdapter extends Adapter implements monaco.languages.RenameProvider {
@@ -134,10 +129,8 @@ export declare class LanguageServiceDefaultsImpl implements monaco.languages.typ
   private _diagnosticsOptions;
   private _onDidExtraLibsChangeTimeout;
   constructor(compilerOptions: monaco.languages.typescript.CompilerOptions, diagnosticsOptions: monaco.languages.typescript.DiagnosticsOptions);
-  // changed from getter syntax
-  readonly onDidChange: IEvent<void>;
-  // changed from getter syntax
-  readonly onDidExtraLibsChange: IEvent<void>;
+  get onDidChange(): IEvent<void>;
+  get onDidExtraLibsChange(): IEvent<void>;
   getExtraLibs(): IExtraLibs;
   addExtraLib(content: string, _filePath?: string): IDisposable;
   setExtraLibs(libs: { content: string; filePath?: string; }[]): void;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
@@ -1,5 +1,4 @@
 import { IUnifiedPickerProps } from '../UnifiedPicker.types';
-import { Omit } from '@fluentui/utilities';
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
 
 export type IUnifiedPeoplePickerProps = Omit<

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -73,7 +73,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    readonly cursorLocation: number | null;
+    get cursorLocation(): number | null;
     // (undocumented)
     static defaultProps: {
         enableAutofillOnKeyPress: number[];
@@ -83,17 +83,17 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     // (undocumented)
     static getDerivedStateFromProps(props: IAutofillProps, state: IAutofillState): IAutofillState | null;
     // (undocumented)
-    readonly inputElement: HTMLInputElement | null;
+    get inputElement(): HTMLInputElement | null;
     // (undocumented)
-    readonly isValueSelected: boolean;
+    get isValueSelected(): boolean;
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
-    readonly selectionEnd: number | null;
+    get selectionEnd(): number | null;
     // (undocumented)
-    readonly selectionStart: number | null;
+    get selectionStart(): number | null;
     // (undocumented)
-    readonly value: string;
+    get value(): string;
 }
 
 // @public (undocumented)
@@ -112,17 +112,17 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     // (undocumented)
     floatingPicker: React.RefObject<BaseFloatingPicker<T, IBaseFloatingPickerProps<T>>>;
     // (undocumented)
-    protected readonly floatingPickerProps: IBaseFloatingPickerProps<T>;
+    protected get floatingPickerProps(): IBaseFloatingPickerProps<T>;
     // (undocumented)
     focus(): void;
     // (undocumented)
-    readonly highlightedItems: T[];
+    get highlightedItems(): T[];
     // (undocumented)
     protected input: React.RefObject<Autofill>;
     // (undocumented)
-    readonly inputElement: HTMLInputElement | null;
+    get inputElement(): HTMLInputElement | null;
     // (undocumented)
-    readonly items: any;
+    get items(): any;
     // (undocumented)
     protected onBackspace: (ev: React.KeyboardEvent<HTMLElement>) => void;
     // (undocumented)
@@ -152,7 +152,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     // (undocumented)
     selectedItemsList: React.RefObject<BaseSelectedItemsList<T, IBaseSelectedItemsListProps<T>>>;
     // (undocumented)
-    protected readonly selectedItemsListProps: IBaseSelectedItemsListProps<T>;
+    protected get selectedItemsListProps(): IBaseSelectedItemsListProps<T>;
     // (undocumented)
     protected selection: Selection;
 }
@@ -175,17 +175,17 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     // (undocumented)
     protected currentPromise: PromiseLike<T[]>;
     // (undocumented)
-    readonly currentSelectedSuggestionIndex: number;
+    get currentSelectedSuggestionIndex(): number;
     // (undocumented)
     forceResolveSuggestion(): void;
     // (undocumented)
     hidePicker: () => void;
     // (undocumented)
-    readonly inputText: string;
+    get inputText(): string;
     // (undocumented)
     protected isComponentMounted: boolean;
     // (undocumented)
-    readonly isSuggestionsShown: boolean;
+    get isSuggestionsShown(): boolean;
     // (undocumented)
     protected onChange(item: T): void;
     // (undocumented)
@@ -209,7 +209,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     // (undocumented)
     showPicker: (updateValue?: boolean) => void;
     // (undocumented)
-    readonly suggestions: any[];
+    get suggestions(): any[];
     // (undocumented)
     protected suggestionsControl: React.RefObject<SuggestionsControl<T>>;
     // (undocumented)
@@ -276,7 +276,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // (undocumented)
     protected input: React.RefObject<IAutofill>;
     // (undocumented)
-    readonly items: T[];
+    get items(): T[];
     // (undocumented)
     protected onBackspace(ev: React.KeyboardEvent<HTMLElement>): void;
     // (undocumented)
@@ -369,7 +369,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     // (undocumented)
     highlightedItems(): T[];
     // (undocumented)
-    readonly items: T[];
+    get items(): T[];
     // (undocumented)
     protected onChange(items?: T[]): void;
     // (undocumented)
@@ -395,7 +395,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     // (undocumented)
     protected root: HTMLElement;
     // (undocumented)
-    protected readonly selection: Selection;
+    protected get selection(): Selection;
     // (undocumented)
     unselectAll(): void;
     updateItems(items: T[], focusIndex?: number): void;
@@ -460,7 +460,7 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps>;
 export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPickerState> implements IColorPicker {
     constructor(props: IColorPickerProps);
     // (undocumented)
-    readonly color: IColor;
+    get color(): IColor;
     // (undocumented)
     componentDidUpdate(prevProps: Readonly<IColorPickerProps>, prevState: Readonly<IColorPickerState>): void;
     // (undocumented)
@@ -5575,7 +5575,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
     getTotalListHeight(): number;
     // (undocumented)
-    readonly pageRefs: Readonly<Record<string, unknown>>;
+    get pageRefs(): Readonly<Record<string, unknown>>;
     // (undocumented)
     render(): JSX.Element | null;
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
@@ -5693,7 +5693,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     // (undocumented)
     render(): JSX.Element | null;
     // (undocumented)
-    readonly selectedKey: string | undefined;
+    get selectedKey(): string | undefined;
     }
 
 // @public (undocumented)
@@ -6079,7 +6079,7 @@ export class ScrollablePaneBase extends React.Component<IScrollablePaneProps, IS
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    readonly contentContainer: HTMLDivElement | null;
+    get contentContainer(): HTMLDivElement | null;
     // (undocumented)
     forceLayoutUpdate(): void;
     // (undocumented)
@@ -6091,7 +6091,7 @@ export class ScrollablePaneBase extends React.Component<IScrollablePaneProps, IS
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
-    readonly root: HTMLDivElement | null;
+    get root(): HTMLDivElement | null;
     // (undocumented)
     setStickiesDistanceFromTop(): void;
     // (undocumented)
@@ -6099,9 +6099,9 @@ export class ScrollablePaneBase extends React.Component<IScrollablePaneProps, IS
     // (undocumented)
     sortSticky: (sticky: Sticky, sortAgain?: boolean | undefined) => void;
     // (undocumented)
-    readonly stickyAbove: HTMLDivElement | null;
+    get stickyAbove(): HTMLDivElement | null;
     // (undocumented)
-    readonly stickyBelow: HTMLDivElement | null;
+    get stickyBelow(): HTMLDivElement | null;
     // (undocumented)
     subscribe: (handler: Function) => void;
     // (undocumented)
@@ -6343,9 +6343,9 @@ export class Sticky extends React.Component<IStickyProps, IStickyState> {
     // (undocumented)
     addSticky(stickyContent: HTMLDivElement): void;
     // (undocumented)
-    readonly canStickyBottom: boolean;
+    get canStickyBottom(): boolean;
     // (undocumented)
-    readonly canStickyTop: boolean;
+    get canStickyTop(): boolean;
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
@@ -6357,23 +6357,23 @@ export class Sticky extends React.Component<IStickyProps, IStickyState> {
     // (undocumented)
     static defaultProps: IStickyProps;
     // (undocumented)
-    readonly nonStickyContent: HTMLDivElement | null;
+    get nonStickyContent(): HTMLDivElement | null;
     // (undocumented)
-    readonly placeholder: HTMLDivElement | null;
+    get placeholder(): HTMLDivElement | null;
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
     resetSticky(): void;
     // (undocumented)
-    readonly root: HTMLDivElement | null;
+    get root(): HTMLDivElement | null;
     // (undocumented)
     setDistanceFromTop(container: HTMLDivElement): void;
     // (undocumented)
     shouldComponentUpdate(nextProps: IStickyProps, nextState: IStickyState): boolean;
     // (undocumented)
-    readonly stickyContentBottom: HTMLDivElement | null;
+    get stickyContentBottom(): HTMLDivElement | null;
     // (undocumented)
-    readonly stickyContentTop: HTMLDivElement | null;
+    get stickyContentTop(): HTMLDivElement | null;
     // (undocumented)
     syncScroll: (container: HTMLElement) => void;
 }
@@ -6449,9 +6449,9 @@ export class SuggestionsControl<T> extends React.Component<ISuggestionsControlPr
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    readonly currentSuggestion: ISuggestionModel<T> | undefined;
+    get currentSuggestion(): ISuggestionModel<T> | undefined;
     // (undocumented)
-    readonly currentSuggestionIndex: number;
+    get currentSuggestionIndex(): number;
     // (undocumented)
     executeSelectedAction(): void;
     // (undocumented)
@@ -6477,7 +6477,7 @@ export class SuggestionsControl<T> extends React.Component<ISuggestionsControlPr
     // (undocumented)
     protected _searchForMoreButton: IButton;
     // (undocumented)
-    readonly selectedElement: HTMLDivElement | undefined;
+    get selectedElement(): HTMLDivElement | undefined;
     // (undocumented)
     protected _selectedElement: React.RefObject<HTMLDivElement>;
     protected selectFirstItem(): void;
@@ -6547,7 +6547,7 @@ export class SuggestionsCore<T> extends React.Component<ISuggestionsCoreProps<T>
     // (undocumented)
     scrollSelected(): void;
     // (undocumented)
-    readonly selectedElement: HTMLDivElement | undefined;
+    get selectedElement(): HTMLDivElement | undefined;
     // (undocumented)
     protected _selectedElement: React.RefObject<HTMLDivElement>;
     // (undocumented)
@@ -6662,12 +6662,12 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     // (undocumented)
     render(): JSX.Element;
     select(): void;
-    readonly selectionEnd: number | null;
-    readonly selectionStart: number | null;
+    get selectionEnd(): number | null;
+    get selectionStart(): number | null;
     setSelectionEnd(value: number): void;
     setSelectionRange(start: number, end: number): void;
     setSelectionStart(value: number): void;
-    readonly value: string | undefined;
+    get value(): string | undefined;
     }
 
 // @public (undocumented)

--- a/packages/react-internal/src/common/DocPage.types.ts
+++ b/packages/react-internal/src/common/DocPage.types.ts
@@ -1,4 +1,4 @@
-import { IStyleFunctionOrObject, Omit } from '../Utilities';
+import { IStyleFunctionOrObject } from '../Utilities';
 import { ITheme, IStyle } from '../Styling';
 
 export interface IExample {

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -39,7 +39,6 @@ import { ITheme } from '@fluentui/react-internal/lib/Styling';
 import { ITooltipHostProps } from '@fluentui/react-internal/lib/Tooltip';
 import { IViewport } from '@fluentui/react-internal/lib/utilities/decorators/withViewport';
 import { IWithViewportProps } from '@fluentui/react-internal/lib/utilities/decorators/withViewport';
-import { Omit } from '@fluentui/react-internal/lib/Utilities';
 import { PersonaInitialsColor } from '@fluentui/react-internal/lib/Persona';
 import * as React from 'react';
 import { RectangleEdge } from '@fluentui/react-internal/lib/Positioning';
@@ -1881,7 +1880,7 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
     protected _onScrollToItem: (itemIndex: number) => void;
     // (undocumented)
     render(): JSX.Element;
-    readonly selectedOptions: IComboBoxOption[];
+    get selectedOptions(): IComboBoxOption[];
 }
 
 

--- a/packages/react/src/components/DetailsList/ShimmeredDetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/ShimmeredDetailsList.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IDetailsListProps } from './DetailsList.types';
 import { IDetailsRowProps } from './DetailsRow.types';
 import { IStyle } from '../../Styling';
-import { IStyleFunctionOrObject, Omit } from '../../Utilities';
+import { IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * ShimmeredDetailsList props interface

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -95,13 +95,13 @@ export class AutoScroll {
 // @public @deprecated
 export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends React.Component<TProps, TState> {
     constructor(props: TProps, context?: any);
-    protected readonly _async: Async;
-    readonly className: string;
+    protected get _async(): Async;
+    get className(): string;
     componentDidMount(): void;
     componentDidUpdate(prevProps: TProps, prevState: TState): void;
     componentWillUnmount(): void;
-    protected readonly _disposables: IDisposable[];
-    protected readonly _events: EventGroup;
+    protected get _disposables(): IDisposable[];
+    protected get _events(): EventGroup;
     // @deprecated (undocumented)
     static onError: (errorMessage?: string, ex?: any) => void;
     // @deprecated
@@ -1011,14 +1011,14 @@ export class Rectangle {
     // (undocumented)
     bottom: number;
     equals(rect: Rectangle): boolean;
-    readonly height: number;
+    get height(): number;
     // (undocumented)
     left: number;
     // (undocumented)
     right: number;
     // (undocumented)
     top: number;
-    readonly width: number;
+    get width(): number;
 }
 
 // @public (undocumented)

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -69,6 +69,7 @@ export * from './styled';
 export * from './warn';
 export * from './ie11Detector';
 export * from './getPropsWithDefaults';
+// eslint-disable-next-line deprecation/deprecation
 export { IStyleFunctionOrObject, Omit } from '@fluentui/merge-styles';
 export { setFocusVisibility, IsFocusVisibleClassName } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';

--- a/scripts/tasks/postprocess.ts
+++ b/scripts/tasks/postprocess.ts
@@ -5,70 +5,7 @@ export const defaultLibPaths = ['lib/**/*.d.ts', 'lib-commonjs/**/*.d.ts', 'lib-
  */
 export function postprocessTask(libPaths: string[] = defaultLibPaths) {
   return async function() {
-    // Delay load these
-    const { mod } = await import('riceburn');
-    const ts = await import('typescript');
-
-    libPaths.forEach(path => {
-      mod(path).asTypescript((node, modder) => {
-        // TS3.7 changes emits for class fields from readonly to get/set, which breaks
-        // TS3.5 users. This mod reverts these emits for TS3.5 compatibility.
-        // This mod would be better written with something like ts-morph. For now, TS API and regexes are used.
-        // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations
-
-        // Very roughly modeled after downlevel-dts which is not ready for consumption.
-        // https://github.com/sandersn/downlevel-dts/blob/master/index.js
-
-        // Rules:
-        // 1) Find get accessors
-        //    If they have a matching set, remove the set accessor entirely and remove the 'get' keyword.
-        //    If they do not have a matching set accessor, replace 'get' with 'readonly' and remove functional declaration.
-        // 2) Find set accessors
-        //    If they do not have a matching get, remove the keyword 'set' and remove functional declaration while keeping type.
-        //    Other cases already handled as part of #1.
-
-        const mods = [];
-
-        if (ts.isGetAccessor(node)) {
-          let hasMatchingSetAccessor = false;
-
-          if (ts.isClassDeclaration(node.parent)) {
-            node.parent.forEachChild(child => {
-              if (ts.isSetAccessor(child) && node.name.getText() === child.name.getText()) {
-                hasMatchingSetAccessor = true;
-                mods.push(modder.removeFull(child));
-              }
-            });
-
-            const removeParentheses = new RegExp(`(${node.name.getText()})\\(\\)`, 'gm');
-
-            let replacement = node.getText().replace(/(^|\W)get /gm, hasMatchingSetAccessor ? '$1' : '$1readonly ');
-            replacement = replacement.replace(removeParentheses, '$1');
-
-            mods.push(modder.replace(node, replacement));
-          }
-        }
-
-        if (ts.isSetAccessor(node)) {
-          let hasMatchingGetAccessor = false;
-          node.parent.forEachChild(child => {
-            if (ts.isGetAccessor(child) && node.name.getText() === child.name.getText()) {
-              hasMatchingGetAccessor = true;
-            }
-          });
-
-          if (!hasMatchingGetAccessor) {
-            const removeParentheses = new RegExp(`(${node.name.getText()})\\(.*\(: .*\)\\)`, 'gm');
-
-            let replacement = node.getText().replace(/(^|\W)set /gm, '$1');
-            replacement = replacement.replace(removeParentheses, '$1$2');
-
-            mods.push(modder.replace(node, replacement));
-          }
-        }
-
-        return mods;
-      });
-    });
+    // No-op for now. This was previously used for TS 3.7 => 3.5 compat. We'll likely need it again
+    // but not for now, while our TS minbar and local version match.
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #14697
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Deprecate custom `Omit` and `Diff` from `merge-styles` (and remove usage from our code). These were only needed for TS < 3.5, and for v8 our minbar is 3.7. I left the definitions for now to avoid a breaking change.

Remove postprocessing code used to remove `get`/`set` from .d.ts files. This was also needed only for TS < 3.7.