### PR TITLE
Cherry-pick: Fix display issue with Dropdown when using Chrome Translate [v7.0]

### DIFF
--- a/change/office-ui-fabric-react-2020-11-19-19-12-54-7-dropdown-google-translate-fix.json
+++ b/change/office-ui-fabric-react-2020-11-19-19-12-54-7-dropdown-google-translate-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Have Dropdown render the title as a string rather than a string inside a React Fragment, to work around a React bug when using Chrome's translation feature.",
+  "packageName": "office-ui-fabric-react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T03:12:54.397Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -234,14 +234,14 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       panelProps,
       calloutProps,
       multiSelect,
-      onRenderTitle = this._onRenderTitle,
+      onRenderTitle = this._getTitle,
       onRenderContainer = this._onRenderContainer,
       onRenderCaretDown = this._onRenderCaretDown,
       onRenderLabel = this._onRenderLabel,
     } = props;
     const { isOpen, selectedIndices, calloutRenderEdge } = this.state;
     // eslint-disable-next-line deprecation/deprecation
-    const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._onRenderPlaceholder;
+    const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._getPlaceholder;
 
     // If our cached options are out of date update our cache
     if (options !== this._sizePosCache.cachedOptions) {
@@ -434,10 +434,10 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   };
 
   /** Get either props.placeholder (new name) or props.placeHolder (old name) */
-  private get _placeholder(): string | undefined {
+  private _getPlaceholder = (): string | undefined => {
     // eslint-disable-next-line deprecation/deprecation
     return this.props.placeholder || this.props.placeHolder;
-  }
+  };
 
   private _copyArray(array: any[]): any[] {
     const newArray = [];
@@ -506,20 +506,23 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     return index;
   }
 
+  /** Get text in dropdown input as a string */
+  private _getTitle = (items: IDropdownOption[], _unused?: unknown): string => {
+    const { multiSelectDelimiter = ', ' } = this.props;
+    return items.map(i => i.text).join(multiSelectDelimiter);
+  };
+
   /** Render text in dropdown input */
   private _onRenderTitle = (items: IDropdownOption[]): JSX.Element => {
-    const { multiSelectDelimiter = ', ' } = this.props;
-
-    const displayTxt = items.map(i => i.text).join(multiSelectDelimiter);
-    return <>{displayTxt}</>;
+    return <>{this._getTitle(items)}</>;
   };
 
   /** Render placeholder text in dropdown input */
   private _onRenderPlaceholder = (props: IDropdownProps): JSX.Element | null => {
-    if (!this._placeholder) {
+    if (!this._getPlaceholder()) {
       return null;
     }
-    return <>{this._placeholder}</>;
+    return <>{this._getPlaceholder()}</>;
   };
 
   /** Render Callout or Panel container and pass in list */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15930
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-picking PR #15984 into 7.0.

Dropdown currently renders its title text as a string inside of a React.Fragment. That doesn't re-render properly when the selection change, if the user is using Chrome's translate feature; which is likely a bug in React itself.

This change works around the bug by directly displaying the string, rather than wrapping it in a fragment. This causes React to properly re-render the content when it changes.
