### PR TITLE
Adding a callback ref to the modal props

### DIFF
--- a/change/@fluentui-react-internal-2020-12-03-18-26-16-catalina-modal-ref.json
+++ b/change/@fluentui-react-internal-2020-12-03-18-26-16-catalina-modal-ref.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add callback ref to modal props to access the modal main shell",
+  "packageName": "@fluentui/react-internal",
+  "email": "catalina@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-04T02:26:16.002Z"
+}

--- a/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
+++ b/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
@@ -35,20 +35,10 @@ export const DialogTopOffsetFixedExample: React.FunctionComponent = () => {
     setOptionSelected(option.key);
   };
 
-  const modalContainerCallback = React.useCallback((modalContainer: HTMLDivElement | null): void => {
-    if (modalContainer) {
-      modalContainer.style.top = '10px';
-    }
-  }, []);
-
   return (
     <>
       <DefaultButton secondaryText="Opens the Sample Dialog" onClick={toggleHideDialog} text="Open Dialog" />
-      <Dialog
-        hidden={hideDialog}
-        onDismiss={toggleHideDialog}
-        modalProps={{ modalContainerRef: modalContainerCallback, ...modalProps }}
-      >
+      <Dialog hidden={hideDialog} onDismiss={toggleHideDialog} modalProps={modalProps}>
         <ChoiceGroup
           label="Pick one icon"
           options={options}

--- a/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
+++ b/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
@@ -35,10 +35,20 @@ export const DialogTopOffsetFixedExample: React.FunctionComponent = () => {
     setOptionSelected(option.key);
   };
 
+  const modalContainerCallback = React.useCallback((modalContainer: HTMLDivElement | null): void => {
+    if (modalContainer) {
+      modalContainer.style.top = '10px';
+    }
+  }, []);
+
   return (
     <>
       <DefaultButton secondaryText="Opens the Sample Dialog" onClick={toggleHideDialog} text="Open Dialog" />
-      <Dialog hidden={hideDialog} onDismiss={toggleHideDialog} modalProps={modelProps}>
+      <Dialog
+        hidden={hideDialog}
+        onDismiss={toggleHideDialog}
+        modalProps={{ modalContainerRef: modalContainerCallback, ...modalProps }}
+      >
         <ChoiceGroup
           label="Pick one icon"
           options={options}

--- a/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
+++ b/packages/react-examples/src/react/Dialog/Dialog.TopOffsetFixed.Example.tsx
@@ -4,7 +4,7 @@ import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/compat/Button'
 import { ChoiceGroup } from '@fluentui/react/lib/ChoiceGroup';
 import { useBoolean } from '@fluentui/react-hooks';
 
-const modelProps = {
+const modalProps = {
   isBlocking: true,
   topOffsetFixed: true,
 };

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -3274,6 +3274,7 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
     className?: string;
     componentRef?: IRefObject<IModal>;
     containerClassName?: string;
+    containerRef?: (container: HTMLDivElement | null) => void;
     dragOptions?: IDragOptions;
     enableAriaHiddenSiblings?: boolean;
     isBlocking?: boolean;
@@ -3281,7 +3282,6 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
     isModeless?: boolean;
     isOpen?: boolean;
     layerProps?: ILayerProps;
-    modalContainerRef?: (container: HTMLDivElement | null) => void;
     onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
     onDismissed?: () => any;
     // @deprecated

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -3281,6 +3281,7 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
     isModeless?: boolean;
     isOpen?: boolean;
     layerProps?: ILayerProps;
+    modalContainerRef?: (container: HTMLDivElement | null) => void;
     onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
     onDismissed?: () => any;
     // @deprecated

--- a/packages/react-internal/src/components/Modal/Modal.base.tsx
+++ b/packages/react-internal/src/components/Modal/Modal.base.tsx
@@ -124,7 +124,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
 
     const rootRef = React.useRef<HTMLDivElement>(null);
     const focusTrapZone = React.useRef<IFocusTrapZone>(null);
-    const focusTrapZoneElm = useMergedRefs(React.useRef<HTMLDivElement>(null), props.modalContainerRef);
+    const focusTrapZoneElm = useMergedRefs(React.useRef<HTMLDivElement>(null), props.containerRef);
     const mergedRef = useMergedRefs(rootRef, ref);
 
     const modalResponsiveMode = useResponsiveMode(mergedRef);

--- a/packages/react-internal/src/components/Modal/Modal.base.tsx
+++ b/packages/react-internal/src/components/Modal/Modal.base.tsx
@@ -124,7 +124,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
 
     const rootRef = React.useRef<HTMLDivElement>(null);
     const focusTrapZone = React.useRef<IFocusTrapZone>(null);
-    const focusTrapZoneElm = React.useRef<HTMLDivElement>(null);
+    const focusTrapZoneElm = useMergedRefs(React.useRef<HTMLDivElement>(null), props.modalContainerRef);
     const mergedRef = useMergedRefs(rootRef, ref);
 
     const modalResponsiveMode = useResponsiveMode(mergedRef);

--- a/packages/react-internal/src/components/Modal/Modal.types.ts
+++ b/packages/react-internal/src/components/Modal/Modal.types.ts
@@ -64,6 +64,12 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
   componentRef?: IRefObject<IModal>;
 
   /**
+   * Optional ref to access the modal container. Use this to access the container div element
+   * properties of the modal.
+   */
+  modalContainerRef?: (container: HTMLDivElement | null) => void;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;

--- a/packages/react-internal/src/components/Modal/Modal.types.ts
+++ b/packages/react-internal/src/components/Modal/Modal.types.ts
@@ -64,10 +64,10 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
   componentRef?: IRefObject<IModal>;
 
   /**
-   * Optional ref to access the modal container. Use this to access the container div element
-   * properties of the modal.
+   * Optional callback ref to access the modal container. Use this to access the properties
+   * of the modal rectangle container.
    */
-  modalContainerRef?: (container: HTMLDivElement | null) => void;
+  containerRef?: (container: HTMLDivElement | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15927 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- This change adds a callback ref to the modal outer shell to be able to **access and modify** its properties (sample use case: vertically centering the modal in a dialog. We need to access the modal height once its rendered).