### PR TITLE
FocusZone: Consuming theme information from ThemeContext to provide it when calling RTL

### DIFF
--- a/change/@fluentui-react-focus-2020-11-19-11-44-31-focusZoneConsumeTheme.json
+++ b/change/@fluentui-react-focus-2020-11-19-11-44-31-focusZoneConsumeTheme.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "FocusZone: Consuming theme information from ThemeContext to provide it when calling getRTL.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T19:44:31.581Z"
+}

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/merge-styles": "^8.0.0-beta.1",
+    "@fluentui/react-theme-provider": "^0.18.0",
     "@fluentui/set-version": "^8.0.0-beta.0",
     "@fluentui/utilities": "^8.0.0-beta.6",
     "tslib": "^1.10.0"

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -48,8 +48,9 @@
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/merge-styles": "^8.0.0-beta.1",
-    "@fluentui/react-theme-provider": "^0.18.0",
+    "@fluentui/react-theme-provider": "^1.0.0-beta.9",
     "@fluentui/set-version": "^8.0.0-beta.0",
+    "@fluentui/style-utilities": "^8.0.0-beta.6",
     "@fluentui/utilities": "^8.0.0-beta.6",
     "tslib": "^1.10.0"
   },

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -29,6 +29,7 @@ import {
 } from '@fluentui/utilities';
 import { mergeStyles } from '@fluentui/merge-styles';
 import { ThemeContext, Theme } from '@fluentui/react-theme-provider';
+import { getTheme } from '@fluentui/style-utilities';
 
 const IS_FOCUSABLE_ATTRIBUTE = 'data-is-focusable';
 const IS_ENTER_DISABLED_ATTRIBUTE = 'data-disable-click-on-enter';
@@ -274,7 +275,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
             ref={this._mergedRef(this.props.elementRef, this._root)}
             data-focuszone-id={this._id}
             // eslint-disable-next-line react/jsx-no-bind
-            onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme)}
+            onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme || getTheme())}
             onFocus={this._onFocus}
             onMouseDownCapture={this._onMouseDown}
           >
@@ -573,7 +574,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   /**
    * Handle the keystrokes.
    */
-  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme?: Theme): boolean | undefined => {
+  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme: Theme): boolean | undefined => {
     if (this._portalContainsElement(ev.target as HTMLElement)) {
       // If the event target is inside a portal do not process the event.
       return;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -255,7 +255,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     return (
       <ThemeContext.Consumer>
-        {theme => (
+        {(theme) => (
           <Tag
             aria-labelledby={ariaLabelledBy}
             aria-describedby={ariaDescribedBy}
@@ -992,7 +992,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusLeft(theme?: Theme): boolean {
+  private _moveFocusLeft(theme: Theme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
@@ -1034,7 +1034,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusRight(theme?: Theme): boolean {
+  private _moveFocusRight(theme: Theme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -28,6 +28,7 @@ import {
   createMergedRef,
 } from '@fluentui/utilities';
 import { mergeStyles } from '@fluentui/merge-styles';
+import { ThemeContext, Theme } from '@fluentui/react-theme-provider';
 
 const IS_FOCUSABLE_ATTRIBUTE = 'data-is-focusable';
 const IS_ENTER_DISABLED_ATTRIBUTE = 'data-disable-click-on-enter';
@@ -252,30 +253,35 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     this._evaluateFocusBeforeRender();
 
     return (
-      <Tag
-        aria-labelledby={ariaLabelledBy}
-        aria-describedby={ariaDescribedBy}
-        {...divProps}
-        {
-          // root props has been deprecated and should get removed.
-          // it needs to be marked as "any" since root props expects a div element, but really Tag can
-          // be any native element so typescript rightly flags this as a problem.
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ...(rootProps as any)
-        }
-        // Once the getClassName correctly memoizes inputs this should
-        // be replaced so that className is passed to getRootClass and is included there so
-        // the class names will always be in the same order.
-        className={css(getRootClass(), className)}
-        // eslint-disable-next-line deprecation/deprecation
-        ref={this._mergedRef(this.props.elementRef, this._root)}
-        data-focuszone-id={this._id}
-        onKeyDown={this._onKeyDown}
-        onFocus={this._onFocus}
-        onMouseDownCapture={this._onMouseDown}
-      >
-        {this.props.children}
-      </Tag>
+      <ThemeContext.Consumer>
+        {theme => (
+          <Tag
+            aria-labelledby={ariaLabelledBy}
+            aria-describedby={ariaDescribedBy}
+            {...divProps}
+            {
+              // root props has been deprecated and should get removed.
+              // it needs to be marked as "any" since root props expects a div element, but really Tag can
+              // be any native element so typescript rightly flags this as a problem.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ...(rootProps as any)
+            }
+            // Once the getClassName correctly memoizes inputs this should
+            // be replaced so that className is passed to getRootClass and is included there so
+            // the class names will always be in the same order.
+            className={css(getRootClass(), className)}
+            // eslint-disable-next-line deprecation/deprecation
+            ref={this._mergedRef(this.props.elementRef, this._root)}
+            data-focuszone-id={this._id}
+            // eslint-disable-next-line react/jsx-no-bind
+            onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme)}
+            onFocus={this._onFocus}
+            onMouseDownCapture={this._onMouseDown}
+          >
+            {this.props.children}
+          </Tag>
+        )}
+      </ThemeContext.Consumer>
     );
   }
 
@@ -567,7 +573,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   /**
    * Handle the keystrokes.
    */
-  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): boolean | undefined => {
+  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme?: Theme): boolean | undefined => {
     if (this._portalContainsElement(ev.target as HTMLElement)) {
       // If the event target is inside a portal do not process the event.
       return;
@@ -635,7 +641,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         case KeyCodes.left:
           if (direction !== FocusZoneDirection.vertical) {
             this._preventDefaultWhenHandled(ev);
-            if (this._moveFocusLeft()) {
+            if (this._moveFocusLeft(theme)) {
               break;
             }
           }
@@ -644,7 +650,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         case KeyCodes.right:
           if (direction !== FocusZoneDirection.vertical) {
             this._preventDefaultWhenHandled(ev);
-            if (this._moveFocusRight()) {
+            if (this._moveFocusRight(theme)) {
               break;
             }
           }
@@ -694,8 +700,8 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
             ) {
               focusChanged = ev.shiftKey ? this._moveFocusUp() : this._moveFocusDown();
             } else {
-              const tabWithDirection = getRTL() ? !ev.shiftKey : ev.shiftKey;
-              focusChanged = tabWithDirection ? this._moveFocusLeft() : this._moveFocusRight();
+              const tabWithDirection = getRTL(theme) ? !ev.shiftKey : ev.shiftKey;
+              focusChanged = tabWithDirection ? this._moveFocusLeft(theme) : this._moveFocusRight(theme);
             }
             this._processingTabKey = false;
             if (focusChanged) {
@@ -985,16 +991,16 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusLeft(): boolean {
+  private _moveFocusLeft(theme?: Theme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
-        getRTL(),
+        getRTL(theme),
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
           let topBottomComparison;
 
-          if (getRTL()) {
+          if (getRTL(theme)) {
             // When in RTL, this comparison should be the same as the one in _moveFocusRight for LTR.
             // Going left at a leftmost rectangle will go down a line instead of up a line like in LTR.
             // This is important, because we want to be comparing the top of the target rect
@@ -1027,16 +1033,16 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusRight(): boolean {
+  private _moveFocusRight(theme?: Theme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
-        !getRTL(),
+        !getRTL(theme),
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
           let topBottomComparison;
 
-          if (getRTL()) {
+          if (getRTL(theme)) {
             // When in RTL, this comparison should be the same as the one in _moveFocusLeft for LTR.
             // Going right at a rightmost rectangle will go up a line instead of down a line like in LTR.
             // This is important, because we want to be comparing the bottom of the target rect

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,17 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
+"@fluentui/react-compose@^0.19.12":
+  version "0.19.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-compose/-/react-compose-0.19.12.tgz#405dfc19b4ae2b5f1c86bf7091ac15a205978206"
+  integrity sha512-GTcZ3kd2rTk3Q7xXJB8cTPfv0Q0vOdeIrLcJ02lXfjE9h3GPTE62rV4iFzBIZyXIKL8IdR6Jh8WNIBkVMWhhxw==
+  dependencies:
+    "@types/classnames" "^2.2.9"
+    "@uifabric/set-version" "^7.0.23"
+    "@uifabric/utilities" "^7.33.2"
+    classnames "^2.2.6"
+    tslib "^1.10.0"
+
 "@fluentui/react-compose@^0.19.6":
   version "0.19.6"
   resolved "https://registry.yarnpkg.com/@fluentui/react-compose/-/react-compose-0.19.6.tgz#a49e118261096116845b2e87db0a85d3e8ffb3cd"
@@ -1409,6 +1420,48 @@
     "@uifabric/set-version" "^7.0.23"
     "@uifabric/utilities" "^7.32.4"
     classnames "^2.2.6"
+    tslib "^1.10.0"
+
+"@fluentui/react-stylesheets@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-stylesheets/-/react-stylesheets-0.2.4.tgz#65cc6136f84ff3fd3d1c9188bed0a34b9573f589"
+  integrity sha512-zTyDxBsQsm5iz59SXn83+BrC3tUnwQdJc/xcPYWWVISIyPby/75URbWK5uYJ5p5Qy0GrpgKDGYAbpXZlN89SRQ==
+  dependencies:
+    "@uifabric/set-version" "^7.0.23"
+    tslib "^1.10.0"
+
+"@fluentui/react-theme-provider@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-theme-provider/-/react-theme-provider-0.18.0.tgz#72fc1809a2b0720bdb66b9ff7d0505e69e036308"
+  integrity sha512-dKSOZ1Sl2uVrDzjvfRtwHUluedU0MhEASukyeqGTpKTmg3ucPMYEZn+dgzFqRNpjs9trbb++N8R6Z19CWokXOw==
+  dependencies:
+    "@fluentui/react-compose" "^0.19.12"
+    "@fluentui/react-stylesheets" "^0.2.4"
+    "@fluentui/react-window-provider" "^1.0.1"
+    "@fluentui/theme" "^1.7.0"
+    "@uifabric/merge-styles" "^7.19.1"
+    "@uifabric/react-hooks" "^7.13.9"
+    "@uifabric/set-version" "^7.0.23"
+    "@uifabric/utilities" "^7.33.2"
+    classnames "^2.2.6"
+    tslib "^1.10.0"
+
+"@fluentui/react-window-provider@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-window-provider/-/react-window-provider-1.0.1.tgz#8ec71db8cfd57e11f00ed42c5c1377ef4dfe5f6b"
+  integrity sha512-5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==
+  dependencies:
+    "@uifabric/set-version" "^7.0.23"
+    tslib "^1.10.0"
+
+"@fluentui/theme@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/theme/-/theme-1.7.0.tgz#822adcc4b0c9cc057984b4ada21c30856907a8e6"
+  integrity sha512-pzqDZC2bVD6/S45Bnve4wmrXi4cN7XiCr+OhzvgmoQfDkm5vyXsa82/cVtif/zy1OFU96S9zOTtt3e+QQuGUUg==
+  dependencies:
+    "@uifabric/merge-styles" "^7.19.1"
+    "@uifabric/set-version" "^7.0.23"
+    "@uifabric/utilities" "^7.33.2"
     tslib "^1.10.0"
 
 "@gulp-sourcemaps/identity-map@1.X":
@@ -4784,6 +4837,16 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
+"@uifabric/react-hooks@^7.13.9":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz#82373cdfbccc81b6fa00586dd8994bb47c97e99b"
+  integrity sha512-VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==
+  dependencies:
+    "@fluentui/react-window-provider" "^1.0.1"
+    "@uifabric/set-version" "^7.0.23"
+    "@uifabric/utilities" "^7.33.2"
+    tslib "^1.10.0"
+
 "@uifabric/set-version@^7.0.23":
   version "7.0.23"
   resolved "https://registry.yarnpkg.com/@uifabric/set-version/-/set-version-7.0.23.tgz#bfe10b6ba17a2518704cca856bdba8adbc11ffb0"
@@ -4795,6 +4858,17 @@
   version "7.32.4"
   resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.32.4.tgz#6e784c29101742196da69d0b60e63cf193c10c71"
   integrity sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==
+  dependencies:
+    "@fluentui/dom-utilities" "^1.1.1"
+    "@uifabric/merge-styles" "^7.19.1"
+    "@uifabric/set-version" "^7.0.23"
+    prop-types "^15.7.2"
+    tslib "^1.10.0"
+
+"@uifabric/utilities@^7.33.2":
+  version "7.33.2"
+  resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.33.2.tgz#426f9a8d1f9f7738e65abe4a9e36b65583476d81"
+  integrity sha512-v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==
   dependencies:
     "@fluentui/dom-utilities" "^1.1.1"
     "@uifabric/merge-styles" "^7.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,17 +1400,6 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/react-compose@^0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-compose/-/react-compose-0.19.12.tgz#405dfc19b4ae2b5f1c86bf7091ac15a205978206"
-  integrity sha512-GTcZ3kd2rTk3Q7xXJB8cTPfv0Q0vOdeIrLcJ02lXfjE9h3GPTE62rV4iFzBIZyXIKL8IdR6Jh8WNIBkVMWhhxw==
-  dependencies:
-    "@types/classnames" "^2.2.9"
-    "@uifabric/set-version" "^7.0.23"
-    "@uifabric/utilities" "^7.33.2"
-    classnames "^2.2.6"
-    tslib "^1.10.0"
-
 "@fluentui/react-compose@^0.19.6":
   version "0.19.6"
   resolved "https://registry.yarnpkg.com/@fluentui/react-compose/-/react-compose-0.19.6.tgz#a49e118261096116845b2e87db0a85d3e8ffb3cd"
@@ -1420,48 +1409,6 @@
     "@uifabric/set-version" "^7.0.23"
     "@uifabric/utilities" "^7.32.4"
     classnames "^2.2.6"
-    tslib "^1.10.0"
-
-"@fluentui/react-stylesheets@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-stylesheets/-/react-stylesheets-0.2.4.tgz#65cc6136f84ff3fd3d1c9188bed0a34b9573f589"
-  integrity sha512-zTyDxBsQsm5iz59SXn83+BrC3tUnwQdJc/xcPYWWVISIyPby/75URbWK5uYJ5p5Qy0GrpgKDGYAbpXZlN89SRQ==
-  dependencies:
-    "@uifabric/set-version" "^7.0.23"
-    tslib "^1.10.0"
-
-"@fluentui/react-theme-provider@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-theme-provider/-/react-theme-provider-0.18.0.tgz#72fc1809a2b0720bdb66b9ff7d0505e69e036308"
-  integrity sha512-dKSOZ1Sl2uVrDzjvfRtwHUluedU0MhEASukyeqGTpKTmg3ucPMYEZn+dgzFqRNpjs9trbb++N8R6Z19CWokXOw==
-  dependencies:
-    "@fluentui/react-compose" "^0.19.12"
-    "@fluentui/react-stylesheets" "^0.2.4"
-    "@fluentui/react-window-provider" "^1.0.1"
-    "@fluentui/theme" "^1.7.0"
-    "@uifabric/merge-styles" "^7.19.1"
-    "@uifabric/react-hooks" "^7.13.9"
-    "@uifabric/set-version" "^7.0.23"
-    "@uifabric/utilities" "^7.33.2"
-    classnames "^2.2.6"
-    tslib "^1.10.0"
-
-"@fluentui/react-window-provider@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-window-provider/-/react-window-provider-1.0.1.tgz#8ec71db8cfd57e11f00ed42c5c1377ef4dfe5f6b"
-  integrity sha512-5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==
-  dependencies:
-    "@uifabric/set-version" "^7.0.23"
-    tslib "^1.10.0"
-
-"@fluentui/theme@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/theme/-/theme-1.7.0.tgz#822adcc4b0c9cc057984b4ada21c30856907a8e6"
-  integrity sha512-pzqDZC2bVD6/S45Bnve4wmrXi4cN7XiCr+OhzvgmoQfDkm5vyXsa82/cVtif/zy1OFU96S9zOTtt3e+QQuGUUg==
-  dependencies:
-    "@uifabric/merge-styles" "^7.19.1"
-    "@uifabric/set-version" "^7.0.23"
-    "@uifabric/utilities" "^7.33.2"
     tslib "^1.10.0"
 
 "@gulp-sourcemaps/identity-map@1.X":
@@ -4837,16 +4784,6 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@uifabric/react-hooks@^7.13.9":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz#82373cdfbccc81b6fa00586dd8994bb47c97e99b"
-  integrity sha512-VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==
-  dependencies:
-    "@fluentui/react-window-provider" "^1.0.1"
-    "@uifabric/set-version" "^7.0.23"
-    "@uifabric/utilities" "^7.33.2"
-    tslib "^1.10.0"
-
 "@uifabric/set-version@^7.0.23":
   version "7.0.23"
   resolved "https://registry.yarnpkg.com/@uifabric/set-version/-/set-version-7.0.23.tgz#bfe10b6ba17a2518704cca856bdba8adbc11ffb0"
@@ -4858,17 +4795,6 @@
   version "7.32.4"
   resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.32.4.tgz#6e784c29101742196da69d0b60e63cf193c10c71"
   integrity sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==
-  dependencies:
-    "@fluentui/dom-utilities" "^1.1.1"
-    "@uifabric/merge-styles" "^7.19.1"
-    "@uifabric/set-version" "^7.0.23"
-    prop-types "^15.7.2"
-    tslib "^1.10.0"
-
-"@uifabric/utilities@^7.33.2":
-  version "7.33.2"
-  resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.33.2.tgz#426f9a8d1f9f7738e65abe4a9e36b65583476d81"
-  integrity sha512-v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==
   dependencies:
     "@fluentui/dom-utilities" "^1.1.1"
     "@uifabric/merge-styles" "^7.19.1"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue in `FocusZone` where it wasn't picking up the RTL configuration of the theme because it was not consuming that information. To do this it consumes the theme from `ThemeContext` and, if this theme returns empty, defaults it to the one gotten from `getTheme`.

#### Focus areas to test

(optional)
