### PR TITLE
Toggle: fix label click target being too wide

### DIFF
--- a/change/@fluentui-react-toggle-2020-12-09-14-31-47-fix-label.json
+++ b/change/@fluentui-react-toggle-2020-12-09-14-31-47-fix-label.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Toggle: fix label click target being too wide.",
+  "packageName": "@fluentui/react-toggle",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-09T22:31:47.585Z"
+}

--- a/packages/react-examples/src/react-tabs/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
@@ -27,7 +27,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -53,7 +53,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react-tabs/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
@@ -33,7 +33,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -57,7 +57,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -212,7 +212,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -236,7 +236,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -383,7 +383,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -407,7 +407,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react-tabs/__snapshots__/Tabs.AlwaysRender.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Tabs.AlwaysRender.Example.tsx.shot
@@ -27,7 +27,7 @@ exports[`Component Examples renders Tabs.AlwaysRender.Example.tsx correctly 1`] 
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -53,7 +53,7 @@ exports[`Component Examples renders Tabs.AlwaysRender.Example.tsx correctly 1`] 
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
@@ -1704,7 +1704,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -1728,7 +1728,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -1883,7 +1883,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -1907,7 +1907,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -2054,7 +2054,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -2078,7 +2078,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react-toggle/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react-toggle/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -46,7 +46,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -70,7 +70,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -224,7 +224,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -248,7 +248,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -395,7 +395,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -422,7 +422,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -564,7 +564,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -591,7 +591,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -733,7 +733,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -758,7 +758,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -906,7 +906,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -934,7 +934,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1076,7 +1076,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1102,7 +1102,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1208,7 +1208,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1237,7 +1237,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1332,7 +1332,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1356,7 +1356,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react-toggle/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/react-examples/src/react-toggle/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -45,7 +45,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -102,7 +102,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -250,7 +250,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -308,7 +308,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1262,7 +1262,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -1286,7 +1286,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -444,7 +444,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -468,7 +468,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -581,7 +581,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -605,7 +605,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -81,7 +81,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -232,7 +232,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -256,7 +256,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -37,7 +37,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -61,7 +61,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -157,7 +157,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -183,7 +183,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -293,7 +293,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -319,7 +319,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -30,7 +30,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -54,7 +54,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -46,7 +46,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -70,7 +70,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -92,7 +92,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -250,7 +250,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -274,7 +274,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -250,7 +250,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -274,7 +274,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -92,7 +92,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -93,7 +93,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >
@@ -400,7 +400,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     box-shadow: none;
                     box-sizing: border-box;
                     color: #323130;
-                    display: block;
+                    display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 600;
@@ -424,7 +424,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >
@@ -731,7 +731,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         box-shadow: none;
                         box-sizing: border-box;
                         color: #323130;
-                        display: block;
+                        display: inline-block;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 600;
@@ -755,7 +755,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   className=
                       ms-Toggle-innerContainer
                       {
-                        display: inline-flex;
+                        display: flex;
                         position: relative;
                       }
                 >
@@ -1076,7 +1076,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         box-shadow: none;
                         box-sizing: border-box;
                         color: #323130;
-                        display: block;
+                        display: inline-block;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 600;
@@ -1100,7 +1100,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   className=
                       ms-Toggle-innerContainer
                       {
-                        display: inline-flex;
+                        display: flex;
                         position: relative;
                       }
                 >
@@ -1434,7 +1434,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     box-shadow: none;
                     box-sizing: border-box;
                     color: #323130;
-                    display: block;
+                    display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 600;
@@ -1458,7 +1458,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -213,7 +213,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >
@@ -2199,7 +2199,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >
@@ -4185,7 +4185,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1037,7 +1037,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1053,7 +1053,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -27,7 +27,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -53,7 +53,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -42,7 +42,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -68,7 +68,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -175,7 +175,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -201,7 +201,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -60,7 +60,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -205,7 +205,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -231,7 +231,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -381,7 +381,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -407,7 +407,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3608,7 +3608,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3632,7 +3632,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -3737,7 +3737,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3761,7 +3761,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -3866,7 +3866,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3890,7 +3890,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -399,7 +399,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -58,7 +58,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -48,7 +48,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -74,7 +74,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-toggle/src/components/Toggle/Toggle.styles.ts
+++ b/packages/react-toggle/src/components/Toggle/Toggle.styles.ts
@@ -48,6 +48,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
 
     label: [
       'ms-Toggle-label',
+      { display: 'inline-block' },
       disabled && {
         color: textDisabledColor,
         selectors: {
@@ -71,7 +72,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
     container: [
       'ms-Toggle-innerContainer',
       {
-        display: 'inline-flex',
+        display: 'flex',
         position: 'relative',
       },
     ],

--- a/packages/react-toggle/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react-toggle/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -125,7 +125,7 @@ exports[`Toggle renders toggle correctly 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -149,7 +149,7 @@ exports[`Toggle renders toggle correctly 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -257,7 +257,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -285,7 +285,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -393,7 +393,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -419,7 +419,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -527,7 +527,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -552,7 +552,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13721
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fixing the issue by updating label inside `Toggle` to be as wide as the text width, not as the width of its container.

#### Focus areas to test

(optional)
