### PR TITLE
Fix which content is used by localization page language section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@ packages/web-components @chrisdholt @EisenbergEffect @nicholasrice
 
 #### Apps
 # component-demo/
-public-docsite/ @ecraig12345 @Jahnp
+public-docsite/ @ecraig12345
 public-docsite-resources/ @ecraig12345
 perf-test/ @JasonGore @xugao
 # ssr-tests/
@@ -121,7 +121,7 @@ packages/react-internal/src/components/Facepile/ @markionium @mtennoe
 packages/react-internal/src/components/FolderCover/ @ThomasMichon @bigbadcapers
 packages/react-internal/src/components/FocusTrapZone/ @khmakoto
 packages/react/src/components/GroupedList/  @aditima @dzearing
-packages/react-internal/src/components/HoverCard/   @atneik @Jahnp @Vitalius1
+packages/react-internal/src/components/HoverCard/  @Jahnp @Vitalius1
 packages/react-internal/src/components/Icon/ @dzearing @ecraig12345
 packages/react-internal/src/components/Image/ @dzearing
 packages/react-internal/src/components/Label/ @khmakoto
@@ -145,7 +145,7 @@ packages/react-internal/src/components/Rating/ @jdhuntington
 packages/react-internal/src/components/ResizeGroup/ @micahgodbolt
 packages/react-internal/src/components/SearchBox/ @ecraig12345
 packages/react-internal/src/components/Separator/ @natalieethell
-packages/react-internal/src/components/Shimmer/ @Vitalius1 @atneik
+packages/react-internal/src/components/Shimmer/ @Vitalius1
 packages/react-internal/src/components/SpinButton/ @khmakoto
 packages/react-internal/src/components/Spinner/ @xugao
 packages/react-internal/src/components/Stack/  @khmakoto

--- a/apps/public-docsite/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
+++ b/apps/public-docsite/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
@@ -68,7 +68,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
           content: (
             <>
               <Markdown>
-                {require('!raw-loader!@fluentui/public-docsite/src/pages/Styles/LocalizationPage/docs/web/LocalizationRTL.md')}
+                {require('!raw-loader!@fluentui/public-docsite/src/pages/Styles/LocalizationPage/docs/web/LocalizationFonts.md')}
               </Markdown>
               <MarkdownHeader as="h3">Supported languages</MarkdownHeader>
               <p>Fluent UI supports a variety of language codes, which map to the following font stacks:</p>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15863

#### Description of changes

The "Language-optimized fonts" section of the [Localization page](https://developer.microsoft.com/en-us/fluentui#/styles/web/localization) was accidentally reusing the content for the "Right-to-left layouts" section rather than the proper content.

Also remove @Jahnp as a website codeowner since he's not working on it now, and remove Aniket from a couple things since he left the company.