### PR TITLE
Allow for custom overflow button in breadcrumb with correct props

### DIFF
--- a/change/@fluentui-react-2020-11-18-12-29-27-pb-breadcrumb-fixes.json
+++ b/change/@fluentui-react-2020-11-18-12-29-27-pb-breadcrumb-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add text to breacrumb overflow items",
+  "packageName": "@fluentui/react",
+  "email": "pbelsal@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T20:29:27.909Z"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -383,6 +383,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     onRenderItem?: IRenderFunction<IBreadcrumbItem>;
     onRenderOverflowIcon?: IRenderFunction<IButtonProps>;
     overflowAriaLabel?: string;
+    overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowIndex?: number;
     // (undocumented)
     styles?: IStyleFunctionOrObject<IBreadcrumbStyleProps, IBreadcrumbStyles>;

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -169,6 +169,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       (item): IContextualMenuItem => {
         const isActionable = !!(item.onClick || item.href);
         return {
+          text: item.text,
           name: item.text,
           key: item.key,
           onClick: item.onClick ? this._onBreadcrumbClicked.bind(this, item) : null,

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -162,6 +162,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       overflowAriaLabel,
       overflowIndex,
       onRenderOverflowIcon,
+      overflowButtonAs,
     } = data.props;
     const { renderedOverflowItems, renderedItems } = data;
 
@@ -201,12 +202,13 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
     if (hasOverflowItems) {
       const iconProps = !onRenderOverflowIcon ? { iconName: 'More' } : {};
       const onRenderMenuIcon = onRenderOverflowIcon ? onRenderOverflowIcon : nullFunction;
+      const OverflowButton = overflowButtonAs ? overflowButtonAs : IconButton;
 
       itemElements.splice(
         overflowIndex!,
         0,
         <li className={this._classNames.overflow} key={OVERFLOW_KEY}>
-          <IconButton
+          <OverflowButton
             className={this._classNames.overflowButton}
             iconProps={iconProps}
             role="button"

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -54,6 +54,12 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    * Render a custom overflow icon in place of the default icon `...`
    */
   onRenderOverflowIcon?: IRenderFunction<IButtonProps>;
+
+  /**
+   * Custom component for the overflow button.
+   */
+  overflowButtonAs?: IComponentAs<IButtonProps>;
+
   /**
    * The maximum number of breadcrumbs to display before coalescing.
    * If not specified, all breadcrumbs will be rendered.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15881
- [x] Include a change request file using `$ yarn change`

#### Description of changes

While working on breadcrumb I noticed two issues:

- The `IContextualMenuItem` type mentions that `name` is deprecated and we should use `text` instead, but when trying to render custom overflow items I noticed that the breadcrumb was transforming my `text` to `name` on each item and removing `text`, so I added it so we don't have to rely on deprecate props.
- I need a way to render custom overflow menu items (to render router aware links instead of normal <a> tags), since other components (CommandBar and OverflowSet) have a prop to render a custom overflow button, I created my own `OverflowMenu` component that uses a `IconButton` with it's own `onRenderOverflowItem` to allow this. While working with the breadcrumb I noticed there's no way to do this, since the current prop (`onRenderOverflowIcon`) only allows you to render a custom icon, but not the wrapper button, so if I use this to render my `OverflowMenu` component I end up with a button with a menu inside a button with a menu. Here I'm adding a prop that matches exactly the prop in the CommandBar to allow for this.

Sorry that I didn't open an issue first, since it's a simple change I thought it would be faster just to send a PR and discuss any chances needed here.

This is a bit related to https://github.com/microsoft/fluentui/issues/15881