### PR TITLE
Remove wrapper around Nav which inhibits proper styling

### DIFF
--- a/change/office-ui-fabric-react-2020-11-03-14-38-53-nav-style.json
+++ b/change/office-ui-fabric-react-2020-11-03-14-38-53-nav-style.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove wrapper element around Nav inhibiting proper styling",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-03T22:38:53.422Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -67,10 +67,15 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
     return (
-      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone}>
-        <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
-          {groupElements}
-        </nav>
+      <FocusZone
+        as="nav"
+        role="navigation"
+        className={classNames.root}
+        aria-label={this.props.ariaLabel}
+        direction={FocusZoneDirection.vertical}
+        componentRef={this._focusZone}
+      >
+        {groupElements}
       </FocusZone>
     );
   }


### PR DESCRIPTION
#### Description of changes

Updated `Nav` to reuse the `FocusZone` element as the 'root' element of the component, allowing `className` to apply properly to the entire box, not just the content of the `FocusZone`. This allows `className` to be used to apply flex-styling and positioning.

#### Focus areas to test

Validate `Nav` examples.
