### PR TITLE
Keyboard focus should be visible on selected footers in pickers in high contrast

### DIFF
--- a/change/@fluentui-react-internal-2020-11-18-14-52-57-floatingpickerfooteraccfix.json
+++ b/change/@fluentui-react-internal-2020-11-18-14-52-57-floatingpickerfooteraccfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Keyboard focus should be visible in selected footers in pickers in high contrast",
+  "packageName": "@fluentui/react-internal",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T22:52:57.249Z"
+}

--- a/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.SelectableFooter.Example.tsx
+++ b/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.SelectableFooter.Example.tsx
@@ -67,6 +67,14 @@ export const FloatingPeoplePickerTypesSelectableFooterExample: React.FunctionCom
       footerItemsProps: [
         {
           renderItem: () => {
+            return <>Showing {picker.current ? picker.current.suggestions.length : 0} results</>;
+          },
+          shouldShow: () => {
+            return !!picker.current && picker.current.suggestions.length > 0;
+          },
+        },
+        {
+          renderItem: () => {
             return <>Click me!</>;
           },
           shouldShow: () => {

--- a/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.SelectableFooter.Example.tsx
+++ b/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.SelectableFooter.Example.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import {
+  IBaseFloatingPicker,
+  IBaseFloatingPickerSuggestionProps,
+  FloatingPeoplePicker,
+  SuggestionsStore,
+} from '@fluentui/react/lib/FloatingPicker';
+import { SearchBox } from '@fluentui/react/lib/SearchBox';
+import { people } from '@fluentui/example-data';
+import { useConst } from '@fluentui/react-hooks';
+
+const searchBoxWrapperStyling = { width: 208 };
+
+const getTextFromItem = (persona: IPersonaProps): string => {
+  return persona.text || '';
+};
+
+const listContainsPersona = (persona: IPersonaProps, personas?: IPersonaProps[]): boolean => {
+  return !!personas && personas.some((item: IPersonaProps) => item.text === persona.text);
+};
+
+const validateInput = (input: string): boolean => {
+  return input.indexOf('@') !== -1;
+};
+
+const startsWith = (text: string, filterText: string): boolean => {
+  return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
+};
+
+export const FloatingPeoplePickerTypesSelectableFooterExample: React.FunctionComponent = () => {
+  const inputElementRef = React.useRef<HTMLInputElement>(null);
+  const suggestionsStore = useConst(() => new SuggestionsStore<IPersonaProps>());
+  const [peopleList, setPeopleList] = React.useState(people);
+  const [searchValue, setSearchValue] = React.useState('');
+  const picker = React.useRef<IBaseFloatingPicker>(null);
+
+  const onFocus = (): void => {
+    if (picker.current) {
+      picker.current.showPicker();
+    }
+  };
+
+  const onSearchChange = (ev: React.ChangeEvent<HTMLInputElement>, newValue: string): void => {
+    if (newValue !== searchValue && picker.current) {
+      setSearchValue(newValue);
+      picker.current.onQueryStringChanged(newValue);
+    }
+  };
+
+  const onPickerChange = (selectedSuggestion: IPersonaProps): void => {
+    setSearchValue(selectedSuggestion.text || '');
+    if (picker.current) {
+      picker.current.hidePicker();
+    }
+  };
+
+  const onRemoveSuggestion = (item: any): void => {
+    const itemIndex = peopleList.indexOf(item);
+    if (itemIndex >= 0) {
+      setPeopleList(peopleList.slice(0, itemIndex).concat(peopleList.slice(itemIndex + 1)));
+    }
+  };
+
+  const suggestionProps: IBaseFloatingPickerSuggestionProps = useConst(() => {
+    return {
+      footerItemsProps: [
+        {
+          renderItem: () => {
+            return <>Click me!</>;
+          },
+          shouldShow: () => {
+            return !!picker.current && picker.current.suggestions.length < 5;
+          },
+          onExecute: () => {
+            alert('Footer selected');
+          },
+        },
+      ],
+    };
+  });
+
+  const onFilterChanged = (filterText: string, currentPersonas?: IPersonaProps[]): IPersonaProps[] => {
+    if (filterText) {
+      // Filter by items starting with the current filter text, then remove duplicates
+      return peopleList
+        .filter((item: IPersonaProps) => startsWith(item.text || '', filterText))
+        .filter((persona: IPersonaProps) => !listContainsPersona(persona, currentPersonas));
+    }
+    return [];
+  };
+
+  return (
+    <>
+      <div style={searchBoxWrapperStyling} ref={inputElementRef}>
+        <SearchBox
+          placeholder="Search for person"
+          // eslint-disable-next-line react/jsx-no-bind
+          onChange={onSearchChange}
+          value={searchValue}
+          // eslint-disable-next-line react/jsx-no-bind
+          onFocus={onFocus}
+        />
+      </div>
+      <FloatingPeoplePicker
+        suggestionsStore={suggestionsStore}
+        // eslint-disable-next-line react/jsx-no-bind
+        onResolveSuggestions={onFilterChanged}
+        getTextFromItem={getTextFromItem}
+        pickerSuggestionsProps={suggestionProps}
+        key="normal"
+        // eslint-disable-next-line react/jsx-no-bind
+        onRemoveSuggestion={onRemoveSuggestion}
+        onValidateInput={validateInput}
+        componentRef={picker}
+        // eslint-disable-next-line react/jsx-no-bind
+        onChange={onPickerChange}
+        inputElement={inputElementRef.current}
+        resolveDelay={300}
+      />
+    </>
+  );
+};

--- a/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.doc.tsx
+++ b/packages/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.doc.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { FloatingPeoplePickerTypesExample } from './FloatingPeoplePicker.Basic.Example';
+import { FloatingPeoplePickerTypesSelectableFooterExample } from './FloatingPeoplePicker.SelectableFooter.Example';
 
 import { IDocPageProps } from '@fluentui/react-internal/lib/common/DocPage.types';
 
 const FloatingPeoplePickerBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.Basic.Example.tsx') as string;
+const FloatingPeoplePickerSelectableFooterExampleCode = require('!raw-loader!@fluentui/react-examples/src/react/FloatingPeoplePicker/FloatingPeoplePicker.SelectableFooter.Example.tsx') as string;
 
 export const FloatingPeoplePickerPageProps: IDocPageProps = {
   title: 'FloatingPeoplePicker',
@@ -15,6 +17,11 @@ export const FloatingPeoplePickerPageProps: IDocPageProps = {
       title: 'Floating People Picker',
       code: FloatingPeoplePickerBasicExampleCode,
       view: <FloatingPeoplePickerTypesExample />,
+    },
+    {
+      title: 'Floating People Picker',
+      code: FloatingPeoplePickerSelectableFooterExampleCode,
+      view: <FloatingPeoplePickerTypesSelectableFooterExample />,
     },
   ],
   propertiesTablesSources: [

--- a/packages/react-examples/src/react/__snapshots__/FloatingPeoplePicker.SelectableFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FloatingPeoplePicker.SelectableFooter.Example.tsx.shot
@@ -1,0 +1,149 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders FloatingPeoplePicker.SelectableFooter.Example.tsx correctly 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "width": 208,
+      }
+    }
+  >
+    <div
+      className=
+          ms-SearchBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: stretch;
+            background-color: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 1px;
+            padding-left: 4px;
+            padding-right: 0;
+            padding-top: 1px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          &:hover .ms-SearchBox-iconContainer {
+            color: #005a9e;
+          }
+      onFocusCapture={[Function]}
+    >
+      <div
+        aria-hidden={true}
+        className=
+            ms-SearchBox-iconContainer
+            {
+              color: #0078d4;
+              cursor: text;
+              display: flex;
+              flex-direction: column;
+              flex-shrink: 0;
+              font-size: 16px;
+              justify-content: center;
+              text-align: center;
+              transition: width 0.167s;
+              width: 32px;
+            }
+        onClick={[Function]}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-SearchBox-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+                transition: opacity 0.167s 0s;
+              }
+          data-icon-name="Search"
+        >
+          
+        </i>
+      </div>
+      <input
+        className=
+            ms-SearchBox-field
+            {
+              background-color: transparent;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              flex: 1 1 0px;
+              font-family: inherit;
+              font-size: inherit;
+              font-weight: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: none;
+              overflow: hidden;
+              padding-bottom: 0.5px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              text-overflow: ellipsis;
+            }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+        id="SearchBox0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Search for person"
+        role="searchbox"
+        value=""
+      />
+    </div>
+  </div>,
+  <div
+    className="ms-BasePicker ms-BaseFloatingPicker"
+  />,
+]
+`;

--- a/packages/react-internal/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
+++ b/packages/react-internal/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
@@ -41,6 +41,17 @@
   &:hover {
     background-color: $ms-color-themeLight;
     cursor: pointer;
+
+    @include high-contrast {
+      background-color: Highlight;
+      color: HighlightText;
+    }
+  }
+
+  @include high-contrast {
+    background-color: Highlight;
+    color: HighlightText;
+    -ms-high-contrast-adjust: none;
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, keyboard focus is not visible for SuggestionsHeaderFooterItems in high contrast. Regularly they get the same treatment as suggestion items.

- Added a high contrast state to the css.
- Added a FloatingPeoplePicker example that has a selectable footer for testing

![footer hc fix hc black](https://user-images.githubusercontent.com/64664025/99598408-54483a00-29ae-11eb-8c39-d0b104d7bbae.png)
![footer hc fix hc white](https://user-images.githubusercontent.com/64664025/99598412-54e0d080-29ae-11eb-8520-933a92226ebb.png)

