### PR TITLE
Fix navigating across suggestion items in narrator scan mode

### DIFF
--- a/apps/vr-tests/src/stories/Suggestions.stories.tsx
+++ b/apps/vr-tests/src/stories/Suggestions.stories.tsx
@@ -135,7 +135,7 @@ storiesOf('(Dev-Only) Suggestions', module)
         .snapshot('default', { cropTo: '.testRoot' })
         .hover('#province-fake-long-province')
         .snapshot('Hovering over a wide suggestion element', { cropTo: '.testRoot' })
-        .hover('#sug-0 .ms-Suggestions-closeButton')
+        .hover('#sug-0+.ms-Suggestions-closeButton')
         .snapshot('Hovering over the X button on a wide suggestion element', {
           cropTo: '.testRoot',
         })

--- a/change/@fluentui-react-internal-2020-12-08-03-39-02-pickerscanmode.json
+++ b/change/@fluentui-react-internal-2020-12-08-03-39-02-pickerscanmode.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix narrator scan mode navigation for picker",
+  "packageName": "@fluentui/react-internal",
+  "email": "kuanubha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-08T11:39:02.171Z"
+}

--- a/packages/react-internal/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react-internal/src/components/pickers/Suggestions/Suggestions.tsx
@@ -390,10 +390,6 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
           <div
             ref={suggestion.selected ? this._selectedElement : undefined}
             key={(suggestion.item as any).key ? (suggestion.item as any).key : index}
-            id={'sug-' + index}
-            aria-selected={suggestion.selected}
-            role="option"
-            aria-label={suggestion.ariaLabel}
           >
             <StyledTypedSuggestionsItem
               suggestionModel={suggestion}
@@ -403,6 +399,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
               showRemoveButton={showRemoveButtons}
               removeButtonAriaLabel={removeSuggestionAriaLabel}
               onRemoveItem={this._onRemoveTypedSuggestionsItem(suggestion.item, index)}
+              id={'sug-' + index}
             />
           </div>
         ))}

--- a/packages/react-internal/src/components/pickers/Suggestions/SuggestionsItem.tsx
+++ b/packages/react-internal/src/components/pickers/Suggestions/SuggestionsItem.tsx
@@ -26,6 +26,7 @@ export class SuggestionsItem<T> extends React.Component<ISuggestionItemProps<T>,
       RenderSuggestion,
       onClick,
       className,
+      id,
       onRemoveItem,
       isSelectedOverride,
       removeButtonAriaLabel,
@@ -66,7 +67,14 @@ export class SuggestionsItem<T> extends React.Component<ISuggestionItemProps<T>,
 
     return (
       <div className={classNames.root}>
-        <CommandButton onClick={onClick} className={classNames.itemButton}>
+        <CommandButton
+          onClick={onClick}
+          className={classNames.itemButton}
+          id={id}
+          aria-selected={suggestionModel.selected}
+          role="option"
+          aria-label={suggestionModel.ariaLabel}
+        >
           {RenderSuggestion(suggestionModel.item, this.props)}
         </CommandButton>
         {this.props.showRemoveButton ? (

--- a/packages/react-internal/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react-internal/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -13,11 +13,7 @@ exports[`Suggestions renders a list properly 1`] = `
     className="ms-Suggestions-container"
     role="listbox"
   >
-    <div
-      aria-selected={true}
-      id="sug-0"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -46,6 +42,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={true}
           className=
               ms-Button
               ms-Button--action
@@ -131,12 +128,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: HighlightText;
               }
           data-is-focusable={true}
+          id="sug-0"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -160,11 +159,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-1"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -183,6 +178,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -263,12 +259,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-1"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -292,11 +290,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-2"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -315,6 +309,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -395,12 +390,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-2"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -424,11 +421,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-3"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -447,6 +440,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -527,12 +521,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-3"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -556,11 +552,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-4"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -579,6 +571,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -659,12 +652,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-4"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -688,11 +683,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-5"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -711,6 +702,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -791,12 +783,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-5"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -820,11 +814,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-6"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -843,6 +833,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -923,12 +914,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-6"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -952,11 +945,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-7"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -975,6 +964,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1055,12 +1045,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-7"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1084,11 +1076,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-8"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1107,6 +1095,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1187,12 +1176,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-8"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1216,11 +1207,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-9"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1239,6 +1226,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1319,12 +1307,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-9"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1348,11 +1338,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-10"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1371,6 +1357,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1451,12 +1438,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-10"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1480,11 +1469,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-11"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1503,6 +1488,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1583,12 +1569,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-11"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1612,11 +1600,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-12"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1635,6 +1619,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1715,12 +1700,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-12"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1744,11 +1731,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-13"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1767,6 +1750,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1847,12 +1831,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-13"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -1876,11 +1862,7 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-14"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -1899,6 +1881,7 @@ exports[`Suggestions renders a list properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -1979,12 +1962,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-14"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2036,11 +2021,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         }
     role="listbox"
   >
-    <div
-      aria-selected={true}
-      id="sug-0"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2069,6 +2050,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={true}
           className=
               ms-Button
               ms-Button--action
@@ -2154,12 +2136,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: HighlightText;
               }
           data-is-focusable={true}
+          id="sug-0"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2183,11 +2167,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-1"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2206,6 +2186,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2286,12 +2267,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-1"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2315,11 +2298,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-2"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2338,6 +2317,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2418,12 +2398,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-2"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2447,11 +2429,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-3"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2470,6 +2448,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2550,12 +2529,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-3"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2579,11 +2560,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-4"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2602,6 +2579,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2682,12 +2660,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-4"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2711,11 +2691,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-5"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2734,6 +2710,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2814,12 +2791,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-5"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2843,11 +2822,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-6"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2866,6 +2841,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -2946,12 +2922,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-6"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -2975,11 +2953,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-7"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -2998,6 +2972,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3078,12 +3053,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-7"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3107,11 +3084,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-8"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3130,6 +3103,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3210,12 +3184,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-8"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3239,11 +3215,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-9"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3262,6 +3234,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3342,12 +3315,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-9"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3371,11 +3346,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-10"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3394,6 +3365,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3474,12 +3446,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-10"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3503,11 +3477,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-11"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3526,6 +3496,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3606,12 +3577,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-11"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3635,11 +3608,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-12"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3658,6 +3627,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3738,12 +3708,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-12"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3767,11 +3739,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-13"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3790,6 +3758,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -3870,12 +3839,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-13"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -3899,11 +3870,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-14"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -3922,6 +3889,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4002,12 +3970,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-14"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4048,11 +4018,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
     className="ms-Suggestions-container"
     role="listbox"
   >
-    <div
-      aria-selected={false}
-      id="sug-0"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4071,6 +4037,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4151,12 +4118,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-0"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4180,11 +4149,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-1"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4203,6 +4168,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4283,12 +4249,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-1"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4312,11 +4280,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-2"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4335,6 +4299,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4415,12 +4380,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-2"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4444,11 +4411,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-3"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4467,6 +4430,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4547,12 +4511,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-3"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4576,11 +4542,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-4"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4599,6 +4561,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4679,12 +4642,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-4"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4708,11 +4673,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-5"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4731,6 +4692,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4811,12 +4773,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-5"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4840,11 +4804,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-6"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4863,6 +4823,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -4943,12 +4904,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-6"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -4972,11 +4935,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-7"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -4995,6 +4954,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5075,12 +5035,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-7"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5104,11 +5066,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={true}
-      id="sug-8"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5137,6 +5095,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={true}
           className=
               ms-Button
               ms-Button--action
@@ -5222,12 +5181,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: HighlightText;
               }
           data-is-focusable={true}
+          id="sug-8"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5251,11 +5212,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-9"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5274,6 +5231,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5354,12 +5312,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-9"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5383,11 +5343,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-10"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5406,6 +5362,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5486,12 +5443,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-10"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5515,11 +5474,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-11"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5538,6 +5493,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5618,12 +5574,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-11"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5647,11 +5605,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-12"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5670,6 +5624,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5750,12 +5705,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-12"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5779,11 +5736,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-13"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5802,6 +5755,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -5882,12 +5836,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-13"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span
@@ -5911,11 +5867,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div
-      aria-selected={false}
-      id="sug-14"
-      role="option"
-    >
+    <div>
       <div
         className=
             ms-Suggestions-item
@@ -5934,6 +5886,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             }
       >
         <button
+          aria-selected={false}
           className=
               ms-Button
               ms-Button--action
@@ -6014,12 +5967,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 color: WindowText;
               }
           data-is-focusable={true}
+          id="sug-14"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
+          role="option"
           type="button"
         >
           <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15866
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Suggestion items are currently rendered as a button within the `option` div. This arrangement is causing problems with narrator and the position of the suggestion items are not being announced in scan mode. Moving the `option` role and other aria attributes from the outer div to the button fixes the issue.

#### Focus areas to test

Test navigation in picker element with narrator scan mode on and off.
