### PR TITLE
Cherry pick tooltip propagation fix

### DIFF
--- a/change/@fluentui-react-internal-2020-11-19-14-45-00-cherry-pick-tooltip-propagation-fix.json
+++ b/change/@fluentui-react-internal-2020-11-19-14-45-00-cherry-pick-tooltip-propagation-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "packageName": "@fluentui/react-internal",
+  "email": "stefhan@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T22:45:00.034Z"
+}

--- a/change/@fluentui-react-internal-2020-11-19-14-45-00-cherry-pick-tooltip-propagation-fix.json
+++ b/change/@fluentui-react-internal-2020-11-19-14-45-00-cherry-pick-tooltip-propagation-fix.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "packageName": "@fluentui/react-internal",
-  "email": "stefhan@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-11-19T22:45:00.034Z"
-}

--- a/change/@fluentui-react-internal-2020-11-19-14-47-24-cherry-pick-tooltip-propagation-fix.json
+++ b/change/@fluentui-react-internal-2020-11-19-14-47-24-cherry-pick-tooltip-propagation-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Only attempt to handle keydown event for tooltip close if the tooltip is currently open",
+  "packageName": "@fluentui/react-internal",
+  "email": "stefhan@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-19T22:47:24.181Z"
+}

--- a/packages/react-internal/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react-internal/src/components/Tooltip/TooltipHost.base.tsx
@@ -223,7 +223,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
   };
 
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    if (ev.which === KeyCodes.escape || ev.ctrlKey) {
+    if ((ev.which === KeyCodes.escape || ev.ctrlKey) && this.state.isTooltipVisible) {
       this._hideTooltip();
       ev.stopPropagation();
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Currently, we are attempting to capture keydown events on the tooltip (particularly the Escape and Ctrl key) even when the tooltip is closed. This means that in the event that the tooltip belongs to an element in a dialog or another component that listens to the same keydown event, the event is swallowed. We should check to see that the tooltip is open before attempting to handle this event (so that we don't stop event propagation).

This is a cherry-pick from a change that was recently merged into v7.0 in this pull request.
https://github.com/microsoft/fluentui/pull/15990

#### Focus areas to test

(optional)
