### PR TITLE
SplitButton: Fix ariaDescription behavior so that it is correctly picked up by screen-readers

### DIFF
--- a/change/office-ui-fabric-react-2020-10-30-14-04-46-splitButtonAriaDescription7.0.json
+++ b/change/office-ui-fabric-react-2020-10-30-14-04-46-splitButtonAriaDescription7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: Fix ariaDescription behavior so that it is correctly picked up by screen-readers.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T21:04:46.511Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -596,8 +596,6 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       'data-is-focusable': false,
     });
 
-    const ariaDescribedBy = buttonProps.ariaDescription;
-
     if (keytipProps && menuProps) {
       keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
@@ -619,7 +617,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         aria-expanded={!menuHidden}
         aria-pressed={toggle ? !!checked : undefined} // should only be present for toggle buttons
         aria-describedby={mergeAriaAttributeValues(
-          ariaDescribedBy,
+          buttonProps['aria-describedby'],
           keytipAttributes ? keytipAttributes['aria-describedby'] : undefined,
         )}
         className={classNames && classNames.splitButtonContainer}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15721
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Port of #15797._

_Original PR description:_

This PR fixes an issue with split buttons where `ariaDescription` was being incorrectly passed into `aria-describedby` instead of providing the correct id there, which in turn was causing the description to not be read.

#### Focus areas to test

(optional)
