### PR TITLE
Fixes custom error rendering in TextField

### DIFF
--- a/change/office-ui-fabric-react-2020-11-24-13-02-52-sorgh-issue16049.json
+++ b/change/office-ui-fabric-react-2020-11-24-13-02-52-sorgh-issue16049.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fixes TextField custom error message rendering",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "19e01f57155f984d2e0be14f84f0de7ed9573b5a",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T21:02:52.692Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -429,7 +429,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
           <span data-automation-id="error-message">{errorMessage}</span>
         </p>
       ) : (
-        errorMessage
+        <div data-automation-id="error-message">{errorMessage}</div>
       )
     ) : null;
   }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -235,11 +235,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {onRenderDescription(this.props, this._onRenderDescription)}
             {errorMessage && (
               <div role="alert">
-                <DelayedRender>
-                  <p className={this._classNames.errorMessage}>
-                    <span data-automation-id="error-message">{errorMessage}</span>
-                  </p>
-                </DelayedRender>
+                <DelayedRender>{this._renderErrorMessage()}</DelayedRender>
               </div>
             )}
           </span>
@@ -416,6 +412,26 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   private get _errorMessage(): string | JSX.Element {
     const { errorMessage = this.state.errorMessage } = this.props;
     return errorMessage || '';
+  }
+
+  /**
+   * Renders error message based on the type of the message.
+   *
+   * - If error message is string, it will render using the built in styles.
+   * - If error message is an element, user has full control over how it's rendered.
+   */
+  private _renderErrorMessage(): JSX.Element | null {
+    const errorMessage = this._errorMessage;
+
+    return errorMessage ? (
+      typeof errorMessage === 'string' ? (
+        <p className={this._classNames.errorMessage}>
+          <span data-automation-id="error-message">{errorMessage}</span>
+        </p>
+      ) : (
+        errorMessage
+      )
+    ) : null;
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.ErrorMessage.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.ErrorMessage.Example.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Stack, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Text } from 'office-ui-fabric-react/lib/Text';
 
 export interface ITextFieldErrorMessageExampleState {
   /**
@@ -86,6 +88,11 @@ export class TextFieldErrorMessageExample extends React.Component<{}, ITextField
               placeholder="This field always has an error"
               errorMessage="This is a statically set error message"
             />
+            <TextField
+              label="Custom rich error message"
+              defaultValue="This value is too long"
+              onGetErrorMessage={this._getRichErrorMessage}
+            />
           </>
         )}
       </Stack>
@@ -98,6 +105,21 @@ export class TextFieldErrorMessageExample extends React.Component<{}, ITextField
 
   private _getErrorMessage = (value: string): string => {
     return value.length < 3 ? '' : `Input value length must be less than 3. Actual length is ${value.length}.`;
+  };
+
+  private _getRichErrorMessage = (value: string) => {
+    return (
+      <div>
+        {value.length < 3 ? (
+          ''
+        ) : (
+          <Stack styles={{ root: { height: 24 } }} verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
+            <Icon iconName="Error" styles={{ root: { color: 'red' } }} />
+            <Text variant="smallPlus">Input value length must be less than 3. Actual length is ${value.length}.</Text>
+          </Stack>
+        )}
+      </div>
+    );
   };
 
   private _getErrorMessagePromise = (value: string): Promise<string> => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16049 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

TextField renders all the error messages under a p tag with custom styles, that's fine as long as the error message is string.
When there is a custom error message (i.e., JSX.Element) rendering it under the p tag violates DOM validation (e.g, div can't be child of p). This PR addresses this issue.