### PR TITLE
fix: add high contrast forced-color-adjust in styles for menu-item component

### DIFF
--- a/change/@fluentui-web-components-2020-11-19-14-21-59-users-khamu-menu-item-hover-hc.json
+++ b/change/@fluentui-web-components-2020-11-19-14-21-59-users-khamu-menu-item-hover-hc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add forced color adjust to host selector",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T22:21:59.223Z"
+}

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -67,7 +67,7 @@ export const MenuItemStyles = css`
     .end,
     ::slotted(svg) {
         ${
-          /* Glyph size and margin-left is temporary - 
+          /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ''
         } width: 16px;
         height: 16px;
@@ -90,6 +90,7 @@ export const MenuItemStyles = css`
   forcedColorsStylesheetBehavior(
     css`
             :host {
+                forced-color-adjust: none;
                 border-color: transparent;
                 color: ${SystemColors.ButtonText};
                 fill: ${SystemColors.ButtonText};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added `force-color-adjust="none"` to remove the text backplate and borders around the item.

before 
![image](https://user-images.githubusercontent.com/37851220/99729857-612d6200-2a70-11eb-82e3-46c04a729354.png)
![image](https://user-images.githubusercontent.com/37851220/99730073-ba959100-2a70-11eb-91e6-14c338e53065.png)


after
![image](https://user-images.githubusercontent.com/37851220/99730053-b36e8300-2a70-11eb-8ba8-f9730a658946.png)
![image](https://user-images.githubusercontent.com/37851220/99730336-1e1fbe80-2a71-11eb-891b-03d457b8ed1f.png)


#### Focus areas to test

(optional)
