### PR TITLE
Fix scoped builds (7.0)

### DIFF
--- a/.devops/templates/pr-target-branch.yml
+++ b/.devops/templates/pr-target-branch.yml
@@ -1,5 +1,0 @@
-steps:
-  - script: |
-      node -e "process.stdout.write('##vso[task.setvariable variable=target_branch]origin/$(System.PullRequest.TargetBranch)')"
-    displayName: Set target_branch variable (PR)
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/7.0')

--- a/.devops/templates/variables.yml
+++ b/.devops/templates/variables.yml
@@ -13,3 +13,6 @@ variables:
     deployBasePath: "pr-deploy-site/${{ variables['Build.SourceVersion'] }}"
 
   deployHost: 'fabricweb.z5.web.core.windows.net'
+
+  ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/7.0') }}:
+    targetBranch: 'origin/$(System.PullRequest.TargetBranch)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,9 @@ trigger:
 
 variables:
   - group: fabric-variables
+  - template: .devops/templates/variables.yml
+    parameters:
+      pathPrefix: SourceVersion
 
 pool: 'Self Host Ubuntu'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,6 @@ jobs:
   - job: Deploy
     workspace:
       clean: all
-    variables:
-      - template: .devops/templates/variables.yml
     steps:
       - template: .devops/templates/tools.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,6 @@ jobs:
       - script: npx midgard-yarn install
         displayName: yarn
 
-      - template: .devops/templates/pr-target-branch.yml
-
       - script: |
           yarn checkchange
         displayName: check change
@@ -32,7 +30,7 @@ jobs:
 
       ## only do scoped builds with PRs
       - script: |
-          yarn buildci --no-cache --since $(target_branch)
+          yarn buildci --no-cache --since $(targetBranch)
         displayName: build, test, lint (pr, scoped)
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/7.0')
         env:
@@ -61,11 +59,9 @@ jobs:
       - script: npx midgard-yarn install
         displayName: yarn
 
-      - template: .devops/templates/pr-target-branch.yml
-
       ## only do scoped bundle with PRs
       - script: |
-          yarn bundle --no-cache --grouped --since $(target_branch)
+          yarn bundle --no-cache --grouped --since $(targetBranch)
         displayName: bundle (pr, scoped)
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/7.0')
         env:
@@ -117,8 +113,6 @@ jobs:
 
       - script: npx midgard-yarn install
         displayName: yarn
-
-      - template: .devops/templates/pr-target-branch.yml
 
       - script: |
           yarn lage screener --to vr-tests --debug --verbose --no-cache --grouped


### PR DESCRIPTION
Scoped builds have stopped working: the scope ends up undefined or empty or something and so it doesn't build anything.

It looks like the method previously being used to set the variable `target_branch` is no longer working, so switch to a simpler method like the other variables.