### PR TITLE
(fix) DetailsList group header aria-posinset and aria-setsize attributes

### DIFF
--- a/change/@fluentui-react-2020-11-02-15-59-07-detailslist-row-aria.json
+++ b/change/@fluentui-react-2020-11-02-15-59-07-detailslist-row-aria.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "update detailslist to use grid aria props for group rows",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-02T23:59:07.237Z"
+}

--- a/change/@fluentui-react-examples-4662e02c-d172-44c1-b627-1b967953920b.json
+++ b/change/@fluentui-react-examples-4662e02c-d172-44c1-b627-1b967953920b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot changes for grouped detailslist",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -905,6 +905,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                         </div>
                       </div>
                       <div
+                        aria-label="group 0"
                         className="ms-List"
                         id="GroupedListSection3"
                         role="rowgroup"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -907,7 +907,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                       <div
                         className="ms-List"
                         id="GroupedListSection3"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1243,10 +1243,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"red\\""
+                          aria-label="Color: \\"red\\" (2)"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={2}
+                          aria-selected={false}
                           className=
                               ms-GroupHeader
                               {
@@ -1632,6 +1633,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           </div>
                         </div>
                         <div
+                          aria-label="Color: \\"red\\""
                           className="ms-List"
                           id="GroupedListSection8"
                           role="rowgroup"
@@ -2636,10 +2638,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"green\\""
+                          aria-label="Color: \\"green\\" (0)"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={3}
+                          aria-selected={false}
                           className=
                               ms-GroupHeader
                               {
@@ -3025,6 +3028,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           </div>
                         </div>
                         <div
+                          aria-label="Color: \\"green\\""
                           className="ms-List"
                           id="GroupedListSection9"
                         >
@@ -3057,10 +3061,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"blue\\""
+                          aria-label="Color: \\"blue\\" (3)"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={4}
+                          aria-selected={false}
                           className=
                               ms-GroupHeader
                               {
@@ -3446,6 +3451,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           </div>
                         </div>
                         <div
+                          aria-label="Color: \\"blue\\""
                           className="ms-List"
                           id="GroupedListSection10"
                           role="rowgroup"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1243,7 +1243,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"red\\" (2)"
+                          aria-labelledby="GroupHeader9"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={2}
@@ -1610,6 +1610,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
+                              id="GroupHeader9"
                               role="gridcell"
                             >
                               <span>
@@ -1724,7 +1725,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone11"
+                                  data-focuszone-id="FocusZone14"
                                   data-is-focusable={true}
                                   data-item-index={0}
                                   data-selection-index={0}
@@ -2206,7 +2207,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone12"
+                                  data-focuszone-id="FocusZone15"
                                   data-is-focusable={true}
                                   data-item-index={1}
                                   data-selection-index={1}
@@ -2638,7 +2639,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"green\\" (0)"
+                          aria-labelledby="GroupHeader11"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={3}
@@ -3005,6 +3006,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
+                              id="GroupHeader11"
                               role="gridcell"
                             >
                               <span>
@@ -3030,7 +3032,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           aria-label="Color: \\"green\\""
                           className="ms-List"
-                          id="GroupedListSection9"
+                          id="GroupedListSection10"
                         >
                           <div
                             className="ms-List-surface"
@@ -3061,7 +3063,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"blue\\" (3)"
+                          aria-labelledby="GroupHeader13"
                           aria-level={1}
                           aria-rowcount={4}
                           aria-rowindex={4}
@@ -3428,6 +3430,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
+                              id="GroupHeader13"
                               role="gridcell"
                             >
                               <span>
@@ -3453,7 +3456,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           aria-label="Color: \\"blue\\""
                           className="ms-List"
-                          id="GroupedListSection10"
+                          id="GroupedListSection12"
                           role="rowgroup"
                         >
                           <div
@@ -3542,7 +3545,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone13"
+                                  data-focuszone-id="FocusZone16"
                                   data-is-focusable={true}
                                   data-item-index={2}
                                   data-selection-index={2}
@@ -4024,7 +4027,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone14"
+                                  data-focuszone-id="FocusZone17"
                                   data-is-focusable={true}
                                   data-item-index={3}
                                   data-selection-index={3}
@@ -4506,7 +4509,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone15"
+                                  data-focuszone-id="FocusZone18"
                                   data-is-focusable={true}
                                   data-item-index={4}
                                   data-selection-index={4}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1245,8 +1245,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-label="Color: \\"red\\""
                           aria-level={1}
-                          aria-posinset={1}
-                          aria-setsize={3}
+                          aria-rowcount={4}
+                          aria-rowindex={2}
                           className=
                               ms-GroupHeader
                               {
@@ -1634,7 +1634,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           className="ms-List"
                           id="GroupedListSection8"
-                          role="presentation"
+                          role="rowgroup"
                         >
                           <div
                             className="ms-List-surface"
@@ -2638,8 +2638,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-label="Color: \\"green\\""
                           aria-level={1}
-                          aria-posinset={2}
-                          aria-setsize={3}
+                          aria-rowcount={4}
+                          aria-rowindex={3}
                           className=
                               ms-GroupHeader
                               {
@@ -3059,8 +3059,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-label="Color: \\"blue\\""
                           aria-level={1}
-                          aria-posinset={3}
-                          aria-setsize={3}
+                          aria-rowcount={4}
+                          aria-rowindex={4}
                           className=
                               ms-GroupHeader
                               {
@@ -3448,7 +3448,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           className="ms-List"
                           id="GroupedListSection10"
-                          role="presentation"
+                          role="rowgroup"
                         >
                           <div
                             className="ms-List-surface"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -898,10 +898,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="0"
+                        aria-label="0 (100)"
                         aria-level={1}
                         aria-rowcount={11}
                         aria-rowindex={2}
+                        aria-selected={false}
                         className=
                             ms-GroupHeader
                             {
@@ -1287,6 +1288,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         </div>
                       </div>
                       <div
+                        aria-label="0"
                         className="ms-List"
                         id="GroupedListSection3"
                         role="rowgroup"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -900,8 +900,8 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         aria-expanded={true}
                         aria-label="0"
                         aria-level={1}
-                        aria-posinset={1}
-                        aria-setsize={10}
+                        aria-rowcount={11}
+                        aria-rowindex={2}
                         className=
                             ms-GroupHeader
                             {
@@ -1289,7 +1289,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       <div
                         className="ms-List"
                         id="GroupedListSection3"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -898,7 +898,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="0 (100)"
+                        aria-labelledby="GroupHeader4"
                         aria-level={1}
                         aria-rowcount={11}
                         aria-rowindex={2}
@@ -1265,6 +1265,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
+                            id="GroupHeader4"
                             role="gridcell"
                           >
                             <span>
@@ -1379,7 +1380,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone4"
+                                data-focuszone-id="FocusZone5"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
@@ -1853,7 +1854,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone5"
+                                data-focuszone-id="FocusZone6"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
@@ -2327,7 +2328,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone6"
+                                data-focuszone-id="FocusZone7"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
@@ -2801,7 +2802,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone7"
+                                data-focuszone-id="FocusZone8"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
@@ -3275,7 +3276,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone8"
+                                data-focuszone-id="FocusZone9"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}
@@ -3749,7 +3750,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone9"
+                                data-focuszone-id="FocusZone10"
                                 data-is-focusable={true}
                                 data-item-index={5}
                                 data-selection-index={5}
@@ -4223,7 +4224,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone10"
+                                data-focuszone-id="FocusZone11"
                                 data-is-focusable={true}
                                 data-item-index={6}
                                 data-selection-index={6}
@@ -4697,7 +4698,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone11"
+                                data-focuszone-id="FocusZone12"
                                 data-is-focusable={true}
                                 data-item-index={7}
                                 data-selection-index={7}
@@ -5171,7 +5172,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone12"
+                                data-focuszone-id="FocusZone13"
                                 data-is-focusable={true}
                                 data-item-index={8}
                                 data-selection-index={8}
@@ -5645,7 +5646,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone13"
+                                data-focuszone-id="FocusZone14"
                                 data-is-focusable={true}
                                 data-item-index={9}
                                 data-selection-index={9}

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -80,9 +80,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 0"
+                    aria-label="group 0 (3)"
                     aria-level={1}
                     aria-posinset={1}
+                    aria-selected={false}
                     aria-setsize={3}
                     className=
                         ms-GroupHeader
@@ -439,6 +440,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     </div>
                   </div>
                   <div
+                    aria-label="group 0"
                     className="ms-List"
                     id="GroupedListSection2"
                     role="group"
@@ -2069,9 +2071,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 1"
+                    aria-label="group 1 (3)"
                     aria-level={1}
                     aria-posinset={2}
+                    aria-selected={false}
                     aria-setsize={3}
                     className=
                         ms-GroupHeader
@@ -2428,6 +2431,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     </div>
                   </div>
                   <div
+                    aria-label="group 1"
                     className="ms-List"
                     id="GroupedListSection4"
                     role="group"
@@ -4058,9 +4062,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 2"
+                    aria-label="group 2 (3)"
                     aria-level={1}
                     aria-posinset={3}
+                    aria-selected={false}
                     aria-setsize={3}
                     className=
                         ms-GroupHeader
@@ -4417,6 +4422,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     </div>
                   </div>
                   <div
+                    aria-label="group 2"
                     className="ms-List"
                     id="GroupedListSection6"
                     role="group"

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 0 (3)"
+                    aria-labelledby="GroupHeader3"
                     aria-level={1}
                     aria-posinset={1}
                     aria-selected={false}
@@ -270,7 +270,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                     }
                                 data-is-focusable={true}
                                 data-ktp-target={true}
-                                id="Toggle3"
+                                id="Toggle4"
                                 onClick={[Function]}
                                 role="switch"
                                 type="button"
@@ -417,6 +417,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               text-overflow: ellipsis;
                               white-space: nowrap;
                             }
+                        id="GroupHeader3"
                         role="gridcell"
                       >
                         <span>
@@ -531,7 +532,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone8"
+                            data-focuszone-id="FocusZone11"
                             data-is-focusable={true}
                             data-item-index={0}
                             data-selection-index={0}
@@ -1061,7 +1062,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone9"
+                            data-focuszone-id="FocusZone12"
                             data-is-focusable={true}
                             data-item-index={1}
                             data-selection-index={1}
@@ -1591,7 +1592,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone10"
+                            data-focuszone-id="FocusZone13"
                             data-is-focusable={true}
                             data-item-index={2}
                             data-selection-index={2}
@@ -2071,7 +2072,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 1 (3)"
+                    aria-labelledby="GroupHeader6"
                     aria-level={1}
                     aria-posinset={2}
                     aria-selected={false}
@@ -2261,7 +2262,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                     }
                                 data-is-focusable={true}
                                 data-ktp-target={true}
-                                id="Toggle5"
+                                id="Toggle7"
                                 onClick={[Function]}
                                 role="switch"
                                 type="button"
@@ -2408,6 +2409,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               text-overflow: ellipsis;
                               white-space: nowrap;
                             }
+                        id="GroupHeader6"
                         role="gridcell"
                       >
                         <span>
@@ -2433,7 +2435,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                   <div
                     aria-label="group 1"
                     className="ms-List"
-                    id="GroupedListSection4"
+                    id="GroupedListSection5"
                     role="group"
                   >
                     <div
@@ -2522,7 +2524,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone11"
+                            data-focuszone-id="FocusZone14"
                             data-is-focusable={true}
                             data-item-index={3}
                             data-selection-index={3}
@@ -3052,7 +3054,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone12"
+                            data-focuszone-id="FocusZone15"
                             data-is-focusable={true}
                             data-item-index={4}
                             data-selection-index={4}
@@ -3582,7 +3584,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone13"
+                            data-focuszone-id="FocusZone16"
                             data-is-focusable={true}
                             data-item-index={5}
                             data-selection-index={5}
@@ -4062,7 +4064,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 2 (3)"
+                    aria-labelledby="GroupHeader9"
                     aria-level={1}
                     aria-posinset={3}
                     aria-selected={false}
@@ -4252,7 +4254,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                     }
                                 data-is-focusable={true}
                                 data-ktp-target={true}
-                                id="Toggle7"
+                                id="Toggle10"
                                 onClick={[Function]}
                                 role="switch"
                                 type="button"
@@ -4399,6 +4401,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               text-overflow: ellipsis;
                               white-space: nowrap;
                             }
+                        id="GroupHeader9"
                         role="gridcell"
                       >
                         <span>
@@ -4424,7 +4427,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                   <div
                     aria-label="group 2"
                     className="ms-List"
-                    id="GroupedListSection6"
+                    id="GroupedListSection8"
                     role="group"
                   >
                     <div
@@ -4513,7 +4516,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone14"
+                            data-focuszone-id="FocusZone17"
                             data-is-focusable={true}
                             data-item-index={6}
                             data-selection-index={6}
@@ -5043,7 +5046,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone15"
+                            data-focuszone-id="FocusZone18"
                             data-is-focusable={true}
                             data-item-index={7}
                             data-selection-index={7}
@@ -5573,7 +5576,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                   opacity: 1;
                                 }
                             data-automationid="DetailsRow"
-                            data-focuszone-id="FocusZone16"
+                            data-focuszone-id="FocusZone19"
                             data-is-focusable={true}
                             data-item-index={8}
                             data-selection-index={8}

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -441,7 +441,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                   <div
                     className="ms-List"
                     id="GroupedListSection2"
-                    role="presentation"
+                    role="group"
                   >
                     <div
                       className="ms-List-surface"
@@ -2430,7 +2430,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                   <div
                     className="ms-List"
                     id="GroupedListSection4"
-                    role="presentation"
+                    role="group"
                   >
                     <div
                       className="ms-List-surface"
@@ -4419,7 +4419,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                   <div
                     className="ms-List"
                     id="GroupedListSection6"
-                    role="presentation"
+                    role="group"
                   >
                     <div
                       className="ms-List-surface"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4975,6 +4975,10 @@ export interface IGroup {
 // @public (undocumented)
 export interface IGroupDividerProps {
     ariaColSpan?: number;
+    ariaPosInSet?: number;
+    ariaRowCount?: number;
+    ariaRowIndex?: number;
+    ariaSetSize?: number;
     className?: string;
     compact?: boolean;
     // (undocumented)
@@ -5139,8 +5143,6 @@ export interface IGroupHeaderCheckboxProps {
 
 // @public (undocumented)
 export interface IGroupHeaderProps extends IGroupDividerProps {
-    ariaPosInSet?: number;
-    ariaSetSize?: number;
     expandButtonIcon?: string;
     expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
     groupedListId?: string;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -354,6 +354,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const finalOnRenderDetailsGroupHeader = React.useMemo(() => {
     return onRenderDetailsGroupHeader
       ? (groupHeaderProps: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
+          const { ariaPosInSet, ariaSetSize } = groupHeaderProps;
+
           return onRenderDetailsGroupHeader(
             {
               ...groupHeaderProps,
@@ -368,20 +370,22 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               ariaColSpan: adjustedColumns.length,
               ariaPosInSet: undefined,
               ariaSetSize: undefined,
-              ariaRowCount: groupHeaderProps.ariaSetSize + (isHeaderVisible ? 1 : 0),
-              ariaRowIndex: groupHeaderProps.ariaPosInSet + (isHeaderVisible ? 1 : 0),
+              ariaRowCount: ariaSetSize ? ariaSetSize + (isHeaderVisible ? 1 : 0) : undefined,
+              ariaRowIndex: ariaPosInSet ? ariaPosInSet + (isHeaderVisible ? 1 : 0) : undefined,
             },
             defaultRender,
           );
         }
       : (groupHeaderProps: IGroupDividerProps, defaultRender: IRenderFunction<IGroupDividerProps>) => {
+          const { ariaPosInSet, ariaSetSize } = groupHeaderProps;
+
           return defaultRender({
             ...groupHeaderProps,
             ariaColSpan: adjustedColumns.length,
             ariaPosInSet: undefined,
             ariaSetSize: undefined,
-            ariaRowCount: groupHeaderProps.ariaSetSize + (isHeaderVisible ? 1 : 0),
-            ariaRowIndex: groupHeaderProps.ariaPosInSet + (isHeaderVisible ? 1 : 0),
+            ariaRowCount: ariaSetSize ? ariaSetSize + (isHeaderVisible ? 1 : 0) : undefined,
+            ariaRowIndex: ariaPosInSet ? ariaPosInSet + (isHeaderVisible ? 1 : 0) : undefined,
           });
         };
   }, [

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -366,6 +366,10 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               checkboxVisibility,
               cellStyleProps,
               ariaColSpan: adjustedColumns.length,
+              ariaPosInSet: undefined,
+              ariaSetSize: undefined,
+              ariaRowCount: groupHeaderProps.ariaSetSize + (isHeaderVisible ? 1 : 0),
+              ariaRowIndex: groupHeaderProps.ariaPosInSet + (isHeaderVisible ? 1 : 0),
             },
             defaultRender,
           );
@@ -374,6 +378,10 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
           return defaultRender({
             ...groupHeaderProps,
             ariaColSpan: adjustedColumns.length,
+            ariaPosInSet: undefined,
+            ariaSetSize: undefined,
+            ariaRowCount: groupHeaderProps.ariaSetSize + (isHeaderVisible ? 1 : 0),
+            ariaRowIndex: groupHeaderProps.ariaPosInSet + (isHeaderVisible ? 1 : 0),
           });
         };
   }, [
@@ -381,6 +389,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     adjustedColumns,
     groupNestingDepth,
     indentWidth,
+    isHeaderVisible,
     selection,
     selectionMode,
     viewport,
@@ -391,6 +400,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const finalGroupProps = React.useMemo((): IGroupRenderProps | undefined => {
     return {
       ...groupProps,
+      role: 'rowgroup',
       onRenderFooter: finalOnRenderDetailsGroupFooter,
       onRenderHeader: finalOnRenderDetailsGroupHeader,
     };

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection117"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -209,7 +209,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection118"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -403,7 +403,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection117"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -481,7 +481,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection118"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -683,7 +683,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection110"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -743,7 +743,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection111"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -803,7 +803,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection112"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -863,7 +863,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection113"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1047,7 +1047,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection110"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1107,7 +1107,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection111"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1167,7 +1167,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection112"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1227,7 +1227,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection113"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1411,7 +1411,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection114"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1489,7 +1489,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection115"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1691,7 +1691,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection114"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -1769,7 +1769,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection115"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -6893,8 +6893,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         aria-expanded={true}
                         aria-label="Group 0"
                         aria-level={1}
-                        aria-posinset={1}
-                        aria-setsize={2}
+                        aria-rowcount={3}
+                        aria-rowindex={2}
                         className=
                             ms-GroupHeader
                             {
@@ -7105,7 +7105,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection18"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"
@@ -7519,8 +7519,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         aria-expanded={true}
                         aria-label="Group 1"
                         aria-level={1}
-                        aria-posinset={2}
-                        aria-setsize={2}
+                        aria-rowcount={3}
+                        aria-rowindex={3}
                         className=
                             ms-GroupHeader
                             {
@@ -7731,7 +7731,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         className="ms-List"
                         id="GroupedListSection19"
-                        role="presentation"
+                        role="rowgroup"
                       >
                         <div
                           className="ms-List-surface"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                         two 1
                       </div>
                       <div
+                        aria-label="two 1"
                         className="ms-List"
                         id="GroupedListSection117"
                         role="rowgroup"
@@ -207,6 +208,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                         two 2
                       </div>
                       <div
+                        aria-label="two 2"
                         className="ms-List"
                         id="GroupedListSection118"
                         role="rowgroup"
@@ -401,6 +403,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                         two 1
                       </div>
                       <div
+                        aria-label="two 1"
                         className="ms-List"
                         id="GroupedListSection117"
                         role="rowgroup"
@@ -479,6 +482,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                         two 2
                       </div>
                       <div
+                        aria-label="two 2"
                         className="ms-List"
                         id="GroupedListSection118"
                         role="rowgroup"
@@ -681,6 +685,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                         one 1
                       </div>
                       <div
+                        aria-label="one 1"
                         className="ms-List"
                         id="GroupedListSection110"
                         role="rowgroup"
@@ -741,6 +746,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                         one 2
                       </div>
                       <div
+                        aria-label="one 2"
                         className="ms-List"
                         id="GroupedListSection111"
                         role="rowgroup"
@@ -801,6 +807,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                         one 3
                       </div>
                       <div
+                        aria-label="one 3"
                         className="ms-List"
                         id="GroupedListSection112"
                         role="rowgroup"
@@ -861,6 +868,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                         one 4
                       </div>
                       <div
+                        aria-label="one 4"
                         className="ms-List"
                         id="GroupedListSection113"
                         role="rowgroup"
@@ -1045,6 +1053,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                         one 1
                       </div>
                       <div
+                        aria-label="one 1"
                         className="ms-List"
                         id="GroupedListSection110"
                         role="rowgroup"
@@ -1105,6 +1114,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                         one 2
                       </div>
                       <div
+                        aria-label="one 2"
                         className="ms-List"
                         id="GroupedListSection111"
                         role="rowgroup"
@@ -1165,6 +1175,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                         one 3
                       </div>
                       <div
+                        aria-label="one 3"
                         className="ms-List"
                         id="GroupedListSection112"
                         role="rowgroup"
@@ -1225,6 +1236,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                         one 4
                       </div>
                       <div
+                        aria-label="one 4"
                         className="ms-List"
                         id="GroupedListSection113"
                         role="rowgroup"
@@ -1409,6 +1421,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                         two 1
                       </div>
                       <div
+                        aria-label="two 1"
                         className="ms-List"
                         id="GroupedListSection114"
                         role="rowgroup"
@@ -1487,6 +1500,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                         two 2
                       </div>
                       <div
+                        aria-label="two 2"
                         className="ms-List"
                         id="GroupedListSection115"
                         role="rowgroup"
@@ -1689,6 +1703,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                         two 1
                       </div>
                       <div
+                        aria-label="two 1"
                         className="ms-List"
                         id="GroupedListSection114"
                         role="rowgroup"
@@ -1767,6 +1782,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                         two 2
                       </div>
                       <div
+                        aria-label="two 2"
                         className="ms-List"
                         id="GroupedListSection115"
                         role="rowgroup"
@@ -6891,7 +6907,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 0"
+                        aria-label="Group 0 (2)"
                         aria-level={1}
                         aria-rowcount={3}
                         aria-rowindex={2}
@@ -7103,6 +7119,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         </div>
                       </div>
                       <div
+                        aria-label="Group 0"
                         className="ms-List"
                         id="GroupedListSection18"
                         role="rowgroup"
@@ -7517,7 +7534,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 1"
+                        aria-label="Group 1 (3)"
                         aria-level={1}
                         aria-rowcount={3}
                         aria-rowindex={3}
@@ -7729,6 +7746,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         </div>
                       </div>
                       <div
+                        aria-label="Group 1"
                         className="ms-List"
                         id="GroupedListSection19"
                         role="rowgroup"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone116"
+            data-focuszone-id="FocusZone118"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -139,7 +139,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection117"
+                        id="GroupedListSection119"
                         role="rowgroup"
                       >
                         <div
@@ -210,7 +210,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection118"
+                        id="GroupedListSection120"
                         role="rowgroup"
                       >
                         <div
@@ -364,7 +364,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone116"
+            data-focuszone-id="FocusZone118"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -405,7 +405,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection117"
+                        id="GroupedListSection119"
                         role="rowgroup"
                       >
                         <div
@@ -484,7 +484,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection118"
+                        id="GroupedListSection120"
                         role="rowgroup"
                       >
                         <div
@@ -646,7 +646,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone109"
+            data-focuszone-id="FocusZone111"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -687,7 +687,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection110"
+                        id="GroupedListSection112"
                         role="rowgroup"
                       >
                         <div
@@ -748,7 +748,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection111"
+                        id="GroupedListSection113"
                         role="rowgroup"
                       >
                         <div
@@ -809,7 +809,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection112"
+                        id="GroupedListSection114"
                         role="rowgroup"
                       >
                         <div
@@ -870,7 +870,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection113"
+                        id="GroupedListSection115"
                         role="rowgroup"
                       >
                         <div
@@ -1014,7 +1014,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone109"
+            data-focuszone-id="FocusZone111"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1055,7 +1055,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection110"
+                        id="GroupedListSection112"
                         role="rowgroup"
                       >
                         <div
@@ -1116,7 +1116,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection111"
+                        id="GroupedListSection113"
                         role="rowgroup"
                       >
                         <div
@@ -1177,7 +1177,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection112"
+                        id="GroupedListSection114"
                         role="rowgroup"
                       >
                         <div
@@ -1238,7 +1238,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection113"
+                        id="GroupedListSection115"
                         role="rowgroup"
                       >
                         <div
@@ -1382,7 +1382,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone109"
+            data-focuszone-id="FocusZone111"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1423,7 +1423,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection114"
+                        id="GroupedListSection116"
                         role="rowgroup"
                       >
                         <div
@@ -1502,7 +1502,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection115"
+                        id="GroupedListSection117"
                         role="rowgroup"
                       >
                         <div
@@ -1664,7 +1664,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone109"
+            data-focuszone-id="FocusZone111"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1705,7 +1705,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection114"
+                        id="GroupedListSection116"
                         role="rowgroup"
                       >
                         <div
@@ -1784,7 +1784,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection115"
+                        id="GroupedListSection117"
                         role="rowgroup"
                       >
                         <div
@@ -6907,7 +6907,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 0 (2)"
+                        aria-labelledby="GroupHeader19"
                         aria-level={1}
                         aria-rowcount={3}
                         aria-rowindex={2}
@@ -7096,6 +7096,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
+                            id="GroupHeader19"
                             role="gridcell"
                           >
                             <span>
@@ -7210,7 +7211,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone20"
+                                data-focuszone-id="FocusZone22"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
@@ -7397,7 +7398,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone21"
+                                data-focuszone-id="FocusZone23"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
@@ -7534,7 +7535,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 1 (3)"
+                        aria-labelledby="GroupHeader21"
                         aria-level={1}
                         aria-rowcount={3}
                         aria-rowindex={3}
@@ -7723,6 +7724,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
+                            id="GroupHeader21"
                             role="gridcell"
                           >
                             <span>
@@ -7748,7 +7750,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 1"
                         className="ms-List"
-                        id="GroupedListSection19"
+                        id="GroupedListSection20"
                         role="rowgroup"
                       >
                         <div
@@ -7837,7 +7839,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone22"
+                                data-focuszone-id="FocusZone24"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
@@ -8024,7 +8026,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone23"
+                                data-focuszone-id="FocusZone25"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
@@ -8211,7 +8213,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone24"
+                                data-focuszone-id="FocusZone26"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IProcessedStyleSet, ITheme } from '../../Styling';
-import { composeRenderFunction, classNamesFunction, getRTL, getRTLSafeKeyCode, KeyCodes } from '../../Utilities';
+import { composeRenderFunction, classNamesFunction, getId, getRTL, getRTLSafeKeyCode, KeyCodes } from '../../Utilities';
 import { SelectionMode } from '../../Selection';
 import { Check } from '../../Check';
 import { Icon } from '../../Icon';
@@ -27,6 +27,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
   };
 
   private _classNames: IProcessedStyleSet<IGroupHeaderStyles>;
+  private _id: string;
 
   public static getDerivedStateFromProps(
     nextProps: IGroupHeaderProps,
@@ -49,6 +50,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
 
   constructor(props: IGroupHeaderProps) {
     super(props);
+
+    this._id = getId('GroupHeader');
 
     this.state = {
       isCollapsed: (this.props.group && this.props.group.isCollapsed) as boolean,
@@ -110,8 +113,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       return null;
     }
 
-    const groupLabel = `${group.name} (${group.count}${group.hasMoreData ? '+' : ''})`;
-
     return (
       <div
         className={this._classNames.root}
@@ -124,7 +125,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-rowindex={ariaRowIndex}
         data-is-focusable={true}
         onKeyUp={this._onKeyUp}
-        aria-label={group.ariaLabel || groupLabel}
+        aria-label={group.ariaLabel}
+        aria-labelledby={group.ariaLabel ? undefined : this._id}
         aria-expanded={!this.state.isCollapsed}
         aria-selected={canSelectGroup ? currentlySelected : undefined}
         aria-level={groupLevel + 1}
@@ -258,7 +260,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     }
 
     return (
-      <div className={this._classNames.title} role="gridcell" aria-colspan={ariaColSpan}>
+      <div className={this._classNames.title} id={this._id} role="gridcell" aria-colspan={ariaColSpan}>
         <span>{group.name}</span>
         {
           // hasMoreData flag is set when grouping is throttled by SPO server which in turn resorts to regular

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -109,6 +109,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     if (!group) {
       return null;
     }
+
+    const groupLabel = `${group.name} (${group.count}${group.hasMoreData ? '+' : ''})`;
+
     return (
       <div
         className={this._classNames.root}
@@ -121,8 +124,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-rowindex={ariaRowIndex}
         data-is-focusable={true}
         onKeyUp={this._onKeyUp}
-        aria-label={group.ariaLabel || group.name}
+        aria-label={group.ariaLabel || groupLabel}
         aria-expanded={!this.state.isCollapsed}
+        aria-selected={canSelectGroup ? currentlySelected : undefined}
         aria-level={groupLevel + 1}
       >
         <div className={this._classNames.groupHeaderContainer} role="presentation">

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -79,6 +79,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       compact,
       ariaPosInSet,
       ariaSetSize,
+      ariaRowCount,
+      ariaRowIndex,
       useFastIcons,
     } = this.props;
 
@@ -115,6 +117,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         role="row"
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
+        aria-rowcount={ariaRowCount}
+        aria-rowindex={ariaRowIndex}
         data-is-focusable={true}
         onKeyUp={this._onKeyUp}
         aria-label={group.ariaLabel || group.name}

--- a/packages/react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/react/src/components/GroupedList/GroupHeader.types.ts
@@ -22,18 +22,6 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
   /** Native props for the GroupHeader select all button */
   selectAllButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
 
-  /** Defines the number of items in the current set of listitems or treeitems */
-  ariaSetSize?: number;
-
-  /** Defines an element's number or position in the current set of listitems or treeitems */
-  ariaPosInSet?: number;
-
-  /** Defines the number of items in the current set of grid items */
-  ariaRowCount?: number;
-
-  /** Defines an element's number or position in the current set of grid items */
-  ariaRowIndex?: number;
-
   /**
    * If provided, can be used to render a custom checkbox
    */

--- a/packages/react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/react/src/components/GroupedList/GroupHeader.types.ts
@@ -28,6 +28,12 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
   /** Defines an element's number or position in the current set of listitems or treeitems */
   ariaPosInSet?: number;
 
+  /** Defines the number of items in the current set of grid items */
+  ariaRowCount?: number;
+
+  /** Defines an element's number or position in the current set of grid items */
+  ariaRowIndex?: number;
+
   /**
    * If provided, can be used to render a custom checkbox
    */

--- a/packages/react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedList.types.ts
@@ -283,6 +283,18 @@ export interface IGroupDividerProps {
   /** Defines the number of columns a group header needs to span in the case of a grid or treegrid */
   ariaColSpan?: number;
 
+  /** Defines the number of items in the current set of listitems or treeitems */
+  ariaSetSize?: number;
+
+  /** Defines an element's number or position in the current set of listitems or treeitems */
+  ariaPosInSet?: number;
+
+  /** Defines the number of items in the current set of grid items */
+  ariaRowCount?: number;
+
+  /** Defines an element's number or position in the current set of grid items */
+  ariaRowIndex?: number;
+
   /**
    * Width corresponding to a single level.
    * This is multiplied by the groupLevel to get the full spacer width for the group.

--- a/packages/react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListSection.tsx
@@ -250,7 +250,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         {onRenderGroupHeader(groupHeaderProps, this._onRenderGroupHeader)}
         {group && group.isCollapsed ? null : hasNestedGroups ? (
           <List
-            role="presentation"
+            role="group"
             ref={this._list}
             items={group ? group.children : []}
             onRenderCell={this._renderSubGroup}
@@ -340,7 +340,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
     return (
       <List
-        role={groupProps && groupProps.role ? groupProps.role : 'presentation'}
+        role={groupProps && groupProps.role ? groupProps.role : 'group'}
         items={items}
         onRenderCell={this._onRenderGroupCell(onRenderCell, groupNestingDepth)}
         ref={this._list}

--- a/packages/react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListSection.tsx
@@ -341,6 +341,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
     return (
       <List
         role={groupProps && groupProps.role ? groupProps.role : 'group'}
+        aria-label={group?.name}
         items={items}
         onRenderCell={this._onRenderGroupCell(onRenderCell, groupNestingDepth)}
         ref={this._list}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15355
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates the Grouped Detailslist to use grid row semantics for index and count on the group header rows. Does not fix the actual index values on nested grid rows.

#### Focus areas to test

- Grouped Detailslist's group headers should have `aria-rowindex` and `aria-rowcount`, both of which should include the header row when calculating index/count
- GroupedList should use `aria-posinset` and `aria-setsize` for group headers
