### PR TITLE
fixing the color for y-axis line in dark mode

### DIFF
--- a/change/@uifabric-charting-2020-11-11-08-36-19-user-v-sivsar-YaxisLinesDarkMode.json
+++ b/change/@uifabric-charting-2020-11-11-08-36-19-user-v-sivsar-YaxisLinesDarkMode.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "replacing fill with the stroke, as y-axis lines are not showing up in the darkMode",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-11T03:06:19.332Z"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -417,8 +417,8 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -728,8 +728,8 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -907,8 +907,8 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1238,8 +1238,8 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1569,8 +1569,8 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1900,8 +1900,8 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;

--- a/packages/charting/src/components/CommonComponents/CartesianChart.styles.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.styles.ts
@@ -66,7 +66,7 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
         },
         line: {
           opacity: 0.2,
-          fill: theme.semanticColors.bodyText,
+          stroke: theme.semanticColors.bodyText,
           selectors: {
             [HighContrastSelectorBlack]: {
               opacity: 0.1,

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -647,8 +647,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1188,8 +1188,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1419,8 +1419,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1980,8 +1980,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -2541,8 +2541,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -3102,8 +3102,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -405,8 +405,8 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -813,8 +813,8 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -980,8 +980,8 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1299,8 +1299,8 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -402,8 +402,8 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -698,8 +698,8 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -862,8 +862,8 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1178,8 +1178,8 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1494,8 +1494,8 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1810,8 +1810,8 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -573,8 +573,8 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1040,8 +1040,8 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1197,8 +1197,8 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1684,8 +1684,8 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -2171,8 +2171,8 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -2658,8 +2658,8 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -430,8 +430,8 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -754,8 +754,8 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -857,8 +857,8 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1201,8 +1201,8 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1545,8 +1545,8 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -1889,8 +1889,8 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;
@@ -2233,8 +2233,8 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               display: none;
             }
             & line {
-              fill: #323130;
               opacity: 0.2;
+              stroke: #323130;
             }
             @media screen and (-ms-high-contrast: white-on-black){& line {
               opacity: 0.1;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15908
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In the Dark mode the y-axis line are not changing to white color. because we set the property `fill` instead of `stroke`, this pr fixes that issue

#### Focus areas to test

all charts in dark mode

**after fix , lines are visible**
![image](https://user-images.githubusercontent.com/33802398/98760659-c393bc00-23f9-11eb-95d3-fd1645dd5036.png)

**before fix, lines are not visible**
![image](https://user-images.githubusercontent.com/33802398/98760997-79f7a100-23fa-11eb-8809-74a1249fb857.png)
