### PR TITLE
7.0: Add function to the UnifiedPicker so that consumers have access to which items are selected 

### DIFF
--- a/change/@fluentui-react-examples-2020-11-20-11-10-30-getselecteditems7.0.json
+++ b/change/@fluentui-react-examples-2020-11-20-11-10-30-getselecteditems7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Modify UnifiedPicker example to have a context menu with copy",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-20T19:10:30.221Z"
+}

--- a/change/@uifabric-experiments-2020-11-20-11-10-30-getselecteditems7.0.json
+++ b/change/@uifabric-experiments-2020-11-20-11-10-30-getselecteditems7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add function so consumers of UnifiedPicker can access selected items",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-20T19:10:14.452Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -114,6 +114,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         input.current.focus();
       }
     },
+    getSelectedItems: () => {
+      return getSelectedItems() as T[];
+    },
   }));
 
   // All of the drag drop functions are the default behavior. Users can override that by setting the dragDropEvents prop

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -14,6 +14,7 @@ import {
   EditableItem,
   DefaultEditingItem,
   EditingItemInnerFloatingPickerProps,
+  ItemWithContextMenu,
 } from '@uifabric/experiments/lib/SelectedItemsList';
 import { IInputProps } from 'office-ui-fabric-react';
 import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
@@ -79,7 +80,6 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
    * Build a custom selected item capable of being edited when the item is right clicked
    */
   const SelectedItem = EditableItem({
-    itemComponent: TriggerOnContextMenu(SelectedPersona),
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
@@ -90,7 +90,45 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
         />
       ),
     }),
+    itemComponent: ItemWithContextMenu<IPersona>({
+      menuItems: (item, onTrigger) => [
+        {
+          key: 'copy',
+          text: 'copy',
+          onClick: () => {
+            _copyToClipboardWrapper(item);
+          },
+        },
+        {
+          key: 'edit',
+          text: 'Edit',
+          onClick: () => onTrigger && onTrigger(),
+        },
+      ],
+      itemComponent: TriggerOnContextMenu(SelectedPersona),
+    }),
   });
+
+  const _copyToClipboardWrapper = (item: IPersona) => {
+    const selectedItems = ref.current?.getSelectedItems();
+    if (selectedItems && selectedItems.length > 1) {
+      _copyToClipboard(_getItemsCopyText(selectedItems));
+    } else {
+      _copyToClipboard(_getItemsCopyText([item]));
+    }
+  };
+
+  const _copyToClipboard = (copyString: string): void => {
+    navigator.clipboard.writeText(copyString).then(
+      () => {
+        /* clipboard successfully set */
+      },
+      () => {
+        /* clipboard write failed */
+        throw new Error();
+      },
+    );
+  };
 
   const _onSuggestionSelected = (
     ev: React.MouseEvent<HTMLElement, MouseEvent>,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

V8 PR - #16006 

- Added a function in the useImperativeHandle section to return the selected items.
- Added a context menu with copy functionality to one of the examples. The example copies all of the selected items if there is more than just that item selected.
