### PR TITLE
Fixed SearchBox maximum call stack size on keydown

### DIFF
--- a/change/@fluentui-react-internal-2020-11-20-16-37-01-bugfix-searchbox-maximum-call-stack-size-on-keydown.json
+++ b/change/@fluentui-react-internal-2020-11-20-16-37-01-bugfix-searchbox-maximum-call-stack-size-on-keydown.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed SearchBox maximum call stack size on keydown",
+  "packageName": "@fluentui/react-internal",
+  "email": "richardkooiman@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T15:37:01.511Z"
+}

--- a/packages/react-internal/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-internal/src/components/SearchBox/SearchBox.base.tsx
@@ -56,6 +56,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     onBlur: customOnBlur,
     onEscape,
     onSearch,
+    onKeyDown: customOnKeyDown,
     iconProps,
     role,
   } = props;
@@ -126,32 +127,35 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     setValue(ev.target.value);
   };
 
-  const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (ev.which) {
-      case KeyCodes.escape:
-        onEscape?.(ev);
-        if (!ev.defaultPrevented) {
-          onClear(ev);
-        }
-        break;
-      case KeyCodes.enter:
-        if (onSearch) {
-          onSearch(value);
+  const onKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (ev.which) {
+        case KeyCodes.escape:
+          onEscape?.(ev);
+          if (!ev.defaultPrevented) {
+            onClear(ev);
+          }
           break;
-        }
-        // if we don't handle the enter press then we shouldn't prevent default
-        return;
-      default:
-        onKeyDown?.(ev);
-        if (!ev.defaultPrevented) {
+        case KeyCodes.enter:
+          if (onSearch) {
+            onSearch(value);
+            break;
+          }
+          // if we don't handle the enter press then we shouldn't prevent default
           return;
-        }
-    }
-    // We only get here if the keypress has been handled,
-    // or preventDefault was called in case of default keyDown handler
-    ev.preventDefault();
-    ev.stopPropagation();
-  };
+        default:
+          customOnKeyDown?.(ev);
+          if (!ev.defaultPrevented) {
+            return;
+          }
+      }
+      // We only get here if the keypress has been handled,
+      // or preventDefault was called in case of default keyDown handler
+      ev.preventDefault();
+      ev.stopPropagation();
+    },
+    [onEscape, onClear, onSearch, customOnKeyDown],
+  );
 
   useDebugWarning(props);
   useComponentRef(props.componentRef, inputElementRef, hasFocus);

--- a/packages/react-internal/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-internal/src/components/SearchBox/SearchBox.base.tsx
@@ -127,35 +127,32 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     setValue(ev.target.value);
   };
 
-  const onKeyDown = React.useCallback(
-    (ev: React.KeyboardEvent<HTMLInputElement>) => {
-      switch (ev.which) {
-        case KeyCodes.escape:
-          onEscape?.(ev);
-          if (!ev.defaultPrevented) {
-            onClear(ev);
-          }
+  const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (ev.which) {
+      case KeyCodes.escape:
+        onEscape?.(ev);
+        if (!ev.defaultPrevented) {
+          onClear(ev);
+        }
+        break;
+      case KeyCodes.enter:
+        if (onSearch) {
+          onSearch(value);
           break;
-        case KeyCodes.enter:
-          if (onSearch) {
-            onSearch(value);
-            break;
-          }
-          // if we don't handle the enter press then we shouldn't prevent default
+        }
+        // if we don't handle the enter press then we shouldn't prevent default
+        return;
+      default:
+        customOnKeyDown?.(ev);
+        if (!ev.defaultPrevented) {
           return;
-        default:
-          customOnKeyDown?.(ev);
-          if (!ev.defaultPrevented) {
-            return;
-          }
-      }
-      // We only get here if the keypress has been handled,
-      // or preventDefault was called in case of default keyDown handler
-      ev.preventDefault();
-      ev.stopPropagation();
-    },
-    [onEscape, onClear, onSearch, customOnKeyDown],
-  );
+        }
+    }
+    // We only get here if the keypress has been handled,
+    // or preventDefault was called in case of default keyDown handler
+    ev.preventDefault();
+    ev.stopPropagation();
+  };
 
   useDebugWarning(props);
   useComponentRef(props.componentRef, inputElementRef, hasFocus);

--- a/packages/react-internal/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react-internal/src/components/SearchBox/SearchBox.test.tsx
@@ -177,4 +177,38 @@ describe('SearchBox', () => {
         .getAttribute('value'),
     ).toBe('0');
   });
+
+  it('invokes escape and clear callbacks on escape keydown', () => {
+    const onEscape = jest.fn();
+    const onClear = jest.fn();
+    const keyDownEvent = new CustomEvent('keydown');
+    (keyDownEvent as any).which = KeyCodes.escape;
+
+    wrapper = mount(<SearchBox onEscape={onEscape} onClear={onClear} />);
+    wrapper.find('input').simulate('keydown', keyDownEvent);
+
+    expect(onEscape.mock.calls.length).toBe(1);
+    expect(onClear.mock.calls.length).toBe(1);
+  });
+
+  it('invokes search callback on enter keydown', () => {
+    const onSearch = jest.fn();
+    const keyDownEvent = new CustomEvent('keydown');
+    (keyDownEvent as any).which = KeyCodes.enter;
+
+    wrapper = mount(<SearchBox onSearch={onSearch} />);
+    wrapper.find('input').simulate('keydown', keyDownEvent);
+
+    expect(onSearch.mock.calls.length).toBe(1);
+  });
+
+  it('invokes keydown callback event on keydown', () => {
+    const onKeyDown = jest.fn();
+    const keyDownEvent = new CustomEvent('keydown');
+
+    wrapper = mount(<SearchBox onKeyDown={onKeyDown} />);
+    wrapper.find('input').simulate('keydown', keyDownEvent);
+
+    expect(onKeyDown.mock.calls.length).toBe(1);
+  });
 });

--- a/packages/react-internal/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react-internal/src/components/SearchBox/SearchBox.test.tsx
@@ -202,7 +202,7 @@ describe('SearchBox', () => {
     expect(onSearch.mock.calls.length).toBe(1);
   });
 
-  it('invokes keydown callback event on keydown', () => {
+  it('invokes keydown callback on keydown', () => {
     const onKeyDown = jest.fn();
     const keyDownEvent = new CustomEvent('keydown');
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16027
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added custom onKeyDown callback which seems to have gotten overlooked during a recent refactoring.
(https://github.com/microsoft/fluentui/commit/6a007733fedfc986e81993cba67418e1b62db8a0#diff-edf3df7a05914bc2ed8ef8e588c4c835115f7751c82b0fce09ab73a4eeee8419L198-R143)
- Added dependencies to callback hooks.
- Added tests.

#### Focus areas to test
-
