### PR TITLE
Calendar date picker spacing around "Go to today"

### DIFF
--- a/change/@fluentui-react-date-time-2020-11-05-10-29-25-calendar_date_picker.json
+++ b/change/@fluentui-react-date-time-2020-11-05-10-29-25-calendar_date_picker.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update Calendar spacing around \"Go to today\" button.",
+  "packageName": "@fluentui/react-date-time",
+  "email": "lesliewilliams234@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-05T18:29:25.460Z"
+}

--- a/packages/react/src/components/Calendar/Calendar.styles.ts
+++ b/packages/react/src/components/Calendar/Calendar.styles.ts
@@ -45,8 +45,7 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
         boxSizing: 'content-box',
         padding: '0 4px',
         alignSelf: 'flex-end',
-        marginRight: 16,
-        marginTop: 3,
+        margin: '3px 16px 11px 0',
         fontSize: FontSizes.small,
         fontFamily: 'inherit',
         overflow: 'visible', // explicitly specify for IE11

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -21,6 +21,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         width: 196,
         padding: 12,
         boxSizing: 'content-box',
+        minHeight: 238,
       },
       showWeekNumbers && {
         width: 226,

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -21,7 +21,6 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         width: 196,
         padding: 12,
         boxSizing: 'content-box',
-        minHeight: 238,
       },
       showWeekNumbers && {
         width: 226,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15651
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently the spacing around the "Go to today" button varies between the [first DatePicker example from OUFR](http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/7.0/fabric-website-resources/dist/index.html#/examples/datepicker) and the [first DatePicker example from date-time](http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/date-time/demo/index.html#/examples/datepicker). In addition to reduced padding, first DatePicker example from date-time also behaves differently when presented with months of varying lengths. For instance, when August is selected (or any month with 6 weeks due to transitions), the height of the component changes.

Current DatePicker example from date-time:
![before_nov](https://user-images.githubusercontent.com/25760457/98283501-9c9a3d80-1f54-11eb-811e-470fe4a6ce53.png)
![before_aug](https://user-images.githubusercontent.com/25760457/98283526-a02dc480-1f54-11eb-9769-2c950282e92e.png)

This change adds space beneath the button and eliminates variability in overall component height by adding `min-height: 238`. While multiple approaches were considered, this one was selected for its simplicity.

Updated DatePicker example from date-time:
![after_nov](https://user-images.githubusercontent.com/25760457/98284232-ab352480-1f55-11eb-95aa-17b8fbce2048.png)
![after_aug](https://user-images.githubusercontent.com/25760457/98284242-ae301500-1f55-11eb-8f03-dafe5dc6b9a2.png)


#### Focus areas to test

(optional)
