### PR TITLE
SearchBox: Don't prevent Esc from propagating if the box is empty [v7.0]

### DIFF
--- a/change/office-ui-fabric-react-2020-11-19-18-38-18-12447-searchbox-escape-7.0.json
+++ b/change/office-ui-fabric-react-2020-11-19-18-38-18-12447-searchbox-escape-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: Don't prevent Esc from propagating if the box is empty",
+  "packageName": "office-ui-fabric-react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T02:38:18.606Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -201,6 +201,8 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     switch (ev.which) {
       case KeyCodes.escape:
         this.props.onEscape && this.props.onEscape(ev);
+        // Only call onClear if the search box has a value to clear. Otherwise, allow the Esc key
+        // to propagate from the empty search box to a parent element such as a dialog, etc.
         if (this.state.value && !ev.defaultPrevented) {
           this._onClear(ev);
         }
@@ -216,6 +218,9 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
 
       default:
         this.props.onKeyDown && this.props.onKeyDown(ev);
+        if (ev.defaultPrevented) {
+          ev.stopPropagation();
+        }
         break;
     }
   };

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -201,7 +201,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     switch (ev.which) {
       case KeyCodes.escape:
         this.props.onEscape && this.props.onEscape(ev);
-        if (!ev.defaultPrevented) {
+        if (this.state.value && !ev.defaultPrevented) {
           this._onClear(ev);
         }
         break;
@@ -209,22 +209,15 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
       case KeyCodes.enter:
         if (this.props.onSearch) {
           this.props.onSearch(this.state.value);
-          break;
+          ev.preventDefault();
+          ev.stopPropagation();
         }
-        // if we don't handle the enter press then we shouldn't prevent default
-        return;
+        break;
 
       default:
         this.props.onKeyDown && this.props.onKeyDown(ev);
-        if (!ev.defaultPrevented) {
-          return;
-        }
+        break;
     }
-
-    // We only get here if the keypress has been handled,
-    // or preventDefault was called in case of default keyDown handler
-    ev.preventDefault();
-    ev.stopPropagation();
   };
 
   private _onBlur = (ev: React.FocusEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12447
- [x] Include a change request file using `$ yarn change`

#### Description of changes

SearchBox was always eating the Esc key, even if there was no text to clear from the search box. This prevented any parent components from handling the Esc key. For example, a dialog should dismiss when Esc is pressed on an empty search box in the dialog.

Fix: Don't handle the Esc key or call `onClear` if the search box is empty.