### PR TITLE
fix: set high contrast color on label and status-message in switch component

### DIFF
--- a/change/@fluentui-web-components-2020-12-02-10-03-53-users-khamu-switch-label-indicator-hc.json
+++ b/change/@fluentui-web-components-2020-12-02-10-03-53-users-khamu-switch-label-indicator-hc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "set FieldText color on label and status-message",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-02T18:03:53.521Z"
+}

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -206,6 +206,10 @@ export const SwitchStyles = css`
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.GrayText};
             }
+            .status-message,
+            .label {
+              color: ${SystemColors.FieldText};
+          }
         `,
   ),
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Set `FieldText` color on `label` and `status-message` to assure the colors are set correctly when the component is being implemented. 

#### Focus areas to test

(optional)
