### PR TITLE
fix(Tree): avoid focus goes to tree element in the dom

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -60,6 +60,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Input` content overlaping with `Icon` @assuncaocharles ([#16083](https://github.com/microsoft/fluentui/pull/16083))
 - Fix `variables` not being propagated in `Carousel` @assuncaocharles ([#16084](https://github.com/microsoft/fluentui/pull/16084))
 - Fix `Carousel` `onActiveIndexChange` to contain `activeIndex` @assuncaocharles ([#16118](https://github.com/microsoft/fluentui/pull/16118))
+- Fix `Tree` behavior adding `shouldFocusInnerElementWhenReceivedFocus` to avoid root element to be focused @assuncaocharles ([#16145](https://github.com/microsoft/fluentui/pull/16145))
 
 ### Features
 - `Tree`: added `useTree` hook @yuanboxue-amber ([#15831](https://github.com/microsoft/fluentui/pull/15831))

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeBehavior.ts
@@ -35,6 +35,7 @@ export const treeBehavior: Accessibility<TreeBehaviorProps> = props => {
     focusZone: {
       props: {
         direction: FocusZoneDirection.vertical,
+        shouldFocusInnerElementWhenReceivedFocus: true,
       },
     },
     childBehaviors: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When clicking in some part of `Tree` root element the focus where going to the element itself, this was happening because we missed a `FocusZone` prop in the behavior. This PR adds `shouldFocusInnerElementWhenReceivedFocus: true` to fix it.

Previously behavior ( bug ):

![xBAURdxKSz](https://user-images.githubusercontent.com/8545105/101193715-c15d0000-363b-11eb-93e7-5932b2709543.gif)

#### Focus areas to test

(optional)
