### PR TITLE
Fix Callout example targets and simplify styling

### DIFF
--- a/change/@fluentui-react-internal-2020-11-13-19-47-04-callout-position.json
+++ b/change/@fluentui-react-internal-2020-11-13-19-47-04-callout-position.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add interface for onRestoreFocus params",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-14T03:47:00.200Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-11-13-19-47-04-callout-position.json
+++ b/change/@fluentui-react-theme-provider-2020-11-13-19-47-04-callout-position.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix syntax error in readme",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-14T03:47:03.997Z"
+}

--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
@@ -8,8 +8,8 @@ const styles = mergeStyleSets({
   control: { maxWidth: 300, marginBottom: 15 },
 });
 
-const onFormatDate = (date: Date): string => {
-  return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
+const onFormatDate = (date?: Date): string => {
+  return !date ? '' : date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
 };
 
 export const DatePickerFormatExample: React.FunctionComponent = () => {
@@ -49,8 +49,8 @@ export const DatePickerFormatExample: React.FunctionComponent = () => {
         label="Start date"
         allowTextInput
         ariaLabel="Select a date. Input format is day slash month slash year."
-        value={value as Date | undefined}
-        onSelectDate={setValue as (date: Date | null | undefined) => void}
+        value={value}
+        onSelectDate={setValue as (date?: Date) => void}
         formatDate={onFormatDate}
         parseDateFromString={onParseDateFromString}
         className={styles.control}

--- a/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
@@ -1,66 +1,22 @@
 import * as React from 'react';
-import { Callout, Link, getTheme, FontWeights, mergeStyleSets, Text } from '@fluentui/react';
+import { Callout, Link, mergeStyleSets, Text, FontWeights } from '@fluentui/react';
 import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 
-const theme = getTheme();
-const styles = mergeStyleSets({
-  buttonArea: {
-    verticalAlign: 'top',
-    display: 'inline-block',
-    textAlign: 'center',
-    margin: '0 100px',
-    minWidth: 130,
-    height: 32,
-  },
-  callout: {
-    maxWidth: 300,
-  },
-  header: {
-    padding: '18px 24px 12px',
-  },
-  title: [
-    theme.fonts.xLarge,
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  inner: {
-    height: '100%',
-    padding: '0 24px 20px',
-  },
-  actions: {
-    position: 'relative',
-    marginTop: 20,
-    width: '100%',
-    whiteSpace: 'nowrap',
-  },
-  subtext: [
-    theme.fonts.small,
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  link: [
-    theme.fonts.medium,
-    {
-      color: theme.palette.neutralPrimary,
-    },
-  ],
-});
-
 export const CalloutBasicExample: React.FunctionComponent = () => {
   const [isCalloutVisible, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
+  const buttonId = useId('callout-button');
+  const labelId = useId('callout-label');
+  const descriptionId = useId('callout-description');
 
-  const labelId: string = useId('callout-label');
-  const descriptionId: string = useId('callout-description');
   return (
     <>
-      <div className={styles.buttonArea}>
-        <DefaultButton onClick={toggleIsCalloutVisible} text={isCalloutVisible ? 'Hide Callout' : 'Show Callout'} />
-      </div>
+      <DefaultButton
+        id={buttonId}
+        onClick={toggleIsCalloutVisible}
+        text={isCalloutVisible ? 'Hide callout' : 'Show callout'}
+        className={styles.button}
+      />
       {isCalloutVisible && (
         <Callout
           className={styles.callout}
@@ -68,28 +24,40 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
           ariaDescribedBy={descriptionId}
           role="alertdialog"
           gapSpace={0}
-          target={`.${styles.buttonArea}`}
+          target={`#${buttonId}`}
           onDismiss={toggleIsCalloutVisible}
           setInitialFocus
         >
-          <div className={styles.header}>
-            <Text className={styles.title} id={labelId}>
-              All of your favorite people
-            </Text>
-          </div>
-          <div className={styles.inner}>
-            <Text className={styles.subtext} id={descriptionId}>
-              Message body is optional. If help documentation is available, consider adding a link to learn more at the
-              bottom.
-            </Text>
-            <div className={styles.actions}>
-              <Link className={styles.link} href="http://microsoft.com" target="_blank">
-                Go to microsoft
-              </Link>
-            </div>
-          </div>
+          <Text block variant="xLarge" className={styles.title} id={labelId}>
+            Callout title here
+          </Text>
+          <Text block variant="small" id={descriptionId}>
+            Message body is optional. If help documentation is available, consider adding a link to learn more at the
+            bottom.
+          </Text>
+          <Link href="http://microsoft.com" target="_blank" className={styles.link}>
+            Sample link
+          </Link>
         </Callout>
       )}
     </>
   );
 };
+
+const styles = mergeStyleSets({
+  button: {
+    width: 130,
+  },
+  callout: {
+    width: 320,
+    padding: '20px 24px',
+  },
+  title: {
+    marginBottom: 12,
+    fontWeight: FontWeights.semilight,
+  },
+  link: {
+    display: 'block',
+    marginTop: 20,
+  },
+});

--- a/packages/react-examples/src/react/Callout/Callout.Cover.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Cover.Example.tsx
@@ -1,104 +1,50 @@
 import * as React from 'react';
-import {
-  Callout,
-  DirectionalHint,
-  Dropdown,
-  IDropdownOption,
-  mergeStyleSets,
-  FontWeights,
-  Text,
-} from '@fluentui/react';
-import { useBoolean } from '@fluentui/react-hooks';
+import { Callout, getTheme, mergeStyleSets, FontWeights, Text } from '@fluentui/react';
+import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
-
-const DIRECTION_OPTIONS = [
-  { key: DirectionalHint.topLeftEdge, text: 'Top Left Edge' },
-  { key: DirectionalHint.topCenter, text: 'Top Center' },
-  { key: DirectionalHint.topRightEdge, text: 'Top Right Edge' },
-  { key: DirectionalHint.topAutoEdge, text: 'Top Auto Edge' },
-  { key: DirectionalHint.bottomLeftEdge, text: 'Bottom Left Edge' },
-  { key: DirectionalHint.bottomCenter, text: 'Bottom Center' },
-  { key: DirectionalHint.bottomRightEdge, text: 'Bottom Right Edge' },
-  { key: DirectionalHint.bottomAutoEdge, text: 'Bottom Auto Edge' },
-  { key: DirectionalHint.leftTopEdge, text: 'Left Top Edge' },
-  { key: DirectionalHint.leftCenter, text: 'Left Center' },
-  { key: DirectionalHint.leftBottomEdge, text: 'Left Bottom Edge' },
-  { key: DirectionalHint.rightTopEdge, text: 'Right Top Edge' },
-  { key: DirectionalHint.rightCenter, text: 'Right Center' },
-  { key: DirectionalHint.rightBottomEdge, text: 'Right Bottom Edge' },
-];
-
-const styles = mergeStyleSets({
-  buttonArea: {
-    verticalAlign: 'top',
-    display: 'inline-block',
-    textAlign: 'center',
-    margin: '0 100px',
-    minWidth: 130,
-    height: 32,
-  },
-  configArea: {
-    minWidth: '300px',
-    display: 'inline-block',
-  },
-  callout: {
-    maxWidth: 300,
-  },
-  header: {
-    padding: '18px 24px 12px',
-  },
-  title: [
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  inner: {
-    height: '100%',
-    padding: '0 24px 20px',
-  },
-});
 
 export const CalloutCoverExample: React.FunctionComponent = () => {
   const [isCalloutVisible, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
-  const [directionalHint, setDirectionalHint] = React.useState<DirectionalHint>(DirectionalHint.bottomLeftEdge);
-  const onDirectionalChanged = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
-    setDirectionalHint(option.key as DirectionalHint);
-  };
+  const buttonId = useId('callout-button');
+  const labelId = useId('callout-label');
 
   return (
     <>
-      <div className={styles.configArea}>
-        <Dropdown
-          label="Directional hint"
-          selectedKey={directionalHint!}
-          options={DIRECTION_OPTIONS}
-          // eslint-disable-next-line react/jsx-no-bind
-          onChange={onDirectionalChanged}
-        />
-      </div>
-      <div className={styles.buttonArea}>
-        <DefaultButton text={isCalloutVisible ? 'Hide callout' : 'Show callout'} onClick={toggleIsCalloutVisible} />
-      </div>
-      {isCalloutVisible ? (
+      <DefaultButton id={buttonId} text="Show callout" onClick={toggleIsCalloutVisible} />
+      {isCalloutVisible && (
         <Callout
+          coverTarget
+          ariaLabelledBy={labelId}
           className={styles.callout}
           onDismiss={toggleIsCalloutVisible}
-          target={`.${styles.buttonArea}`}
-          directionalHint={directionalHint}
-          coverTarget
+          target={`#${buttonId}`}
           isBeakVisible={false}
-          gapSpace={0}
           setInitialFocus
         >
-          <div className={styles.header}>
-            <Text className={styles.title}>I'm covering the target!</Text>
-          </div>
-          <div className={styles.inner}>
+          <Text block variant="xLarge" className={styles.title} id={labelId}>
+            I'm covering the target!
+          </Text>
+          <div className={styles.actions}>
             <DefaultButton onClick={toggleIsCalloutVisible} text="Click to dismiss" />
           </div>
         </Callout>
-      ) : null}
+      )}
     </>
   );
 };
+
+const theme = getTheme();
+const styles = mergeStyleSets({
+  callout: {
+    width: 320,
+    padding: '20px 24px',
+    background: theme.semanticColors.bodyBackground,
+  },
+  title: {
+    marginBottom: 12,
+    fontWeight: FontWeights.semilight,
+  },
+  actions: {
+    marginTop: 20,
+  },
+});

--- a/packages/react-examples/src/react/Callout/Callout.Directional.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Directional.Example.tsx
@@ -4,96 +4,28 @@ import {
   DirectionalHint,
   Dropdown,
   IDropdownOption,
-  Checkbox,
+  Toggle,
   Slider,
-  getTheme,
   mergeStyleSets,
   FontWeights,
   Link,
   Text,
+  Stack,
 } from '@fluentui/react';
 import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
-
-const DIRECTION_OPTIONS = [
-  { key: DirectionalHint.topLeftEdge, text: 'Top Left Edge' },
-  { key: DirectionalHint.topCenter, text: 'Top Center' },
-  { key: DirectionalHint.topRightEdge, text: 'Top Right Edge' },
-  { key: DirectionalHint.topAutoEdge, text: 'Top Auto Edge' },
-  { key: DirectionalHint.bottomLeftEdge, text: 'Bottom Left Edge' },
-  { key: DirectionalHint.bottomCenter, text: 'Bottom Center' },
-  { key: DirectionalHint.bottomRightEdge, text: 'Bottom Right Edge' },
-  { key: DirectionalHint.bottomAutoEdge, text: 'Bottom Auto Edge' },
-  { key: DirectionalHint.leftTopEdge, text: 'Left Top Edge' },
-  { key: DirectionalHint.leftCenter, text: 'Left Center' },
-  { key: DirectionalHint.leftBottomEdge, text: 'Left Bottom Edge' },
-  { key: DirectionalHint.rightTopEdge, text: 'Right Top Edge' },
-  { key: DirectionalHint.rightCenter, text: 'Right Center' },
-  { key: DirectionalHint.rightBottomEdge, text: 'Right Bottom Edge' },
-];
-
-const theme = getTheme();
-const checkBoxStyles = { root: { margin: '10px 0' } };
-const styles = mergeStyleSets({
-  buttonArea: {
-    verticalAlign: 'top',
-    display: 'inline-block',
-    textAlign: 'center',
-    margin: '0 100px',
-    minWidth: 130,
-    height: 32,
-  },
-  configArea: {
-    minWidth: '300px',
-    display: 'inline-block',
-  },
-  callout: {
-    maxWidth: 300,
-  },
-  calloutExampleButton: {
-    width: '100%',
-  },
-  header: {
-    padding: '18px 24px 12px',
-  },
-  title: [
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  inner: {
-    height: '100%',
-    padding: '0 24px 20px',
-  },
-  subtext: [
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  link: [
-    theme.fonts.medium,
-    {
-      color: theme.palette.neutralPrimary,
-    },
-  ],
-  actions: {
-    position: 'relative',
-    marginTop: 20,
-    width: '100%',
-    whiteSpace: 'nowrap',
-  },
-});
 
 export const CalloutDirectionalExample: React.FunctionComponent = () => {
   const [isCalloutVisible, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
   const [isBeakVisible, { toggle: toggleIsBeakVisible }] = useBoolean(true);
   const [gapSpace, setGapSpace] = React.useState<number>();
   const [beakWidth, setBeakWidth] = React.useState<number>();
-  const labelId: string = useId('callout-label');
-  const descriptionId: string = useId('callout-description');
   const [directionalHint, setDirectionalHint] = React.useState<DirectionalHint>(DirectionalHint.bottomLeftEdge);
+
+  const buttonId = useId('callout-button');
+  const labelId = useId('callout-label');
+  const descriptionId = useId('callout-description');
+
   const onDirectionalChanged = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
     setDirectionalHint(option.key as DirectionalHint);
   };
@@ -112,25 +44,26 @@ export const CalloutDirectionalExample: React.FunctionComponent = () => {
 
   return (
     <>
-      <div className={styles.configArea}>
+      <Stack tokens={{ childrenGap: 10 }} className={styles.configArea}>
         {/* eslint-disable react/jsx-no-bind */}
-        <Checkbox styles={checkBoxStyles} label="Show beak" checked={isBeakVisible} onChange={onShowBeakChange} />
+        <Toggle label="Show beak" checked={isBeakVisible} onChange={onShowBeakChange} />
 
-        <Slider max={30} label="Gap Space" min={0} defaultValue={0} onChange={onGapSliderChange} />
+        <Slider max={30} label="Gap space" min={0} defaultValue={0} onChange={onGapSliderChange} />
         {isBeakVisible && (
-          <Slider max={50} label="Beak Width" min={10} defaultValue={16} onChange={onBeakWidthSliderChange} />
+          <Slider max={50} label="Beak width" min={10} defaultValue={16} onChange={onBeakWidthSliderChange} />
         )}
         <Dropdown
           label="Directional hint"
-          selectedKey={directionalHint!}
+          selectedKey={directionalHint}
           options={DIRECTION_OPTIONS}
           onChange={onDirectionalChanged}
         />
         {/* eslint-enable react/jsx-no-bind */}
-      </div>
+      </Stack>
       <div className={styles.buttonArea}>
         <DefaultButton
-          className={styles.calloutExampleButton}
+          id={buttonId}
+          className={styles.button}
           onClick={toggleIsCalloutVisible}
           text={isCalloutVisible ? 'Hide callout' : 'Show callout'}
         />
@@ -141,31 +74,72 @@ export const CalloutDirectionalExample: React.FunctionComponent = () => {
           ariaDescribedBy={descriptionId}
           className={styles.callout}
           gapSpace={gapSpace}
-          target={`.${styles.buttonArea}`}
+          target={`#${buttonId}`}
           isBeakVisible={isBeakVisible}
           beakWidth={beakWidth}
           onDismiss={toggleIsCalloutVisible}
           directionalHint={directionalHint}
           setInitialFocus
         >
-          <div className={styles.header}>
-            <Text className={styles.title} id={labelId}>
-              All of your favorite people
-            </Text>
-          </div>
-          <div className={styles.inner}>
-            <Text className={styles.subtext} id={descriptionId}>
-              Message body is optional. If help documentation is available, consider adding a link to learn more at the
-              bottom.
-            </Text>
-            <div className={styles.actions}>
-              <Link className={styles.link} href="http://microsoft.com" target="_blank">
-                Go to Microsoft
-              </Link>
-            </div>
-          </div>
+          <Text block variant="xLarge" className={styles.title} id={labelId}>
+            Callout title here
+          </Text>
+          <Text block variant="small" id={descriptionId}>
+            Message body is optional. If help documentation is available, consider adding a link to learn more at the
+            bottom.
+          </Text>
+          <Link href="http://microsoft.com" target="_blank" className={styles.link}>
+            Sample link
+          </Link>
         </Callout>
       ) : null}
     </>
   );
 };
+
+const DIRECTION_OPTIONS: IDropdownOption[] = [
+  { key: DirectionalHint.topLeftEdge, text: 'Top left edge' },
+  { key: DirectionalHint.topCenter, text: 'Top center' },
+  { key: DirectionalHint.topRightEdge, text: 'Top right edge' },
+  { key: DirectionalHint.topAutoEdge, text: 'Top auto edge' },
+  { key: DirectionalHint.bottomLeftEdge, text: 'Bottom left edge' },
+  { key: DirectionalHint.bottomCenter, text: 'Bottom center' },
+  { key: DirectionalHint.bottomRightEdge, text: 'Bottom right edge' },
+  { key: DirectionalHint.bottomAutoEdge, text: 'Bottom auto edge' },
+  { key: DirectionalHint.leftTopEdge, text: 'Left top edge' },
+  { key: DirectionalHint.leftCenter, text: 'Left center' },
+  { key: DirectionalHint.leftBottomEdge, text: 'Left bottom edge' },
+  { key: DirectionalHint.rightTopEdge, text: 'Right top edge' },
+  { key: DirectionalHint.rightCenter, text: 'Right center' },
+  { key: DirectionalHint.rightBottomEdge, text: 'Right bottom edge' },
+];
+
+const styles = mergeStyleSets({
+  buttonArea: {
+    verticalAlign: 'top',
+    display: 'inline-block',
+    textAlign: 'center',
+    margin: '0 100px',
+    minWidth: 130,
+    height: 32,
+  },
+  configArea: {
+    width: 300,
+    display: 'inline-block',
+  },
+  button: {
+    width: 130,
+  },
+  callout: {
+    width: 320,
+    padding: '20px 24px',
+  },
+  title: {
+    marginBottom: 12,
+    fontWeight: FontWeights.semilight,
+  },
+  link: {
+    display: 'block',
+    marginTop: 20,
+  },
+});

--- a/packages/react-examples/src/react/Callout/Callout.FocusTrap.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.FocusTrap.Example.tsx
@@ -1,91 +1,57 @@
 import * as React from 'react';
 import { FocusTrapCallout, Stack, FocusZone, mergeStyleSets, FontWeights, Text } from '@fluentui/react';
-import { useBoolean } from '@fluentui/react-hooks';
+import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/compat/Button';
-
-const styles = mergeStyleSets({
-  buttonArea: {
-    verticalAlign: 'top',
-    display: 'inline-block',
-    textAlign: 'center',
-    margin: '0 100px',
-    minWidth: 130,
-    height: 32,
-  },
-  callout: {
-    maxWidth: 300,
-  },
-  header: {
-    padding: '18px 24px 12px',
-  },
-  title: [
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-  inner: {
-    height: '100%',
-    padding: '0 24px 20px',
-  },
-  actions: {
-    position: 'relative',
-    marginTop: 20,
-    width: '100%',
-    whiteSpace: 'nowrap',
-  },
-  buttons: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    padding: '0 24px 24px',
-  },
-  subtext: [
-    {
-      margin: 0,
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-});
 
 export const CalloutFocusTrapExample: React.FunctionComponent = () => {
   const [isCalloutVisible, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
+  const buttonId = useId('callout-button');
+
   return (
     <>
-      <div className={styles.buttonArea}>
-        <DefaultButton
-          onClick={toggleIsCalloutVisible}
-          text={isCalloutVisible ? 'Hide FocusTrapCallout' : 'Show FocusTrapCallout'}
-        />
-      </div>
+      <DefaultButton id={buttonId} onClick={toggleIsCalloutVisible} text="Show callout" />
       {isCalloutVisible ? (
-        <div>
-          <FocusTrapCallout
-            role="alertdialog"
-            className={styles.callout}
-            gapSpace={0}
-            target={`.${styles.buttonArea}`}
-            onDismiss={toggleIsCalloutVisible}
-            setInitialFocus
-          >
-            <div className={styles.header}>
-              <Text className={styles.title}>Callout title here</Text>
-            </div>
-            <div className={styles.inner}>
-              <div>
-                <Text className={styles.subtext}>
-                  Content is wrapped in a FocusTrapZone so that user cannot accidentally tab out of this callout.
-                </Text>
-              </div>
-            </div>
-            <FocusZone>
-              <Stack className={styles.buttons} gap={8} horizontal>
-                <PrimaryButton onClick={toggleIsCalloutVisible}>Button 1</PrimaryButton>
-                <DefaultButton onClick={toggleIsCalloutVisible}>Button 2</DefaultButton>
-              </Stack>
-            </FocusZone>
-          </FocusTrapCallout>
-        </div>
+        <FocusTrapCallout
+          role="alertdialog"
+          className={styles.callout}
+          gapSpace={0}
+          target={`#${buttonId}`}
+          onDismiss={toggleIsCalloutVisible}
+          setInitialFocus
+        >
+          <Text block variant="xLarge" className={styles.title}>
+            Focus trapping callout
+          </Text>
+          <Text block variant="small">
+            Content is wrapped in a FocusTrapZone so the user cannot accidentally tab or focus out of this callout. Use
+            the buttons to close.
+          </Text>
+          {/* This FocusZone allows the user to go between buttons with the arrow keys.
+              It's not related to or required for FocusTrapCallout's built-in focus trapping. */}
+          <FocusZone>
+            <Stack className={styles.buttons} gap={8} horizontal>
+              <PrimaryButton onClick={toggleIsCalloutVisible}>Done</PrimaryButton>
+              <DefaultButton onClick={toggleIsCalloutVisible}>Cancel</DefaultButton>
+            </Stack>
+          </FocusZone>
+        </FocusTrapCallout>
       ) : null}
     </>
   );
 };
+
+const styles = mergeStyleSets({
+  callout: {
+    width: 320,
+    padding: '20px 24px',
+  },
+  title: {
+    marginBottom: 12,
+    fontWeight: FontWeights.semilight,
+  },
+  buttons: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: 20,
+  },
+});

--- a/packages/react-examples/src/react/Callout/Callout.Status.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Status.Example.tsx
@@ -1,58 +1,46 @@
 import * as React from 'react';
-import { getTheme, FontWeights, mergeStyleSets, DelayedRender, Callout } from '@fluentui/react';
-import { useBoolean } from '@fluentui/react-hooks';
+import { mergeStyleSets, DelayedRender, Callout, Text } from '@fluentui/react';
+import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
-
-const theme = getTheme();
-const styles = mergeStyleSets({
-  buttonArea: {
-    verticalAlign: 'top',
-    display: 'inline-block',
-    textAlign: 'center',
-    margin: '0 100px',
-    minWidth: 130,
-    height: 32,
-  },
-  callout: {
-    maxWidth: 300,
-  },
-  subtext: [
-    theme.fonts.small,
-    {
-      margin: 0,
-      height: '100%',
-      padding: '24px 20px',
-      fontWeight: FontWeights.semilight,
-    },
-  ],
-});
 
 export const StatusCalloutExample: React.FunctionComponent = () => {
   const [isCalloutVisible, { toggle: toggleIsCalloutVisible }] = useBoolean(false);
+  const buttonId = useId('callout-button');
+
   return (
     <>
-      <div className={styles.buttonArea}>
-        <DefaultButton
-          onClick={toggleIsCalloutVisible}
-          text={isCalloutVisible ? 'Hide StatusCallout' : 'Show StatusCallout'}
-        />
-      </div>
+      <DefaultButton
+        id={buttonId}
+        onClick={toggleIsCalloutVisible}
+        text={isCalloutVisible ? 'Hide callout' : 'Show callout'}
+        className={styles.button}
+      />
       {isCalloutVisible && (
         <Callout
           className={styles.callout}
-          target={`.${styles.buttonArea}`}
+          target={`#${buttonId}`}
           onDismiss={toggleIsCalloutVisible}
           role="status"
           aria-live="assertive"
         >
           <DelayedRender>
-            <p className={styles.subtext}>
+            <Text variant="small">
               This message is treated as an aria-live assertive status message, and will be read by a screen reader
               regardless of focus.
-            </p>
+            </Text>
           </DelayedRender>
         </Callout>
       )}
     </>
   );
 };
+
+const styles = mergeStyleSets({
+  button: {
+    width: 130,
+  },
+  callout: {
+    width: 320,
+    padding: '20px 24px',
+  },
+});

--- a/packages/react-examples/src/react/Callout/Callout.doc.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.doc.tsx
@@ -24,12 +24,6 @@ export const CalloutPageProps: IDocPageProps = {
       code: CalloutBasicExampleCode,
       view: <CalloutBasicExample />,
     },
-
-    {
-      title: 'FocusTrapCallout Variant',
-      code: CalloutFocusTrapExampleCode,
-      view: <CalloutFocusTrapExample />,
-    },
     {
       title: 'Non-focusable Callout with accessible text',
       code: StatusCalloutExampleCode,
@@ -44,6 +38,11 @@ export const CalloutPageProps: IDocPageProps = {
       title: 'Callout that covers the target element',
       code: CalloutCoverExampleCode,
       view: <CalloutCoverExample />,
+    },
+    {
+      title: 'FocusTrapCallout variant',
+      code: CalloutFocusTrapExampleCode,
+      view: <CalloutFocusTrapExample />,
     },
   ],
   overview: require<string>('!raw-loader!@fluentui/react-examples/src/react/Callout/docs/CalloutOverview.md'),

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -1341,7 +1341,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
     onDismiss?: (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
     onLayerMounted?: () => void;
     onPositioned?: (positions?: ICalloutPositionedInfo) => void;
-    onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
+    onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
     onScroll?: () => void;
     preventDismissOnEvent?: (ev: Event | React.FocusEvent | React.KeyboardEvent | React.MouseEvent) => boolean;
     // @deprecated
@@ -2078,7 +2078,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
     onRenderMenuList?: IRenderFunction<IContextualMenuListProps>;
     onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
-    onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
+    onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
     shouldFocusOnContainer?: boolean;
     shouldFocusOnMount?: boolean;
     shouldUpdateWhenHidden?: boolean;

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -1341,11 +1341,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
     onDismiss?: (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
     onLayerMounted?: () => void;
     onPositioned?: (positions?: ICalloutPositionedInfo) => void;
-    onRestoreFocus?: (options: {
-        originalElement?: HTMLElement | Window;
-        containsFocus: boolean;
-        documentContainsFocus: boolean;
-    }) => void;
+    onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
     onScroll?: () => void;
     preventDismissOnEvent?: (ev: Event | React.FocusEvent | React.KeyboardEvent | React.MouseEvent) => boolean;
     // @deprecated
@@ -2082,11 +2078,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
     onRenderMenuList?: IRenderFunction<IContextualMenuListProps>;
     onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
-    onRestoreFocus?: (options: {
-        originalElement?: HTMLElement | Window;
-        containsFocus: boolean;
-        documentContainsFocus: boolean;
-    }) => void;
+    onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
     shouldFocusOnContainer?: boolean;
     shouldFocusOnMount?: boolean;
     shouldUpdateWhenHidden?: boolean;
@@ -3275,8 +3267,10 @@ export interface IModal {
 }
 
 // @public (undocumented)
-export interface IModalProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLDivElement>, IAccessiblePopupProps {
+export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAccessiblePopupProps {
     allowTouchBodyScroll?: boolean;
+    // (undocumented)
+    children?: React.ReactNode;
     className?: string;
     componentRef?: IRefObject<IModal>;
     containerClassName?: string;
@@ -3910,14 +3904,17 @@ export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React
     ariaLabelledBy?: string;
     className?: string;
     onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | KeyboardEvent) => any;
-    onRestoreFocus?: (options: {
-        originalElement?: HTMLElement | Window;
-        containsFocus: boolean;
-        documentContainsFocus: boolean;
-    }) => void;
+    onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
     role?: string;
     // @deprecated
     shouldRestoreFocus?: boolean;
+}
+
+// @public
+export interface IPopupRestoreFocusParams {
+    containsFocus: boolean;
+    documentContainsFocus: boolean;
+    originalElement?: HTMLElement | Window;
 }
 
 // @public

--- a/packages/react-internal/src/components/Callout/Callout.test.tsx
+++ b/packages/react-internal/src/components/Callout/Callout.test.tsx
@@ -8,6 +8,7 @@ import * as Utilities from '../../Utilities';
 import * as positioning from '../../Positioning';
 import { safeCreate } from '@fluentui/test-utilities';
 import { isConformant } from '../../common/isConformant';
+import { IPopupRestoreFocusParams } from '../../Popup';
 
 describe('Callout', () => {
   let realDom: HTMLDivElement;
@@ -191,11 +192,7 @@ describe('Callout', () => {
     let previousFocusElement;
     let isFocused;
     let restoreCalled = false;
-    const onRestoreFocus = (options: {
-      originalElement: HTMLElement | Window | undefined;
-      containsFocus: boolean;
-      documentContainsFocus: boolean;
-    }) => {
+    const onRestoreFocus = (options: IPopupRestoreFocusParams) => {
       previousFocusElement = options.originalElement;
       isFocused = options.containsFocus;
       restoreCalled = true;

--- a/packages/react-internal/src/components/Callout/Callout.types.ts
+++ b/packages/react-internal/src/components/Callout/Callout.types.ts
@@ -5,6 +5,7 @@ import { IRectangle, IStyleFunctionOrObject } from '../../Utilities';
 import { ICalloutPositionedInfo } from '../../Positioning';
 import { ILayerProps } from '../../Layer';
 import { Target } from '@fluentui/react-hooks';
+import { IPopupRestoreFocusParams } from '../../Popup';
 
 export { Target };
 
@@ -211,16 +212,13 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
 
   /**
    * If true then the callout will attempt to focus the first focusable element that it contains.
-   * If it doesn't find an element, no focus will be set and the method will return false.
-   * This means that it's the contents responsibility to either set focus or have
-   * focusable items.
-   * @returns True if focus was set, false if it was not.
+   * If it doesn't find a focusable element, no focus will be set.
    */
   setInitialFocus?: boolean;
 
   /**
-   * Set max height of callout
-   * When not set the callout will expand with contents up to the bottom of the screen
+   * Set max height of callout.
+   * When not set, the callout will expand with contents up to the bottom of the screen.
    */
   calloutMaxHeight?: number;
 
@@ -249,9 +247,8 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
   hidden?: boolean;
 
   /**
-   * If true, the component will be updated even when hidden=true.
-   * Note that this would consume resources to update even though
-   * nothing is being shown to the user.
+   * If true, the component will be updated even when `hidden` is true.
+   * Note that this would consume resources to update even though nothing is being shown to the user.
    * This might be helpful though if your updates are small and you want the
    * callout to be revealed fast to the user when hidden is set to false.
    */
@@ -261,22 +258,15 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
    * If true, when this component is unmounted, focus will be restored to the element that had focus when the component
    * first mounted.
    * @defaultvalue true
-   * @deprecated use onRestoreFocus callback instead
+   * @deprecated use `onRestoreFocus` instead
    */
   shouldRestoreFocus?: boolean;
 
   /**
-   * Called when the component is unmounting, and focus needs to be restored.
-   * Argument passed down contains two variables, the element that the underlying
-   * popup believes focus should go to * and whether or not the popup currently
-   * contains focus. If this is provided, focus will not be restored automatically,
-   * you'll need to call originalElement.focus()
+   * Called when the component is unmounting, and focus needs to be restored. If this is provided,
+   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
    */
-  onRestoreFocus?: (options: {
-    originalElement?: HTMLElement | Window;
-    containsFocus: boolean;
-    documentContainsFocus: boolean;
-  }) => void;
+  onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
 }
 
 /**

--- a/packages/react-internal/src/components/Callout/Callout.types.ts
+++ b/packages/react-internal/src/components/Callout/Callout.types.ts
@@ -264,9 +264,9 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
 
   /**
    * Called when the component is unmounting, and focus needs to be restored. If this is provided,
-   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
+   * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
-  onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
+  onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
 }
 
 /**

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -51,6 +51,7 @@ import { getItemStyles } from './ContextualMenu.classNames';
 import { useTarget, usePrevious, useMergedRefs } from '@fluentui/react-hooks';
 import { useResponsiveMode } from '../../utilities/hooks/useResponsiveMode';
 import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { IPopupRestoreFocusParams } from '../../Popup';
 
 const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>();
 const getContextualMenuItemClassNames = classNamesFunction<IContextualMenuItemStyleProps, IContextualMenuItemStyles>();
@@ -484,11 +485,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     }
   }
 
-  private _tryFocusPreviousActiveElement = (options: {
-    containsFocus: boolean;
-    documentContainsFocus: boolean;
-    originalElement: HTMLElement | Window | undefined;
-  }) => {
+  private _tryFocusPreviousActiveElement = (options: IPopupRestoreFocusParams) => {
     if (options && options.containsFocus && this._previousActiveElement) {
       // Make sure that the focus method actually exists
       // In some cases the object might exist but not be a real element.

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -277,9 +277,9 @@ export interface IContextualMenuProps
 
   /**
    * Called when the component is unmounting, and focus needs to be restored. If this is provided,
-   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
+   * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
-  onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
+  onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
 }
 
 /**

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -18,6 +18,7 @@ import {
 } from './ContextualMenuItem.types';
 import { IKeytipProps } from '../../Keytip';
 import { Target } from '@fluentui/react-hooks';
+import { IPopupRestoreFocusParams } from '../../Popup';
 
 export { DirectionalHint } from '../../common/DirectionalHint';
 
@@ -275,17 +276,10 @@ export interface IContextualMenuProps
   delayUpdateFocusOnHover?: boolean;
 
   /**
-   * Called when the component is unmounting, and focus needs to be restored.
-   * Argument passed down contains two variables, the element that the underlying
-   * popup believes focus should go to and whether or not the popup currently
-   * contains focus. If this prop is provided, focus will not be restored automatically,
-   * you'll need to call originalElement.focus()
+   * Called when the component is unmounting, and focus needs to be restored. If this is provided,
+   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
    */
-  onRestoreFocus?: (options: {
-    originalElement?: HTMLElement | Window;
-    containsFocus: boolean;
-    documentContainsFocus: boolean;
-  }) => void;
+  onRestoreFocus?: (options: IPopupRestoreFocusParams) => void;
 }
 
 /**

--- a/packages/react-internal/src/components/Modal/Modal.types.ts
+++ b/packages/react-internal/src/components/Modal/Modal.types.ts
@@ -54,13 +54,12 @@ export interface IModal {
 /**
  * {@docCategory Modal}
  */
-export interface IModalProps
-  extends React.HTMLAttributes<HTMLElement>,
-    React.RefAttributes<HTMLDivElement>,
-    IAccessiblePopupProps {
+export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAccessiblePopupProps {
+  children?: React.ReactNode;
+
   /**
-   * Optional callback to access the IDialog interface. Use this instead of ref for accessing
-   * the public methods and properties of the component.
+   * Optional ref to access the `IModal` interface. Use this instead of `ref` for accessing
+   * public API of the component.
    */
   componentRef?: IRefObject<IModal>;
 
@@ -70,7 +69,7 @@ export interface IModalProps
   styles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;
 
   /**
-   * Theme provided by High-Order Component.
+   * Theme provided by higher-order component.
    */
   theme?: ITheme;
 

--- a/packages/react-internal/src/components/Popup/Popup.tsx
+++ b/packages/react-internal/src/components/Popup/Popup.tsx
@@ -7,7 +7,7 @@ import {
   getNativeProps,
   getWindow,
 } from '../../Utilities';
-import { IPopupProps } from './Popup.types';
+import { IPopupProps, IPopupRestoreFocusParams } from './Popup.types';
 import { useMergedRefs, useAsync, useOnEvent } from '@fluentui/react-hooks';
 
 function useScrollbarAsync(props: IPopupProps, root: React.RefObject<HTMLDivElement | undefined>) {
@@ -48,11 +48,7 @@ function useScrollbarAsync(props: IPopupProps, root: React.RefObject<HTMLDivElem
   return needsVerticalScrollBarState;
 }
 
-function defaultFocusRestorer(options: {
-  originalElement?: HTMLElement | Window;
-  containsFocus: boolean;
-  documentContainsFocus: boolean;
-}) {
+function defaultFocusRestorer(options: IPopupRestoreFocusParams) {
   const { originalElement, containsFocus } = options;
 
   if (originalElement && containsFocus && originalElement !== getWindow()) {

--- a/packages/react-internal/src/components/Popup/Popup.types.ts
+++ b/packages/react-internal/src/components/Popup/Popup.types.ts
@@ -44,15 +44,21 @@ export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React
   shouldRestoreFocus?: boolean;
 
   /**
-   * Called when the component is unmounting, and focus needs to be restored.
-   * Argument passed down contains two variables, the element that the underlying
-   * popup believes focus should go to * and whether or not the popup currently
-   * contains focus. If this is provided, focus will not be restored automatically,
-   * you'll need to call originalElement.focus()
+   * Called when the component is unmounting, and focus needs to be restored. If this is provided,
+   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
    */
-  onRestoreFocus?: (options: {
-    originalElement?: HTMLElement | Window;
-    containsFocus: boolean;
-    documentContainsFocus: boolean;
-  }) => void;
+  onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
+}
+
+/**
+ * Parameters passed to `onRestoreFocus` callback of `Popup` and related components.
+ * {@docCategory Popup}
+ */
+export interface IPopupRestoreFocusParams {
+  /** Element the underlying Popup believes focus should go to */
+  originalElement?: HTMLElement | Window;
+  /** Whether the popup currently contains focus */
+  containsFocus: boolean;
+  /** Whether the document the popup belongs to contains focus (or false if unknown) */
+  documentContainsFocus: boolean;
 }

--- a/packages/react-internal/src/components/Popup/Popup.types.ts
+++ b/packages/react-internal/src/components/Popup/Popup.types.ts
@@ -45,7 +45,7 @@ export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React
 
   /**
    * Called when the component is unmounting, and focus needs to be restored. If this is provided,
-   * focus will not be restored automatically, and you'll need to call `options.originalElement.focus()`.
+   * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
   onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
 }

--- a/packages/react-theme-provider/README.md
+++ b/packages/react-theme-provider/README.md
@@ -143,11 +143,12 @@ Theme can be accessed using the `makeStyles` hook. This hook abstracts rendering
 import { makeStyles } from '@fluentui/react-theme-provider';
 
 const useFooStyles = makeStyles(theme => ({
-    root: {
-      background: theme.semanticColors.bodyBackground,
-      ':hover': {
-        background: theme.semanticColors.bodyBackgroundHovered
+  root: {
+    background: theme.semanticColors.bodyBackground,
+    ':hover': {
+      background: theme.semanticColors.bodyBackgroundHovered,
     },
+  },
 }));
 
 const Foo = props => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

While investigating Callout screener issues, we noticed that the examples on the doc site were not targeting the correct element due to an overly general selector. Fix that issue and simplify some of the styling of the example callout contents.

I also started looking at the Callout docs while trying to understand some things about the examples and fixed a couple minor issues there, as well as adding an explicit interface for `onRestoreFocus`'s parameters since the signature is reused several places.

One other issue I noticed and fixed (while seeing if I could use ThemeProvider in an example) was a missing bracket in a code example in the `react-theme-provider` readme.