### PR TITLE
[6.0] Restrict to Node versions which work with this branch's tools

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -75,14 +75,9 @@
     "postRushBuild": []
   },
   /**
-   * Older releases of the NodeJS engine may be missing features required by your system.
-   * Other releases may have bugs.  In particular, the "latest" version will not be a
-   * Long Term Support (LTS) version and is likely to have regressions.
-   *
-   * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
-   * for your repo.
+   * `rush install` fails on Node 12+ (and 9 and 11 are no longer supported)
    */
-  "nodeSupportedVersionRange": ">=8.9.0",
+  "nodeSupportedVersionRange": ">=8.9.0 <9.0.0 || >=10.9.0 <11.0.0",
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then
    * uncomment this line. This is effectively similar to running "rush check" before any


### PR DESCRIPTION
At least on Mac and Linux, on Node 12 `rush install` with the Rush version used in the `6.0` branch fails to complete with this error. Switching back to Node 10 fixes it. Since the `6.0` branch is very old and rarely modified at this point, rather than spending time trying to track this down I think we should just restrict the supported Node versions on that branch to 8 and 10.

```
/Users/me/.rush/node-v12.18.4/pnpm-2.19.2/node_modules/pnpm/lib/node_modules/graceful-fs/polyfills.js:285
        if (cb) cb.apply(this, arguments)
                   ^

TypeError: cb.apply is not a function
    at /Users/me/.rush/node-v12.18.4/pnpm-2.19.2/node_modules/pnpm/lib/node_modules/graceful-fs/polyfills.js:285:20
    at /Users/me/.rush/node-v12.18.4/pnpm-2.19.2/node_modules/pnpm/lib/node_modules/graceful-fs/polyfills.js:285:20
    at FSReqCallback.oncomplete (fs.js:169:5)

The command failed:
 /Users/me/git/fabric-react6/common/temp/pnpm-local/node_modules/.bin/pnpm install --store /Users/me/git/fabric-react6/common/temp/pnpm-store --no-lock --no-prefer-frozen-shrinkwrap --strict-peer-dependencies
ERROR: Error: The command failed with exit code 1
```