### PR TITLE
fix: set high contrast colors on button and anchor components

### DIFF
--- a/change/@fluentui-web-components-2020-11-11-17-49-32-users-khamu-button-anchor-high-contrast.json
+++ b/change/@fluentui-web-components-2020-11-11-17-49-32-users-khamu-button-anchor-high-contrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "moved high contrast work into common button styles file",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-12T01:49:32.286Z"
+}

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -1,6 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { SystemColors } from '@microsoft/fast-web-utilities';
-import { disabledCursor, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import {
   AccentButtonStyles,
   accentFillActiveBehavior,
@@ -56,78 +54,4 @@ export const ButtonStyles = css`
   neutralOutlineActiveBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
-  forcedColorsStylesheetBehavior(
-    css`
-            :host(.disabled),
-            :host(.disabled) .control {
-                forced-color-adjust: none;
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.GrayText};
-                color: ${SystemColors.GrayText};
-                cursor: ${disabledCursor};
-                opacity: 1;
-            }
-            :host(.accent) .control {
-                forced-color-adjust: none;
-                background: ${SystemColors.Highlight};
-                color: ${SystemColors.HighlightText};
-            }
-    
-            :host(.accent) .control:hover {
-                background: ${SystemColors.HighlightText};
-                border-color: ${SystemColors.Highlight};
-                color: ${SystemColors.Highlight};
-            }
-    
-            :host(.accent:${focusVisible}) .control {
-                border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
-            }
-    
-            :host(.accent.disabled) .control,
-            :host(.accent.disabled) .control:hover {
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.GrayText};
-                color: ${SystemColors.GrayText};
-            }
-            :host(.lightweight) .control:hover {
-                forced-color-adjust: none;
-                color: ${SystemColors.Highlight};
-            }
-    
-            :host(.lightweight) .control:hover .content::before {
-                background: ${SystemColors.Highlight};
-            }
-    
-            :host(.lightweight.disabled) .control {
-                forced-color-adjust: none;
-                color: ${SystemColors.GrayText};
-            }
-        
-            :host(.lightweight.disabled) .control:hover .content::before {
-                background: none;
-            }
-            :host(.outline.disabled) .control {
-                border-color: ${SystemColors.GrayText};
-            }
-            :host(.stealth) .control {
-                forced-color-adjust: none;
-                background: none;
-                border-color: transparent;
-                color: ${SystemColors.ButtonText};
-                fill: currentColor;
-            }
-            :host(.stealth) .control:hover,
-            :host(.stealth:${focusVisible}) .control {
-                background: ${SystemColors.Highlight};
-                border-color: ${SystemColors.Highlight};
-                color: ${SystemColors.HighlightText};
-            }
-            :host(.stealth.disabled) .control {
-                background: none;
-                border-color: transparent;
-                color: ${SystemColors.GrayText};
-            }
-        `,
-  ),
 );

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -1,4 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
+import { SystemColors } from '@microsoft/fast-web-utilities';
 import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { heightNumber } from '../size';
 import {
@@ -22,7 +23,6 @@ import {
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
 } from '../behaviors';
-import { SystemColors } from '@microsoft/fast-web-utilities';
 
 /**
  * @internal

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -149,6 +149,22 @@ export const BaseButtonStyles: ElementStyles = css`
             cursor: ${disabledCursor};
             opacity: 1;
         }
+
+        :host([href]) {
+          color: ${SystemColors.LinkText};
+        }
+
+        :host([href]) .control:hover,
+        :host(.outline[href]) .control:hover
+        :host(:hover[href]),
+        :host([href]) .control:${focusVisible}{
+          forced-color-adjust: none;
+          background: ${SystemColors.ButtonFace};
+          border-color: ${SystemColors.LinkText};
+          box-shadow: 0 0 0 1px ${SystemColors.LinkText} inset;
+          color: ${SystemColors.LinkText};
+          fill: currentColor;
+        }
     `,
   ),
 );
@@ -187,27 +203,45 @@ export const AccentButtonStyles = css`
     css`
         :host(.accent) .control {
             forced-color-adjust: none;
-            background-color: ${SystemColors.Highlight};
+            background: ${SystemColors.Highlight};
             color: ${SystemColors.HighlightText};
         }
 
         :host(.accent) .control:hover {
-            background-color: ${SystemColors.HighlightText};
+            background: ${SystemColors.HighlightText};
             border-color: ${SystemColors.Highlight};
             color: ${SystemColors.Highlight};
         }
 
-        :host(.accent:${focusVisible}) .control {
+        :host(.accent) .control:${focusVisible} {
             border-color: ${SystemColors.ButtonText};
             box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
         }
 
         :host(.accent.disabled) .control,
         :host(.accent.disabled) .control:hover {
-            background-color: ${SystemColors.ButtonFace};
+            background: ${SystemColors.ButtonFace};
             border-color: ${SystemColors.GrayText};
             color: ${SystemColors.GrayText};
         }
+
+        :host(.accent[href]) .control{
+            background: ${SystemColors.LinkText};
+            color: ${SystemColors.HighlightText};
+        }
+
+        :host(.accent[href]) .control:hover {
+            background: ${SystemColors.ButtonFace};
+            border-color: ${SystemColors.LinkText};
+            box-shadow: none;
+            color: ${SystemColors.LinkText};
+            fill: currentColor;
+        }
+
+        :host(.accent[href]) .control:${focusVisible} {
+          border-color: ${SystemColors.LinkText};
+          box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
+      }
     `,
   ),
 );
@@ -330,7 +364,7 @@ export const LightweightButtonStyles = css`
         :host(.lightweight) .control:hover,
         :host(.lightweight) .control:${focusVisible} {
             forced-color-adjust: none;
-            background-color: ${SystemColors.ButtonFace};
+            background: ${SystemColors.ButtonFace};
             color: ${SystemColors.Highlight};
         }
         :host(.lightweight) .control:hover .content::before,
@@ -345,6 +379,18 @@ export const LightweightButtonStyles = css`
 
         :host(.lightweight.disabled) .control:hover .content::before {
             background: none;
+        }
+
+        :host(.lightweight[href]) .control:hover,
+        :host(.lightweight[href]) .control:${focusVisible} {
+            background: ${SystemColors.ButtonFace};
+            box-shadow: none;
+            color: ${SystemColors.LinkText};
+        }
+
+        :host(.lightweight[href]) .control:hover .content::before,
+        :host(.lightweight[href]) .control:${focusVisible} .content::before {
+            background: ${SystemColors.LinkText};
         }
     `,
   ),
@@ -448,6 +494,23 @@ export const StealthButtonStyles = css`
             border-color: transparent;
             color: ${SystemColors.GrayText};
         }
+
+        :host(.stealth[href]) .control {
+            color: ${SystemColors.LinkText};
+        }
+
+        :host(.stealth:hover[href]) .control {
+            background-color: ${SystemColors.LinkText};
+            border-color: ${SystemColors.LinkText};
+            color: ${SystemColors.HighlightText};
+            fill: currentColor;
+        }
+
+      :host(.stealth:${focusVisible}[href]) .control {
+          box-shadow: 0 0 0 1px ${SystemColors.LinkText};
+          color: ${SystemColors.LinkText};
+          fill: currentColor;
+      }
     `,
   ),
 );

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { disabledCursor, display, focusVisible } from '@microsoft/fast-foundation';
+import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { heightNumber } from '../size';
 import {
   accentFillActiveBehavior,
@@ -22,6 +22,7 @@ import {
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
 } from '../behaviors';
+import { SystemColors } from '@microsoft/fast-web-utilities';
 
 /**
  * @internal
@@ -110,6 +111,46 @@ export const BaseButtonStyles: ElementStyles = css`
   neutralForegroundRestBehavior,
   neutralFillHoverBehavior,
   neutralFillActiveBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+        :host {
+          background-color: ${SystemColors.ButtonFace};
+          border-color: ${SystemColors.ButtonText};
+          color: ${SystemColors.ButtonText};
+          fill: currentColor;
+        }
+
+        :host(:hover) {
+          forced-color-adjust: none;
+          background-color: ${SystemColors.Highlight};
+          color: ${SystemColors.HighlightText};
+        }
+
+        .control:${focusVisible},
+        :host(.outline) .control:${focusVisible} {
+          forced-color-adjust: none;
+          background-color: ${SystemColors.Highlight};
+          border-color: ${SystemColors.ButtonText};
+          box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
+          color: ${SystemColors.HighlightText};
+        }
+
+        .control:hover,
+        :host(.outline) .control:hover {
+          border-color: ${SystemColors.ButtonText};
+        }
+
+        :host(.disabled),
+        :host(.disabled) .control {
+            forced-color-adjust: none;
+            background-color: ${SystemColors.ButtonFace};
+            border-color: ${SystemColors.GrayText};
+            color: ${SystemColors.GrayText};
+            cursor: ${disabledCursor};
+            opacity: 1;
+        }
+    `,
+  ),
 );
 
 /**
@@ -142,6 +183,33 @@ export const AccentButtonStyles = css`
   accentFillHoverBehavior,
   accentFillActiveBehavior,
   neutralFocusInnerAccentBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+        :host(.accent) .control {
+            forced-color-adjust: none;
+            background-color: ${SystemColors.Highlight};
+            color: ${SystemColors.HighlightText};
+        }
+
+        :host(.accent) .control:hover {
+            background-color: ${SystemColors.HighlightText};
+            border-color: ${SystemColors.Highlight};
+            color: ${SystemColors.Highlight};
+        }
+
+        :host(.accent:${focusVisible}) .control {
+            border-color: ${SystemColors.ButtonText};
+            box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
+        }
+
+        :host(.accent.disabled) .control,
+        :host(.accent.disabled) .control:hover {
+            background-color: ${SystemColors.ButtonFace};
+            border-color: ${SystemColors.GrayText};
+            color: ${SystemColors.GrayText};
+        }
+    `,
+  ),
 );
 
 /**
@@ -187,6 +255,14 @@ export const HypertextStyles = css`
   accentForegroundHoverBehavior,
   accentForegroundActiveBehavior,
   neutralFocusBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+      :host(.hypertext) .control:${focusVisible} {
+        color: ${SystemColors.LinkText};
+        border-bottom-color: ${SystemColors.LinkText};
+      }
+    `,
+  ),
 );
 
 /**
@@ -249,6 +325,29 @@ export const LightweightButtonStyles = css`
   accentForegroundActiveBehavior,
   accentForegroundHoverBehavior,
   neutralForegroundRestBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+        :host(.lightweight) .control:hover,
+        :host(.lightweight) .control:${focusVisible} {
+            forced-color-adjust: none;
+            background-color: ${SystemColors.ButtonFace};
+            color: ${SystemColors.Highlight};
+        }
+        :host(.lightweight) .control:hover .content::before,
+        :host(.lightweight) .control:${focusVisible} .content::before {
+            background: ${SystemColors.Highlight};
+        }
+
+        :host(.lightweight.disabled) .control {
+            forced-color-adjust: none;
+            color: ${SystemColors.GrayText};
+        }
+
+        :host(.lightweight.disabled) .control:hover .content::before {
+            background: none;
+        }
+    `,
+  ),
 );
 
 /**
@@ -285,6 +384,13 @@ export const OutlineButtonStyles = css`
   neutralOutlineHoverBehavior,
   neutralOutlineActiveBehavior,
   neutralFocusBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+      :host(.outline.disabled) .control {
+        border-color: ${SystemColors.GrayText};
+      }
+    `,
+  ),
 );
 
 /**
@@ -306,4 +412,42 @@ export const StealthButtonStyles = css`
   :host(.stealth.disabled) {
     background: ${neutralFillStealthRestBehavior.var};
   }
-`.withBehaviors(neutralFillStealthRestBehavior, neutralFillStealthHoverBehavior, neutralFillStealthActiveBehavior);
+`.withBehaviors(
+  neutralFillStealthRestBehavior,
+  neutralFillStealthHoverBehavior,
+  neutralFillStealthActiveBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+        :host(.stealth) .control {
+            forced-color-adjust: none;
+            background-color: none;
+            border-color: transparent;
+            color: ${SystemColors.ButtonText};
+            fill: currentColor;
+        }
+
+        :host(.stealth:hover) .control {
+            background-color: ${SystemColors.Highlight};
+            border-color: ${SystemColors.Highlight};
+            color: ${SystemColors.HighlightText};
+            fill: currentColor;
+        }
+
+        :host(.stealth:${focusVisible}) .control {
+            box-shadow: 0 0 0 1px ${SystemColors.Highlight};
+            color: ${SystemColors.HighlightText};
+            fill: currentColor;
+        }
+
+        :host(.stealth.disabled) {
+          background-color: ${SystemColors.ButtonFace};
+        }
+
+        :host(.stealth.disabled) .control {
+            background-color: ${SystemColors.ButtonFace};
+            border-color: transparent;
+            color: ${SystemColors.GrayText};
+        }
+    `,
+  ),
+);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Moved the high contrast code from `button.styles` to the common button styles file to apply high contrast color on the button and anchor components.

#### Focus areas to test

(optional)
