### PR TITLE
Toggle: update pill background color on hover to use semanticColors from theme (7.0)

### DIFF
--- a/change/office-ui-fabric-react-2020-12-01-18-31-21-fix-toggle-styles-7.json
+++ b/change/office-ui-fabric-react-2020-12-01-18-31-21-fix-toggle-styles-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Toggle: Update toggle pill background color on hover to use semanticColors from theme.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-02T02:31:21.359Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -17,8 +17,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
   // Tokens
   const pillUncheckedBackground = semanticColors.bodyBackground;
   const pillCheckedBackground = semanticColors.inputBackgroundChecked;
-  // TODO: after updating the semanticColors slots mapping this needs to be semanticColors.inputBackgroundCheckedHovered
-  const pillCheckedHoveredBackground = palette.themeDark;
+  const pillCheckedHoveredBackground = semanticColors.inputBackgroundCheckedHovered;
   const thumbUncheckedHoveredBackground = palette.neutralDark;
   const pillCheckedDisabledBackground = semanticColors.disabledBodySubtext;
   const thumbBackground = semanticColors.smallInputBorder;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15286
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Update toggle pill background color on hover to use semanticColors instead of palette from theme.

PR in master: #16108
#### Focus areas to test

(optional)
