### PR TITLE
7.0: Fix selection in UPP on initial load and group expand

### DIFF
--- a/change/@fluentui-react-examples-2020-11-09-10-22-41-fixkeyboardnav7.0.json
+++ b/change/@fluentui-react-examples-2020-11-09-10-22-41-fixkeyboardnav7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "UPP example now has initial item, group expand",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-09T18:22:41.524Z"
+}

--- a/change/@uifabric-experiments-2020-11-09-10-22-41-fixkeyboardnav7.0.json
+++ b/change/@uifabric-experiments-2020-11-09-10-22-41-fixkeyboardnav7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix keyboard selection when UPP loads with items (and group expand)",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-09T18:22:20.097Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -381,6 +381,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       selectedItems: selectedItems,
       focusedItemIndices: focusedItemIndices,
       onItemsRemoved: _onRemoveSelectedItems,
+      replaceItem: _replaceItem,
       dragDropHelper: dragDropHelper,
       dragDropEvents: props.dragDropEvents ? props.dragDropEvents : defaultDragDropEvents,
     });
@@ -415,6 +416,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       props.selectedItemsListProps.onItemsRemoved(itemsToRemove);
     }
   };
+  const _replaceItem = (newItem: T | T[], index: number) => {
+    const newItems = Array.isArray(newItem) ? newItem : [newItem];
+    dropItemsAt(index, newItems, [index]);
+    if (props.selectedItemsListProps.replaceItem) {
+      props.selectedItemsListProps.replaceItem(newItem, index);
+    }
+  };
+
   const _renderFloatingPicker = () =>
     onRenderFloatingSuggestions({
       ...floatingSuggestionProps,

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -22,6 +22,16 @@ export const useSelectedItems = <T extends {}>(
 ): IUseSelectedItemsResponse<T> => {
   const [items, setSelectedItems] = React.useState(selectedItems || []);
 
+  React.useEffect(
+    () => {
+      if (selectedItems !== undefined) {
+        selection.setItems(selectedItems);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- we want to do this once
+    [],
+  );
+
   React.useEffect(() => {
     setSelectedItems(selectedItems ? selectedItems : []);
   }, [selectedItems]);
@@ -43,8 +53,8 @@ export const useSelectedItems = <T extends {}>(
         itemsToAdd.forEach(draggedItem => {
           updatedItems.push(draggedItem);
         });
-        updatedItems.push(item);
-      } else if (!indicesToRemove.includes(i)) {
+      }
+      if (!indicesToRemove.includes(i)) {
         // only insert items into the new list that are not being dragged
         updatedItems.push(item);
       }

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -6,10 +6,11 @@ import {
 } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePicker';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
-import { mru, people } from '@uifabric/example-data';
+import { mru, people, groupOne, groupTwo } from '@uifabric/example-data';
 import { ISelectedPeopleListProps } from '@uifabric/experiments/lib/SelectedItemsList';
 import { IInputProps } from 'office-ui-fabric-react';
 import { useConst } from '@uifabric/react-hooks';
+import { SelectedPersona, ISelectedItemProps } from '@uifabric/experiments/lib/SelectedItemsList';
 
 const _suggestions = [
   {
@@ -75,7 +76,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     ..._suggestions,
   ]);
 
-  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
+  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
 
   const ref = React.useRef<any>();
 
@@ -244,6 +245,40 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
   }
 
+  const _replaceItem = (newItem: IPersonaProps | IPersonaProps[], index: number): void => {
+    const newItemsArray = !Array.isArray(newItem) ? [newItem] : newItem;
+
+    if (index >= 0) {
+      const newItems: IPersonaProps[] = [...peopleSelectedItems];
+      newItems.splice(index, 1, ...newItemsArray);
+      setPeopleSelectedItems(newItems);
+    }
+  };
+
+  /**
+   * Build a custom selected item capable of being edited with a dropdown and
+   * capable of eidting
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const SelectedItem = (props: ISelectedItemProps<IPersonaProps>) => (
+    <SelectedPersona canExpand={_canExpandItem} getExpandedItems={_getExpandedGroupItems} {...props} />
+  );
+
+  const _getExpandedGroupItems = async (item: IPersonaProps): Promise<IPersonaProps[]> => {
+    switch (item.text) {
+      case 'Group One':
+        return groupOne;
+      case 'Group Two':
+        return groupTwo;
+      default:
+        return [];
+    }
+  };
+
+  const _canExpandItem = (item: IPersonaProps): boolean => {
+    return item.text !== undefined && item.text.indexOf('Group') !== -1;
+  };
+
   const floatingPeoplePickerProps = {
     suggestions: [...peopleSuggestions],
     isSuggestionsVisible: false,
@@ -260,10 +295,12 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const selectedPeopleListProps = {
     selectedItems: [...peopleSelectedItems],
+    onRenderItem: SelectedItem,
     removeButtonAriaLabel: 'Remove',
     onItemsRemoved: _onItemsRemoved,
     getItemCopyText: _getItemsCopyText,
     dropItemsAt: _dropItemsAt,
+    replaceItem: _replaceItem,
   } as ISelectedPeopleListProps<IPersonaProps>;
 
   const inputProps = {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - https://github.com/microsoft/fluentui/pull/15872

Previously, users couldn't access items via the keyboard if the UPP loaded with initial items, they had to add or remove an item. Items also couldn't be accessed after a group expand.

This was because the selection wasn't being set properly in either of these cases. It is now being set on load if there are items as well as on group expand (added a replaceItems overload in the UPP that does this before passing the info through).

Added a starting item that is a group to the UPP example to cover both of these scenarios.