### PR TITLE
Update react-button readme to not say it's officially releasing with v8

### DIFF
--- a/change/@fluentui-react-button-2020-12-09-18-59-23-button-readme.json
+++ b/change/@fluentui-react-button-2020-12-09-18-59-23-button-readme.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update react-button readme to not say it's officially releasing with v8",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-10T02:59:23.881Z"
+}

--- a/packages/react-button/README.md
+++ b/packages/react-button/README.md
@@ -2,7 +2,7 @@
 
 **Button components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-**WARNING!** These components are still in active development, and the APIs may change before final release. The package will be released with a stable API as part of [Fluent UI React version 8](https://github.com/microsoft/fluentui/issues/12770) in late 2020.
+**WARNING!** These components are still in active development, and the APIs may change before final release.
 
 To use the Button components:
 


### PR DESCRIPTION
I'm updating various documentation around new buttons and v8 and noticed a bit in the react-button readme which should be removed. (Feel free to make further suggestions.)