### PR TITLE
Toggle: update pill background color on hover to use semanticColors from theme

### DIFF
--- a/change/@fluentui-react-toggle-2020-12-01-13-26-59-fix-toggle-styles.json
+++ b/change/@fluentui-react-toggle-2020-12-01-13-26-59-fix-toggle-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update toggle pill background color on hover to use semanticColors from theme.",
+  "packageName": "@fluentui/react-toggle",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-01T21:26:59.402Z"
+}

--- a/packages/react-toggle/src/components/Toggle/Toggle.styles.ts
+++ b/packages/react-toggle/src/components/Toggle/Toggle.styles.ts
@@ -17,8 +17,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
   // Tokens
   const pillUncheckedBackground = semanticColors.bodyBackground;
   const pillCheckedBackground = semanticColors.inputBackgroundChecked;
-  // TODO: after updating the semanticColors slots mapping this needs to be semanticColors.inputBackgroundCheckedHovered
-  const pillCheckedHoveredBackground = palette.themeDark;
+  const pillCheckedHoveredBackground = semanticColors.inputBackgroundCheckedHovered;
   const thumbUncheckedHoveredBackground = palette.neutralDark;
   const pillCheckedDisabledBackground = semanticColors.disabledBodySubtext;
   const thumbBackground = semanticColors.smallInputBorder;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15286
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Update toggle pill background color on hover to use `semanticColors` instead of `palette` from theme.

PR in 7.0: #16114

#### Focus areas to test

(optional)
