### PR TITLE
Remove all dist-storybook folders from being published in npm packages.

### DIFF
--- a/change/@fluentui-azure-themes-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-azure-themes-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/azure-themes",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:10.708Z"
+}

--- a/change/@fluentui-codemods-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-codemods-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/codemods",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:13.551Z"
+}

--- a/change/@fluentui-common-styles-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-common-styles-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/common-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:15.312Z"
+}

--- a/change/@fluentui-date-time-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-date-time-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:16.541Z"
+}

--- a/change/@fluentui-dom-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-dom-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:17.783Z"
+}

--- a/change/@fluentui-example-data-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-example-data-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/example-data",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:19.103Z"
+}

--- a/change/@fluentui-font-icons-mdl2-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-font-icons-mdl2-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:20.219Z"
+}

--- a/change/@fluentui-foundation-legacy-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-foundation-legacy-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:21.519Z"
+}

--- a/change/@fluentui-ie11-polyfills-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-ie11-polyfills-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/ie11-polyfills",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:22.900Z"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-jest-serializer-merge-styles-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:23.984Z"
+}

--- a/change/@fluentui-keyboard-key-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-keyboard-key-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:24.905Z"
+}

--- a/change/@fluentui-merge-styles-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-merge-styles-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/merge-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:25.732Z"
+}

--- a/change/@fluentui-monaco-editor-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-monaco-editor-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:26.557Z"
+}

--- a/change/@fluentui-react-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:03.422Z"
+}

--- a/change/@fluentui-react-avatar-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-avatar-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:27.357Z"
+}

--- a/change/@fluentui-react-button-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-button-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-button",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:28.193Z"
+}

--- a/change/@fluentui-react-cards-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-cards-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-cards",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:29.118Z"
+}

--- a/change/@fluentui-react-charting-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-charting-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-charting",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:30.129Z"
+}

--- a/change/@fluentui-react-checkbox-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-checkbox-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:31.195Z"
+}

--- a/change/@fluentui-react-compose-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-compose-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "ignore dist-storybook.",
+  "packageName": "@fluentui/react-compose",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:31.971Z"
+}

--- a/change/@fluentui-react-date-time-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-date-time-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-date-time",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:35.273Z"
+}

--- a/change/@fluentui-react-docsite-components-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-docsite-components-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:37.914Z"
+}

--- a/change/@fluentui-react-experiments-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-experiments-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:39.084Z"
+}

--- a/change/@fluentui-react-file-type-icons-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-file-type-icons-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:40.202Z"
+}

--- a/change/@fluentui-react-flex-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-flex-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-flex",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:41.163Z"
+}

--- a/change/@fluentui-react-hooks-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-hooks-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-hooks",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:50.543Z"
+}

--- a/change/@fluentui-react-icons-mdl2-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-icons-mdl2-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:51.858Z"
+}

--- a/change/@fluentui-react-image-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-image-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-image",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:53.109Z"
+}

--- a/change/@fluentui-react-internal-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-internal-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-internal",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:54.164Z"
+}

--- a/change/@fluentui-react-link-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-link-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-link",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:55.111Z"
+}

--- a/change/@fluentui-react-monaco-editor-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-monaco-editor-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:55.865Z"
+}

--- a/change/@fluentui-react-next-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-next-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-next",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:56.627Z"
+}

--- a/change/@fluentui-react-shared-contexts-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-shared-contexts-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:57.386Z"
+}

--- a/change/@fluentui-react-slider-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-slider-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-slider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:58.108Z"
+}

--- a/change/@fluentui-react-tabs-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-tabs-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:58.847Z"
+}

--- a/change/@fluentui-react-text-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-text-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-text",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:21:59.598Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-theme-provider-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:00.408Z"
+}

--- a/change/@fluentui-react-toggle-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-toggle-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-toggle",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:01.155Z"
+}

--- a/change/@fluentui-react-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:01.879Z"
+}

--- a/change/@fluentui-react-window-provider-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-react-window-provider-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:02.637Z"
+}

--- a/change/@fluentui-scheme-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-scheme-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:04.171Z"
+}

--- a/change/@fluentui-set-version-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-set-version-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/set-version",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:04.933Z"
+}

--- a/change/@fluentui-style-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-style-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:05.749Z"
+}

--- a/change/@fluentui-test-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-test-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/test-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:06.534Z"
+}

--- a/change/@fluentui-theme-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-theme-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/theme",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:08.076Z"
+}

--- a/change/@fluentui-theme-samples-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-theme-samples-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/theme-samples",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:07.270Z"
+}

--- a/change/@fluentui-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:08.890Z"
+}

--- a/change/@fluentui-webpack-utilities-2020-11-24-16-22-09-fix-npm-size.json
+++ b/change/@fluentui-webpack-utilities-2020-11-24-16-22-09-fix-npm-size.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removing dist-storybook from npm packages.",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T00:22:09.744Z"
+}

--- a/packages/a11y-testing/.npmignore
+++ b/packages/a11y-testing/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/azure-themes/.npmignore
+++ b/packages/azure-themes/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/codemods/.npmignore
+++ b/packages/codemods/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/common-styles/.npmignore
+++ b/packages/common-styles/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/date-time-utilities/.npmignore
+++ b/packages/date-time-utilities/.npmignore
@@ -9,6 +9,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/dom-utilities/.npmignore
+++ b/packages/dom-utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/example-data/.npmignore
+++ b/packages/example-data/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/font-icons-mdl2/.npmignore
+++ b/packages/font-icons-mdl2/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/foundation-legacy/.npmignore
+++ b/packages/foundation-legacy/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/ie11-polyfills/.npmignore
+++ b/packages/ie11-polyfills/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/jest-serializer-merge-styles/.npmignore
+++ b/packages/jest-serializer-merge-styles/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/keyboard-key/.npmignore
+++ b/packages/keyboard-key/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/merge-styles/.npmignore
+++ b/packages/merge-styles/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/monaco-editor/.npmignore
+++ b/packages/monaco-editor/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-avatar/.npmignore
+++ b/packages/react-avatar/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-button/.npmignore
+++ b/packages/react-button/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-cards/.npmignore
+++ b/packages/react-cards/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-charting/.npmignore
+++ b/packages/react-charting/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-checkbox/.npmignore
+++ b/packages/react-checkbox/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-compose/.npmignore
+++ b/packages/react-compose/.npmignore
@@ -13,6 +13,7 @@ coverage
 temp
 images
 results
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-conformance/.npmignore
+++ b/packages/react-conformance/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-date-time/.npmignore
+++ b/packages/react-date-time/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-docsite-components/.npmignore
+++ b/packages/react-docsite-components/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-examples/.npmignore
+++ b/packages/react-examples/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-experiments/.npmignore
+++ b/packages/react-experiments/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-file-type-icons/.npmignore
+++ b/packages/react-file-type-icons/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-flex/.npmignore
+++ b/packages/react-flex/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-hooks/.npmignore
+++ b/packages/react-hooks/.npmignore
@@ -13,6 +13,7 @@ coverage
 temp
 images
 results
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-icons-mdl2/.npmignore
+++ b/packages/react-icons-mdl2/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-image/.npmignore
+++ b/packages/react-image/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-internal/.npmignore
+++ b/packages/react-internal/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-link/.npmignore
+++ b/packages/react-link/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-monaco-editor/.npmignore
+++ b/packages/react-monaco-editor/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-next/.npmignore
+++ b/packages/react-next/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-shared-contexts/.npmignore
+++ b/packages/react-shared-contexts/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-slider/.npmignore
+++ b/packages/react-slider/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-tabs/.npmignore
+++ b/packages/react-tabs/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-text/.npmignore
+++ b/packages/react-text/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-theme-provider/.npmignore
+++ b/packages/react-theme-provider/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-toggle/.npmignore
+++ b/packages/react-toggle/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-utilities/.npmignore
+++ b/packages/react-utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react-window-provider/.npmignore
+++ b/packages/react-window-provider/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/scheme-utilities/.npmignore
+++ b/packages/scheme-utilities/.npmignore
@@ -12,6 +12,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/set-version/.npmignore
+++ b/packages/set-version/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/storybook/.npmignore
+++ b/packages/storybook/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/style-utilities/.npmignore
+++ b/packages/style-utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/test-utilities/.npmignore
+++ b/packages/test-utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/theme-samples/.npmignore
+++ b/packages/theme-samples/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/theme/.npmignore
+++ b/packages/theme/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/utilities/.npmignore
+++ b/packages/utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/webpack-utilities/.npmignore
+++ b/packages/webpack-utilities/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/scripts/create-package/plop-templates/.npmignore
+++ b/scripts/create-package/plop-templates/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+dist-storybook
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json


### PR DESCRIPTION
I was looking at this:

https://packagephobia.com/result?p=%40fluentui%2Freact%408.0.0-beta.20

And was totally surprised that the package ends up being 114 MB for v7, and 104 MB install size for v8 prerelease. I pulled it down:

```bash
md foo
cd foo
npm init
npm install @fluentui/react
```

And sure enough, 114 MB were installed. I took a look at the distribution using windirstat:

![image](https://user-images.githubusercontent.com/1110944/100167785-b0aace00-2e74-11eb-8d19-befdccb71969.png)

Low hanging fruit here is to remove dist-storybook. This alone will remove over 50 MB.

Another optimization would be to remove the unminified bundle files in `@fluentui/react/dist` and only include the UMD minified flavor. This would remove 8 MB.

Every package we have includes `lib-amd` which may be used for some packages and not for others. This could be another optimization but I would strongly hesitate to tweak that. Azure and ODSP sitll use these; i'm just not sure how much.