### PR TITLE
Updated PowerBI and Whiteboard filetype icons. Adding support for .mcworld Minecraft distinct file icons.

### DIFF
--- a/change/@fluentui-react-file-type-icons-2020-12-02-18-04-43-caperez-powerbi_brandupdate_v8.json
+++ b/change/@fluentui-react-file-type-icons-2020-12-02-18-04-43-caperez-powerbi_brandupdate_v8.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Porting filetype icon changes to v8 from PR #15974",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-03T02:04:42.991Z"
+}

--- a/packages/react-file-type-icons/src/FileIconType.ts
+++ b/packages/react-file-type-icons/src/FileIconType.ts
@@ -19,7 +19,6 @@ export enum FileIconType {
   picturesFolder = 11,
   linkedFolder = 12,
   list = 13,
-  whiteboard = 14,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;

--- a/packages/react-file-type-icons/src/FileIconType.ts
+++ b/packages/react-file-type-icons/src/FileIconType.ts
@@ -18,6 +18,8 @@ export enum FileIconType {
   documentsFolder = 10,
   picturesFolder = 11,
   linkedFolder = 12,
+  list = 13,
+  whiteboard = 14,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;

--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -311,6 +311,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
       'layer',
       'layout',
       'max',
+      'mcworld',
       'mtl',
       'obj',
       'off',
@@ -529,6 +530,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   vstx: {
     extensions: ['vst', 'vstm', 'vstx', 'vsx'],
   },
+  whiteboard: {},
   xlsx: {
     extensions: ['xlc', 'xls', 'xlsb', 'xlsm', 'xlsx', 'xlw'],
   },

--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -530,7 +530,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   vstx: {
     extensions: ['vst', 'vstm', 'vstx', 'vsx'],
   },
-  whiteboard: {},
+  whiteboard: {
+    extensions: ['whiteboard'],
+  },
   xlsx: {
     extensions: ['xlc', 'xls', 'xlsb', 'xlsm', 'xlsx', 'xlw'],
   },

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -16,7 +16,6 @@ const DESKTOP_FOLDER = 'desktopfolder';
 const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const LINKED_FOLDER = 'linkedfolder';
-const WHITEBOARD = 'whiteboard';
 
 export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
@@ -97,9 +96,6 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
         break;
       case FileIconType.list:
         iconBaseName = LIST;
-        break;
-      case FileIconType.whiteboard:
-        iconBaseName = WHITEBOARD;
         break;
     }
   }

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -7,7 +7,8 @@ const GENERIC_FILE = 'genericfile';
 const FOLDER = 'folder';
 const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
-const LIST_ITEM = 'splist';
+const LIST_ITEM = 'listitem';
+const LIST = 'splist';
 const MULTIPLE_ITEMS = 'multiple';
 const NEWS = 'sponews';
 const STREAM = 'stream';
@@ -15,8 +16,9 @@ const DESKTOP_FOLDER = 'desktopfolder';
 const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const LINKED_FOLDER = 'linkedfolder';
-const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
+const WHITEBOARD = 'whiteboard';
 
+export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
 export type ImageFileType = 'svg' | 'png';
 
@@ -92,6 +94,12 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
         break;
       case FileIconType.linkedFolder:
         iconBaseName = LINKED_FOLDER;
+        break;
+      case FileIconType.list:
+        iconBaseName = LIST;
+        break;
+      case FileIconType.whiteboard:
+        iconBaseName = WHITEBOARD;
         break;
     }
   }

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201008.001/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201125.001/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Update brand on PowerBI filetype icons. 
- [x] Added support for whiteboard ItemType.
- [x] Adding support for .mcworld Minecraft distinct file icons.
- [x] Porting PR https://github.com/microsoft/fluentui/pull/15974 from the v7 branch into master
- [x] Include a change request file using `$ yarn change`


#### Focus areas to test

https://github.com/microsoft/fluentui/tree/master/packages/file-type-icons
react-experiments > FileTypeIcon
