### PR TITLE
(7.0) Fix which content is used by localization page language section

### DIFF
--- a/.devops/templates/variables.yml
+++ b/.devops/templates/variables.yml
@@ -1,16 +1,5 @@
-parameters:
-  - name: pathPrefix
-    type: string
-    default: SourceBranch
-    values:
-      - SourceBranch # matches branch/PR ref
-      - SourceVersion # matches commit SHA
-
 variables:
-  ${{ if eq( parameters.pathPrefix, 'SourceBranch' ) }}:
-    deployBasePath: "pr-deploy-site/${{ variables['Build.SourceBranch'] }}"
-  ${{ if eq( parameters.pathPrefix, 'SourceVersion' ) }}:
-    deployBasePath: "pr-deploy-site/${{ variables['Build.SourceVersion'] }}"
+  deployBasePath: 'pr-deploy-site/$(Build.SourceBranch)'
 
   deployHost: 'fabricweb.z5.web.core.windows.net'
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,18 +31,15 @@ azure-pipelines* @ecraig12345
 .npmignore @ecraig12345
 sizeauditor.json @aftab-hassan
 
-#### Deprecated API Files
-*.api.ts @natalieethell
-
 #### Apps
 # component-demo/
-fabric-website/ @ecraig12345 @Jahnp
+fabric-website/ @ecraig12345
 fabric-website-resources/ @ecraig12345
 perf-test/ @JasonGore @xugao
 # ssr-tests/
 # test-bundle-button/ @dzearing
 # todo-app/
-Controls/web.tsx @Vitalius1 @natalieethell
+Controls/web.tsx @Vitalius1 @natalieethell @ecraig12345
 
 #### Packages
 packages/charting/ @Raghurk
@@ -101,7 +98,7 @@ packages/office-ui-fabric-react/src/components/FocusTrapZone/ @khmakoto
 packages/office-ui-fabric-react/src/components/FocusZone/ @khmakoto
 packages/react-focus/src/components/FocusZone/ @khmakoto
 packages/office-ui-fabric-react/src/components/GroupedList/  @aditima @dzearing
-packages/office-ui-fabric-react/src/components/HoverCard/   @atneik @Jahnp @Vitalius1
+packages/office-ui-fabric-react/src/components/HoverCard/  @Jahnp @Vitalius1
 packages/office-ui-fabric-react/src/components/Icon/ @dzearing @ecraig12345
 packages/office-ui-fabric-react/src/components/Image/ @dzearing
 packages/office-ui-fabric-react/src/components/Label/ @khmakoto
@@ -127,7 +124,7 @@ packages/office-ui-fabric-react/src/components/Rating/ @jdhuntington
 packages/office-ui-fabric-react/src/components/ResizeGroup/ @micahgodbolt
 packages/office-ui-fabric-react/src/components/SearchBox/ @ecraig12345
 packages/office-ui-fabric-react/src/components/Separator/ @natalieethell
-packages/office-ui-fabric-react/src/components/Shimmer/ @Vitalius1 @atneik
+packages/office-ui-fabric-react/src/components/Shimmer/ @Vitalius1
 packages/office-ui-fabric-react/src/components/Signals/ @ThomasMichon
 packages/office-ui-fabric-react/src/components/Slider/ @joschect
 packages/office-ui-fabric-react/src/components/SpinButton/ @khmakoto

--- a/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
@@ -68,7 +68,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
           content: (
             <>
               <Markdown>
-                {require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationRTL.md')}
+                {require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationFonts.md')}
               </Markdown>
               <MarkdownHeader as="h3">Supported languages</MarkdownHeader>
               <p>Fluent UI supports a variety of language codes, which map to the following font stacks:</p>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ trigger:
 variables:
   - group: fabric-variables
   - template: .devops/templates/variables.yml
-    parameters:
-      pathPrefix: SourceVersion
 
 pool: 'Self Host Ubuntu'
 

--- a/change/@uifabric-fabric-website-2020-11-09-17-30-00-website-loc-7.json
+++ b/change/@uifabric-fabric-website-2020-11-09-17-30-00-website-loc-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix which content is used by localization page language section",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T01:30:00.098Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15863

#### Description of changes

The "Language-optimized fonts" section of the [Localization page](https://developer.microsoft.com/en-us/fluentui#/styles/web/localization) was accidentally reusing the content for the "Right-to-left layouts" section rather than the proper content.

Fix PR deploy site path so I can actually test out the change. :)

Also remove @Jahnp as a website codeowner since he's not working on it now, and remove Aniket from a couple things since he left the company.