### PR TITLE
Fix selection in UPP on initial load and group expand

### DIFF
--- a/change/@fluentui-react-experiments-2020-11-06-15-44-39-keyboardnavfix.json
+++ b/change/@fluentui-react-experiments-2020-11-06-15-44-39-keyboardnavfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix keyboard selection in UPP on initial load with recipients, group expansion",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-06T23:44:39.230Z"
+}

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -245,6 +245,16 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
   }
 
+  const _replaceItem = (newItem: IPersonaProps | IPersonaProps[], index: number): void => {
+    const newItemsArray = !Array.isArray(newItem) ? [newItem] : newItem;
+
+    if (index >= 0) {
+      const newItems: IPersonaProps[] = [...peopleSelectedItems];
+      newItems.splice(index, 1, ...newItemsArray);
+      setPeopleSelectedItems(newItems);
+    }
+  };
+
   /**
    * Build a custom selected item capable of being edited with a dropdown and
    * capable of eidting
@@ -290,6 +300,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     onItemsRemoved: _onItemsRemoved,
     getItemCopyText: _getItemsCopyText,
     dropItemsAt: _dropItemsAt,
+    replaceItem: _replaceItem,
   } as ISelectedPeopleListProps<IPersonaProps>;
 
   const inputProps = {

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -6,10 +6,11 @@ import {
 } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
 import { UnifiedPeoplePicker } from '@fluentui/react-experiments/lib/UnifiedPeoplePicker';
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { mru, people } from '@fluentui/example-data';
+import { mru, people, groupOne, groupTwo } from '@fluentui/example-data';
 import { ISelectedPeopleListProps } from '@fluentui/react-experiments/lib/SelectedItemsList';
 import { IInputProps } from '@fluentui/react';
 import { useConst } from '@fluentui/react-hooks';
+import { SelectedPersona, ISelectedItemProps } from '@fluentui/react-experiments/lib/SelectedItemsList';
 
 const _suggestions = [
   {
@@ -244,6 +245,30 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
   }
 
+  /**
+   * Build a custom selected item capable of being edited with a dropdown and
+   * capable of eidting
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const SelectedItem = (props: ISelectedItemProps<IPersonaProps>) => (
+    <SelectedPersona canExpand={_canExpandItem} getExpandedItems={_getExpandedGroupItems} {...props} />
+  );
+
+  const _getExpandedGroupItems = async (item: IPersonaProps): Promise<IPersonaProps[]> => {
+    switch (item.text) {
+      case 'Group One':
+        return groupOne;
+      case 'Group Two':
+        return groupTwo;
+      default:
+        return [];
+    }
+  };
+
+  const _canExpandItem = (item: IPersonaProps): boolean => {
+    return item.text !== undefined && item.text.indexOf('Group') !== -1;
+  };
+
   const floatingPeoplePickerProps = {
     suggestions: [...peopleSuggestions],
     isSuggestionsVisible: false,
@@ -260,6 +285,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const selectedPeopleListProps = {
     selectedItems: [...peopleSelectedItems],
+    onRenderItem: SelectedItem,
     removeButtonAriaLabel: 'Remove',
     onItemsRemoved: _onItemsRemoved,
     getItemCopyText: _getItemsCopyText,

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -76,7 +76,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     ..._suggestions,
   ]);
 
-  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
+  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
 
   const ref = React.useRef<any>();
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -373,6 +373,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       selectedItems: selectedItems,
       focusedItemIndices: focusedItemIndices,
       onItemsRemoved: _onRemoveSelectedItems,
+      replaceItem: _replaceItem,
       dragDropHelper: dragDropHelper,
       dragDropEvents: props.dragDropEvents ? props.dragDropEvents : defaultDragDropEvents,
     });
@@ -405,6 +406,13 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     removeItems(itemsToRemove);
     if (props.selectedItemsListProps.onItemsRemoved) {
       props.selectedItemsListProps.onItemsRemoved(itemsToRemove);
+    }
+  };
+  const _replaceItem = (newItem: T | T[], index: number) => {
+    const newItems = Array.isArray(newItem) ? newItem : [newItem];
+    dropItemsAt(index, newItems, [index]);
+    if (props.selectedItemsListProps.replaceItem) {
+      props.selectedItemsListProps.replaceItem(newItem, index);
     }
   };
   const _renderFloatingPicker = () =>

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -23,6 +23,12 @@ export const useSelectedItems = <T extends {}>(
   const [items, setSelectedItems] = React.useState(selectedItems || []);
 
   React.useEffect(() => {
+    if (selectedItems !== undefined) {
+      selection.setItems(selectedItems);
+    }
+  }, []);
+
+  React.useEffect(() => {
     setSelectedItems(selectedItems ? selectedItems : []);
   }, [selectedItems]);
 

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -22,11 +22,15 @@ export const useSelectedItems = <T extends {}>(
 ): IUseSelectedItemsResponse<T> => {
   const [items, setSelectedItems] = React.useState(selectedItems || []);
 
-  React.useEffect(() => {
-    if (selectedItems !== undefined) {
-      selection.setItems(selectedItems);
-    }
-  }, []);
+  React.useEffect(
+    () => {
+      if (selectedItems !== undefined) {
+        selection.setItems(selectedItems);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- we want to do this once
+    [],
+  );
 
   React.useEffect(() => {
     setSelectedItems(selectedItems ? selectedItems : []);

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -43,8 +43,8 @@ export const useSelectedItems = <T extends {}>(
         itemsToAdd.forEach(draggedItem => {
           updatedItems.push(draggedItem);
         });
-        updatedItems.push(item);
-      } else if (!indicesToRemove.includes(i)) {
+      }
+      if (!indicesToRemove.includes(i)) {
         // only insert items into the new list that are not being dragged
         updatedItems.push(item);
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously, users couldn't access items via the keyboard if the UPP loaded with initial items, they had to add or remove an item. Items also couldn't be accessed after a group expand.

This was because the selection wasn't being set properly in either of these cases. It is now being set on load if there are items as well as on group expand (added a replaceItems overload in the UPP that does this before passing the info through).

Added a starting item that is a group to the UPP example to cover both of these scenarios.