### PR TITLE
Calling setRTL on loadTheme so that it is respected in non-theme related scenarios

### DIFF
--- a/change/@fluentui-style-utilities-2020-11-18-15-24-34-setRTLInLoadTheme.json
+++ b/change/@fluentui-style-utilities-2020-11-18-15-24-34-setRTLInLoadTheme.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow for custom overflow button in breadcrumb with correct props (#15977)",
+  "packageName": "@fluentui/style-utilities",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T23:24:34.538Z"
+}

--- a/change/@fluentui-style-utilities-2020-11-18-15-25-22-setRTLInLoadTheme.json
+++ b/change/@fluentui-style-utilities-2020-11-18-15-25-22-setRTLInLoadTheme.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Calling setRTL on loadTheme so that it is respected in non-theme related scenarios.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-18T23:25:21.984Z"
+}

--- a/packages/style-utilities/src/styles/theme.ts
+++ b/packages/style-utilities/src/styles/theme.ts
@@ -1,7 +1,7 @@
 import { Customizations, getWindow } from '@fluentui/utilities';
 import { ITheme, IPartialTheme, IFontStyles } from '../interfaces/index';
 import { loadTheme as legacyLoadTheme } from '@microsoft/load-themed-styles';
-import { IRawStyle } from '@fluentui/merge-styles';
+import { IRawStyle, setRTL } from '@fluentui/merge-styles';
 import { createTheme } from '@fluentui/theme/lib/createTheme';
 
 export { createTheme } from '@fluentui/theme/lib/createTheme';
@@ -72,6 +72,9 @@ export function loadTheme(theme: IPartialTheme, depComments: boolean = false): I
 
   // Invoke the legacy method of theming the page as well.
   legacyLoadTheme({ ..._theme.palette, ..._theme.semanticColors, ..._theme.effects, ..._loadFonts(_theme) });
+
+  // Call setRTL
+  _theme.rtl && setRTL(_theme.rtl);
 
   Customizations.applySettings({ [ThemeSettingName]: _theme });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue where certain components, such as `FocusZone`, weren't picking up the RTL configuration when using `loadTheme` because `loadTheme` was not setting the RTL for non-themed related scenarios.

#### Focus areas to test

(optional)
