### PR TITLE
Fix display issue with Dropdown when using Chrome Translate

### DIFF
--- a/change/@fluentui-react-2020-11-18-14-10-23-dropdown-google-translate-fix.json
+++ b/change/@fluentui-react-2020-11-18-14-10-23-dropdown-google-translate-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix display issue with Dropdown when using Chrome Translate",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T22:10:23.735Z"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -304,7 +304,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       panelProps,
       calloutProps,
       multiSelect,
-      onRenderTitle = this._onRenderTitle,
+      onRenderTitle = this._getTitle,
       onRenderContainer = this._onRenderContainer,
       onRenderCaretDown = this._onRenderCaretDown,
       onRenderLabel = this._onRenderLabel,
@@ -312,7 +312,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     } = props;
     const { isOpen, calloutRenderEdge } = this.state;
     // eslint-disable-next-line deprecation/deprecation
-    const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._onRenderPlaceholder;
+    const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._getPlaceholder;
 
     // If our cached options are out of date update our cache
     if (options !== this._sizePosCache.cachedOptions) {
@@ -494,10 +494,10 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   };
 
   /** Get either props.placeholder (new name) or props.placeHolder (old name) */
-  private get _placeholder(): string | undefined {
+  private _getPlaceholder = (): string | null => {
     // eslint-disable-next-line deprecation/deprecation
-    return this.props.placeholder || this.props.placeHolder;
-  }
+    return this.props.placeholder || this.props.placeHolder || null;
+  };
 
   private _copyArray(array: any[]): any[] {
     const newArray = [];
@@ -566,20 +566,23 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     return index;
   }
 
+  /** Get text in dropdown input as a string */
+  private _getTitle = (items: IDropdownOption[], _unused?: unknown): string => {
+    const { multiSelectDelimiter = ', ' } = this.props;
+    return items.map(i => i.text).join(multiSelectDelimiter);
+  };
+
   /** Render text in dropdown input */
   private _onRenderTitle = (items: IDropdownOption[]): JSX.Element => {
-    const { multiSelectDelimiter = ', ' } = this.props;
-
-    const displayTxt = items.map(i => i.text).join(multiSelectDelimiter);
-    return <>{displayTxt}</>;
+    return <>{this._getTitle(items)}</>;
   };
 
   /** Render placeholder text in dropdown input */
   private _onRenderPlaceholder = (props: IDropdownProps): JSX.Element | null => {
-    if (!this._placeholder) {
+    if (!this._getPlaceholder()) {
       return null;
     }
-    return <>{this._placeholder}</>;
+    return <>{this._getPlaceholder()}</>;
   };
 
   /** Render Callout or Panel container and pass in list */

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -494,9 +494,9 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   };
 
   /** Get either props.placeholder (new name) or props.placeHolder (old name) */
-  private _getPlaceholder = (): string | null => {
+  private _getPlaceholder = (): string | undefined => {
     // eslint-disable-next-line deprecation/deprecation
-    return this.props.placeholder || this.props.placeHolder || null;
+    return this.props.placeholder || this.props.placeHolder;
   };
 
   private _copyArray(array: any[]): any[] {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15930
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Dropdown currently renders its title text as a string inside of a React.Fragment. That doesn't re-render properly when the selection change, if the user is using Chrome's translate feature; which is likely a bug in React itself.

This change works around the bug by directly displaying the string, rather than wrapping it in a fragment. This causes React to properly re-render the content when it changes.
