### PR TITLE
U/elisabethcvs/fixdisplaynameregex

### DIFF
--- a/change/@fluentui-react-internal-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
+++ b/change/@fluentui-react-internal-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Modify getInitials to strip [] and {} just like it strips ()",
+  "packageName": "@fluentui/react-internal",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T00:09:37.201Z"
+}

--- a/change/@fluentui-react-internal-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
+++ b/change/@fluentui-react-internal-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Modify getInitials to strip [] and {} just like it strips ()",
+  "comment": "Modify Persona example and tests to cover the new initials behavior",
   "packageName": "@fluentui/react-internal",
   "email": "elvonspa@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-utilities-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
+++ b/change/@fluentui-utilities-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Modify Persona example and tests to cover the new initials behavior",
+  "comment": "Modify getInitials to strip [xyz] and {xyz} just like it strips (xyz)",
   "packageName": "@fluentui/utilities",
   "email": "elvonspa@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-utilities-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
+++ b/change/@fluentui-utilities-2020-11-09-16-09-53-u-elisabethcvs-fixdisplaynameregex.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Modify Persona example and tests to cover the new initials behavior",
+  "packageName": "@fluentui/utilities",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T00:09:53.058Z"
+}

--- a/packages/react-examples/src/react/Persona/Persona.Initials.Example.tsx
+++ b/packages/react-examples/src/react/Persona/Persona.Initials.Example.tsx
@@ -21,6 +21,8 @@ export const PersonaInitialsExample: React.FunctionComponent = () => {
       <Persona {...examplePersona} text="Annie" size={PersonaSize.size24} />
       <Persona {...examplePersona} text="Annie Lind" size={PersonaSize.size32} />
       <Persona {...examplePersona} text="Annie Boyl Lind" size={PersonaSize.size32} />
+      <Persona {...examplePersona} text="David (The man) Goff" size={PersonaSize.size32} />
+      <Persona {...examplePersona} text="David Goff [The man]" size={PersonaSize.size32} />
       <Persona {...examplePersona} text="Annie Boyl Carrie Lindqvist" size={PersonaSize.size40} />
       <Persona {...examplePersona} text="+1 (111) 123-4567 X4567" size={PersonaSize.size40} />
       <Persona {...examplePersona} text="+1 (555) 123-4567 X4567" size={PersonaSize.size48} allowPhoneInitials={true} />

--- a/packages/react-examples/src/react/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -913,6 +913,450 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
   <div
     className=
         ms-Persona
+        ms-Persona--size32
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
+        role="presentation"
+      >
+        <div
+          aria-hidden="true"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #5C2E91;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 14px;
+                font-weight: 600;
+                height: 32px;
+                line-height: 32px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
+              & i {
+                font-weight: 600;
+              }
+        >
+          <span>
+            DG
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          David (The man) Goff
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Designer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size32
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
+        role="presentation"
+      >
+        <div
+          aria-hidden="true"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #5C2E91;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 14px;
+                font-weight: 600;
+                height: 32px;
+                line-height: 32px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
+              & i {
+                font-weight: 600;
+              }
+        >
+          <span>
+            DG
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          David Goff [The man]
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Designer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona
         ms-Persona--size40
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/react-internal/src/components/Persona/Persona.test.tsx
+++ b/packages/react-internal/src/components/Persona/Persona.test.tsx
@@ -165,6 +165,16 @@ describe('Persona', () => {
       result = wrapper.find(STYLES.initials);
       expect(result).toHaveLength(1);
       expect(result.text()).toEqual('DG');
+
+      wrapper = mount(<Persona text="David [The man] Goff" />);
+      result = wrapper.find(STYLES.initials);
+      expect(result).toHaveLength(1);
+      expect(result.text()).toEqual('DG');
+
+      wrapper = mount(<Persona text="David Goff {The man}" />);
+      result = wrapper.find(STYLES.initials);
+      expect(result).toHaveLength(1);
+      expect(result.text()).toEqual('DG');
     });
 
     it('calculates an expected initials in RTL if one was not specified', () => {

--- a/packages/utilities/src/initials.test.ts
+++ b/packages/utilities/src/initials.test.ts
@@ -37,8 +37,23 @@ describe('getInitials', () => {
     expect(result).toEqual('DG');
   });
 
+  it('calculates an expected initials in LTR with brackets', () => {
+    let result = getInitials('David [The man] Goff', false);
+    expect(result).toEqual('DG');
+  });
+
+  it('calculates an expected initials in LTR with curly braces', () => {
+    let result = getInitials('David {The man} Goff', false);
+    expect(result).toEqual('DG');
+  });
+
   it('calculates an expected initials in LTR with multiple parentheses, extra spaces, and unwanted characters', () => {
     let result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ', false);
+    expect(result).toEqual('DG');
+  });
+
+  it('calculates an expected initials in LTR with multiple parentheses, brackets, extra spaces, and unwanted characters', () => {
+    let result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)  [Beta]  ', false);
     expect(result).toEqual('DG');
   });
 

--- a/packages/utilities/src/initials.test.ts
+++ b/packages/utilities/src/initials.test.ts
@@ -52,7 +52,7 @@ describe('getInitials', () => {
     expect(result).toEqual('DG');
   });
 
-  it('calculates an expected initials in LTR with multiple parentheses, brackets, extra spaces, and unwanted characters', () => {
+  it('calculates an expected initials in LTR with multiple types of unwanted text', () => {
     let result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)  [Beta]  ', false);
     expect(result).toEqual('DG');
   });

--- a/packages/utilities/src/initials.test.ts
+++ b/packages/utilities/src/initials.test.ts
@@ -38,7 +38,7 @@ describe('getInitials', () => {
   });
 
   it('calculates an expected initials in LTR with brackets', () => {
-    let result = getInitials('David [The man] Goff', false);
+    let result = getInitials('David Goff [The man]', false);
     expect(result).toEqual('DG');
   });
 

--- a/packages/utilities/src/initials.ts
+++ b/packages/utilities/src/initials.ts
@@ -3,7 +3,7 @@
  * The first part matches characters within parenthesis, including the parenthesis.
  * The second part matches special ASCII characters except space, plus some unicode special characters.
  */
-const UNWANTED_CHARS_REGEX: RegExp = /\([^)]*\)|[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036F\uD800-\uFFFF]/g;
+const UNWANTED_CHARS_REGEX: RegExp = /[\(\[\{][^\)\]\}]*[\)\]\}]|[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036F\uD800-\uFFFF]/g;
 
 /**
  * Regular expression matching phone numbers. Applied after chars matching UNWANTED_CHARS_REGEX have been removed

--- a/packages/utilities/src/initials.ts
+++ b/packages/utilities/src/initials.ts
@@ -1,10 +1,18 @@
 /**
- * Regular expression matching characters to ignore when calculating the initials.
- * The first part matches characters within parenthesis, including the parenthesis.
- * The second part matches special ASCII characters except space, plus some unicode special characters.
+ * Regular expressions matching characters to ignore when calculating the initials.
  */
-// eslint-disable-next-line @fluentui/max-len
-const UNWANTED_CHARS_REGEX: RegExp = /[\(\[\{][^\)\]\}]*[\)\]\}]|[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036F\uD800-\uFFFF]/g;
+
+/**
+ * Regular expression matching characters within various types of enclosures, including the enclosures themselves
+ *  so for example, (xyz) [xyz] {xyz} all would be ignored
+ */
+const UNWANTED_ENCLOSURES_REGEX: RegExp = /[\(\[\{][^\)\]\}]*[\)\]\}]/g;
+
+/**
+ * Regular expression matching special ASCII characters except space, plus some unicode special characters.
+ * Applies after unwanted enclosures have been removed
+ */
+const UNWANTED_CHARS_REGEX: RegExp = /[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036F\uD800-\uFFFF]/g;
 
 /**
  * Regular expression matching phone numbers. Applied after chars matching UNWANTED_CHARS_REGEX have been removed
@@ -49,6 +57,7 @@ function getInitialsLatin(displayName: string, isRtl: boolean): string {
 }
 
 function cleanupDisplayName(displayName: string): string {
+  displayName = displayName.replace(UNWANTED_ENCLOSURES_REGEX, '');
   displayName = displayName.replace(UNWANTED_CHARS_REGEX, '');
   displayName = displayName.replace(MULTIPLE_WHITESPACES_REGEX, ' ');
   displayName = displayName.trim();

--- a/packages/utilities/src/initials.ts
+++ b/packages/utilities/src/initials.ts
@@ -3,6 +3,7 @@
  * The first part matches characters within parenthesis, including the parenthesis.
  * The second part matches special ASCII characters except space, plus some unicode special characters.
  */
+// eslint-disable-next-line @fluentui/max-len
 const UNWANTED_CHARS_REGEX: RegExp = /[\(\[\{][^\)\]\}]*[\)\]\}]|[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036F\uD800-\uFFFF]/g;
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15878 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
 
Currently, getInitials takes Kevin Andersen (EEE) and turns it into Kevin Andersen but takes Kevin Andersen [EEE] and turns it into Kevin Andersen EEE resulting in initials of KE in the latter case (undesired).

I've modified it so that the regex strips [xyz] and {xyz} now as well.

I've also updated:
- the tests for initials, as they previously did not cover these cases
- the Persona initials example to contain the old case and new one
- the persona tests to cover this case as well

I think ideally we would like to backport this to 7, but as it has the potential for breaks, it might be safer just in 8. Open to suggestions here.
