### PR TITLE
fix(input): prevent text to overlap with icon

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputVariables.ts
@@ -34,7 +34,7 @@ export const inputVariables = (siteVars): InputVariables => ({
   iconLeft: pxToRem(6),
 
   inputPaddingWithIconAtStart: `${pxToRem(5)} ${pxToRem(12)} ${pxToRem(5)} ${pxToRem(24)}`,
-  inputPaddingWithIconAtEnd: `${pxToRem(5)} ${pxToRem(24)} ${pxToRem(5)} ${pxToRem(12)}`,
+  inputPaddingWithIconAtEnd: `${pxToRem(5)} ${pxToRem(39)} ${pxToRem(5)} ${pxToRem(12)}`,
   inputPadding: `${pxToRem(5)} ${pxToRem(12)}`,
   inputInsideLabelPaddingTop: pxToRem(14),
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16053
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Following design spec there's a distance of `15px` from `Icon` to input content:

<img width="142" alt="Screen Shot 2020-11-27 at 14 17 32" src="https://user-images.githubusercontent.com/8545105/100472718-957dcf80-30bb-11eb-9148-a1b334cd790f.png">

Currently on our version content goes to the edge of the icon giving the impression to overlap:

<img width="180" alt="Screen Shot 2020-11-27 at 14 20 33" src="https://user-images.githubusercontent.com/8545105/100473035-38cee480-30bc-11eb-9f9f-ccb95dd679d6.png">
<img width="183" alt="Screen Shot 2020-11-27 at 14 21 28" src="https://user-images.githubusercontent.com/8545105/100473045-3b313e80-30bc-11eb-973e-de37f8873559.png">
<img width="185" alt="Screen Shot 2020-11-27 at 14 22 51" src="https://user-images.githubusercontent.com/8545105/100473049-3cfb0200-30bc-11eb-9951-b3f78fdaecbb.png">


This PR fixes it:

<img width="210" alt="Screen Shot 2020-11-27 at 14 23 10" src="https://user-images.githubusercontent.com/8545105/100473059-45533d00-30bc-11eb-866d-57b5aeff5bc8.png">
<img width="196" alt="Screen Shot 2020-11-27 at 14 23 32" src="https://user-images.githubusercontent.com/8545105/100473063-46846a00-30bc-11eb-9ef1-a249c6f36d73.png">
<img width="211" alt="Screen Shot 2020-11-27 at 14 23 49" src="https://user-images.githubusercontent.com/8545105/100473065-471d0080-30bc-11eb-96af-4e381d75af5a.png">


#### Focus areas to test

(optional)
