### PR TITLE
Allow passing rootListProps to GroupedList (#15772)

### DIFF
--- a/change/@fluentui-react-2020-11-20-12-52-07-noloyola-groupedlist.json
+++ b/change/@fluentui-react-2020-11-20-12-52-07-noloyola-groupedlist.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "GroupedList: Allow passing of rootListProps to allow passing attributes to parent list (#15772)",
+  "packageName": "@fluentui/react",
+  "email": "noloyola@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T20:52:07.580Z"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1616,6 +1616,7 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
     onRenderCell: (nestingDepth?: number, item?: any, index?: number) => React.ReactNode;
     onShouldVirtualize?: (props: IListProps) => boolean;
     role?: string;
+    rootListProps?: IListProps;
     selection?: ISelection;
     selectionMode?: SelectionMode;
     styles?: IStyleFunctionOrObject<IGroupedListStyleProps, IGroupedListStyles>;

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -141,6 +141,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       styles,
       compact,
       focusZoneProps = {},
+      rootListProps = {},
     } = this.props;
     const { groups, version } = this.state;
 
@@ -176,6 +177,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
             usePageCache={usePageCache}
             onShouldVirtualize={onShouldVirtualize}
             version={version}
+            {...rootListProps}
           />
         )}
       </FocusZone>

--- a/packages/react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedList.types.ts
@@ -87,6 +87,9 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
   /** Optional properties to pass through to the list components being rendered. */
   listProps?: IListProps;
 
+  /** Optional properties to pass through to the root list component being rendered. */
+  rootListProps?: IListProps;
+
   /** Rendering callback to render the group items. */
   onRenderCell: (nestingDepth?: number, item?: any, index?: number) => React.ReactNode;
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #15772
- [X] Include a change request file using `$ yarn change`

#### Description of changes

As discussed in issue #15772, `GroupedList` doesn't receive HTML attributes and other properties (e.g. `aria-labelledby`). The agreed solution was to pass `rootListProps` following the pattern of `focusZoneProps`.

#### Focus areas to test

- Making sure props are passed to parent list
