### PR TITLE
Dropdown: fix option text truncation for single-select

### DIFF
--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -43,6 +43,7 @@ storiesOf('Dropdown', module)
           { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
           { key: 'F', text: 'Option f', disabled: true },
           { key: 'G', text: 'Option g' },
+          { key: 'Long', text: 'Option long long long long long long long long long' },
         ]}
       />
     ),
@@ -79,6 +80,7 @@ storiesOf('Dropdown', module)
           { key: 'Banana', text: 'banana', disabled: true },
           { key: 'Lemon', text: 'lemon', disabled: true },
           { key: 'Orange', text: 'orange' },
+          { key: 'Long', text: 'Option long long long long long long long long long' },
         ]}
       />
     ),

--- a/change/@fluentui-react-2020-11-30-12-01-49-dropdown-option-trunction.json
+++ b/change/@fluentui-react-2020-11-30-12-01-49-dropdown-option-trunction.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Dropdown: fix option text truncation for single-select.",
+  "packageName": "@fluentui/react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-30T20:01:49.607Z"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -50,7 +50,6 @@ import { Checkbox, ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
 import { getPropsWithDefaults } from '@fluentui/utilities';
 import { useResponsiveMode } from '@fluentui/react-internal/lib/utilities/hooks/useResponsiveMode';
 import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
-import { commandButtonFlexContainerStyle } from './Dropdown.styles';
 
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
@@ -789,7 +788,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         disabled={item.disabled}
         className={itemClassName}
         onClick={this._onItemClick(item)}
-        styles={commandButtonFlexContainerStyle}
         // eslint-disable-next-line react/jsx-no-bind
         onMouseEnter={this._onItemMouseEnter.bind(this, item)}
         // eslint-disable-next-line react/jsx-no-bind

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -50,6 +50,7 @@ import { Checkbox, ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
 import { getPropsWithDefaults } from '@fluentui/utilities';
 import { useResponsiveMode } from '@fluentui/react-internal/lib/utilities/hooks/useResponsiveMode';
 import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
+import { commandButtonFlexContainerStyle } from './Dropdown.styles';
 
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
@@ -788,6 +789,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         disabled={item.disabled}
         className={itemClassName}
         onClick={this._onItemClick(item)}
+        styles={commandButtonFlexContainerStyle}
         // eslint-disable-next-line react/jsx-no-bind
         onMouseEnter={this._onItemMouseEnter.bind(this, item)}
         // eslint-disable-next-line react/jsx-no-bind

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -13,6 +13,7 @@ import {
   ScreenWidthMinMedium,
   getEdgeChromiumNoHighContrastAdjustSelector,
 } from '../../Styling';
+import { IButtonStyles } from '../../compat/index';
 
 const GlobalClassNames = {
   root: 'ms-Dropdown-container',
@@ -422,4 +423,10 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       },
     },
   };
+};
+
+export const commandButtonFlexContainerStyle: IButtonStyles = {
+  flexContainer: {
+    width: '100%',
+  },
 };

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -13,7 +13,6 @@ import {
   ScreenWidthMinMedium,
   getEdgeChromiumNoHighContrastAdjustSelector,
 } from '../../Styling';
-import { IButtonStyles } from '../../compat/index';
 
 const GlobalClassNames = {
   root: 'ms-Dropdown-container',
@@ -116,6 +115,10 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       wordWrap: 'break-word',
       overflowWrap: 'break-word',
       textAlign: 'left',
+
+      '.ms-Button-flexContainer': {
+        width: '100%',
+      },
     },
   ];
 
@@ -423,10 +426,4 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       },
     },
   };
-};
-
-export const commandButtonFlexContainerStyle: IButtonStyles = {
-  flexContainer: {
-    width: '100%',
-  },
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14200
- [x] Include a change request file using `$ yarn change`

#### Description of changes
fix option text not being truncated in single-select dropdown

#### Focus areas to test

(optional)
