### PR TITLE
chore(docs): Improve typings in component info

### DIFF
--- a/scripts/gulp/plugins/util/getComponentInfo.ts
+++ b/scripts/gulp/plugins/util/getComponentInfo.ts
@@ -144,6 +144,7 @@ export default function getComponentInfo(options: GetComponentInfoOptions): Comp
         defaultValue: defaultProps[propName],
         tags,
         types,
+        resolvedType: (propDef as any).resolvedType,
         name: propName,
         required: propDef.required,
       });

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -19,7 +19,7 @@ import gulpDoctoc from '../plugins/gulp-doctoc';
 import gulpExampleMenu from '../plugins/gulp-example-menu';
 import gulpExampleSource from '../plugins/gulp-example-source';
 import gulpReactDocgen from '../plugins/gulp-react-docgen';
-import { getRelativePathToSourceFile } from '../plugins/util';
+import { getComponentInfo, getRelativePathToSourceFile } from '../plugins/util';
 import webpackPlugin from '../plugins/gulp-webpack';
 import { Server } from 'http';
 import { findGitRoot, getAllPackageInfo } from '../../monorepo';
@@ -205,6 +205,18 @@ task('serve:docs:hot', async () => {
 });
 
 task('serve:docs:stop', () => forceClose(server));
+
+task('component-info:debug', done => {
+  const componentInfo = getComponentInfo({
+    tsconfigPath: paths.docs('tsconfig.json'),
+    filePath: paths.packageSrc('react-northstar', 'components/Box/Box.tsx'),
+    ignoredParentInterfaces: [], // can be omitted?
+  });
+
+  // console.log(JSON.stringify(componentInfo, null, 2));
+  fs.writeFileSync('box.mxinfo.json', JSON.stringify(componentInfo, null, 2));
+  done();
+});
 
 // ----------------------------------------
 // Watch


### PR DESCRIPTION
Traverse Typescript AST to improve typings in component info

To test run `yarn grunt component-info:debug` and check `resolvedType` in the generated `.info.json` file.