### PR TITLE
Updated PowerBI and Whiteboard filetype icons. Adding support for .mcworld Minecraft distinct file icons.

### DIFF
--- a/change/@uifabric-file-type-icons-2020-11-18-08-54-21-caperez-powerbi_brandupdate.json
+++ b/change/@uifabric-file-type-icons-2020-11-18-08-54-21-caperez-powerbi_brandupdate.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Pointing to the new CDN that has the on-brand PowerBI filetype icons. Adding support for .mcworld Minecraft distinct file icons.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T16:54:21.305Z"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -19,6 +19,7 @@ export enum FileIconType {
   picturesFolder = 11,
   linkedFolder = 12,
   list = 13,
+  whiteboard = 14,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -530,6 +530,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   vstx: {
     extensions: ['vst', 'vstm', 'vstx', 'vsx'],
   },
+  whiteboard: {},
   xlsx: {
     extensions: ['xlc', 'xls', 'xlsb', 'xlsm', 'xlsx', 'xlw'],
   },

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -311,6 +311,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
       'layer',
       'layout',
       'max',
+      'mcworld',
       'mtl',
       'obj',
       'off',

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -16,6 +16,7 @@ const DESKTOP_FOLDER = 'desktopfolder';
 const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const LINKED_FOLDER = 'linkedfolder';
+const WHITEBOARD = 'whiteboard';
 
 export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
@@ -129,6 +130,9 @@ export function getFileTypeIconNameFromExtensionOrType(
         break;
       case FileIconType.list:
         iconBaseName = LIST;
+        break;
+      case FileIconType.whiteboard:
+        iconBaseName = WHITEBOARD;
         break;
     }
   }

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201117.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201125.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201008.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201117.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Update brand on PowerBI filetype icons. 
- [x] Added support for whiteboard ItemType.
- [x] Adding support for .mcworld Minecraft distinct file icons.
- [x] Include a change request file using `$ yarn change`


#### Focus areas to test

https://github.com/microsoft/fluentui/tree/7.0/packages/file-type-icons
