### PR TITLE
Add re-exports for date-time-utilities in 7.0

### DIFF
--- a/change/@fluentui-react-2020-11-23-17-11-11-date-time-export.json
+++ b/change/@fluentui-react-2020-11-23-17-11-11-date-time-export.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add re-exports for date-time-utilities",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T01:11:11.042Z"
+}

--- a/change/@fluentui-react-examples-2020-11-23-17-11-11-date-time-export.json
+++ b/change/@fluentui-react-examples-2020-11-23-17-11-11-date-time-export.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix typings in DatePicker example",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T01:11:08.007Z"
+}

--- a/change/@uifabric-date-time-2020-11-23-17-11-11-date-time-export.json
+++ b/change/@uifabric-date-time-2020-11-23-17-11-11-date-time-export.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add re-exports for date-time-utilities",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T01:10:45.776Z"
+}

--- a/change/office-ui-fabric-react-2020-11-23-17-11-11-date-time-export.json
+++ b/change/office-ui-fabric-react-2020-11-23-17-11-11-date-time-export.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add re-exports for date-time-utilities",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T01:10:49.832Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -363,6 +363,7 @@ export const WeeklyDayPicker: import("react").FunctionComponent<import("./Weekly
 
 export * from "@fluentui/date-time-utilities/lib/dateMath/dateMath";
 export * from "@fluentui/date-time-utilities/lib/dateValues/dateValues";
+export * from "@fluentui/date-time-utilities/lib/dateValues/timeConstants";
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/date-time/src/DateTimeUtilities.ts
+++ b/packages/date-time/src/DateTimeUtilities.ts
@@ -1,0 +1,5 @@
+// NOTE: This is not a full re-export because date-time-utilities includes some additional stuff
+// which is exported elsewhere, causes conflicts, or isn't needed.
+export * from '@fluentui/date-time-utilities/lib/dateMath/dateMath';
+export * from '@fluentui/date-time-utilities/lib/dateValues/dateValues';
+export * from '@fluentui/date-time-utilities/lib/dateValues/timeConstants';

--- a/packages/date-time/src/index.ts
+++ b/packages/date-time/src/index.ts
@@ -6,5 +6,4 @@ export * from './DatePicker';
 export * from './WeeklyDayPicker';
 
 // export utilities
-export * from './utilities/dateMath/DateMath';
-export * from './utilities/dateValues/DateValues';
+export * from './DateTimeUtilities';

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -10254,6 +10254,9 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
 }
 
 
+export * from "@fluentui/date-time-utilities/lib/dateMath/dateMath";
+export * from "@fluentui/date-time-utilities/lib/dateValues/dateValues";
+export * from "@fluentui/date-time-utilities/lib/dateValues/timeConstants";
 export * from "@fluentui/react-focus";
 export * from "@fluentui/react-window-provider";
 export * from "@uifabric/icons";

--- a/packages/office-ui-fabric-react/src/DateTimeUtilities.ts
+++ b/packages/office-ui-fabric-react/src/DateTimeUtilities.ts
@@ -1,0 +1,5 @@
+// NOTE: This is not a full re-export because date-time-utilities includes some additional stuff
+// which is exported elsewhere, causes conflicts, or isn't needed.
+export * from '@fluentui/date-time-utilities/lib/dateMath/dateMath';
+export * from '@fluentui/date-time-utilities/lib/dateValues/dateValues';
+export * from '@fluentui/date-time-utilities/lib/dateValues/timeConstants';

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -17,6 +17,7 @@ export * from './ComboBox';
 export * from './CommandBar';
 export * from './ContextualMenu';
 export * from './DatePicker';
+export * from './DateTimeUtilities';
 export * from './DetailsList';
 export * from './Dialog';
 export * from './Divider';

--- a/packages/react-examples/src/date-time/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/date-time/DatePicker/DatePicker.Format.Example.tsx
@@ -54,8 +54,8 @@ export class DatePickerFormatExample extends React.Component<{}, IDatePickerForm
     this.setState({ value: null });
   };
 
-  private _onFormatDate = (date: Date): string => {
-    return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
+  private _onFormatDate = (date?: Date): string => {
+    return !date ? '' : date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
   };
 
   private _onParseDateFromString = (value: string): Date => {

--- a/packages/react-examples/src/office-ui-fabric-react/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DatePicker/DatePicker.Format.Example.tsx
@@ -46,8 +46,8 @@ const controlClass = mergeStyleSets({
   },
 });
 
-const onFormatDate = (date: Date): string => {
-  return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
+const onFormatDate = (date?: Date): string => {
+  return !date ? '' : date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
 };
 
 const desc = 'This field is required. One of the support input formats is year dash month dash day.';

--- a/packages/react/src/DateTimeUtilities.ts
+++ b/packages/react/src/DateTimeUtilities.ts
@@ -1,0 +1,1 @@
+export * from 'office-ui-fabric-react/lib/DateTimeUtilities';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16051, fixes #16043
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add re-exports for stuff from date-time-utilities in 7.0, like we already have in master/8. Mainly this involves adding a root `DateTimeUtilities` file in the date-time package and suite packages which re-exports the appropriate things, then including it in the default exports.

Also fix an issue with typings in one of the DatePicker examples--the typings worked fine locally but caused errors when copy-pasted into a project with `strictFunctionTypes` or `strict` enabled.