### PR TITLE
[FHL fix] Removing exit keytip behaviour using arrow/direction keys

### DIFF
--- a/packages/react-internal/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react-internal/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -393,18 +393,9 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
     // See: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which
     let key = ev.key;
     switch (key) {
-      case 'Tab':
       case 'Enter':
       case 'Spacebar':
       case ' ':
-      case 'ArrowUp':
-      case 'Up':
-      case 'ArrowDown':
-      case 'Down':
-      case 'ArrowLeft':
-      case 'Left':
-      case 'ArrowRight':
-      case 'Right':
         if (this.state.inKeytipMode) {
           this._keyHandled = true;
           this._exitKeytipMode(ev);


### PR DESCRIPTION
This fix specifically relates to keytips behavior on using arrow keys.
Basically, in win 32 apps, keytips persists even after navigating through tab, arrow/direction keys (up, down, left, right). 
However, all office online apps are showing inconsistent behavior i.e. keytips disappear after pressing arrow keys , thus leading to bad accessibility experience.
Thus, we are providing one fix to make this behavior consistent with those present in win 32 apps, thus giving user flawless navigation experience using keytips.
Adding FHL project link for more description: [https://garagehackbox.azurewebsites.net/hackathons/2114/projects/96985](url)

