### PR TITLE
Add deprecation note to foundation readme (7)

### DIFF
--- a/change/@uifabric-foundation-2020-10-30-14-31-53-foundation-message-7.json
+++ b/change/@uifabric-foundation-2020-10-30-14-31-53-foundation-message-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add deprecation note to foundation readme",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T21:31:53.311Z"
+}

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -1,12 +1,3 @@
 # @uifabric/foundation
 
-**Foundation for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
-
-This library provides the foundation for creating and using Fluent UI React components.
-
-To import the foundation:
-
-```js
-import { createStatelessComponent, createComponent } from '@uifabric/foundation';
-```
+This library is deprecated. New [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) components are no longer built on top of the patterns and utilities from this package.


### PR DESCRIPTION
We don't recommend that people use `@uifabric/foundation` for new components, so add a note about that to the readme.