### PR TITLE
feat: add new property onRenderStar for Rating

### DIFF
--- a/change/@fluentui-react-internal-2020-11-19-16-26-06-feat-rating.json
+++ b/change/@fluentui-react-internal-2020-11-19-16-26-06-feat-rating.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add new property onRenderStar for Rating",
+  "packageName": "@fluentui/react-internal",
+  "email": "qiuya@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T08:26:06.150Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -17,6 +17,7 @@ import { IFontStyles } from '@fluentui/style-utilities';
 import { IHTMLSlot } from '@fluentui/foundation-legacy';
 import { IObjectWithKey } from '@fluentui/utilities';
 import { IPoint } from '@fluentui/utilities';
+import { IProcessedStyleSet } from '@fluentui/style-utilities';
 import { IRawStyle } from '@fluentui/style-utilities';
 import { IRectangle } from '@fluentui/utilities';
 import { IRefObject } from '@fluentui/utilities';
@@ -4065,12 +4066,27 @@ export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement>, Reac
     // @deprecated
     min?: number;
     onChange?: (event: React.FormEvent<HTMLElement>, rating?: number) => void;
+    onRenderStar?: IRenderFunction<IRatingStarProps>;
     rating?: number;
     readOnly?: boolean;
     size?: RatingSize;
     styles?: IStyleFunctionOrObject<IRatingStyleProps, IRatingStyles>;
     theme?: ITheme;
     unselectedIcon?: string;
+}
+
+// @public (undocumented)
+export interface IRatingStarProps {
+    // (undocumented)
+    classNames: IProcessedStyleSet<IRatingStyles>;
+    // (undocumented)
+    disabled?: boolean;
+    // (undocumented)
+    fillPercentage: number;
+    // (undocumented)
+    icon: string;
+    // (undocumented)
+    starNum?: number;
 }
 
 // @public (undocumented)

--- a/packages/react-internal/src/components/Rating/Rating.base.tsx
+++ b/packages/react-internal/src/components/Rating/Rating.base.tsx
@@ -1,19 +1,11 @@
 import * as React from 'react';
 import { classNamesFunction, css, format, divProperties, getNativeProps } from '../../Utilities';
-import { IProcessedStyleSet } from '../../Styling';
 import { Icon } from '../../Icon';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { IRatingProps, RatingSize, IRatingStyleProps, IRatingStyles, IRating } from './Rating.types';
+import { IRatingProps, RatingSize, IRatingStyleProps, IRatingStyles, IRating, IRatingStarProps } from './Rating.types';
 import { useId, useWarnings, useControllableValue } from '@fluentui/react-hooks';
 
 const getClassNames = classNamesFunction<IRatingStyleProps, IRatingStyles>();
-
-interface IRatingStarProps {
-  fillPercentage: number;
-  disabled?: boolean;
-  classNames: IProcessedStyleSet<IRatingStyles>;
-  icon: string;
-}
 
 const RatingStar = (props: IRatingStarProps) => {
   return (
@@ -95,6 +87,7 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
       theme,
       icon = 'FavoriteStarFill',
       unselectedIcon = 'FavoriteStar',
+      onRenderStar,
     } = props;
 
     // Ensure min is >= 0 to avoid issues elsewhere
@@ -119,6 +112,9 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
     const ariaLabel = getAriaLabel?.(displayRating, max);
 
     const stars: JSX.Element[] = [];
+
+    const renderStar = (starProps: IRatingStarProps, renderer?: IRatingProps['onRenderStar']) =>
+      renderer ? renderer(starProps) : <RatingStar {...starProps} />;
 
     for (let starNum = 1; starNum <= max; starNum++) {
       const fillPercentage = getFillingPercentage(starNum, displayRating);
@@ -149,12 +145,16 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
           <span id={`${labelId}-${starNum}`} className={classNames.labelText}>
             {format(ariaLabelFormat || '', starNum, max)}
           </span>
-          <RatingStar
-            fillPercentage={fillPercentage}
-            disabled={disabled}
-            classNames={classNames}
-            icon={fillPercentage > 0 ? icon : unselectedIcon}
-          />
+          {renderStar(
+            {
+              fillPercentage,
+              disabled,
+              classNames,
+              icon: fillPercentage > 0 ? icon : unselectedIcon,
+              starNum,
+            },
+            onRenderStar,
+          )}
         </button>,
       );
     }

--- a/packages/react-internal/src/components/Rating/Rating.types.ts
+++ b/packages/react-internal/src/components/Rating/Rating.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IStyle, ITheme, IProcessedStyleSet } from '../../Styling';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * {@docCategory Rating}
@@ -8,6 +8,14 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 export interface IRating {
   /** Current displayed rating value. Will be `min` if the user has not yet set a rating. */
   rating: number;
+}
+
+export interface IRatingStarProps {
+  fillPercentage: number;
+  disabled?: boolean;
+  classNames: IProcessedStyleSet<IRatingStyles>;
+  icon: string;
+  starNum?: number;
 }
 
 /**
@@ -69,6 +77,11 @@ export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement>, Reac
    * @defaultvalue FavoriteStar
    */
   unselectedIcon?: string;
+
+  /**
+   * Optional custom renderer for the star component.
+   */
+  onRenderStar?: IRenderFunction<IRatingStarProps>;
 
   /**
    * Size of rating


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a new property `onRenderStart` to customize star renderring.

#### Focus areas to test

(optional)
