### PR TITLE
Fixing typing errors in create-package script

### DIFF
--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -1,6 +1,5 @@
 import { NodePlopAPI, AddManyActionConfig } from 'plop';
 import { Actions } from 'node-plop';
-import * as inquirer from 'inquirer'; // implicit dep for types only
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as jju from 'jju';
@@ -50,7 +49,7 @@ module.exports = (plop: NodePlopAPI) => {
         default: true,
         when: answers => answers.target === 'node', // react always has tests
       },
-    ] as inquirer.Question<Partial<Answers>>[],
+    ],
 
     actions: (answers: Answers): Actions => {
       const { packageName, target, hasTests } = answers;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes some typing errors that were occurring when using the `create-package` script.

#### Focus areas to test

(optional)
