### PR TITLE
Remove placehold.it reference in projects-test

### DIFF
--- a/packages/fluentui/projects-test/assets/cra/App.tsx
+++ b/packages/fluentui/projects-test/assets/cra/App.tsx
@@ -26,11 +26,14 @@ class App extends React.Component {
             <CalendarIcon circular bordered />
           </Animation>
           <Attachment header="Document.docx" />
-          <Avatar image="//placehold.it" />
+          <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg" />
           <Button content="Click me" />
           <Divider />
           <Header content="This is " />
-          <Image accessibility={imageBehavior} src="//placehold.it" />
+          <Image
+            accessibility={imageBehavior}
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+          />
           <Input placeholder="Type here" />
           <Popup trigger={<Button content="Popup" />} content="Popup content" />
         </div>


### PR DESCRIPTION
The root URL of placehold.it was failing to load and [causing errors](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=158176&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=a347995d-6693-5610-51bd-74417b4bee80&l=7211) in the CRA projects-test. Replace with references to CDN images. 