### PR TITLE
Prevent '.ms-Icon' style overrides from conflicting with the "Move column" target

### DIFF
--- a/change/@fluentui-react-examples-2020-11-25-13-15-47-details-column-marker.json
+++ b/change/@fluentui-react-examples-2020-11-25-13-15-47-details-column-marker.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots",
+  "packageName": "@fluentui/react-examples",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T21:15:46.327Z"
+}

--- a/change/office-ui-fabric-react-2020-11-19-17-49-33-details-column-marker.json
+++ b/change/office-ui-fabric-react-2020-11-19-17-49-33-details-column-marker.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure display style of column drop targets is not overridden",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T01:49:33.243Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -666,14 +666,16 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     const IconComponent = this.props.useFastIcons ? FontIcon : Icon;
     return (
       <div key={'dropHintKey'} className={classNames.dropHintStyle} id={`columnDropHint_${dropHintIndex}`}>
-        <IconComponent
+        <div
+          role="presentation"
           key={`dropHintCircleKey`}
-          aria-hidden={true}
+          className={classNames.dropHintCaretStyle}
           data-is-focusable={false}
           data-sizer-index={dropHintIndex}
-          className={classNames.dropHintCaretStyle}
-          iconName={'CircleShapeSolid'}
-        />
+          aria-hidden={true}
+        >
+          <IconComponent iconName={'CircleShapeSolid'} />
+        </div>
         <div
           key={`dropHintLineKey`}
           aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -537,12 +537,12 @@ describe('DetailsHeader', () => {
     // dead zone : idx 2 and 3 -> no hint shown
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display:');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toBe(null);
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     dropHintElement = component.find('#columnDropHint_3').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display:');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toBe(null);
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     // dragover e
@@ -688,7 +688,7 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toBe(null);
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     // drop on source column itself -> drophintindex should not be set and hence target index not updated

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1115,22 +1115,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                     }
                 id="columnDropHint_1"
               >
-                <i
+                <div
                   aria-hidden={true}
                   className=
-                      ms-Icon
                       ms-DetailsHeader-dropHintCaretStyle
-                      {
-                        display: inline-block;
-                      }
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: "FabricMDL2Icons-15";
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
                       {
                         color: #0078d4;
                         display: none;
@@ -1141,18 +1129,36 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         top: -28px;
                         z-index: 10;
                       }
-                  data-icon-name="CircleShapeSolid"
                   data-is-focusable={false}
                   data-sizer-index={1}
                   role="presentation"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-15\\"",
-                    }
-                  }
                 >
-                  
-                </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons-15";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                    data-icon-name="CircleShapeSolid"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons-15\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
                 <div
                   aria-hidden={true}
                   className=


### PR DESCRIPTION
## Description of changes

Added a wrapper element around the drop target icons for column headers so that styles which mess with the display style for `ms-Icon` do not cause the target hints to all render at once. This way, the visibility of the icon is controlled independently from its style, and should now only appear when the target is active.

#### Focus areas to test

Dragging and dropping column headers in `DetailsList`.
