### PR TITLE
SplitButton: Fix ariaDescription behavior so that it is correctly picked up by screen-readers

### DIFF
--- a/change/@fluentui-react-internal-2020-10-30-13-51-44-splitButtonAriaDescription.json
+++ b/change/@fluentui-react-internal-2020-10-30-13-51-44-splitButtonAriaDescription.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "SplitButton: Fix ariaDescription behavior so that it is correctly picked up by screen-readers.",
+  "packageName": "@fluentui/react-internal",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T20:51:44.033Z"
+}

--- a/packages/react-internal/src/compat/components/Button/BaseButton.tsx
+++ b/packages/react-internal/src/compat/components/Button/BaseButton.tsx
@@ -599,8 +599,6 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       'data-is-focusable': false,
     });
 
-    const ariaDescribedBy = buttonProps.ariaDescription;
-
     if (keytipProps && menuProps) {
       keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
@@ -622,7 +620,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         aria-expanded={!menuHidden}
         aria-pressed={toggle ? !!checked : undefined} // should only be present for toggle buttons
         aria-describedby={mergeAriaAttributeValues(
-          ariaDescribedBy,
+          buttonProps['aria-describedby'],
           keytipAttributes ? keytipAttributes['aria-describedby'] : undefined,
         )}
         className={classNames && classNames.splitButtonContainer}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15721
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue with split buttons where `ariaDescription` was being incorrectly passed into `aria-describedby` instead of providing the correct id there, which in turn was causing the description to not be read.

#### Focus areas to test

(optional)
