### PR TITLE
Fix scoped builds

### DIFF
--- a/.devops/templates/pr-target-branch.yml
+++ b/.devops/templates/pr-target-branch.yml
@@ -1,5 +1,0 @@
-steps:
-  - script: |
-      node -e "process.stdout.write('##vso[task.setvariable variable=target_branch]origin/$(System.PullRequest.TargetBranch)')"
-    displayName: Set target_branch variable (PR)
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/.devops/templates/variables.yml
+++ b/.devops/templates/variables.yml
@@ -16,5 +16,8 @@ variables:
 
   azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
 
+  ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+    targetBranch: 'origin/$(System.PullRequest.TargetBranch)'
+
   backfillProvider: 'azure-blob'
   backfillOptions: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,8 +22,6 @@ jobs:
       - script: npx midgard-yarn install
         displayName: yarn
 
-      - template: .devops/templates/pr-target-branch.yml
-
       - script: |
           yarn checkchange
         displayName: check change
@@ -46,7 +44,7 @@ jobs:
 
       ## only do scoped builds with PRs
       - script: |
-          yarn buildci --no-cache --since $(target_branch)
+          yarn buildci --no-cache --since $(targetBranch)
         displayName: build, test, lint (pr, scoped)
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
@@ -75,11 +73,9 @@ jobs:
       - script: npx midgard-yarn install
         displayName: yarn
 
-      - template: .devops/templates/pr-target-branch.yml
-
       ## only do scoped bundle with PRs
       - script: |
-          yarn bundle --no-cache --grouped --since $(target_branch)
+          yarn bundle --no-cache --grouped --since $(targetBranch)
         displayName: bundle (pr, scoped)
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
@@ -171,8 +167,6 @@ jobs:
 
       - script: npx midgard-yarn install
         displayName: yarn
-
-      - template: .devops/templates/pr-target-branch.yml
 
       - script: |
           yarn lage screener --to vr-tests --debug --verbose --no-cache --grouped


### PR DESCRIPTION
Scoped builds have stopped working: the scope ends up undefined or empty or something and so it doesn't build anything.

It looks like the method previously being used to set the variable `target_branch` is no longer working, so switch to a simpler method like the other variables.