### PR TITLE
fix(Tree): cannot expand/collapse when treeTitle has children

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `selectableParent` prop in favor of `selectable` in `TreeItem` and make `selectionIndicator` visible only on focus or hover @assuncaocharles ([#15133](https://github.com/microsoft/fluentui/pull/15133))
 
 ### Fixes
+- Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16157](https://github.com/microsoft/fluentui/pull/16157))
 - Fix `Attachment` to pass `actionable` to accessibility behaviors @layershifter ([#16023](https://github.com/microsoft/fluentui/pull/16023))
 - Fix `Embed` throws when no style `variables` are passed in @yuanboxue-amber ([#16000](https://github.com/microsoft/fluentui/pull/16000))
 - Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -30,7 +30,7 @@ import {
   ShorthandCollection,
   FluentComponentStaticProps,
 } from '../../types';
-import { TreeTitle, TreeTitleProps } from './TreeTitle';
+import { TreeTitle, TreeTitleProps, treeTitleSlotClassNames } from './TreeTitle';
 import { BoxProps } from '../Box/Box';
 import { TreeContext } from './context';
 
@@ -226,13 +226,24 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    if (hasSubtree && e.target === e.currentTarget) {
+    if (selectable) {
+      if (hasSubtree) {
+        // need to know if click happened on selection indicator or title itself
+        if (e?.target?.className?.includes(treeTitleSlotClassNames.indicator)) {
+          toggleItemSelect(e, id);
+        } else {
+          toggleItemActive(e, id);
+        }
+      } else {
+        toggleItemSelect(e, id);
+      }
+    } else if (hasSubtree) {
       toggleItemActive(e, id);
-    } else if (selectable) {
-      toggleItemSelect(e, id);
     }
+
     _.invoke(props, 'onTitleClick', e, props);
   };
+
   const handleFocusFirstChild = e => {
     _.invoke(props, 'onFocusFirstChild', e, props);
     focusItemById(childrenIds?.[0]);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -30,7 +30,7 @@ import {
   ShorthandCollection,
   FluentComponentStaticProps,
 } from '../../types';
-import { TreeTitle, TreeTitleProps, treeTitleSlotClassNames } from './TreeTitle';
+import { TreeTitle, TreeTitleProps } from './TreeTitle';
 import { BoxProps } from '../Box/Box';
 import { TreeContext } from './context';
 
@@ -100,6 +100,9 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 
   /** A selection indicator icon can be customized. */
   selectionIndicator?: ShorthandValue<BoxProps>;
+
+  /** Called when the item is selectable and the checkbox is clicked */
+  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
 }
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>> & {
@@ -226,13 +229,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    // need to know if click happened on selection indicator or title itself
-    const shouldSelect =
-      (selectable && !hasSubtree) || (hasSubtree && e?.target?.className?.includes(treeTitleSlotClassNames.indicator));
-    if (shouldSelect) {
-      toggleItemSelect(e, id);
-    }
-    if (!shouldSelect && hasSubtree) {
+    if (hasSubtree) {
       toggleItemActive(e, id);
     }
 
@@ -259,7 +256,15 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       handleTitleClick(e);
       _.invoke(predefinedProps, 'onClick', e, titleProps);
     },
+    onSelectionIndicatorClick: (e, boxProps) => {
+      e.stopPropagation(); // otherwise onClick on title will also be executed
+      if (selectable) {
+        toggleItemSelect(e, id);
+      }
+      _.invoke(predefinedProps, 'onSelectionIndicatorClick', e, boxProps);
+    },
   });
+
   const handleClick = (e: React.SyntheticEvent) => {
     if (e.target === e.currentTarget) {
       // onClick listener for mouse click on treeItem DOM only,

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -226,19 +226,15 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    if (selectable) {
-      if (hasSubtree) {
-        // need to know if click happened on selection indicator or title itself
-        if (e?.target?.className?.includes(treeTitleSlotClassNames.indicator)) {
-          toggleItemSelect(e, id);
-        } else {
-          toggleItemActive(e, id);
-        }
-      } else {
-        toggleItemSelect(e, id);
-      }
-    } else if (hasSubtree) {
+    // need to know if click happened on selection indicator or title itself
+    const shouldSelect =
+      (selectable && !hasSubtree) || (hasSubtree && e?.target?.className?.includes(treeTitleSlotClassNames.indicator));
+    if (shouldSelect) {
+      toggleItemSelect(e, id);
+    }
+    if (!shouldSelect && hasSubtree) {
       toggleItemActive(e, id);
+    }
     }
 
     _.invoke(props, 'onTitleClick', e, props);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -235,7 +235,6 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     if (!shouldSelect && hasSubtree) {
       toggleItemActive(e, id);
     }
-    }
 
     _.invoke(props, 'onTitleClick', e, props);
   };

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -102,7 +102,7 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   selectionIndicator?: ShorthandValue<BoxProps>;
 
   /** Called when the item is selectable and the checkbox is clicked */
-  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
+  onSelectionIndicatorClick?: (e: React.SyntheticEvent) => void;
 }
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>> & {
@@ -256,12 +256,12 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       handleTitleClick(e);
       _.invoke(predefinedProps, 'onClick', e, titleProps);
     },
-    onSelectionIndicatorClick: (e, boxProps) => {
-      e.stopPropagation(); // otherwise onClick on title will also be executed
+    onSelectionIndicatorClick: e => {
       if (selectable) {
+        e.stopPropagation(); // otherwise onClick on title will also be executed
         toggleItemSelect(e, id);
+        _.invoke(props, 'onSelectionIndicatorClick', e);
       }
-      _.invoke(predefinedProps, 'onSelectionIndicatorClick', e, boxProps);
     },
   });
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -62,6 +62,9 @@ export interface TreeTitleProps extends UIComponentProps, ChildrenComponentProps
   /** A selection indicator icon can be customized. */
   selectionIndicator?: ShorthandValue<BoxProps>;
 
+  /** Called when the item is selectable and the checkbox is clicked */
+  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
+
   /** A selection indicator can appear disabled and be unable to change states. */
   disabled?: SupportedIntrinsicInputProps['disabled'];
 
@@ -175,6 +178,10 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     _.invoke(props, 'onClick', e, props);
   };
 
+  const handleSelectionIndicatorClick = e => {
+    _.invoke(props, 'onSelectionIndicatorClick', e, props);
+  };
+
   const selectIndicator = Box.create(selectionIndicator, {
     defaultProps: () => ({
       as: 'span',
@@ -184,6 +191,9 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         styles: resolvedStyles.selectionIndicator,
       }),
     }),
+    overrideProps: {
+      onClick: handleSelectionIndicatorClick,
+    },
   });
 
   const element = (

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -228,6 +228,7 @@ TreeTitle.propTypes = {
   selectable: PropTypes.bool,
   treeSize: PropTypes.number,
   selectionIndicator: customPropTypes.shorthandAllowingChildren,
+  onSelectionIndicatorClick: PropTypes.func,
   indeterminate: PropTypes.bool,
   parent: PropTypes.string,
 };

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -178,9 +178,12 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     _.invoke(props, 'onClick', e, props);
   };
 
-  const handleSelectionIndicatorClick = e => {
-    _.invoke(props, 'onSelectionIndicatorClick', e, props);
-  };
+  const selectionIndicatorOverrideProps = (predefinedProps: BoxProps) => ({
+    onClick: (e: React.SyntheticEvent) => {
+      _.invoke(props, 'onSelectionIndicatorClick', e);
+      _.invoke(predefinedProps, 'onClick', e);
+    },
+  });
 
   const selectIndicator = Box.create(selectionIndicator, {
     defaultProps: () => ({
@@ -191,9 +194,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         styles: resolvedStyles.selectionIndicator,
       }),
     }),
-    overrideProps: {
-      onClick: handleSelectionIndicatorClick,
-    },
+    overrideProps: selectionIndicatorOverrideProps,
   });
 
   const element = (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When treeTitle has children, expand/collapse doesn't work

#### Focus areas to test

(optional)
