### PR TITLE
chore(Carousel): pass active index onActiveIndexChange

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -57,6 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix shorthand `id` prop not being passed to control in `FormField` component @assuncaocharles ([#16003](https://github.com/microsoft/fluentui/pull/16003))
 - Fix outdated `onChange` call in `RadioGroupItem` @assuncaocharles ([#15997](https://github.com/microsoft/fluentui/pull/15997))
 - Fix `Dropdown` to not break new lines for button trigger after listbox was introduced wrapping selected items @assuncaocharles ([#15898](https://github.com/microsoft/fluentui/pull/15898))
+- Fix `Carousel` `onActiveIndexChange` to contain `activeIndex` @assuncaocharles ([#16118](https://github.com/microsoft/fluentui/pull/16118))
 
 ### Features
 - `Tree`: added `useTree` hook @yuanboxue-amber ([#15831](https://github.com/microsoft/fluentui/pull/15831))

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -261,7 +261,7 @@ export const Carousel: ComponentWithAs<'div', CarouselProps> &
 
     actions.setIndexes(nextActiveIndex, lastActiveIndex);
 
-    _.invoke(props, 'onActiveIndexChange', e, props);
+    _.invoke(props, 'onActiveIndexChange', e, { ...props, activeIndex: index });
 
     if (focusItem) {
       focusItemAtIndex(nextActiveIndex);

--- a/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
@@ -79,6 +79,19 @@ describe('Carousel', () => {
       expect(pagination.getDOMNode().textContent).toBe(`2 of ${items.length}`);
     });
 
+    it('should pass activeIndex onActiveIndexChange', () => {
+      const onActiveIndexChange = jest.fn();
+      const wrapper = renderCarousel({ onActiveIndexChange });
+      const paddleNext = getPaddleNextWrapper(wrapper);
+
+      paddleNext.simulate('click');
+
+      expect(onActiveIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'click' }),
+        expect.objectContaining({ activeIndex: 1 }),
+      );
+    });
+
     it('should decrese at paddle previous press', () => {
       const wrapper = renderCarousel({ defaultActiveIndex: 3 });
       const paddlePrevious = getPaddlePreviousWrapper(wrapper);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16117
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Previously `onActiveIndexChange` didn't contained the updated `activeIndex` this PR fixes it. 

#### Focus areas to test

(optional)
