### PR TITLE
chore(Popup): add best practice how to pass aria-labelledby

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -123,6 +123,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added support to silently fail the version dropdown @ling1726 ([#16002](https://github.com/microsoft/fluentui/pull/16002))
 - Adding JAWS bug for radiogroup @kolaps33 ([#16076](https://github.com/microsoft/fluentui/pull/16076))
 - `Alert` - labelling dismiss action, to prevent narrate "unlabeled" button @kolaps33 ([#16092](https://github.com/microsoft/fluentui/pull/16092))
+- Update `Popup` best practices to describe how to pass `aria-labelledby` when `trapFocus` is `true` @assuncaocharles ([#16119](https://github.com/microsoft/fluentui/pull/16119))
 
 <!--------------------------------[ v0.51.2 ]------------------------------- -->
 ## [v0.51.2](https://github.com/microsoft/fluentui/tree/'@fluentui/react-northstar_v'0.51.2) (2020-09-25)

--- a/packages/fluentui/docs/src/examples/components/Popup/BestPractices/PopupBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Popup/BestPractices/PopupBestPractices.tsx
@@ -16,6 +16,7 @@ const doList = [
     To set aria-label, aria-labelledby and aria-describedby attributes on the popup slot you need to set it inside of
     the content prop shorthand. See {link('close button example', '#usage-close-button')} for details.
   </Text>,
+  <Text>When setting `trapFocus` in the `Popup` pass `ariaLabelledBy` to content rather than `"aria-labelledby"`</Text>,
   "If Popup's content is lazy loaded and focus needs to be trapped inside - make sure to use state change to trigger `componentDidUpdate`, so the focus can be set correctly to the first tabbable element inside Popup or manually set focus to the element inside once content is loaded.",
 ];
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16057
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In order to avoid breaking changes in the `FocusTrapZone` we added to `Popup` best practices how to correctly pass `aria-labelledby` when using `trapFocus`

#### Focus areas to test

(optional)
