### PR TITLE
Update the DefaultEditingItem in the SelectedItemsList to use FloatingSuggestionsComposite

### DIFF
--- a/change/@fluentui-react-experiments-2020-12-07-16-16-33-editfloatingpicker.json
+++ b/change/@fluentui-react-experiments-2020-12-07-16-16-33-editfloatingpicker.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update the DefaultEditingItem in the SelectedItemsList to use FloatingSuggestionsComposite",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-08T00:16:33.783Z"
+}

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton } from '@fluentui/react/lib/compat/Button';
 import { IPersonaProps, IPersona } from '@fluentui/react/lib/Persona';
-import { people, mru } from '@fluentui/example-data';
+import { people } from '@fluentui/example-data';
 import {
   SelectedPeopleList,
   SelectedPersona,
@@ -13,53 +13,24 @@ import {
 import {
   FloatingPeopleSuggestions,
   IFloatingSuggestionItem,
+  IFloatingSuggestionItemProps,
 } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
-
-const _suggestions = [
-  {
-    key: '1',
-    id: '1',
-    displayText: 'Suggestion 1',
-    item: mru[0],
-    isSelected: true,
-    showRemoveButton: true,
-  },
-  {
-    key: '2',
-    id: '2',
-    displayText: 'Suggestion 2',
-    item: mru[1],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '3',
-    id: '3',
-    displayText: 'Suggestion 3',
-    item: mru[2],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '4',
-    id: '4',
-    displayText: 'Suggestion 4',
-    item: mru[3],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '5',
-    id: '5',
-    displayText: 'Suggestion 5',
-    item: mru[4],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-] as IFloatingSuggestionItem<IPersonaProps>[];
 
 export const SelectedPeopleListWithEditExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
+
+  const _startsWith = (text: string, filterText: string): boolean => {
+    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
+  };
+
+  const _getSuggestions = (value: string): IFloatingSuggestionItemProps<IPersonaProps>[] => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
 
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
@@ -68,8 +39,9 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
     itemComponent: TriggerOnContextMenu(SelectedPersona),
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
+      getSuggestions: _getSuggestions,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} suggestions={_suggestions} />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
   });

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton } from '@fluentui/react/lib/compat/Button';
 import { IPersonaProps, IPersona } from '@fluentui/react/lib/Persona';
-import { people } from '@fluentui/example-data';
+import { people, mru } from '@fluentui/example-data';
 import {
   SelectedPeopleList,
   SelectedPersona,
@@ -10,15 +10,56 @@ import {
   DefaultEditingItem,
   EditingItemInnerFloatingPickerProps,
 } from '@fluentui/react-experiments/lib/SelectedItemsList';
-import { FloatingPeopleSuggestions } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestions';
-import { SuggestionsStore } from '@fluentui/react-experiments/lib/FloatingSuggestions';
+import {
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+} from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
+
+const _suggestions = [
+  {
+    key: '1',
+    id: '1',
+    displayText: 'Suggestion 1',
+    item: mru[0],
+    isSelected: true,
+    showRemoveButton: true,
+  },
+  {
+    key: '2',
+    id: '2',
+    displayText: 'Suggestion 2',
+    item: mru[1],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '3',
+    id: '3',
+    displayText: 'Suggestion 3',
+    item: mru[2],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '4',
+    id: '4',
+    displayText: 'Suggestion 4',
+    item: mru[3],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '5',
+    id: '5',
+    displayText: 'Suggestion 5',
+    item: mru[4],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+] as IFloatingSuggestionItem<IPersonaProps>[];
 
 export const SelectedPeopleListWithEditExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
-
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
 
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
@@ -28,11 +69,7 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} suggestions={_suggestions} />
       ),
     }),
   });
@@ -87,60 +124,3 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
     </>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton } from '@fluentui/react/lib/compat/Button';
 import { IPersonaProps, IPersona } from '@fluentui/react/lib/Persona';
-import { people } from '@fluentui/example-data';
+import { people, mru } from '@fluentui/example-data';
 import {
   SelectedPeopleList,
   SelectedPersona,
@@ -11,15 +11,56 @@ import {
   DefaultEditingItem,
   EditingItemInnerFloatingPickerProps,
 } from '@fluentui/react-experiments/lib/SelectedItemsList';
-import { FloatingPeopleSuggestions } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestions';
-import { SuggestionsStore } from '@fluentui/react-experiments/lib/FloatingSuggestions';
+import {
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+} from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
+
+const _suggestions = [
+  {
+    key: '1',
+    id: '1',
+    displayText: 'Suggestion 1',
+    item: mru[0],
+    isSelected: true,
+    showRemoveButton: true,
+  },
+  {
+    key: '2',
+    id: '2',
+    displayText: 'Suggestion 2',
+    item: mru[1],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '3',
+    id: '3',
+    displayText: 'Suggestion 3',
+    item: mru[2],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '4',
+    id: '4',
+    displayText: 'Suggestion 4',
+    item: mru[3],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '5',
+    id: '5',
+    displayText: 'Suggestion 5',
+    item: mru[4],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+] as IFloatingSuggestionItem<IPersonaProps>[];
 
 export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
-
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
 
   /**
    * Build a custom selected item capable of being edited with a dropdown and capable of editing
@@ -28,11 +69,7 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: (persona: IPersonaProps) => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} suggestions={_suggestions} />
       ),
     }),
     itemComponent: ItemWithContextMenu<IPersona>({
@@ -134,60 +171,3 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
     </div>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton } from '@fluentui/react/lib/compat/Button';
 import { IPersonaProps, IPersona } from '@fluentui/react/lib/Persona';
-import { people, mru } from '@fluentui/example-data';
+import { people } from '@fluentui/example-data';
 import {
   SelectedPeopleList,
   SelectedPersona,
@@ -16,51 +16,21 @@ import {
   IFloatingSuggestionItem,
 } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
 
-const _suggestions = [
-  {
-    key: '1',
-    id: '1',
-    displayText: 'Suggestion 1',
-    item: mru[0],
-    isSelected: true,
-    showRemoveButton: true,
-  },
-  {
-    key: '2',
-    id: '2',
-    displayText: 'Suggestion 2',
-    item: mru[1],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '3',
-    id: '3',
-    displayText: 'Suggestion 3',
-    item: mru[2],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '4',
-    id: '4',
-    displayText: 'Suggestion 4',
-    item: mru[3],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-  {
-    key: '5',
-    id: '5',
-    displayText: 'Suggestion 5',
-    item: mru[4],
-    isSelected: false,
-    showRemoveButton: true,
-  },
-] as IFloatingSuggestionItem<IPersonaProps>[];
-
 export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
+
+  const _startsWith = (text: string, filterText: string): boolean => {
+    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
+  };
+
+  const _getSuggestions = (value: string) => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
 
   /**
    * Build a custom selected item capable of being edited with a dropdown and capable of editing
@@ -69,8 +39,9 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: (persona: IPersonaProps) => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} suggestions={_suggestions} />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
+      getSuggestions: _getSuggestions,
     }),
     itemComponent: ItemWithContextMenu<IPersona>({
       menuItems: (item, onTrigger) => [

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -262,6 +262,10 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     }
   };
 
+  const _createGenericItem = (input: string): IPersona => {
+    return { text: input };
+  };
+
   const _onInputChange = (filterText: string): void => {
     // Clear the input if the user types a semicolon or comma
     // This is meant to be an example of using the forward ref,
@@ -305,6 +309,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     getItemCopyText: _getItemsCopyText,
     onRenderItem: SelectedItem,
     replaceItem: _replaceItem,
+    createGenericItem: _createGenericItem,
   } as ISelectedPeopleListProps<IPersonaProps>;
 
   const inputProps = {

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -17,8 +17,7 @@ import {
   ItemWithContextMenu,
 } from '@fluentui/react-experiments/lib/SelectedItemsList';
 import { IInputProps } from '@fluentui/react';
-import { SuggestionsStore } from '@fluentui/react-experiments/lib/FloatingSuggestions';
-import { FloatingPeopleSuggestions } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestions';
+import { FloatingPeopleSuggestions } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
 
 const _suggestions = [
   {
@@ -72,9 +71,14 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
 
   const ref = React.useRef<any>();
 
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
+  const _getSuggestions = (value: string): IFloatingSuggestionItemProps<IPersonaProps>[] => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
 
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
@@ -82,12 +86,9 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
   const SelectedItem = EditableItem({
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
+      getSuggestions: _getSuggestions,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
     itemComponent: ItemWithContextMenu<IPersona>({
@@ -280,60 +281,3 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     </>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useConst } from '@fluentui/react-hooks';
 import {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,
@@ -71,6 +72,50 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
 
   const ref = React.useRef<any>();
 
+  const suggestionProps = useConst(() => {
+    return {
+      // uncomment below section to see any example of a selectable header item
+      headerItemsProps: [
+        {
+          renderItem: () => {
+            return <>People Suggestions</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          /*onExecute: () => {
+            alert('People suggestions selected');
+          },*/
+        },
+      ],
+      footerItemsProps: [
+        {
+          renderItem: () => {
+            return <>Showing {peopleSuggestions.length} results</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          // uncomment to see an example of multiple selectable footer items
+          /*onExecute: () => {
+            alert('Showing people suggestions executed');
+          },*/
+        },
+        {
+          renderItem: () => {
+            return <>Select to log out to console</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            console.log(peopleSuggestions);
+          },
+        },
+      ],
+    };
+  });
+
   const _getSuggestions = (value: string): IFloatingSuggestionItemProps<IPersonaProps>[] => {
     const allPeople = people;
     const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
@@ -88,7 +133,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
       getEditingItemText: persona => persona.text || '',
       getSuggestions: _getSuggestions,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} pickerSuggestionsProps={suggestionProps} />
       ),
     }),
     itemComponent: ItemWithContextMenu<IPersona>({

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -132,8 +132,9 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
       getSuggestions: _getSuggestions,
+      pickerSuggestionsProps: suggestionProps,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} pickerSuggestionsProps={suggestionProps} />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
     itemComponent: ItemWithContextMenu<IPersona>({

--- a/packages/react-experiments/src/UnifiedPicker.ts
+++ b/packages/react-experiments/src/UnifiedPicker.ts
@@ -1,2 +1,1 @@
-export * from './components/UnifiedPicker/UnifiedPicker';
-export * from './components/UnifiedPicker/UnifiedPicker.types';
+export * from './components/UnifiedPicker/index';

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
@@ -7,6 +7,7 @@ export type EditingItemComponentProps<T> = {
   item: T;
   onEditingComplete: (oldItem: T, newItem: T) => void;
   onDismiss?: () => void;
+  createGenericItem?: (input: string) => T;
 };
 
 /**
@@ -39,6 +40,7 @@ export const EditableItem = <T extends any>(editableItemProps: EditableItemProps
         item={selectedItemProps.item}
         onEditingComplete={onItemEdited}
         onDismiss={setEditingFalse}
+        createGenericItem={selectedItemProps.createGenericItem}
       />
     ) : (
       <ItemComponent {...selectedItemProps} onTrigger={setEditingTrue} />

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { KeyCodes, getId, getNativeProps, inputProperties, css } from '@fluentui/react/lib/Utilities';
-import { FloatingSuggestions } from '../../../FloatingSuggestions/FloatingSuggestions';
-import { IFloatingSuggestionsProps } from '../../../FloatingSuggestions/FloatingSuggestions.types';
+import { IBaseFloatingSuggestionsProps } from '../../../FloatingSuggestionsComposite';
+import { IFloatingSuggestionItemProps } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { EditingItemComponentProps } from '../EditableItem';
 
 import * as styles from './DefaultEditingItem.scss';
@@ -44,8 +44,8 @@ export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttribut
 }
 
 export type EditingItemInnerFloatingPickerProps<T> = Pick<
-  IFloatingSuggestionsProps<T>,
-  'componentRef' | 'onSuggestionSelected' | 'inputElement' | 'onRemoveSuggestion' | 'onSuggestionsHidden'
+  IBaseFloatingSuggestionsProps<T>,
+  'componentRef' | 'onSuggestionSelected' | 'targetElement' | 'onRemoveSuggestion' | 'onFloatingSuggestionsDismiss'
 >;
 
 /**
@@ -56,12 +56,12 @@ export const DefaultEditingItemInner = <TItem extends any>(
   props: IDefaultEditingItemInnerProps<TItem>,
 ): JSX.Element => {
   let editingInput: HTMLInputElement;
-  const editingFloatingPicker = React.createRef<FloatingSuggestions<TItem>>();
+  const editingFloatingPicker = React.createRef<any>();
 
   React.useEffect(() => {
     const itemText: string = props.getEditingItemText(props.item);
 
-    editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(itemText);
+    //editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(itemText);
     editingInput.value = itemText;
     editingInput.focus();
   }, []);
@@ -75,9 +75,9 @@ export const DefaultEditingItemInner = <TItem extends any>(
       <FloatingPicker
         componentRef={editingFloatingPicker}
         onSuggestionSelected={_onSuggestionSelected}
-        inputElement={editingInput}
-        onRemoveSuggestion={props.onRemoveItem}
-        onSuggestionsHidden={props.onDismiss}
+        targetElement={editingInput}
+        onRemoveSuggestion={_onRemoveItem}
+        onFloatingSuggestionsDismiss={props.onDismiss}
       />
     );
   };
@@ -109,9 +109,9 @@ export const DefaultEditingItemInner = <TItem extends any>(
       if (props.onRemoveItem) {
         props.onRemoveItem(props.item);
       }
-    } else {
+    } /*else {
       editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(value);
-    }
+    }*/
   };
 
   const _onInputKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>): void => {
@@ -120,8 +120,14 @@ export const DefaultEditingItemInner = <TItem extends any>(
     }
   };
 
-  const _onSuggestionSelected = (item: TItem): void => {
-    props.onEditingComplete(props.item, item);
+  const _onSuggestionSelected = (ev: React.MouseEvent<HTMLElement>, itemProps: IFloatingSuggestionItemProps<TItem>) => {
+    props.onEditingComplete(props.item, itemProps.item);
+  };
+
+  const _onRemoveItem = (ev: any, itemProps: IFloatingSuggestionItemProps<TItem>) => {
+    if (props.onRemoveItem) {
+      props.onRemoveItem(itemProps.item);
+    }
   };
 
   const itemId = getId();

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -74,7 +74,7 @@ export type EditingItemInnerFloatingPickerProps<T> = Pick<
 export const DefaultEditingItemInner = <TItem extends any>(
   props: IDefaultEditingItemInnerProps<TItem>,
 ): JSX.Element => {
-  let editingInput: HTMLInputElement;
+  const editingInput = React.useRef<any>();
   const editingFloatingPicker = React.createRef<any>();
   const [editingSuggestions, setEditingSuggestions] = React.useState<IFloatingSuggestionItemProps<TItem>[]>([]);
 
@@ -97,8 +97,10 @@ export const DefaultEditingItemInner = <TItem extends any>(
     const itemText: string = props.getEditingItemText(props.item);
 
     setEditingSuggestions(props.getSuggestions(itemText));
-    editingInput.value = itemText;
-    editingInput.focus();
+    if (editingInput.current) {
+      editingInput.current.value = itemText;
+      editingInput.current.focus();
+    }
   }, []);
 
   const _renderEditingSuggestions = (): JSX.Element => {
@@ -110,7 +112,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
       <FloatingPicker
         componentRef={editingFloatingPicker}
         onSuggestionSelected={_onSuggestionSelected}
-        targetElement={editingInput}
+        targetElement={editingInput.current}
         onRemoveSuggestion={_onRemoveItem}
         onFloatingSuggestionsDismiss={props.onDismiss}
         suggestions={suggestionItems}
@@ -120,10 +122,6 @@ export const DefaultEditingItemInner = <TItem extends any>(
         pickerSuggestionsProps={props.pickerSuggestionsProps}
       />
     );
-  };
-
-  const _resolveInputRef = (ref: HTMLInputElement): void => {
-    editingInput = ref;
   };
 
   const _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
@@ -203,7 +201,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
     <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
       <input
         {...nativeProps}
-        ref={_resolveInputRef}
+        ref={editingInput}
         autoCapitalize={'off'}
         autoComplete={'off'}
         onChange={_onInputChange}

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -100,10 +100,6 @@ export const DefaultEditingItemInner = <TItem extends any>(
     editingInput = ref;
   };
 
-  const _onInputClick = (): void => {
-    editingFloatingPicker.current && editingFloatingPicker.current.showPicker(true /*updatevalue*/);
-  };
-
   const _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
     if (editingFloatingPicker.current && ev.relatedTarget !== null) {
       const target = ev.relatedTarget as HTMLElement;
@@ -208,7 +204,6 @@ export const DefaultEditingItemInner = <TItem extends any>(
         onChange={_onInputChange}
         onKeyDown={_onInputKeyDown}
         onBlur={_onInputBlur}
-        onClick={_onInputClick}
         data-lpignore={true}
         className={styles.editingInput}
         id={itemId}

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { KeyCodes, getId, getNativeProps, inputProperties, css } from '@fluentui/react/lib/Utilities';
-import { IBaseFloatingSuggestionsProps } from '../../../FloatingSuggestionsComposite';
+import {
+  IBaseFloatingSuggestionsProps,
+  IBaseFloatingPickerHeaderFooterProps,
+} from '../../../FloatingSuggestionsComposite';
 import { IFloatingSuggestionItemProps } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { EditingItemComponentProps } from '../EditableItem';
 import { useFloatingSuggestionItems } from '../../../UnifiedPicker';
 
 import * as styles from './DefaultEditingItem.scss';
+import { header } from '@fluentui/react-experiments/src/components/TilesList/TilesList.scss';
 
 export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttributes<any> {
   /**
@@ -44,6 +48,8 @@ export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttribut
   getEditingItemText: (item: TItem) => string;
 
   getSuggestions: (value: string) => IFloatingSuggestionItemProps<TItem>[];
+
+  pickerSuggestionsProps?: IBaseFloatingPickerHeaderFooterProps;
 }
 
 export type EditingItemInnerFloatingPickerProps<T> = Pick<
@@ -58,6 +64,7 @@ export type EditingItemInnerFloatingPickerProps<T> = Pick<
   | 'selectedSuggestionIndex'
   | 'selectedHeaderIndex'
   | 'selectedFooterIndex'
+  | 'pickerSuggestionsProps'
 >;
 
 /**
@@ -80,7 +87,11 @@ export const DefaultEditingItemInner = <TItem extends any>(
     headerItems,
     selectPreviousSuggestion,
     selectNextSuggestion,
-  } = useFloatingSuggestionItems(editingSuggestions);
+  } = useFloatingSuggestionItems(
+    editingSuggestions,
+    props.pickerSuggestionsProps?.footerItemsProps,
+    props.pickerSuggestionsProps?.headerItemsProps,
+  );
 
   React.useEffect(() => {
     const itemText: string = props.getEditingItemText(props.item);
@@ -95,8 +106,6 @@ export const DefaultEditingItemInner = <TItem extends any>(
     if (!FloatingPicker) {
       return <></>;
     }
-    //setHeaderItems(editingFloatingPicker.current.pickerSuggestionsProps.headerItemProps);
-    //setFooterItems(editingFloatingPicker.current.pickerSuggestionsProps.footerItemProps);
     return (
       <FloatingPicker
         componentRef={editingFloatingPicker}
@@ -108,6 +117,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
         selectedSuggestionIndex={focusItemIndex}
         selectedHeaderIndex={headerItemIndex}
         selectedFooterIndex={footerItemIndex}
+        pickerSuggestionsProps={props.pickerSuggestionsProps}
       />
     );
   };
@@ -149,7 +159,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
         break;
       case KeyCodes.enter:
       case KeyCodes.tab:
-        if (!ev.shiftKey && !ev.ctrlKey && focusItemIndex >= 0) {
+        if (!ev.shiftKey && !ev.ctrlKey && (focusItemIndex >= 0 || footerItemIndex >= 0 || headerItemIndex >= 0)) {
           ev.preventDefault();
           ev.stopPropagation();
           if (focusItemIndex >= 0) {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -41,11 +41,18 @@ export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttribut
    * Callback used by the EditingItem to populate the initial value of the editing item
    */
   getEditingItemText: (item: TItem) => string;
+
+  getSuggestions: (value: string) => IFloatingSuggestionItemProps<TItem>[];
 }
 
 export type EditingItemInnerFloatingPickerProps<T> = Pick<
   IBaseFloatingSuggestionsProps<T>,
-  'componentRef' | 'onSuggestionSelected' | 'targetElement' | 'onRemoveSuggestion' | 'onFloatingSuggestionsDismiss'
+  | 'componentRef'
+  | 'suggestions'
+  | 'onSuggestionSelected'
+  | 'targetElement'
+  | 'onRemoveSuggestion'
+  | 'onFloatingSuggestionsDismiss'
 >;
 
 /**
@@ -57,11 +64,12 @@ export const DefaultEditingItemInner = <TItem extends any>(
 ): JSX.Element => {
   let editingInput: HTMLInputElement;
   const editingFloatingPicker = React.createRef<any>();
+  const [editingSuggestions, setEditingSuggestions] = React.useState<IFloatingSuggestionItemProps<TItem>[]>([]);
 
   React.useEffect(() => {
     const itemText: string = props.getEditingItemText(props.item);
 
-    //editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(itemText);
+    setEditingSuggestions(props.getSuggestions(itemText));
     editingInput.value = itemText;
     editingInput.focus();
   }, []);
@@ -78,6 +86,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
         targetElement={editingInput}
         onRemoveSuggestion={_onRemoveItem}
         onFloatingSuggestionsDismiss={props.onDismiss}
+        suggestions={editingSuggestions}
       />
     );
   };
@@ -109,9 +118,9 @@ export const DefaultEditingItemInner = <TItem extends any>(
       if (props.onRemoveItem) {
         props.onRemoveItem(props.item);
       }
-    } /*else {
-      editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(value);
-    }*/
+    } else {
+      setEditingSuggestions(props.getSuggestions(value));
+    }
   };
 
   const _onInputKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>): void => {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -127,7 +127,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
   };
 
   const _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
-    if (editingFloatingPicker.current && ev.relatedTarget !== null) {
+    /*if (editingFloatingPicker.current && ev.relatedTarget !== null) {
       const target = ev.relatedTarget as HTMLElement;
       if (
         target.className.indexOf('ms-Suggestions-itemButton') === -1 &&
@@ -135,7 +135,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
       ) {
         editingFloatingPicker.current.forceResolveSuggestion();
       }
-    }
+    }*/
   };
 
   const _onInputChange = (ev: React.FormEvent<HTMLElement>): void => {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -52,107 +52,99 @@ export type EditingItemInnerFloatingPickerProps<T> = Pick<
  * Wrapper around an item in a selection well that renders an item with a context menu for
  * replacing that item with another item.
  */
-export class DefaultEditingItemInner<TItem> extends React.PureComponent<IDefaultEditingItemInnerProps<TItem>> {
-  private _editingInput: HTMLInputElement;
-  private _editingFloatingPicker = React.createRef<FloatingSuggestions<TItem>>();
+export const DefaultEditingItemInner = <TItem extends any>(
+  props: IDefaultEditingItemInnerProps<TItem>,
+): JSX.Element => {
+  let editingInput: HTMLInputElement;
+  const editingFloatingPicker = React.createRef<FloatingSuggestions<TItem>>();
 
-  constructor(props: IDefaultEditingItemInnerProps<TItem>) {
-    super(props);
-  }
+  React.useEffect(() => {
+    const itemText: string = props.getEditingItemText(props.item);
 
-  public componentDidMount(): void {
-    const itemText: string = this.props.getEditingItemText(this.props.item);
+    editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(itemText);
+    editingInput.value = itemText;
+    editingInput.focus();
+  }, []);
 
-    this._editingFloatingPicker.current && this._editingFloatingPicker.current.onQueryStringChanged(itemText);
-    this._editingInput.value = itemText;
-    this._editingInput.focus();
-  }
-
-  public render(): JSX.Element {
-    const itemId = getId();
-    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
-    return (
-      <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
-        <input
-          {...nativeProps}
-          ref={this._resolveInputRef}
-          autoCapitalize={'off'}
-          autoComplete={'off'}
-          onChange={this._onInputChange}
-          onKeyDown={this._onInputKeyDown}
-          onBlur={this._onInputBlur}
-          onClick={this._onInputClick}
-          data-lpignore={true}
-          className={styles.editingInput}
-          id={itemId}
-        />
-        {this._renderEditingSuggestions()}
-      </span>
-    );
-  }
-
-  private _renderEditingSuggestions = (): JSX.Element => {
-    const FloatingPicker = this.props.onRenderFloatingPicker;
+  const _renderEditingSuggestions = (): JSX.Element => {
+    const FloatingPicker = props.onRenderFloatingPicker;
     if (!FloatingPicker) {
       return <></>;
     }
     return (
       <FloatingPicker
-        componentRef={this._editingFloatingPicker}
-        onSuggestionSelected={this._onSuggestionSelected}
-        inputElement={this._editingInput}
-        onRemoveSuggestion={this.props.onRemoveItem}
-        onSuggestionsHidden={this.props.onDismiss}
+        componentRef={editingFloatingPicker}
+        onSuggestionSelected={_onSuggestionSelected}
+        inputElement={editingInput}
+        onRemoveSuggestion={props.onRemoveItem}
+        onSuggestionsHidden={props.onDismiss}
       />
     );
   };
 
-  private _resolveInputRef = (ref: HTMLInputElement): void => {
-    this._editingInput = ref;
-
-    this.forceUpdate(() => {
-      this._editingInput.focus();
-    });
+  const _resolveInputRef = (ref: HTMLInputElement): void => {
+    editingInput = ref;
   };
 
-  private _onInputClick = (): void => {
-    this._editingFloatingPicker.current && this._editingFloatingPicker.current.showPicker(true /*updatevalue*/);
+  const _onInputClick = (): void => {
+    editingFloatingPicker.current && editingFloatingPicker.current.showPicker(true /*updatevalue*/);
   };
 
-  private _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
-    if (this._editingFloatingPicker.current && ev.relatedTarget !== null) {
+  const _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
+    if (editingFloatingPicker.current && ev.relatedTarget !== null) {
       const target = ev.relatedTarget as HTMLElement;
       if (
         target.className.indexOf('ms-Suggestions-itemButton') === -1 &&
         target.className.indexOf('ms-Suggestions-sectionButton') === -1
       ) {
-        this._editingFloatingPicker.current.forceResolveSuggestion();
+        editingFloatingPicker.current.forceResolveSuggestion();
       }
     }
   };
 
-  private _onInputChange = (ev: React.FormEvent<HTMLElement>): void => {
+  const _onInputChange = (ev: React.FormEvent<HTMLElement>): void => {
     const value: string = (ev.target as HTMLInputElement).value;
 
     if (value === '') {
-      if (this.props.onRemoveItem) {
-        this.props.onRemoveItem(this.props.item);
+      if (props.onRemoveItem) {
+        props.onRemoveItem(props.item);
       }
     } else {
-      this._editingFloatingPicker.current && this._editingFloatingPicker.current.onQueryStringChanged(value);
+      editingFloatingPicker.current && editingFloatingPicker.current.onQueryStringChanged(value);
     }
   };
 
-  private _onInputKeyDown(ev: React.KeyboardEvent<HTMLInputElement>): void {
+  const _onInputKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>): void => {
     if (ev.which === KeyCodes.backspace || ev.which === KeyCodes.del) {
       ev.stopPropagation();
     }
-  }
-
-  private _onSuggestionSelected = (item: TItem): void => {
-    this.props.onEditingComplete(this.props.item, item);
   };
-}
+
+  const _onSuggestionSelected = (item: TItem): void => {
+    props.onEditingComplete(props.item, item);
+  };
+
+  const itemId = getId();
+  const nativeProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(props, inputProperties);
+  return (
+    <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
+      <input
+        {...nativeProps}
+        ref={_resolveInputRef}
+        autoCapitalize={'off'}
+        autoComplete={'off'}
+        onChange={_onInputChange}
+        onKeyDown={_onInputKeyDown}
+        onBlur={_onInputBlur}
+        onClick={_onInputClick}
+        data-lpignore={true}
+        className={styles.editingInput}
+        id={itemId}
+      />
+      {_renderEditingSuggestions()}
+    </span>
+  );
+};
 
 type EditingItemProps<T> = Pick<
   IDefaultEditingItemInnerProps<T>,

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -77,6 +77,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
                 onItemChange={_replaceItem}
                 dragDropEvents={dragDropEvents}
                 dragDropHelper={dragDropHelper}
+                createGenericItem={props.createGenericItem}
               />
             ))}
         </div>

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IPickerItemProps, ISuggestionModel, ValidationState } from '@fluentui/react/lib/Pickers';
+import { IPickerItemProps } from '@fluentui/react/lib/Pickers';
 import { IRefObject } from '@fluentui/react/lib/Utilities';
 import { IDragDropEvents, IDragDropHelper } from '@fluentui/react/lib/DragDrop';
 export interface ISelectedItemsList<T> {

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -50,6 +50,11 @@ export interface ISelectedItemProps<T> extends IPickerItemProps<T> {
    * A list of events to register
    */
   eventsToRegister?: { eventName: string; callback: (item?: any, index?: number, event?: any) => void }[];
+
+  /**
+   * Function that specifies how arbitrary text entered into the edit input is handled.
+   */
+  createGenericItem?: (input: string) => T;
 }
 
 export type BaseSelectedItem = {
@@ -84,7 +89,7 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
   /**
    * Function that specifies how arbitrary text entered into the well is handled.
    */
-  createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T>;
+  createGenericItem?: (input: string) => T;
   /**
    * The items that the base picker should currently display as selected. If this is provided then the picker will
    * act as a controlled component.

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -47,11 +47,11 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     selectNextSuggestion,
   } = useFloatingSuggestionItems(
     suggestions,
+    pickerSuggestionsProps?.footerItemsProps,
+    pickerSuggestionsProps?.headerItemsProps,
     selectedSuggestionIndex,
     selectedFooterIndex,
-    pickerSuggestionsProps?.footerItemsProps,
     selectedHeaderIndex,
-    pickerSuggestionsProps?.headerItemsProps,
     isSuggestionsVisible,
   );
 

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -25,11 +25,11 @@ export interface IUseFloatingSuggestionItems<T> {
 
 export const useFloatingSuggestionItems = <T extends {}>(
   floatingSuggestionItems: T[],
+  footerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
+  headerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   focusSuggestionIndex?: number,
   focusFooterIndex?: number,
-  footerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   focusHeaderIndex?: number,
-  headerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   isSuggestionsVisible?: boolean,
 ) => {
   const [focusItemIndex, setFocusItemIndex] = React.useState(focusSuggestionIndex || -1);

--- a/packages/react-experiments/src/components/UnifiedPicker/index.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/index.ts
@@ -1,0 +1,3 @@
+export * from './UnifiedPicker';
+export * from './UnifiedPicker.types';
+export * from './hooks/useFloatingSuggestionItems';


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updated this to use the new picker. These are both used in the UnifiedPicker, but previously the input was using the new FloatingSuggestionsComposite, while editing items were using the old picker. Now they're both using the new picker.

The three editing examples are updated SelectedItemsList with edit, with edit in context menu, UnifiedPeoplePicker with edit. The unified people picker edit picker has headers and footers.

As this is a breaking change, I'm inclined to just check this in to 8 and not backport to 7.