### PR TITLE
fix: Improve variant style inheritance in Text component

### DIFF
--- a/change/@fluentui-react-internal-2020-11-14-21-42-00-feat-text-variant-styling.json
+++ b/change/@fluentui-react-internal-2020-11-14-21-42-00-feat-text-variant-styling.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "improve Text variant style inheritance",
+  "packageName": "@fluentui/react-internal",
+  "email": "blaymist@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-14T20:42:00.390Z"
+}

--- a/packages/react-internal/src/components/Text/Text.styles.ts
+++ b/packages/react-internal/src/components/Text/Text.styles.ts
@@ -9,13 +9,9 @@ export const TextStyles: ITextComponent['styles'] = (props: ITextProps, theme: I
 
   return {
     root: [
-      theme.fonts.medium,
+      variantObject,
       {
         display: block ? (as === 'td' ? 'table-cell' : 'block') : 'inline',
-        fontFamily: variantObject.fontFamily,
-        fontSize: variantObject.fontSize,
-        fontWeight: variantObject.fontWeight,
-        color: variantObject.color,
         mozOsxFontSmoothing: variantObject.MozOsxFontSmoothing,
         webkitFontSmoothing: variantObject.WebkitFontSmoothing,
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

When applying custom styles to a font variant using `loadTheme()`, majority of the custom styles are not persisted to the style settings of the Text component.

The component has previously taken *all style settings* of the `medium` variant as base, however it would only apply a handful of style properties from the style settings of the actual variant. The pull request fixes this issue by taking the actual variant of the component as base while maintaining `medium` as a fallback option.
