### PR TITLE
Remove focus for horizontal bar chart grey area  

### DIFF
--- a/change/@fluentui-react-charting-2020-11-16-20-07-06-user-v-gorraj-Bug_4221798.json
+++ b/change/@fluentui-react-charting-2020-11-16-20-07-06-user-v-gorraj-Bug_4221798.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove focus for horizental bar chart grey area",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-16T14:37:06.066Z"
+}

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -99,24 +99,6 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                         this._refCallback(e, points!.chartData![0].legend);
                       }}
                       className={this._classNames.barWrapper}
-                      onMouseOver={this._hoverOn.bind(
-                        this,
-                        points!
-                          .chartData![0].horizontalBarChartdata!.x.toString()
-                          .replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                        points!.chartData![0],
-                      )}
-                      onFocus={this._hoverOn.bind(
-                        this,
-                        points!
-                          .chartData![0].horizontalBarChartdata!.x.toString()
-                          .replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                        points!.chartData![0],
-                      )}
-                      aria-labelledby={this._calloutId}
-                      data-is-focusable={true}
-                      onBlur={this._hoverOff}
-                      onMouseLeave={this._hoverOff}
                     >
                       {bars}
                     </g>
@@ -255,14 +237,42 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
       }
       startingPoint.push(prevPosition);
       return (
-        <rect
-          key={index}
-          x={startingPoint[index] + '%'}
-          y={0}
-          width={value + '%'}
-          height={this._barHeight}
-          fill={color}
-        />
+        <>
+          {point.legend !== '' ? (
+            <rect
+              key={index}
+              x={startingPoint[index] + '%'}
+              y={0}
+              data-is-focusable={true}
+              width={value + '%'}
+              height={this._barHeight}
+              fill={color}
+              onMouseOver={this._hoverOn.bind(
+                this,
+                point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
+                point,
+              )}
+              onFocus={this._hoverOn.bind(
+                this,
+                point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
+                point,
+              )}
+              aria-labelledby={this._calloutId}
+              onBlur={this._hoverOff}
+              onMouseLeave={this._hoverOff}
+            />
+          ) : (
+            <rect
+              key={index}
+              x={startingPoint[index] + '%'}
+              y={0}
+              data-is-focusable={false}
+              width={value + '%'}
+              height={this._barHeight}
+              fill={color}
+            />
+          )}
+        </>
       );
     });
     return bars;

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -237,42 +237,36 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
       }
       startingPoint.push(prevPosition);
       return (
-        <>
-          {point.legend !== '' ? (
-            <rect
-              key={index}
-              x={startingPoint[index] + '%'}
-              y={0}
-              data-is-focusable={true}
-              width={value + '%'}
-              height={this._barHeight}
-              fill={color}
-              onMouseOver={this._hoverOn.bind(
-                this,
-                point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                point,
-              )}
-              onFocus={this._hoverOn.bind(
-                this,
-                point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                point,
-              )}
-              aria-labelledby={this._calloutId}
-              onBlur={this._hoverOff}
-              onMouseLeave={this._hoverOff}
-            />
-          ) : (
-            <rect
-              key={index}
-              x={startingPoint[index] + '%'}
-              y={0}
-              data-is-focusable={false}
-              width={value + '%'}
-              height={this._barHeight}
-              fill={color}
-            />
-          )}
-        </>
+        <rect
+          key={index}
+          x={startingPoint[index] + '%'}
+          y={0}
+          data-is-focusable={point.legend !== '' ? true : false}
+          width={value + '%'}
+          height={this._barHeight}
+          fill={color}
+          onMouseOver={
+            point.legend !== ''
+              ? this._hoverOn.bind(
+                  this,
+                  point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
+                  point,
+                )
+              : undefined
+          }
+          onFocus={
+            point.legend !== ''
+              ? this._hoverOn.bind(
+                  this,
+                  point.horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','),
+                  point,
+                )
+              : undefined
+          }
+          aria-labelledby={this._calloutId}
+          onBlur={this._hoverOff}
+          onMouseLeave={this._hoverOff}
+        />
       );
     });
     return bars;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Remove focus for horizontal bar chart grey area , where don't have callout 

#### Focus areas to test
horizontal bar chart keyboard focus and screen reader 


