### PR TITLE
Spin button: ensure default fonts are set

### DIFF
--- a/change/@fluentui-react-examples-2020-10-30-17-14-23-spin_button_7.0.json
+++ b/change/@fluentui-react-examples-2020-10-30-17-14-23-spin_button_7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update SpinButton snapshots to show inherited Fabric font styles.",
+  "packageName": "@fluentui/react-examples",
+  "email": "lesliewilliams234@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-31T00:14:23.222Z"
+}

--- a/change/office-ui-fabric-react-2020-10-30-17-14-23-spin_button_7.0.json
+++ b/change/office-ui-fabric-react-2020-10-30-17-14-23-spin_button_7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update SpinButton to inherit Fabric font styles.",
+  "packageName": "office-ui-fabric-react",
+  "email": "lesliewilliams234@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-31T00:12:09.844Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -143,12 +143,14 @@ export const getStyles = memoizeFunction(
     const SpinButtonIconDisabledColor = semanticColors.disabledText;
 
     const defaultStyles: ISpinButtonStyles = {
-      root: {
-        outline: 'none',
-        fontSize: fonts.medium.fontSize,
-        width: '100%',
-        minWidth: DEFAULT_MIN_WIDTH,
-      },
+      root: [
+        fonts.medium,
+        {
+          outline: 'none',
+          width: '100%',
+          minWidth: DEFAULT_MIN_WIDTH,
+        },
+      ],
       labelWrapper: {
         display: 'inline-flex',
         alignItems: 'center',

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -5,7 +5,11 @@ exports[`SpinButton renders correctly 1`] = `
   className=
 
       {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
+        font-weight: 400;
         min-width: 86px;
         outline: none;
         width: 100%;
@@ -442,7 +446,11 @@ exports[`SpinButton renders correctly with user-provided values 1`] = `
   className=
 
       {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
+        font-weight: 400;
         min-width: 86px;
         outline: none;
         width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -574,7 +574,11 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             className=
 
                 {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
+                  font-weight: 400;
                   max-width: 200px;
                   min-width: 86px;
                   outline: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -26,7 +26,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;
@@ -484,7 +488,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -12,7 +12,11 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -12,7 +12,11 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -12,7 +12,11 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -12,7 +12,11 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -6,7 +6,11 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 400px;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -12,7 +12,11 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
     className=
 
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
+          font-weight: 400;
           min-width: 86px;
           outline: none;
           width: 100%;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15362
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, the SpinButton font family is not inherited from Fabric and defaults to 'Times'.

This change adds fonts.medium to the SpinButton component styles so that font family results in the Fabric default. This change mimics the use of font styling across other button types.

Before:
![spin_button_before](https://user-images.githubusercontent.com/25760457/97767043-ce378280-1ad6-11eb-8656-16f809e61626.png)

After:
![spin_button_after](https://user-images.githubusercontent.com/25760457/97767047-d4c5fa00-1ad6-11eb-8078-a551f91fd346.png)

#### Focus areas to test

(optional)
