### PR TITLE
Fix tooltip swallowing keydown events for close in the event that the tooltip is already closed.

### DIFF
--- a/change/office-ui-fabric-react-2020-11-18-18-03-34-fix-tooltip-propagation.json
+++ b/change/office-ui-fabric-react-2020-11-18-18-03-34-fix-tooltip-propagation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Only attempt to handle keydown event for tooltip close if the tooltip is currently open",
+  "packageName": "office-ui-fabric-react",
+  "email": "stefhan@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T02:03:34.529Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -223,7 +223,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
   };
 
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    if (ev.which === KeyCodes.escape || ev.ctrlKey) {
+    if ((ev.which === KeyCodes.escape || ev.ctrlKey) && this.state.isTooltipVisible) {
       this._hideTooltip();
       ev.stopPropagation();
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #15811
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Currently, we are attempting to capture keydown events on the tooltip (particularly the Escape and Ctrl key) even when the tooltip is closed. This means that in the event that the tooltip belongs to an element in a dialog or another component that listens to the same keydown event, the event is swallowed. We should check to see that the tooltip is open before attempting to handle this event (so that we don't stop event propagation).

#### Focus areas to test

(optional)
