### PR TITLE
Fix ComboBox onBlur when relatedTarget is an ancestor to menu

### DIFF
--- a/change/@fluentui-react-2020-11-26-23-52-32-16077-combobox-onblur-ancestor.json
+++ b/change/@fluentui-react-2020-11-26-23-52-32-16077-combobox-onblur-ancestor.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed ComboBox onBlur was not submitting pending value when relatedTarget is an ancestor to menu",
+  "packageName": "@fluentui/react",
+  "email": "marwankhalili@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-26T22:52:32.342Z"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1136,7 +1136,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         findElementRecursive(this._comboBoxMenu.current, (element: HTMLElement) => element === relatedTarget);
 
       if (isBlurFromComboBoxTitle || isBlurFromComboBoxMenu || isBlurFromComboBoxMenuAncestor) {
-        if (isBlurFromComboBoxMenuAncestor && (!this.props.multiSelect || this.props.allowFreeform)) {
+        if (
+          isBlurFromComboBoxMenuAncestor &&
+          this._hasFocus() &&
+          (!this.props.multiSelect || this.props.allowFreeform)
+        ) {
           this._submitPendingValue(event);
         }
         event.preventDefault();

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1125,21 +1125,24 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       // on the event
       relatedTarget = document.activeElement as Element;
     }
-    if (
-      relatedTarget &&
-      // when event coming from withing the comboBox title
-      ((this.props.hoisted.rootRef.current &&
-        this.props.hoisted.rootRef.current.contains(relatedTarget as HTMLElement)) ||
-        // when event coming from within the comboBox list menu
-        (this._comboBoxMenu.current &&
-          (this._comboBoxMenu.current.contains(relatedTarget as HTMLElement) ||
-            // when event coming from the callout containing the comboBox list menu (ex: when scrollBar of the
-            // Callout is clicked) checks if the relatedTarget is a parent of _comboBoxMenu
-            findElementRecursive(this._comboBoxMenu.current, element => element === relatedTarget))))
-    ) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
+
+    if (relatedTarget) {
+      const isBlurFromComboBoxTitle =
+        this.props.hoisted.rootRef.current && this.props.hoisted.rootRef.current.contains(relatedTarget as HTMLElement);
+      const isBlurFromComboBoxMenu =
+        this._comboBoxMenu.current && this._comboBoxMenu.current.contains(relatedTarget as HTMLElement);
+      const isBlurFromComboBoxMenuAncestor =
+        this._comboBoxMenu.current &&
+        findElementRecursive(this._comboBoxMenu.current, (element: HTMLElement) => element === relatedTarget);
+
+      if (isBlurFromComboBoxTitle || isBlurFromComboBoxMenu || isBlurFromComboBoxMenuAncestor) {
+        if (isBlurFromComboBoxMenuAncestor && (!this.props.multiSelect || this.props.allowFreeform)) {
+          this._submitPendingValue(event);
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
     }
 
     if (this._hasFocus()) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16077
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ComboBox onBlur function will now call `_submitPendingValue` if the event was triggered by an ancestor element to the ComboBox's dropdown menu.

Previously, the onBlur function would return without doing anything in this case. The intended behavior was to ignore onblur events triggered by ancestor elements that were located within the menu (e.g. scrollbar when the menu is too small), however it only checks that the `relatedTarget` element is an ancestor to the menu and not its location (see examples in #16077).

#### Focus areas to test

I've focused on visual regression tests for ComboBox with allowFreeform and triggering onBlur on related elements. Also tested IE11 compatibility.