### PR TITLE
FileTypeIcon : Changing .whiteboard to be by-extension instead of special enum based.

### DIFF
--- a/change/@fluentui-react-examples-2020-12-08-11-09-14-caperez-filetype_whiteboard_byext.json
+++ b/change/@fluentui-react-examples-2020-12-08-11-09-14-caperez-filetype_whiteboard_byext.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tweaking test file for FileTypeIcon example",
+  "packageName": "@fluentui/react-examples",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-08T19:09:14.344Z"
+}

--- a/change/@uifabric-file-type-icons-2020-12-07-12-13-44-caperez-filetype_whiteboard_byext.json
+++ b/change/@uifabric-file-type-icons-2020-12-07-12-13-44-caperez-filetype_whiteboard_byext.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "changing .whiteboard to be by-extension instead of special enum based.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-07T20:13:44.573Z"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -19,7 +19,6 @@ export enum FileIconType {
   picturesFolder = 11,
   linkedFolder = 12,
   list = 13,
-  whiteboard = 14,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -530,7 +530,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   vstx: {
     extensions: ['vst', 'vstm', 'vstx', 'vsx'],
   },
-  whiteboard: {},
+  whiteboard: {
+    extensions: ['whiteboard'],
+  },
   xlsx: {
     extensions: ['xlc', 'xls', 'xlsb', 'xlsm', 'xlsx', 'xlw'],
   },

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -16,7 +16,6 @@ const DESKTOP_FOLDER = 'desktopfolder';
 const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const LINKED_FOLDER = 'linkedfolder';
-const WHITEBOARD = 'whiteboard';
 
 export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
@@ -130,9 +129,6 @@ export function getFileTypeIconNameFromExtensionOrType(
         break;
       case FileIconType.list:
         iconBaseName = LIST;
-        break;
-      case FileIconType.whiteboard:
-        iconBaseName = WHITEBOARD;
         break;
     }
   }

--- a/packages/react-examples/src/experiments/FileTypeIcon/FileTypeIcon.Basic.Example.tsx
+++ b/packages/react-examples/src/experiments/FileTypeIcon/FileTypeIcon.Basic.Example.tsx
@@ -19,7 +19,7 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <h3>Size 48 csv icon as .png</h3>
         <Icon {...getFileTypeIconProps({ extension: 'csv', size: 48, imageFileType: 'png' })} />
         <h3>Size 64 model icon as .png</h3>
-        <Icon {...getFileTypeIconProps({ extension: 'blend', size: 64, imageFileType: 'png' })} />
+        <Icon {...getFileTypeIconProps({ extension: 'whiteboard', size: 64, imageFileType: 'png' })} />
         <h3>Size 96 docx icon as .png</h3>
         <Icon {...getFileTypeIconProps({ extension: 'docx', size: 96, imageFileType: 'png' })} />
         <h3>Size 16 dotx icon as .svg</h3>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Enable special icon for .whiteboard files
- [x] Adding example line in FileTypeIcon.Example in Storyboard
- [x] Include a change request file using `$ yarn change`


#### Focus areas to test

Do `yarn-start` then `react-experiments` then http://...?path=/story/filetypeicon--file-type-icon-basic-example
