### PR TITLE
SpinButton: remove default min and max

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -143,7 +143,7 @@ packages/react-internal/src/components/ResizeGroup/ @micahgodbolt
 packages/react-internal/src/components/SearchBox/ @ecraig12345
 packages/react-internal/src/components/Separator/ @joschemd @khmakoto
 packages/react-internal/src/components/Shimmer/ @Vitalius1
-packages/react-internal/src/components/SpinButton/ @khmakoto
+packages/react-internal/src/components/SpinButton/ @ecraig12345
 packages/react-internal/src/components/Spinner/ @xugao
 packages/react-internal/src/components/Stack/  @khmakoto
 packages/react-internal/src/components/SwatchColorPicker/ @ecraig12345

--- a/change/@fluentui-react-internal-2020-12-01-14-40-15-spinbutton-max.json
+++ b/change/@fluentui-react-internal-2020-12-01-14-40-15-spinbutton-max.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "SpinButton: remove defaults for min and max",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-01T22:40:15.969Z"
+}

--- a/packages/react-examples/src/react/Keytip/Keytips.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Keytip/Keytips.Basic.Example.tsx
@@ -37,7 +37,7 @@ export const KeytipsBasicExample: React.FunctionComponent = () => {
       <Pivot>
         <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={pivotItemStyle}>
           <Stack tokens={stackTokens}>
-            <SpinButton ref={spinButtonRef} label="Spin Button" styles={spinButtonStyles} />
+            <SpinButton ref={spinButtonRef} label="Spin Button" min={0} max={100} styles={spinButtonStyles} />
             <Toggle ref={toggleRef} onText="Yes" offText="No" />
             <span>
               Go to{' '}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -4594,7 +4594,7 @@ export interface ISpinButton {
 }
 
 // @public (undocumented)
-export interface ISpinButtonProps extends React.HTMLAttributes<HTMLInputElement>, React.RefAttributes<HTMLDivElement> {
+export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaPositionInSet?: number;

--- a/packages/react-internal/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react-internal/src/components/SpinButton/SpinButton.base.tsx
@@ -26,17 +26,20 @@ interface ISpinButtonInternalState {
 const getClassNames = classNamesFunction<ISpinButtonStyleProps, ISpinButtonStyles>();
 
 const COMPONENT_NAME = 'SpinButton';
-const DEFAULT_PROPS = {
+const DEFAULT_PROPS: Required<Pick<
+  ISpinButtonProps,
+  // These are explicitly specified so that the only the things which actually have defaults
+  // get marked as required in ISpinButtonPropsWithDefaults below
+  'disabled' | 'label' | 'step' | 'labelPosition' | 'incrementButtonIcon' | 'decrementButtonIcon'
+>> = {
   disabled: false,
   label: '',
-  min: 0,
-  max: 100,
   step: 1,
   labelPosition: Position.start,
   incrementButtonIcon: { iconName: 'ChevronUpSmall' },
   decrementButtonIcon: { iconName: 'ChevronDownSmall' },
 };
-type ISpinButtonPropsWithDefaults = ISpinButtonProps & Required<Pick<ISpinButtonProps, keyof typeof DEFAULT_PROPS>>;
+type ISpinButtonPropsWithDefaults = ISpinButtonProps & typeof DEFAULT_PROPS;
 
 const INITIAL_STEP_DELAY = 400;
 const STEP_DELAY = 75;
@@ -120,7 +123,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
   const [keyboardSpinDirection, setKeyboardSpinDirection] = React.useState(KeyboardSpinDirection.notSpinning);
   const { setTimeout, clearTimeout } = useSetTimeout();
 
-  const [value, setValue] = useControllableValue(valueFromProps, defaultValue ?? String(min));
+  const [value, setValue] = useControllableValue(valueFromProps, defaultValue ?? String(min || 0));
 
   const { current: internalState } = React.useRef<ISpinButtonInternalState>({
     lastValidValue: value,
@@ -156,14 +159,20 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
     if (onValidate) {
       return onValidate(newValue, ev);
     }
-    if (!newValue || newValue.trim().length === 0 || isNaN(Number(newValue))) {
-      return internalState.lastValidValue;
+    // default validation handling
+    let newNumber = Number(newValue);
+    if (newValue && newValue.trim().length && !isNaN(newNumber)) {
+      if (typeof min === 'number') {
+        newNumber = Math.max(min, newNumber);
+      }
+      if (typeof max === 'number') {
+        newNumber = Math.min(max, newNumber);
+      }
+      return String(newNumber);
     }
-    return String(Math.min(max, Math.max(min, Number(newValue))));
   };
 
   /** Validate function called on blur or enter keypress. */
-
   const validate = (ev: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>): void => {
     if (
       value !== undefined &&
@@ -250,7 +259,10 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
       if (onIncrement) {
         return onIncrement(newValue);
       } else {
-        let numericValue: number = Math.min(Number(newValue) + Number(step), max);
+        let numericValue = Number(newValue) + Number(step);
+        if (typeof max === 'number') {
+          numericValue = Math.min(numericValue, max);
+        }
         numericValue = precisionRound(numericValue, precision);
         return String(numericValue);
       }
@@ -264,7 +276,10 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
       if (onDecrement) {
         return onDecrement(newValue);
       } else {
-        let numericValue: number = Math.max(Number(newValue) - Number(step), min);
+        let numericValue = Number(newValue) - Number(step);
+        if (typeof min === 'number') {
+          numericValue = Math.max(numericValue, min);
+        }
         numericValue = precisionRound(numericValue, precision);
         return String(numericValue);
       }

--- a/packages/react-internal/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react-internal/src/components/SpinButton/SpinButton.base.tsx
@@ -366,18 +366,20 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
   useComponentRef(props, input, value);
   useDebugWarnings(props);
 
+  const labelContent = (iconProps || label) && (
+    <div className={classNames.labelWrapper}>
+      {iconProps && <Icon {...iconProps} className={classNames.icon} aria-hidden="true" />}
+      {label && (
+        <Label id={labelId} htmlFor={inputId} className={classNames.label} disabled={disabled}>
+          {label}
+        </Label>
+      )}
+    </div>
+  );
+
   return (
     <div className={classNames.root} ref={ref}>
-      {labelPosition !== Position.bottom && (iconProps || label) && (
-        <div className={classNames.labelWrapper}>
-          {iconProps && <Icon {...iconProps} className={classNames.icon} aria-hidden="true" />}
-          {label && (
-            <Label id={labelId} htmlFor={inputId} className={classNames.label} disabled={disabled}>
-              {label}
-            </Label>
-          )}
-        </div>
-      )}
+      {labelPosition !== Position.bottom && labelContent}
       <div
         {...nativeProps}
         className={classNames.spinButtonWrapper}
@@ -449,16 +451,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
           />
         </span>
       </div>
-      {labelPosition === Position.bottom && (iconProps || label) && (
-        <div className={classNames.labelWrapper}>
-          {iconProps && <Icon iconName={iconProps.iconName} className={classNames.icon} aria-hidden="true" />}
-          {label && (
-            <Label id={labelId} htmlFor={inputId} className={classNames.label} disabled={disabled}>
-              {label}
-            </Label>
-          )}
-        </div>
-      )}
+      {labelPosition === Position.bottom && labelContent}
     </div>
   );
 });

--- a/packages/react-internal/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-internal/src/components/SpinButton/SpinButton.test.tsx
@@ -76,14 +76,14 @@ describe('SpinButton', () => {
 
   describe('snapshots', () => {
     it('renders correctly', () => {
-      const component = create(<SpinButton label="label" />);
+      const component = create(<SpinButton min={0} max={100} label="label" />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
     it('renders correctly with user-provided values', () => {
       const component = create(
-        <SpinButton label="label" value="0" ariaValueNow={0} ariaValueText="0 pt" data-test="test" />,
+        <SpinButton min={0} max={100} label="label" value="0" ariaValueNow={0} ariaValueText="0 pt" data-test="test" />,
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
@@ -102,21 +102,30 @@ describe('SpinButton', () => {
       expect(inputDOM.getAttribute('aria-labelledby')).toBe(labelDOM.id);
     });
 
-    it('uses default min and max', () => {
+    it('leaves min and max unset by default', () => {
       wrapper = mount(<SpinButton />);
 
       const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-      expect(inputDOM.getAttribute('aria-valuemin')).toBe('0');
-      expect(inputDOM.getAttribute('aria-valuemax')).toBe('100');
+      expect(inputDOM.getAttribute('aria-valuemin')).toBe(null);
+      expect(inputDOM.getAttribute('aria-valuemax')).toBe(null);
     });
 
-    it('respects min and max', () => {
-      wrapper = mount(<SpinButton min={2} max={22} />);
+    it('respects min', () => {
+      wrapper = mount(<SpinButton min={-1} />);
 
       const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-      expect(inputDOM.getAttribute('aria-valuemin')).toBe('2');
+      expect(inputDOM.getAttribute('aria-valuemin')).toBe('-1');
+      expect(inputDOM.getAttribute('aria-valuemax')).toBe(null);
+    });
+
+    it('respects max', () => {
+      wrapper = mount(<SpinButton max={22} />);
+
+      const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+      expect(inputDOM.getAttribute('aria-valuemin')).toBe(null);
       expect(inputDOM.getAttribute('aria-valuemax')).toBe('22');
     });
 
@@ -292,6 +301,12 @@ describe('SpinButton', () => {
 
       simulateArrowKey(KeyCodes.down, '11');
       simulateArrowKey(KeyCodes.up, '12');
+    });
+
+    it('can step below 0 if min is unspecified', () => {
+      wrapper = mount(<SpinButton componentRef={ref} />);
+
+      simulateArrowKey(KeyCodes.down, '-1');
     });
 
     it('supports decimal steps', () => {

--- a/packages/react-internal/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-internal/src/components/SpinButton/SpinButton.types.ts
@@ -58,14 +58,12 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement>, 
   value?: string;
 
   /**
-   * Min value of the control.
-   * @defaultvalue 0
+   * Min value of the control. If not provided, the control has no minimum value.
    */
   min?: number;
 
   /**
-   * Max value of the control.
-   * @defaultvalue 100
+   * Max value of the control. If not provided, the control has no maximum value.
    */
   max?: number;
 

--- a/packages/react-internal/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-internal/src/components/SpinButton/SpinButton.types.ts
@@ -34,7 +34,7 @@ export enum KeyboardSpinDirection {
 /**
  * {@docCategory SpinButton}
  */
-export interface ISpinButtonProps extends React.HTMLAttributes<HTMLInputElement>, React.RefAttributes<HTMLDivElement> {
+export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Gets the component ref.
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11358
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove the defaults of `min=0` and `max=100` from SpinButton, so that it's unbounded by default. This makes it behave more consistently with the built-in `<input type="number"/>` and likely is more consistent with user expectations.

Other minor changes:
- Revert native props extension back to using `div` props (not `input` props). `div` is the correct element type based on where the native props are actually applied, and it's the element type that was used in v7.
- De-duplicate rendering of the label
- Mark myself as codeowner instead of @khmakoto since I've worked on SpinButton so much recently