### PR TITLE
Creating an applyClasses helper and moving logic out of makeClasses.

### DIFF
--- a/change/@fluentui-react-theme-provider-2020-11-17-09-18-25-feat-apply-classes.json
+++ b/change/@fluentui-react-theme-provider-2020-11-17-09-18-25-feat-apply-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Moving the auto-distribution logic out of makeClasses and into an applyClasses helper.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-17T17:18:25.630Z"
+}

--- a/packages/react-theme-provider/etc/react-theme-provider.api.md
+++ b/packages/react-theme-provider/etc/react-theme-provider.api.md
@@ -18,6 +18,9 @@ import { Theme } from '@fluentui/theme';
 import { TokenSetType } from '@fluentui/theme';
 import { Variants } from '@fluentui/theme';
 
+// @public
+export const applyClasses: <TState extends {}>(state: TState, classMap: Record<string, string>) => void;
+
 // @public (undocumented)
 export type FontFace = IFontFace;
 

--- a/packages/react-theme-provider/src/applyClasses.test.ts
+++ b/packages/react-theme-provider/src/applyClasses.test.ts
@@ -44,6 +44,7 @@ describe('applyClasses', () => {
     applyClasses(state, testClassMap);
 
     expect(state).toEqual({
+      primary: true,
       className: 'existing1 root primary',
       slot1: { className: 'existing2 slot1' },
     });
@@ -60,6 +61,7 @@ describe('applyClasses', () => {
 
     expect(state).toEqual({
       className: 'existing1 root small',
+      size: 'small',
       slot1: { className: 'existing2 slot1' },
     });
   });

--- a/packages/react-theme-provider/src/applyClasses.test.ts
+++ b/packages/react-theme-provider/src/applyClasses.test.ts
@@ -1,0 +1,66 @@
+import { applyClasses } from './applyClasses';
+
+describe('applyClasses', () => {
+  const testClassMap = {
+    root: 'root',
+    slot1: 'slot1',
+    _primary: 'primary',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _size_small: 'small',
+  };
+
+  it('applies classes correctly', () => {
+    const state = {};
+
+    applyClasses(state, testClassMap);
+
+    expect(state).toEqual({
+      className: 'root',
+      slot1: { className: 'slot1' },
+    });
+  });
+
+  it('appends classes as appropriate', () => {
+    const state = {
+      className: 'existing1',
+      slot1: { className: 'existing2' },
+    };
+
+    applyClasses(state, testClassMap);
+
+    expect(state).toEqual({
+      className: 'existing1 root',
+      slot1: { className: 'existing2 slot1' },
+    });
+  });
+
+  it('can apply a modifier', () => {
+    const state = {
+      primary: true,
+      className: 'existing1',
+      slot1: { className: 'existing2' },
+    };
+
+    applyClasses(state, testClassMap);
+
+    expect(state).toEqual({
+      className: 'existing1 root primary',
+      slot1: { className: 'existing2 slot1' },
+    });
+  });
+
+  it('can apply an enum', () => {
+    const state = {
+      size: 'small',
+      className: 'existing1',
+      slot1: { className: 'existing2' },
+    };
+
+    applyClasses(state, testClassMap);
+
+    expect(state).toEqual({
+      className: 'existing1 root small',
+      slot1: { className: 'existing2 slot1' },
+    });
+  });
+});

--- a/packages/react-theme-provider/src/applyClasses.ts
+++ b/packages/react-theme-provider/src/applyClasses.ts
@@ -36,7 +36,8 @@ export const applyClasses = <TState extends {}>(state: TState, classMap: Record<
       case 1:
         if (key === 'root') {
           _setClass(state, value);
-        } else {
+        } else if (key !== 'subComponentStyles') {
+          // The subComponentStyles check is an unfortunate workaround to avoid breaking partners.
           _setClass(state, value, key);
         }
         break;

--- a/packages/react-theme-provider/src/applyClasses.ts
+++ b/packages/react-theme-provider/src/applyClasses.ts
@@ -1,0 +1,75 @@
+/**
+ * The `applyClasses` takes in a mutable state and a class map and, given the class map
+ * follows the a naming convention described below, auto-applies classes to the appropriate places
+ * in the state.
+ *
+ * Usage:
+ *
+ * ```tsx
+ * const useButtonClasses makeClasses(theme => {
+ *   root: { ... },
+ *   _primary: { ... },
+ *   _size_small: { ... }
+ * });
+ * ```
+ *
+ * The class naming convention is broken down as follows:
+ *
+ * * No underscores - a slot class name. (E.g. "root", "icon", etc)
+ * * Prefixed with underscore - a modifier. (E.g. "_primary", "_fluid")
+ * * Contains 2 underscores - a name/value matcher. (E.g. "_size_small")
+ *
+ * Modifier classnames are added to the root className when the state contains a truthy value
+ * of the same name. For example, when the primary flag is present, the "_primary" modifier
+ * class will be appended to the root className prop.
+ *
+ * Enum classnames are also added to the root className when teh state contains an enum value
+ * which matches the value in the className. for example, when the `size` enum value is `small`,
+ * the "_size_small" enum class will be appended to the root className prop.
+ */
+export const applyClasses = <TState extends {}>(state: TState, classMap: Record<string, string>) => {
+  for (const key of Object.keys(classMap)) {
+    const value = classMap[key];
+    const parts = key.split('_');
+
+    switch (parts.length) {
+      case 1:
+        if (key === 'root') {
+          _setClass(state, value);
+        } else {
+          _setClass(state, value, key);
+        }
+        break;
+
+      case 2:
+        const modifierName = parts[1];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((state as any)[modifierName] || (state as any).variant === modifierName) {
+          _setClass(state, value);
+        }
+        break;
+
+      case 3:
+        const enumName = parts[1];
+        const enumValue = parts[2];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((state as any)[enumName] === enumValue) {
+          _setClass(state, value);
+        }
+        break;
+    }
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function _setClass(state: Record<string, any>, className: string, slot?: string) {
+  const currentSlot = slot ? (state[slot] = state[slot] || {}) : state;
+
+  if (currentSlot.className) {
+    currentSlot.className += ' ' + className;
+  } else {
+    currentSlot.className = className;
+  }
+}

--- a/packages/react-theme-provider/src/index.ts
+++ b/packages/react-theme-provider/src/index.ts
@@ -6,7 +6,7 @@ export * from './useThemeProviderClasses';
 export * from './useThemeProvider';
 export * from './useThemeProviderState';
 export * from './withThemeProvider';
-
+export * from './applyClasses';
 export { useTheme } from './useTheme';
 export { ThemeContext } from './ThemeContext';
 export * from './types';

--- a/packages/react-theme-provider/src/makeClasses.ts
+++ b/packages/react-theme-provider/src/makeClasses.ts
@@ -1,5 +1,6 @@
 import { IStyle } from '@fluentui/merge-styles';
 import { Theme } from '@fluentui/theme';
+import { applyClasses } from './applyClasses';
 import { makeStyles, UseStylesOptions } from './makeStyles';
 
 /**
@@ -39,56 +40,7 @@ export const makeClasses = <TState extends {}>(
 
   return (state: TState, options?: UseStylesOptions) => {
     const classes = useStyles(options);
-    const slotNames = Object.keys(classes);
 
-    for (const slotName of slotNames) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const value = (classes as any)[slotName];
-
-      // If the renderer returns non-classNames (like subComponentStyles), ignore.
-      if (typeof value === 'string') {
-        const parts = slotName.split('_');
-
-        switch (parts.length) {
-          case 1:
-            if (slotName === 'root') {
-              _setClass(state, value);
-            } else {
-              _setClass(state, value, slotName);
-            }
-            break;
-
-          case 2:
-            const modifierName = parts[1];
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if ((state as any)[modifierName] || (state as any).variant === modifierName) {
-              _setClass(state, value);
-            }
-            break;
-
-          case 3:
-            const enumName = parts[1];
-            const enumValue = parts[2];
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if ((state as any)[enumName] === enumValue) {
-              _setClass(state, value);
-            }
-            break;
-        }
-      }
-    }
+    applyClasses(state, classes);
   };
 };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function _setClass(state: Record<string, any>, className: string, slot?: string) {
-  const currentSlot = slot ? (state[slot] = state[slot] || {}) : state;
-
-  if (currentSlot.className) {
-    currentSlot.className += ' ' + className;
-  } else {
-    currentSlot.className = className;
-  }
-}


### PR DESCRIPTION
Rather than burying the "auto class distribution" logic in the `makeClasses` hook, I've moved it into a very testable, standalone helper which now can be used in conjunction with `makeStyles`, thus reducing the need to have `makeClasses`. Before I proceed to remove `makeClasses`, need to use this directly in `makeVariantClasses`.

I'd like to get the step 1 here checked in however, and then proceed with additional work as a step 2 in a separate PR.

Usage of `applyClasses`:

```jsx
const useStyles = makeStyles({
  root: { ... },
  _primary: { ... } // styles when primary is applied
  _size_small: { ... } // styles when size equals value "small"
});

const Button = (p) => {
  const state = { ...p };
  const styles = useStyles();

  // Automatically mix in root/slot classes and conditionally apply modifiers and
  // enums to the root className based on state.
  applyClasses(state, styles);

 return <button { ...state } />
};
```
