### PR TITLE
fix(toolbar): screen reader gets incorrect items count for toolbar menu with radio group 

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `selectableParent` prop in favor of `selectable` in `TreeItem` and make `selectionIndicator` visible only on focus or hover @assuncaocharles ([#15133](https://github.com/microsoft/fluentui/pull/15133))
 
 ### Fixes
+- Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))
 - Fix `treeAsListBehavior` to support multi-select `Tree` @yuanboxue-amber ([#15147](https://github.com/microsoft/fluentui/pull/15147))
 - Fix `Tree` to have prop `onFocusParent` triggered on `ArrowLeft` for leaf node @yuanboxue-amber ([#15442](https://github.com/microsoft/fluentui/pull/15442))
 - Use `aria-checked` for multi-select tree instead of `aria-selected` @yuanboxue-amber ([#15142](https://github.com/microsoft/fluentui/pull/15142))

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuDividerBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuDividerBehavior.ts
@@ -1,0 +1,18 @@
+import { Accessibility } from '../../types';
+
+/**
+ * @description
+ * toolbar menu divider is used to separate and distinguish groups of menuitems.
+ *
+ * @specification
+ * Adds role='separator'.
+ */
+export const toolbarMenuDividerBehavior: Accessibility<ToolbarMenuDividerBehaviorProps> = () => ({
+  attributes: {
+    root: {
+      role: 'separator',
+    },
+  },
+});
+
+export type ToolbarMenuDividerBehaviorProps = never;

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuDividerBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuDividerBehavior.ts
@@ -2,15 +2,15 @@ import { Accessibility } from '../../types';
 
 /**
  * @description
- * toolbar menu divider is used to separate and distinguish groups of menuitems.
+ * toolbar menu divider is used only visualy to separate and distinguish groups of menuitems.
  *
  * @specification
- * Adds role='separator'.
+ * Adds role='presentation'.
  */
 export const toolbarMenuDividerBehavior: Accessibility<ToolbarMenuDividerBehaviorProps> = () => ({
   attributes: {
     root: {
-      role: 'separator',
+      role: 'presentation',
     },
   },
 });

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuRadioGroupBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuRadioGroupBehavior.ts
@@ -2,14 +2,15 @@ import { Accessibility } from '../../types';
 
 /**
  * @description
- * Implements ARIA Menu Radio Group design pattern.
+ * Toolbar's Menu Radio Group needs to be ignored by screen reader. This way the screen reader can correctly narrate the number of menu items
+ *
  * @specification
- *  Adds role='group'.
+ * Adds role='presentation'.
  */
 export const toolbarMenuRadioGroupBehavior: Accessibility<ToolbarMenuRadioGroupBehaviorProps> = () => ({
   attributes: {
     root: {
-      role: 'group',
+      role: 'presentation',
     },
   },
 });

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuRadioGroupWrapperBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuRadioGroupWrapperBehavior.ts
@@ -1,0 +1,18 @@
+import { Accessibility } from '../../types';
+
+/**
+ * @description
+ * Toolbar's Menu Radio Group's wrapper needs to be ignored by screen reader. This way the screen reader can correctly narrate the number of menu items
+ *
+ * @specification
+ * Adds role='presentation'.
+ */
+export const toolbarMenuRadioGroupWrapperBehavior: Accessibility<ToolbarMenuRadioGroupWrapperBehaviorProps> = () => ({
+  attributes: {
+    root: {
+      role: 'presentation',
+    },
+  },
+});
+
+export type ToolbarMenuRadioGroupWrapperBehaviorProps = never;

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -41,12 +41,13 @@ export * from './Toolbar/menuAsToolbarBehavior';
 export * from './Toolbar/toolbarMenuBehavior';
 export * from './Toolbar/toolbarMenuItemBehavior';
 export * from './Toolbar/toolbarMenuItemRadioBehavior';
-export * from './Toolbar/toolbarMenuDividerBehavior';
 export * from './Toolbar/menuItemAsToolbarButtonBehavior';
 export * from './Toolbar/toolbarBehavior';
 export * from './Toolbar/toolbarItemBehavior';
 export * from './Toolbar/toolbarMenuItemCheckboxBehavior';
+export * from './Toolbar/toolbarMenuDividerBehavior';
 export * from './Toolbar/toolbarMenuRadioGroupBehavior';
+export * from './Toolbar/toolbarMenuRadioGroupWrapperBehavior';
 export * from './Toolbar/toolbarRadioGroupBehavior';
 export * from './Toolbar/toolbarRadioGroupItemBehavior';
 

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -41,6 +41,7 @@ export * from './Toolbar/menuAsToolbarBehavior';
 export * from './Toolbar/toolbarMenuBehavior';
 export * from './Toolbar/toolbarMenuItemBehavior';
 export * from './Toolbar/toolbarMenuItemRadioBehavior';
+export * from './Toolbar/toolbarMenuDividerBehavior';
 export * from './Toolbar/menuItemAsToolbarButtonBehavior';
 export * from './Toolbar/toolbarBehavior';
 export * from './Toolbar/toolbarItemBehavior';

--- a/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
@@ -51,6 +51,7 @@ import {
   toolbarMenuItemBehavior,
   toolbarMenuItemRadioBehavior,
   toolbarMenuRadioGroupBehavior,
+  toolbarMenuDividerBehavior,
   toolbarRadioGroupBehavior,
   toolbarRadioGroupItemBehavior,
   tooltipAsDescriptionBehavior,
@@ -157,6 +158,7 @@ testHelper.addBehavior('toolbarMenuItemBehavior', toolbarMenuItemBehavior);
 testHelper.addBehavior('toolbarMenuItemCheckboxBehavior', toolbarMenuItemCheckboxBehavior);
 testHelper.addBehavior('toolbarMenuItemRadioBehavior', toolbarMenuItemRadioBehavior);
 testHelper.addBehavior('toolbarMenuRadioGroupBehavior', toolbarMenuRadioGroupBehavior);
+testHelper.addBehavior('toolbarMenuDividerBehavior', toolbarMenuDividerBehavior);
 testHelper.addBehavior('toolbarRadioGroupBehavior', toolbarRadioGroupBehavior);
 testHelper.addBehavior('toolbarRadioGroupItemBehavior', toolbarRadioGroupItemBehavior);
 testHelper.addBehavior('tooltipAsDescriptionBehavior', tooltipAsDescriptionBehavior);

--- a/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
@@ -52,6 +52,7 @@ import {
   toolbarMenuItemRadioBehavior,
   toolbarMenuRadioGroupBehavior,
   toolbarMenuDividerBehavior,
+  toolbarMenuRadioGroupWrapperBehavior,
   toolbarRadioGroupBehavior,
   toolbarRadioGroupItemBehavior,
   tooltipAsDescriptionBehavior,
@@ -157,8 +158,9 @@ testHelper.addBehavior('toolbarMenuBehavior', toolbarMenuBehavior);
 testHelper.addBehavior('toolbarMenuItemBehavior', toolbarMenuItemBehavior);
 testHelper.addBehavior('toolbarMenuItemCheckboxBehavior', toolbarMenuItemCheckboxBehavior);
 testHelper.addBehavior('toolbarMenuItemRadioBehavior', toolbarMenuItemRadioBehavior);
-testHelper.addBehavior('toolbarMenuRadioGroupBehavior', toolbarMenuRadioGroupBehavior);
 testHelper.addBehavior('toolbarMenuDividerBehavior', toolbarMenuDividerBehavior);
+testHelper.addBehavior('toolbarMenuRadioGroupBehavior', toolbarMenuRadioGroupBehavior);
+testHelper.addBehavior('toolbarMenuRadioGroupWrapperBehavior', toolbarMenuRadioGroupWrapperBehavior);
 testHelper.addBehavior('toolbarRadioGroupBehavior', toolbarRadioGroupBehavior);
 testHelper.addBehavior('toolbarRadioGroupItemBehavior', toolbarRadioGroupItemBehavior);
 testHelper.addBehavior('tooltipAsDescriptionBehavior', tooltipAsDescriptionBehavior);

--- a/packages/fluentui/docs/src/examples/components/Toolbar/BestPractices/ToolbarBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/BestPractices/ToolbarBestPractices.tsx
@@ -14,6 +14,7 @@ const doList = [
   </Text>,
   'Use `active` prop on a ToolbarMenuItem if you want to have an active icon indicator displayed next to it.',
   'If `Toolbar` contains menu, the menu closes after clicking on one of the menu items. To prevent losing focus, move it manually in the `onClick` handler.',
+  'If `Toolbar` contains multiple radio groups in the menu, consider using role="group" and `aria-label` for radio group shorthands',
 ];
 
 const ToolbarBestPractices: React.FunctionComponent<{}> = () => {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -1,4 +1,4 @@
-import { Accessibility } from '@fluentui/accessibility';
+import { Accessibility, toolbarMenuDividerBehavior, ToolbarMenuDividerBehaviorProps } from '@fluentui/accessibility';
 import {
   getElementType,
   mergeVariablesOverrides,
@@ -19,7 +19,7 @@ export interface ToolbarMenuDividerProps extends UIComponentProps, ChildrenCompo
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility<never>;
+  accessibility?: Accessibility<ToolbarMenuDividerBehaviorProps>;
 }
 
 export type ToolbarMenuDividerStylesProps = never;
@@ -74,4 +74,5 @@ export const ToolbarMenuDivider = compose<'li', ToolbarMenuDividerProps, Toolbar
 ToolbarMenuDivider.propTypes = commonPropTypes.createCommon();
 ToolbarMenuDivider.defaultProps = {
   as: 'li',
+  accessibility: toolbarMenuDividerBehavior,
 };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -1,5 +1,5 @@
 import { compose } from '@fluentui/react-bindings';
-
+import { toolbarMenuRadioGroupWrapperBehavior } from '@fluentui/accessibility';
 import { commonPropTypes } from '../../utils';
 import { Box, BoxProps, BoxStylesProps } from '../Box/Box';
 
@@ -28,5 +28,6 @@ export const ToolbarMenuRadioGroupWrapper = compose<
 
 ToolbarMenuRadioGroupWrapper.defaultProps = {
   as: 'li',
+  accessibility: toolbarMenuRadioGroupWrapperBehavior,
 };
 ToolbarMenuRadioGroupWrapper.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
@@ -12,7 +12,7 @@ describe('ToolbarMenuRadioGroup', () => {
 
   describe('accessibility', () => {
     handlesAccessibility(ToolbarMenuRadioGroup, {
-      defaultRootRole: 'group',
+      defaultRootRole: 'presentation',
       partSelector: 'ul',
       usesWrapperSlot: true,
     });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #15238
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Change `ToolbarMenuRadioGroup`'s role from `group` to `presentation`.
Add `role='presentation'` to `ToolbarMenuRadioGroupWrapper`
Add `role='separator'` to the divider on toolbar's menu. This is important only for VoiceOver. VoiceOver will consider the horizontal spliter when counting items. But without this role, it will not be able to navigate to and narrate the horizontal spliter.


Result:
- NVDA 
<img width="704" alt="Screenshot 2020-11-17 at 11 56 43" src="https://user-images.githubusercontent.com/28751745/99382801-55556a80-28cd-11eb-8aab-1b6c9c345cb1.png">


- JAWS 
<img width="510" alt="Screenshot 2020-11-17 at 11 55 47" src="https://user-images.githubusercontent.com/28751745/99382847-67370d80-28cd-11eb-94f3-4db35ef2c877.png">
<img width="571" alt="Screenshot 2020-11-17 at 11 54 40" src="https://user-images.githubusercontent.com/28751745/99382855-6a31fe00-28cd-11eb-87e8-546a3f363476.png">


- Voice Over 
![Tga9GyPpvE](https://user-images.githubusercontent.com/28751745/99538721-a6d52680-29ad-11eb-9fcb-4f765f79c0e1.gif)



#### Focus areas to test

(optional)
