### PR TITLE
UI Builder top toolbar ux updates

### DIFF
--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import {
-  Button,
-  Checkbox,
-  Image,
-  RadioGroup,
-  RadioGroupItemProps,
-  Toolbar as FUIToolbar,
-} from '@fluentui/react-northstar';
+import { Button, Image, MenuButton, Toolbar as FUIToolbar } from '@fluentui/react-northstar';
 import { DesignerMode } from './types';
-import { OpenOutsideIcon, TrashCanIcon, UndoIcon, RedoIcon } from '@fluentui/react-icons-northstar';
+import { CodeSnippetIcon, OpenOutsideIcon, TrashCanIcon, UndoIcon, RedoIcon } from '@fluentui/react-icons-northstar';
 
 export type ToolbarProps = {
   isExpanding: boolean;
@@ -62,31 +55,32 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
     </div>
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 'auto' }}>
       <div>
-        <strong>Mode:</strong>
-        &emsp;
-        <RadioGroup
-          style={{ display: 'inline-block' }}
-          checkedValue={mode}
-          onCheckedValueChange={(e, data: RadioGroupItemProps & { value: DesignerMode }) => {
-            onModeChange(data.value);
-          }}
-          items={[
+        <MenuButton
+          trigger={<Button text iconOnly content={mode} aria-label="Select mode" />}
+          menu={[
             {
               key: 'build',
-              label: 'Build',
-              value: 'build',
+              content: 'Build',
+              onClick: () => {
+                onModeChange('build');
+              },
             },
             {
               key: 'design',
-              label: 'Design',
-              value: 'design',
+              content: 'Design',
+              onClick: () => {
+                onModeChange('design');
+              },
             },
             {
               key: 'use',
-              label: 'Use',
-              value: 'use',
+              content: 'Use',
+              onClick: () => {
+                onModeChange('use');
+              },
             },
           ]}
+          on="click"
         />
       </div>
       <FUIToolbar
@@ -151,18 +145,29 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
       />
     </div>
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 'auto' }}>
-      <Checkbox label="Show Code" toggle checked={!!showCode} onChange={(e, data) => onShowCodeChange(data.checked)} />
-      &emsp;
-      <Checkbox
-        label="Show JSON"
-        toggle
-        checked={!!showJSONTree}
-        onChange={(e, data) => onShowJSONTreeChange(data.checked)}
+      <MenuButton
+        trigger={<Button iconOnly icon={<CodeSnippetIcon outline />} aria-label="Show code" />}
+        menu={[
+          {
+            key: 'code',
+            content: 'Show code',
+            onClick: () => {
+              onShowCodeChange(!showCode);
+            },
+          },
+          {
+            key: 'json',
+            content: 'Show JSON',
+            onClick: () => {
+              onShowJSONTreeChange(!showJSONTree);
+            },
+          },
+        ]}
       />
-      &emsp;
       <Button
+        style={{ marginLeft: '.8rem' }}
         iconOnly
-        icon={<OpenOutsideIcon />}
+        icon={<OpenOutsideIcon outline />}
         aria-label="Popout"
         onClick={() => {
           window.open(`/builder/maximize${window.location.hash}`, '_blank', 'noopener noreferrer');

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Button, Checkbox, Image, RadioGroup, RadioGroupItemProps } from '@fluentui/react-northstar';
+import {
+  Button,
+  Checkbox,
+  Image,
+  RadioGroup,
+  RadioGroupItemProps,
+  Toolbar as FUIToolbar,
+} from '@fluentui/react-northstar';
 import { DesignerMode } from './types';
 import { OpenOutsideIcon, TrashCanIcon, UndoIcon, RedoIcon } from '@fluentui/react-icons-northstar';
 
@@ -41,57 +48,108 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
       display: 'flex',
       padding: '0 1rem',
       alignItems: 'center',
-      boxShadow: '0 1px 3px rgba(0, 0, 0, 0.25)',
+      borderBottom: '1px solid #E1DFDD', //TODO: replace with `Default Border 2` color scheme token
+      background: '#FAF9F8', //TODO: replace with `Default Background 1` color scheme token
       ...style,
     }}
   >
     <Image
-      styles={{ height: '1.5rem', marginRight: '0.25rem' }}
+      styles={{ height: '1.5rem' }}
       src="https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png"
     />
-    <div style={{ position: 'relative', width: '8em', fontSize: '18px', lineHeight: 1 }}>
-      FluentUI
-      <div style={{ position: 'absolute', fontSize: '11px', opacity: 0.625 }}>Builder</div>
+    <div style={{ position: 'relative', padding: '0 .8rem', fontSize: '14px', lineHeight: 1, fontWeight: 'bold' }}>
+      FluentUI <span style={{ fontWeight: 'normal' }}>Builder</span>
     </div>
-    <div>
-      <strong>Mode:</strong>
-      &emsp;
-      <RadioGroup
-        style={{ display: 'inline-block' }}
-        checkedValue={mode}
-        onCheckedValueChange={(e, data: RadioGroupItemProps & { value: DesignerMode }) => {
-          onModeChange(data.value);
-        }}
+    <div style={{ display: 'flex', alignItems: 'center', marginLeft: 'auto' }}>
+      <div>
+        <strong>Mode:</strong>
+        &emsp;
+        <RadioGroup
+          style={{ display: 'inline-block' }}
+          checkedValue={mode}
+          onCheckedValueChange={(e, data: RadioGroupItemProps & { value: DesignerMode }) => {
+            onModeChange(data.value);
+          }}
+          items={[
+            {
+              key: 'build',
+              label: 'Build',
+              value: 'build',
+            },
+            {
+              key: 'design',
+              label: 'Design',
+              value: 'design',
+            },
+            {
+              key: 'use',
+              label: 'Use',
+              value: 'use',
+            },
+          ]}
+        />
+      </div>
+      <FUIToolbar
+        aria-label="Builder toolbar"
         items={[
           {
-            key: 'build',
-            label: 'Build',
-            value: 'build',
+            key: 'divider-1',
+            kind: 'divider',
           },
           {
-            key: 'design',
-            label: 'Design',
-            value: 'design',
+            icon: (
+              <UndoIcon
+                {...{
+                  outline: true,
+                }}
+              />
+            ),
+            key: 'undo',
+            // kind: 'toggle',
+            disabled: !canUndo,
+            title: 'Undo',
+            onClick: () => {
+              onUndo;
+            },
           },
           {
-            key: 'use',
-            label: 'Use',
-            value: 'use',
+            icon: (
+              <RedoIcon
+                {...{
+                  outline: true,
+                }}
+              />
+            ),
+            key: 'redo',
+            // kind: 'toggle',
+            disabled: !canRedo,
+            title: 'Redo',
+            onClick: () => {
+              onRedo;
+            },
+          },
+          {
+            key: 'divider-2',
+            kind: 'divider',
+          },
+          {
+            icon: (
+              <TrashCanIcon
+                {...{
+                  outline: true,
+                }}
+              />
+            ),
+            key: 'delete',
+            // kind: 'toggle',
+            title: 'Start over',
+            onClick: () => {
+              onReset;
+            },
           },
         ]}
       />
     </div>
-    &nbsp; &nbsp;
-    <Button
-      text
-      icon={<OpenOutsideIcon />}
-      content="Popout"
-      onClick={() => {
-        window.open(`/builder/maximize${window.location.hash}`, '_blank', 'noopener noreferrer');
-      }}
-    />
-    <Button text icon={<UndoIcon />} content="Undo" onClick={onUndo} disabled={!canUndo} />
-    <Button text icon={<RedoIcon />} content="Redo" onClick={onRedo} disabled={!canRedo} />
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 'auto' }}>
       <Checkbox label="Show Code" toggle checked={!!showCode} onChange={(e, data) => onShowCodeChange(data.checked)} />
       &emsp;
@@ -102,7 +160,14 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
         onChange={(e, data) => onShowJSONTreeChange(data.checked)}
       />
       &emsp;
-      <Button text onClick={onReset} icon={<TrashCanIcon />} content="Start Over" />
+      <Button
+        iconOnly
+        icon={<OpenOutsideIcon />}
+        aria-label="Popout"
+        onClick={() => {
+          window.open(`/builder/maximize${window.location.hash}`, '_blank', 'noopener noreferrer');
+        }}
+      />
     </div>
   </div>
 );

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -155,6 +155,7 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
             content: 'Show code',
             onClick: () => {
               onShowCodeChange(!showCode);
+              if (showJSONTree) onShowJSONTreeChange(!showJSONTree);
             },
           },
           {
@@ -162,6 +163,7 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
             content: 'Show JSON',
             onClick: () => {
               onShowJSONTreeChange(!showJSONTree);
+              if (showCode) onShowCodeChange(!showCode);
             },
           },
         ]}

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Image, MenuButton, Toolbar as FUIToolbar } from '@fluentui/react-northstar';
+import { Box, Button, Image, MenuButton, Toolbar as FUIToolbar } from '@fluentui/react-northstar';
 import { DesignerMode } from './types';
 import { CodeSnippetIcon, OpenOutsideIcon, TrashCanIcon, UndoIcon, RedoIcon } from '@fluentui/react-icons-northstar';
 
@@ -36,15 +36,15 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
   showJSONTree,
   style,
 }) => (
-  <div
-    style={{
+  <Box
+    styles={({ theme }) => ({
       display: 'flex',
       padding: '0 1rem',
       alignItems: 'center',
-      borderBottom: '1px solid #E1DFDD', //TODO: replace with `Default Border 2` color scheme token
-      background: '#FAF9F8', //TODO: replace with `Default Background 1` color scheme token
+      borderBottom: `1px solid ${theme.siteVariables.colorScheme.default.border2}`,
+      background: theme.siteVariables.colorScheme.default.background1,
       ...style,
-    }}
+    })}
   >
     <Image
       styles={{ height: '1.5rem' }}
@@ -174,5 +174,5 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
         }}
       />
     </div>
-  </div>
+  </Box>
 );

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -56,7 +56,9 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 'auto' }}>
       <div>
         <MenuButton
-          trigger={<Button text iconOnly content={mode} aria-label="Select mode" />}
+          trigger={
+            <Button text iconOnly content={mode.replace(/^\w/, c => c.toUpperCase())} aria-label="Select mode" />
+          }
           menu={[
             {
               key: 'build',


### PR DESCRIPTION
## Description of changes
### Before
![image](https://user-images.githubusercontent.com/828692/101234914-5bdb3480-3678-11eb-90e2-6b3fab2cce38.png)

### After
![image](https://user-images.githubusercontent.com/828692/101234915-6269ac00-3678-11eb-80bd-ecfdc2f71c91.png)

## Open questions
1. <s>How can I pull in color schemes to use in the toolbar?</s>
2. <s>How to show 'build' and other options as the capitalized version?</s>
3. Do we have support for a selected menu item? I couldn't find it in the docs, but seems like a common scenario.
    > Will keep as-is for now and wait for support to come in MenuButton

## In a future PR
1. Adding tooltips for the icon buttons
2. Move the share link next to the show code and popout icon buttons