### PR TITLE
Pass React event to SelectionZone onItemContextMenu handler

### DIFF
--- a/change/office-ui-fabric-react-2020-11-03-15-23-37-selection-context-menu.json
+++ b/change/office-ui-fabric-react-2020-11-03-15-23-37-selection-context-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Pass React event into onItemContextMenu callback",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-03T23:23:37.290Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -408,7 +408,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
 
         this._onInvokeMouseDown(ev, index);
 
-        const skipPreventDefault = onItemContextMenu(selection.getItems()[index], index, ev.nativeEvent);
+        const skipPreventDefault = onItemContextMenu(selection.getItems()[index], index, (ev as unknown) as Event);
 
         // In order to keep back compat, if the value here is undefined, then we should still
         // call preventDefault(). Only in the case where true is explicitly returned should


### PR DESCRIPTION
#### Description of changes

Revised `onItemContextMenu` in `SelectionZone` so that the React synthetic event is passed to the callback instead of the `nativeEvent`. The issue is that `nativeEvent` is a DOM event *which has already propagated to `window`*, thus making it impossible to stop propagation to `oncontextmenu` handlers higher in the React tree.

Since most handlers are likely to use only a few fields of the `event` parameter, it should be safe to simply force-cast the React event to `Event`, since there is significant overlap.

#### Focus areas to test

Validate examples which use the context menu callback of `SelectionZone`.
