### PR TITLE
[UPP] Fix color contrast in UPP suggestion item close button

### DIFF
--- a/change/@fluentui-react-experiments-2020-12-09-15-40-12-upp-remove-button-highlight.json
+++ b/change/@fluentui-react-experiments-2020-12-09-15-40-12-upp-remove-button-highlight.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "[UPP] Fix color contrast in UPP suggestion item close button",
+  "packageName": "@fluentui/react-experiments",
+  "email": "chrp@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-09T23:40:12.829Z"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -86,6 +86,11 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
           ':hover, :active': {
             background: neutralLight,
             color: neutralDark,
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'HighlightText',
+              MsHighContrastAdjust: 'none',
+            },
           },
           [HighContrastSelector]: {
             color: 'WindowText',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -18,7 +18,7 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
 
   const { isSelected } = props;
   const { palette, semanticColors, fonts } = theme;
-  const { neutralDark, neutralTertiaryAlt, neutralSecondary } = palette;
+  const { neutralDark, neutralLight, neutralSecondary } = palette;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
@@ -84,7 +84,7 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
         width: 32,
         selectors: {
           ':hover, :active': {
-            background: neutralTertiaryAlt,
+            background: neutralLight,
             color: neutralDark,
           },
           [HighContrastSelector]: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Replace neutralTertiaryAlt with neutralLight to fix a contrast issue with the remove button's hover state. neutralLight is what the old picker uses.

Before:
![image](https://user-images.githubusercontent.com/654562/101702179-39a93400-3a35-11eb-9920-15a4ef505576.png)

After:
![image](https://user-images.githubusercontent.com/654562/101702232-534a7b80-3a35-11eb-8a93-0fdc2147a270.png)