### PR TITLE
Fully respect `skipViewportMeasures` in the `withViewport` decorator

### DIFF
--- a/change/office-ui-fabric-react-2020-11-17-12-19-36-viewport-measure.json
+++ b/change/office-ui-fabric-react-2020-11-17-12-19-36-viewport-measure.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fully disable viewport measurement with 'skipViewportMeasures'",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-17T20:19:36.495Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8501,6 +8501,7 @@ export interface IWindowWithSegments extends Window {
 
 // @public
 export interface IWithViewportProps {
+    disableResizeObserver?: boolean;
     skipViewportMeasures?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -29,12 +29,19 @@ export interface IWithViewportState {
  */
 export interface IWithViewportProps {
   /**
-   * Whether or not to use ResizeObserver (if available) to detect
-   * and measure viewport on 'resize' events.
+   * Whether or not `withViewport` should disable its viewport measurements, effectively making this decorator
+   * pass-through with no impact on the rendered component.
    *
-   * Falls back to window 'resize' event.
+   * Since `withViewport` measures the `viewport` on mount, after each React update, and in response to events,
+   * it may cause a component which does not currently need this information due to its configuration to re-render
+   * too often. `skipViewportMeasures` may be toggled on and off based on current state, and will suspend and resume
+   * measurement as-needed.
    *
-   * @defaultValue false
+   * For example, when this wraps `DetailsList`, set `skipViewportMeasures` to `true` when the `layoutMode` is
+   * `fixedColumns`, since the `DetailsList` does not use the viewport size in any calculations.
+   *
+   * In addition, consider setting `skipViewportMeasures` to `true` when running within a React test renderer, to avoid
+   * direct DOM dependencies.
    */
   skipViewportMeasures?: boolean;
 }
@@ -80,38 +87,37 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
         leading: false,
       });
 
-      // ResizeObserver seems always fire even window is not resized. This is
-      // particularly bad when skipViewportMeasures is set when optimizing fixed layout lists.
-      // It will measure and update and re-render the entire list after list is fully rendered.
-      // So fallback to listen to resize event when skipViewportMeasures is set.
-      if (!skipViewportMeasures && this._isResizeObserverAvailable()) {
-        this._registerResizeObserver();
-      } else {
-        this._events.on(win, 'resize', this._onAsyncResize);
-      }
-
       if (!skipViewportMeasures) {
+        if (this._isResizeObserverAvailable()) {
+          this._registerResizeObserver();
+        } else {
+          this._events.on(win, 'resize', this._onAsyncResize);
+        }
+
         this._updateViewport();
       }
     }
 
-    public componentDidUpdate(newProps: TProps) {
-      const { skipViewportMeasures: oldSkipViewportMeasures } = this.props as IWithViewportProps;
-      const { skipViewportMeasures: newSkipViewportMeasures } = newProps as IWithViewportProps;
+    public componentDidUpdate(previousProps: TProps) {
+      const { skipViewportMeasures: oldSkipViewportMeasures } = previousProps as IWithViewportProps;
+      const { skipViewportMeasures: newSkipViewportMeasures } = this.props as IWithViewportProps;
       const win = getWindow(this._root.current);
 
-      if (oldSkipViewportMeasures !== newSkipViewportMeasures) {
-        if (newSkipViewportMeasures) {
-          this._unregisterResizeObserver();
-          this._events.on(win, 'resize', this._onAsyncResize);
-        } else if (!newSkipViewportMeasures && this._isResizeObserverAvailable()) {
-          this._events.off(win, 'resize', this._onAsyncResize);
-          this._registerResizeObserver();
-        }
-      }
+      if (newSkipViewportMeasures !== oldSkipViewportMeasures) {
+        if (!newSkipViewportMeasures) {
+          if (this._isResizeObserverAvailable()) {
+            if (!this._viewportResizeObserver) {
+              this._registerResizeObserver();
+            }
+          } else {
+            this._events.on(win, 'resize', this._onAsyncResize);
+          }
 
-      if (newSkipViewportMeasures) {
-        this._updateViewport();
+          this._updateViewport();
+        } else {
+          this._unregisterResizeObserver();
+          this._events.off(win, 'resize', this._onAsyncResize);
+        }
       }
     }
 


### PR DESCRIPTION
#### Description of changes

The expectation of `skipViewportMeasures` on `withViewport` (and thus on `DetailsList`) is that when set, no measurement of the viewport size occurs and thus `viewport` will never be set to a non-empty size in the `props` of the wrapped component.
However, somewhere along the way, `skipViewportMeasures` got partially repurposed so that it only disables usage of `ResizeObserver` and does not fully prevent the wrapped component from re-rendering in response to viewport size changes.
This change restores `skipViewportMeasures` to its original intent and how existing apps already expect it to work.
This change also fixes the comment in order to explain *why* to use it.

#### Focus areas to test

The justified layout behavior of `DetailsList` relies on viewport measurement continuing to work correctly. Test code and 'fixed layout' behaviors rely on `skipViewportMeasures` completely disabling measurment.
