### PR TITLE
fix(SplitButton): fix SplitButton width

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updated `ReactionsIcon` @TanelVari ([#15358](https://github.com/microsoft/fluentui/pull/15358))
 - Memoize context value in `Provider` to avoid rerenders @layershifter ([#15358](https://github.com/microsoft/fluentui/pull/15380))
 - Cleanup `src` on `Video` component unmount @SreepriyaV, @miroslavstastny ([#15494](https://github.com/microsoft/fluentui/pull/15494))
+- Fix `SplitButton` focus outline @assuncaocharles ([#15873](https://github.com/microsoft/fluentui/pull/15873))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
@@ -50,8 +50,7 @@ export const splitButtonStyles: ComponentSlotStylesPrepared<SplitButtonStylesPro
     return {
       borderRadius: v.borderRadius,
       position: 'relative',
-      display: 'flex',
-      flexWrap: 'nowrap',
+      display: 'inline-block',
       ':focus-within': {
         boxShadow: 'none',
         ...(p.isFromKeyboard && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
@@ -48,9 +48,11 @@ export const splitButtonStyles: ComponentSlotStylesPrepared<SplitButtonStylesPro
     });
 
     return {
+      width: 'fit-content',
       borderRadius: v.borderRadius,
       position: 'relative',
-      display: 'inline-block',
+      display: 'flex',
+      flexWrap: 'nowrap',
       ':focus-within': {
         boxShadow: 'none',
         ...(p.isFromKeyboard && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
@@ -48,11 +48,10 @@ export const splitButtonStyles: ComponentSlotStylesPrepared<SplitButtonStylesPro
     });
 
     return {
-      width: 'fit-content',
       borderRadius: v.borderRadius,
       position: 'relative',
-      display: 'flex',
-      flexWrap: 'nowrap',
+      whiteSpace: 'nowrap',
+      display: 'inline-block',
       ':focus-within': {
         boxShadow: 'none',
         ...(p.isFromKeyboard && {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15641
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The current implementation for `SplitButtton` is computing more than its content width for `root` slot creating the following bug:

<img width="1484" alt="Screen Shot 2020-11-09 at 14 29 58" src="https://user-images.githubusercontent.com/8545105/98576181-f5414180-2298-11eb-80e8-4f877b9c40cc.png">


~~This PR fixes it removing `display: flex`, I didn't see any strong reason to keep it but if needed we can keep `display: flex` and set `width: fit-contetnt`.~~ 

~~This PR fixes it adding `width: fit-content`~~

This PR fixes it adding: 

```css
whiteSpace: 'nowrap',
display: 'inline-block',
```

Visual after this PR:

<img width="294" alt="Screen Shot 2020-11-09 at 14 26 16" src="https://user-images.githubusercontent.com/8545105/98576238-0a1dd500-2299-11eb-9466-c3065e9083ee.png">




#### Focus areas to test

(optional)
