### PR TITLE
Disable grouped build output and fix the build issue

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -18,7 +18,7 @@ jobs:
       - script: npx midgard-yarn install
         displayName: yarn
 
-      - script: yarn build --to test-bundles --no-cache --grouped
+      - script: yarn build --to test-bundles --no-cache
         displayName: yarn build to test-bundles
 
       - script: yarn workspace test-bundles bundle:size

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -24,7 +24,7 @@ steps:
 
   # @fluentui/perf-test needs build and bundle steps
   - script: |
-      yarn lage build --to @fluentui/perf-test --to perf-test --verbose --no-cache --grouped
+      yarn lage build --to @fluentui/perf-test --to perf-test --verbose --no-cache
     displayName: build  @fluentui v0
     env:
       BACKFILL_CACHE_PROVIDER: $(backfillProvider)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
 
       ## only do scoped bundle with PRs
       - script: |
-          yarn bundle --no-cache --grouped --since $(targetBranch)
+          yarn bundle --no-cache --since $(targetBranch)
         displayName: bundle (pr, scoped)
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
@@ -84,7 +84,7 @@ jobs:
 
       ## duplicated for master CI builds
       - script: |
-          yarn bundle --no-cache --grouped
+          yarn bundle --no-cache
         displayName: bundle (master)
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
@@ -169,7 +169,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn lage screener --to vr-tests --debug --verbose --no-cache --grouped
+          yarn lage screener --to vr-tests --debug --verbose --no-cache
         displayName: run VR Test
         env:
           SCREENER_API_KEY: $(screener.key)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:fluentui:docs": "gulp build:docs",
     "build:min": "yarn build --to @fluentui/react --to @fluentui/react-northstar --min",
     "build:prod": "yarn build --production",
-    "buildci": "yarn prelint && lage build test lint --verbose --grouped",
+    "buildci": "yarn prelint && lage build test lint --verbose",
     "buildci:prod": "yarn build:prod && yarn test && yarn lint && yarn bundle:prod",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",

--- a/packages/fluentui/projects-test/assets/cra/App.tsx
+++ b/packages/fluentui/projects-test/assets/cra/App.tsx
@@ -1,4 +1,3 @@
-/** @jsxRuntime classic */
 import {
   Accordion,
   Animation,

--- a/packages/fluentui/projects-test/assets/cra/App.tsx
+++ b/packages/fluentui/projects-test/assets/cra/App.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 import {
   Accordion,
   Animation,

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -33,6 +33,16 @@ async function prepareApp(tmpDirectory: string, appName: string): Promise<string
   return appProjectPath;
 }
 
+async function fixTypescript(testAppPath: string) {
+  // TS 4.1 emits an import of `react/jsx-runtime` which doesn't exist in the types as of writing.
+  // Temporary workaround is to downgrade to 4.0.
+  await sh('yarn add typescript@~4.0.0', testAppPath);
+  // Also revert the change to the "jsx" tsconfig setting
+  const tsconfigPath = path.join(testAppPath, 'tsconfig.json');
+  const tsconfigContent = fs.readFileSync(tsconfigPath, 'utf8');
+  fs.writeFileSync(tsconfigPath, tsconfigContent.replace('react-jsx', 'react'));
+}
+
 /**
  * Tests the following scenario:
  *  - Create a new react test app
@@ -49,7 +59,9 @@ export async function createReactApp() {
   logger('STEP 1. Create test React project with TSX scripts..');
 
   const testAppPath = config.paths.withRootAt(await prepareApp(tmpDirectory, 'test-app'));
+  await fixTypescript(testAppPath());
   logger(`Test React project is successfully created: ${testAppPath()}`);
+
   logger('STEP 2. Add Fluent UI dependency to test project..');
 
   const packedPackages = await packProjectPackages(logger);

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -20,7 +20,7 @@ async function prepareApp(tmpDirectory: string, appName: string): Promise<string
 
   try {
     // restoring bits of create-react-app inside util project
-    await sh('yarn add create-react-app@3', tempUtilProjectPath);
+    await sh('yarn add create-react-app', tempUtilProjectPath);
 
     // create test project with util's create-react-app
     fs.mkdirSync(appProjectPath);

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -20,7 +20,7 @@ async function prepareApp(tmpDirectory: string, appName: string): Promise<string
 
   try {
     // restoring bits of create-react-app inside util project
-    await sh('yarn add create-react-app', tempUtilProjectPath);
+    await sh('yarn add create-react-app@3', tempUtilProjectPath);
 
     // create test project with util's create-react-app
     fs.mkdirSync(appProjectPath);

--- a/packages/fluentui/projects-test/src/index.ts
+++ b/packages/fluentui/projects-test/src/index.ts
@@ -1,4 +1,4 @@
-// import { createReactApp } from './createReactApp';
+import { createReactApp } from './createReactApp';
 import { nextjs } from './nextjs';
 import { rollup } from './rollup';
 import { typings } from './typings';
@@ -10,7 +10,7 @@ async function performTest() {
     await rollup();
     await typings();
 
-    // await createReactApp();
+    await createReactApp();
     await nextjs();
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
Something is causing part of the output for some build tasks (which have especially long output) to be eaten, which makes it hard to debug errors. [2 examples here...](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=154603&view=logs&j=a8a82d6e-f5e1-5356-31e4-5989f531914b&t=7435ac5c-7c8f-5a6b-afd7-ffd5f69a92ea) I suspect this has something to do with `lage`'s `--grouped` flag, so trying out removing it as a workaround.

Update: removing grouped build output revealed the real issue, which was in the `create-react-app` test in `projects-test`. This error seems to be caused by a change in `typescript@4.1.2` which was released today, so update the test script to temporarily downgrade the test project's TS version.