### PR TITLE
Callout ordering and line opacity

### DIFF
--- a/change/@uifabric-charting-2020-11-03-10-35-15-user-v-sivsar-CalloutOrderingAndLineOpacity.json
+++ b/change/@uifabric-charting-2020-11-03-10-35-15-user-v-sivsar-CalloutOrderingAndLineOpacity.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "applied the ordering(descending order) in the callout for line points, fixed the opacity of the line also ",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-03T05:05:15.514Z"
+}

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -282,7 +282,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             y1={y1}
             x2={x2}
             y2={y2}
-            opacity={shouldHighlight ? 1 : 0.4}
+            opacity={shouldHighlight ? 1 : 0.1}
             strokeWidth={3}
             stroke={lineObject[item][i].color}
             {...(isLegendSelected &&
@@ -581,7 +581,12 @@ export class VerticalStackedBarChartBase extends React.Component<
       refSelected: mouseEvent,
       isCalloutVisible: true,
       YValueHover: isLinesPresent
-        ? [...lineData!, ...found!.chartData.slice().reverse()]
+        ? [
+            ...lineData!.sort((a: ILineDataInVerticalStackedBarChart, b: ILineDataInVerticalStackedBarChart) => {
+              return a.data! < b.data! ? 1 : -1;
+            }),
+            ...found!.chartData.slice().reverse(),
+          ]
         : found!.chartData.slice().reverse(),
       hoverXValue: xAxisPoint,
       stackCalloutProps: found!,
@@ -628,7 +633,12 @@ export class VerticalStackedBarChartBase extends React.Component<
       refSelected: groupRef.refElement,
       isCalloutVisible: true,
       YValueHover: isLinesPresent
-        ? [...lineData!, ...found!.chartData.slice().reverse()]
+        ? [
+            ...lineData!.sort((a: ILineDataInVerticalStackedBarChart, b: ILineDataInVerticalStackedBarChart) => {
+              return a.data! < b.data! ? 1 : -1;
+            }),
+            ...found!.chartData.slice().reverse(),
+          ]
         : found!.chartData.slice().reverse(),
       hoverXValue: xAxisPoint,
       stackCalloutProps: found!,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15815
- [x] Include a change request file using `$ yarn change`

#### Description of changes

fixing the opacity of the line, when we select a line from the chart, the other lines(un-selected) should have the same opacity as the rectangle

also fixed the ordering of the line data in the callout. i have made it to descending oreder
#### Focus areas to test

vertical stacked bar chart



**after fix**
![image](https://user-images.githubusercontent.com/33802398/97951715-23b6ac80-1dc1-11eb-8bca-5f59e8c35126.png)
![image](https://user-images.githubusercontent.com/33802398/97951724-2b765100-1dc1-11eb-80e0-5fe3539731b9.png)

**before fix**
![image](https://user-images.githubusercontent.com/33802398/97951754-3f21b780-1dc1-11eb-94d3-edea2e61bf92.png)
![image](https://user-images.githubusercontent.com/33802398/97951764-46e15c00-1dc1-11eb-8c31-9e64811a1dfa.png)


