### PR TITLE
Update ColorPicker RGBA fields to have aria-atomic

### DIFF
--- a/change/@fluentui-react-examples-2020-12-03-20-59-00-7.0_picker_atomic.json
+++ b/change/@fluentui-react-examples-2020-12-03-20-59-00-7.0_picker_atomic.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react-examples",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-04T04:59:00.915Z"
+}

--- a/change/@fluentui-react-examples-2020-12-03-20-59-00-7.0_picker_atomic.json
+++ b/change/@fluentui-react-examples-2020-12-03-20-59-00-7.0_picker_atomic.json
@@ -1,5 +1,6 @@
 {
-  "type": "patch",
+  "type": "none",
+  "comment": "Update ColorPicker RGB fields to use aria-atomic",
   "packageName": "@fluentui/react-examples",
   "email": "jslone@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-12-03-20-42-03-7.0_picker_atomic.json
+++ b/change/office-ui-fabric-react-2020-12-03-20-42-03-7.0_picker_atomic.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update ColorPicker RGB fields to use aria-atomic",
+  "packageName": "office-ui-fabric-react",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-04T04:42:03.248Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -252,6 +252,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                         spellCheck={false}
                         ariaLabel={textLabels[comp]}
                         aria-live={comp !== 'hex' ? 'assertive' : undefined}
+                        aria-atomic={comp !== 'hex' ? 'true' : undefined}
                         autoComplete="off"
                       />
                     </td>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -252,7 +252,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                         spellCheck={false}
                         ariaLabel={textLabels[comp]}
                         aria-live={comp !== 'hex' ? 'assertive' : undefined}
-                        aria-atomic={comp !== 'hex' ? 'true' : undefined}
+                        aria-atomic={comp !== 'hex' ? true : undefined}
                         autoComplete="off"
                       />
                     </td>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -578,6 +578,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -751,6 +752,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -924,6 +926,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -1097,6 +1100,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Alpha"
                     aria-live="assertive"
@@ -1806,6 +1810,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -1979,6 +1984,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -2152,6 +2158,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -2325,6 +2332,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Alpha"
                     aria-live="assertive"
@@ -3011,6 +3019,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -3184,6 +3193,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -3357,6 +3367,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -3530,6 +3541,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
+                    aria-atomic="true"
                     aria-invalid={false}
                     aria-label="Transparency"
                     aria-live="assertive"

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -578,7 +578,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -752,7 +752,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -926,7 +926,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -1100,7 +1100,7 @@ exports[`ColorPicker renders correctly 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Alpha"
                     aria-live="assertive"
@@ -1810,7 +1810,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -1984,7 +1984,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -2158,7 +2158,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -2332,7 +2332,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Alpha"
                     aria-live="assertive"
@@ -3019,7 +3019,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Red"
                     aria-live="assertive"
@@ -3193,7 +3193,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Green"
                     aria-live="assertive"
@@ -3367,7 +3367,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Blue"
                     aria-live="assertive"
@@ -3541,7 +3541,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                       }
                 >
                   <input
-                    aria-atomic="true"
+                    aria-atomic={true}
                     aria-invalid={false}
                     aria-label="Transparency"
                     aria-live="assertive"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -614,7 +614,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
-                      aria-atomic="true"
+                      aria-atomic={true}
                       aria-invalid={false}
                       aria-label="Red"
                       aria-live="assertive"
@@ -788,7 +788,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
-                      aria-atomic="true"
+                      aria-atomic={true}
                       aria-invalid={false}
                       aria-label="Green"
                       aria-live="assertive"
@@ -962,7 +962,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
-                      aria-atomic="true"
+                      aria-atomic={true}
                       aria-invalid={false}
                       aria-label="Blue"
                       aria-live="assertive"
@@ -1136,7 +1136,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
-                      aria-atomic="true"
+                      aria-atomic={true}
                       aria-invalid={false}
                       aria-label="Alpha"
                       aria-live="assertive"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -614,6 +614,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
+                      aria-atomic="true"
                       aria-invalid={false}
                       aria-label="Red"
                       aria-live="assertive"
@@ -787,6 +788,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
+                      aria-atomic="true"
                       aria-invalid={false}
                       aria-label="Green"
                       aria-live="assertive"
@@ -960,6 +962,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
+                      aria-atomic="true"
                       aria-invalid={false}
                       aria-label="Blue"
                       aria-live="assertive"
@@ -1133,6 +1136,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         }
                   >
                     <input
+                      aria-atomic="true"
                       aria-invalid={false}
                       aria-label="Alpha"
                       aria-live="assertive"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When clamping the values of the RGBA fields, screen readers such as NVDA will only read the changed value. So 259 -> 255 reads "5" instead of "255". Adding aria-atomic="true" prevents this from happening and ensure that the whole new value "255" is read. 

#### Focus areas to test
- [x] Narrator 😐
- [x] NVDA 😐
- [x] TalkBack 😐
- [x] VoiceOver 👎 

This method improves the situation and barely fixes the bug with Narrator, but is only a stopgap solution. We need to consider a more involved change to color picker filed issue for that. 
Opened #16194 to track the issue long term

