### PR TITLE
Charting: Legends background color updated in HC mode.

### DIFF
--- a/change/@uifabric-charting-2020-11-25-14-52-55-user-v-jasha-HCmode.json
+++ b/change/@uifabric-charting-2020-11-25-14-52-55-user-v-jasha-HCmode.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "HC mode for legends",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-11-25T09:22:55.615Z"
 }

--- a/change/@uifabric-charting-2020-11-25-14-52-55-user-v-jasha-HCmode.json
+++ b/change/@uifabric-charting-2020-11-25-14-52-55-user-v-jasha-HCmode.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "HC mode for legends",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T09:22:55.615Z"
+}

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -21,7 +21,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev:storybook",
+    "start": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
     "update-snapshots": "just-scripts jest -u"
   },

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -21,7 +21,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev",
+    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "update-snapshots": "just-scripts jest -u"
   },

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -614,7 +614,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, red, red);
+                    content: linear-gradient(to right, red, red);
                     opacity: ;
                   }
             />
@@ -1121,7 +1121,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -1452,7 +1452,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -1783,7 +1783,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -2114,7 +2114,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #E5E5E5, #E5E5E5);
+                          content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
                   />
@@ -331,7 +331,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078D4, #0078D4);
+                          content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
                   />
@@ -604,7 +604,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #E5E5E5, #E5E5E5);
+                          content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
                   />
@@ -693,7 +693,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078D4, #0078D4);
+                          content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
                   />
@@ -1095,7 +1095,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #E5E5E5, #E5E5E5);
+                          content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
                   />
@@ -1184,7 +1184,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078D4, #0078D4);
+                          content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
                   />
@@ -1461,7 +1461,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #E5E5E5, #E5E5E5);
+                          content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
                   />
@@ -1550,7 +1550,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078D4, #0078D4);
+                          content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -352,7 +352,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -441,7 +441,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -530,7 +530,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                          content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
                   />
@@ -896,7 +896,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #0078d4, #0078d4);
+                    content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
             />
@@ -985,7 +985,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #00188f, #00188f);
+                    content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
             />
@@ -1074,7 +1074,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                    content: linear-gradient(to right, #00bcf2, #00bcf2);
                     opacity: ;
                   }
             />
@@ -1685,7 +1685,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1774,7 +1774,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -1863,7 +1863,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                          content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
                   />
@@ -2246,7 +2246,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2335,7 +2335,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2424,7 +2424,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                          content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
                   />
@@ -2807,7 +2807,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2896,7 +2896,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2985,7 +2985,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                          content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
                   />
@@ -3368,7 +3368,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -3457,7 +3457,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -3546,7 +3546,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00bcf2, #00bcf2);
+                          content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
+                          content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }
                   />
@@ -607,7 +607,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, rgb(255, 203, 169), rgb(255, 203, 169));
+                          content: linear-gradient(to right, rgb(255, 203, 169), rgb(255, 203, 169));
                           opacity: ;
                         }
                   />
@@ -696,7 +696,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, rgb(255, 213, 135), rgb(255, 213, 135));
+                          content: linear-gradient(to right, rgb(255, 213, 135), rgb(255, 213, 135));
                           opacity: ;
                         }
                   />
@@ -1182,7 +1182,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
+                          content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }
                   />
@@ -1501,7 +1501,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
+                          content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -42,7 +42,6 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
     rect: {
       selectors: {
         [HighContrastSelector]: {
-          // background property won't support in HC mode
           content: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
           opacity: props.colorOnSelectedState === palette.white ? '0.6' : '',
         },

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -42,7 +42,8 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
     rect: {
       selectors: {
         [HighContrastSelector]: {
-          backgroundImage: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
+          // background property won't support in HC mode
+          content: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
           opacity: props.colorOnSelectedState === palette.white ? '0.6' : '',
         },
       },
@@ -73,7 +74,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
           height: '10.4px',
           width: '10.4px',
           clipPath: 'polygon(50% 100%, 0 0, 100% 0)',
-          backgroundImage: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
+          content: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
         } as IStyle,
       },
     },

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -285,7 +285,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -584,7 +584,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, red, red);
+                    content: linear-gradient(to right, red, red);
                     opacity: ;
                   }
             />
@@ -1061,7 +1061,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -1377,7 +1377,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -1693,7 +1693,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />
@@ -2009,7 +2009,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, red, red);
+                          content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1242,7 +1242,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #e81123, #e81123);
+                          content: linear-gradient(to right, #e81123, #e81123);
                           opacity: ;
                         }
                   />
@@ -1331,7 +1331,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #107c10, #107c10);
+                          content: linear-gradient(to right, #107c10, #107c10);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1088,7 +1088,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #5c005c, #5c005c);
+                          content: linear-gradient(to right, #5c005c, #5c005c);
                           opacity: ;
                         }
                   />
@@ -1177,7 +1177,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #e81123, #e81123);
+                          content: linear-gradient(to right, #e81123, #e81123);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -367,7 +367,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #002050, #002050);
+                          content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
                   />
@@ -456,7 +456,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -748,7 +748,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #0078d4, #0078d4);
+                    content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
             />
@@ -837,7 +837,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #002050, #002050);
+                    content: linear-gradient(to right, #002050, #002050);
                     opacity: ;
                   }
             />
@@ -926,7 +926,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #00188f, #00188f);
+                    content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
             />
@@ -1389,7 +1389,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1478,7 +1478,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #002050, #002050);
+                          content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
                   />
@@ -1567,7 +1567,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -1876,7 +1876,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1965,7 +1965,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #002050, #002050);
+                          content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
                   />
@@ -2054,7 +2054,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2363,7 +2363,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2452,7 +2452,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #002050, #002050);
+                          content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
                   />
@@ -2541,7 +2541,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2850,7 +2850,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2939,7 +2939,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #002050, #002050);
+                          content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
                   />
@@ -3028,7 +3028,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -313,7 +313,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -551,7 +551,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #0078d4, #0078d4);
+                    content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
             />
@@ -640,7 +640,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active){& {
-                    background-image: linear-gradient(to right, #00188f, #00188f);
+                    content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
             />
@@ -995,7 +995,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1084,7 +1084,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -1339,7 +1339,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1428,7 +1428,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -1683,7 +1683,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -1772,7 +1772,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2027,7 +2027,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2116,7 +2116,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />
@@ -2371,7 +2371,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #0078d4, #0078d4);
+                          content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
                   />
@@ -2460,7 +2460,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          background-image: linear-gradient(to right, #00188f, #00188f);
+                          content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
                   />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/16066
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In High contrast mode, not able to differentiate among legends. 
In HC mode, background property won't work, updated to `'content'`

#### Focus areas to test

Legeds

#### Before fix
![image](https://user-images.githubusercontent.com/20105532/100208605-e90ee280-2f2e-11eb-9512-ce54b0f3e066.png)
![image](https://user-images.githubusercontent.com/20105532/100214347-ca601a00-2f35-11eb-8a8d-0e2545717d3b.png)


#### After fix
**_High contrast black_**
![image](https://user-images.githubusercontent.com/20105532/100208283-8f0e1d00-2f2e-11eb-880e-a05e853ac13f.png)

**_High contrast while_**
![image](https://user-images.githubusercontent.com/20105532/100214258-ae5c7880-2f35-11eb-8b9a-4fb40c72f326.png)

