### PR TITLE
fix(Tree): cannot expand/collapse when treeTitle has children; fixed by passing id to treeTitle

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `selectableParent` prop in favor of `selectable` in `TreeItem` and make `selectionIndicator` visible only on focus or hover @assuncaocharles ([#15133](https://github.com/microsoft/fluentui/pull/15133))
 
 ### Fixes
-- Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16157](https://github.com/microsoft/fluentui/pull/16157))
+- Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16199](https://github.com/microsoft/fluentui/pull/16199))
 - Fix `Attachment` to pass `actionable` to accessibility behaviors @layershifter ([#16023](https://github.com/microsoft/fluentui/pull/16023))
 - Fix `Embed` throws when no style `variables` are passed in @yuanboxue-amber ([#16000](https://github.com/microsoft/fluentui/pull/16000))
 - Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `selectableParent` prop in favor of `selectable` in `TreeItem` and make `selectionIndicator` visible only on focus or hover @assuncaocharles ([#15133](https://github.com/microsoft/fluentui/pull/15133))
 
 ### Fixes
+- Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16157](https://github.com/microsoft/fluentui/pull/16157))
 - Fix `Attachment` to pass `actionable` to accessibility behaviors @layershifter ([#16023](https://github.com/microsoft/fluentui/pull/16023))
 - Fix `Embed` throws when no style `variables` are passed in @yuanboxue-amber ([#16000](https://github.com/microsoft/fluentui/pull/16000))
 - Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -30,7 +30,7 @@ import {
   ShorthandCollection,
   FluentComponentStaticProps,
 } from '../../types';
-import { TreeTitle, TreeTitleProps } from './TreeTitle';
+import { TreeTitle, TreeTitleProps, treeTitleSlotClassNames } from './TreeTitle';
 import { BoxProps } from '../Box/Box';
 import { TreeContext } from './context';
 
@@ -226,13 +226,24 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    if (hasSubtree && e.target === e.currentTarget) {
+    if (selectable) {
+      if (hasSubtree) {
+        // need to know if click happened on selection indicator or title itself
+        if (e?.target?.className?.includes(treeTitleSlotClassNames.indicator)) {
+          toggleItemSelect(e, id);
+        } else {
+          toggleItemActive(e, id);
+        }
+      } else {
+        toggleItemSelect(e, id);
+      }
+    } else if (hasSubtree) {
       toggleItemActive(e, id);
-    } else if (selectable) {
-      toggleItemSelect(e, id);
     }
+
     _.invoke(props, 'onTitleClick', e, props);
   };
+
   const handleFocusFirstChild = e => {
     _.invoke(props, 'onFocusFirstChild', e, props);
     focusItemById(childrenIds?.[0]);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -100,9 +100,6 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 
   /** A selection indicator icon can be customized. */
   selectionIndicator?: ShorthandValue<BoxProps>;
-
-  /** Called when the item is selectable and the checkbox is clicked */
-  onSelectionIndicatorClick?: (e: React.SyntheticEvent) => void;
 }
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>> & {
@@ -159,7 +156,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
           e.preventDefault();
         }
         e.stopPropagation();
-        handleTitleClick(e);
+        toggleItemActive(e, id);
       },
       focusParent: e => {
         e.preventDefault();
@@ -170,14 +167,12 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       collapse: e => {
         e.preventDefault();
         e.stopPropagation();
-
-        handleTitleClick(e);
+        toggleItemActive(e, id);
       },
       expand: e => {
         e.preventDefault();
         e.stopPropagation();
-
-        handleTitleClick(e);
+        toggleItemActive(e, id);
       },
       focusFirstChild: e => {
         e.preventDefault();
@@ -228,14 +223,6 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     _.invoke(props, 'onTitleClick', e, props);
   };
 
-  const handleTitleClick = e => {
-    if (hasSubtree) {
-      toggleItemActive(e, id);
-    }
-
-    _.invoke(props, 'onTitleClick', e, props);
-  };
-
   const handleFocusFirstChild = e => {
     _.invoke(props, 'onFocusFirstChild', e, props);
     focusItemById(childrenIds?.[0]);
@@ -252,16 +239,10 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleOverrides = (predefinedProps: TreeTitleProps) => ({
+    id,
     onClick: (e, titleProps) => {
-      handleTitleClick(e);
+      _.invoke(props, 'onTitleClick', e, props);
       _.invoke(predefinedProps, 'onClick', e, titleProps);
-    },
-    onSelectionIndicatorClick: e => {
-      if (selectable) {
-        e.stopPropagation(); // otherwise onClick on title will also be executed
-        toggleItemSelect(e, id);
-        _.invoke(props, 'onSelectionIndicatorClick', e);
-      }
     },
   });
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -30,7 +30,7 @@ import {
   ShorthandCollection,
   FluentComponentStaticProps,
 } from '../../types';
-import { TreeTitle, TreeTitleProps, treeTitleSlotClassNames } from './TreeTitle';
+import { TreeTitle, TreeTitleProps } from './TreeTitle';
 import { BoxProps } from '../Box/Box';
 import { TreeContext } from './context';
 
@@ -100,6 +100,9 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 
   /** A selection indicator icon can be customized. */
   selectionIndicator?: ShorthandValue<BoxProps>;
+
+  /** Called when the item is selectable and the checkbox is clicked */
+  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
 }
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>> & {
@@ -226,13 +229,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    // need to know if click happened on selection indicator or title itself
-    const shouldSelect =
-      (selectable && !hasSubtree) || (hasSubtree && e?.target?.className?.includes(treeTitleSlotClassNames.indicator));
-    if (shouldSelect) {
-      toggleItemSelect(e, id);
-    }
-    if (!shouldSelect && hasSubtree) {
+    if (hasSubtree) {
       toggleItemActive(e, id);
     }
 
@@ -259,7 +256,15 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       handleTitleClick(e);
       _.invoke(predefinedProps, 'onClick', e, titleProps);
     },
+    onSelectionIndicatorClick: (e, boxProps) => {
+      e.stopPropagation(); // otherwise onClick on title will also be executed
+      if (selectable) {
+        toggleItemSelect(e, id);
+      }
+      _.invoke(predefinedProps, 'onSelectionIndicatorClick', e, boxProps);
+    },
   });
+
   const handleClick = (e: React.SyntheticEvent) => {
     if (e.target === e.currentTarget) {
       // onClick listener for mouse click on treeItem DOM only,

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -226,19 +226,15 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
 
   const handleTitleClick = e => {
-    if (selectable) {
-      if (hasSubtree) {
-        // need to know if click happened on selection indicator or title itself
-        if (e?.target?.className?.includes(treeTitleSlotClassNames.indicator)) {
-          toggleItemSelect(e, id);
-        } else {
-          toggleItemActive(e, id);
-        }
-      } else {
-        toggleItemSelect(e, id);
-      }
-    } else if (hasSubtree) {
+    // need to know if click happened on selection indicator or title itself
+    const shouldSelect =
+      (selectable && !hasSubtree) || (hasSubtree && e?.target?.className?.includes(treeTitleSlotClassNames.indicator));
+    if (shouldSelect) {
+      toggleItemSelect(e, id);
+    }
+    if (!shouldSelect && hasSubtree) {
       toggleItemActive(e, id);
+    }
     }
 
     _.invoke(props, 'onTitleClick', e, props);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -235,7 +235,6 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     if (!shouldSelect && hasSubtree) {
       toggleItemActive(e, id);
     }
-    }
 
     _.invoke(props, 'onTitleClick', e, props);
   };

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -102,7 +102,7 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   selectionIndicator?: ShorthandValue<BoxProps>;
 
   /** Called when the item is selectable and the checkbox is clicked */
-  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
+  onSelectionIndicatorClick?: (e: React.SyntheticEvent) => void;
 }
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>> & {
@@ -256,12 +256,12 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       handleTitleClick(e);
       _.invoke(predefinedProps, 'onClick', e, titleProps);
     },
-    onSelectionIndicatorClick: (e, boxProps) => {
-      e.stopPropagation(); // otherwise onClick on title will also be executed
+    onSelectionIndicatorClick: e => {
       if (selectable) {
+        e.stopPropagation(); // otherwise onClick on title will also be executed
         toggleItemSelect(e, id);
+        _.invoke(props, 'onSelectionIndicatorClick', e);
       }
-      _.invoke(predefinedProps, 'onSelectionIndicatorClick', e, boxProps);
     },
   });
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -36,7 +36,7 @@ export interface TreeTitleProps extends UIComponentProps, ChildrenComponentProps
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<TreeTitleBehaviorProps>;
 
-  /** Id needed to identify this item inside the Tree. */
+  /** Internal usage only -  Id needed to identify this item inside the Tree, passed down from TreeItem .*/
   id?: string;
 
   /** Whether or not the title has a subtree. */

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -62,6 +62,9 @@ export interface TreeTitleProps extends UIComponentProps, ChildrenComponentProps
   /** A selection indicator icon can be customized. */
   selectionIndicator?: ShorthandValue<BoxProps>;
 
+  /** Called when the item is selectable and the checkbox is clicked */
+  onSelectionIndicatorClick?: ComponentEventHandler<BoxProps>;
+
   /** A selection indicator can appear disabled and be unable to change states. */
   disabled?: SupportedIntrinsicInputProps['disabled'];
 
@@ -175,6 +178,10 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     _.invoke(props, 'onClick', e, props);
   };
 
+  const handleSelectionIndicatorClick = e => {
+    _.invoke(props, 'onSelectionIndicatorClick', e, props);
+  };
+
   const selectIndicator = Box.create(selectionIndicator, {
     defaultProps: () => ({
       as: 'span',
@@ -184,6 +191,9 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         styles: resolvedStyles.selectionIndicator,
       }),
     }),
+    overrideProps: {
+      onClick: handleSelectionIndicatorClick,
+    },
   });
 
   const element = (

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -36,7 +36,7 @@ export interface TreeTitleProps extends UIComponentProps, ChildrenComponentProps
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<TreeTitleBehaviorProps>;
 
-  /** Internal usage only -  Id needed to identify this item inside the Tree, passed down from TreeItem .*/
+  /** Internal usage only -  Id needed to identify this item inside the Tree, passed down from TreeItem */
   id?: string;
 
   /** Whether or not the title has a subtree. */

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -228,6 +228,7 @@ TreeTitle.propTypes = {
   selectable: PropTypes.bool,
   treeSize: PropTypes.number,
   selectionIndicator: customPropTypes.shorthandAllowingChildren,
+  onSelectionIndicatorClick: PropTypes.func,
   indeterminate: PropTypes.bool,
   parent: PropTypes.string,
 };

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -178,9 +178,12 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     _.invoke(props, 'onClick', e, props);
   };
 
-  const handleSelectionIndicatorClick = e => {
-    _.invoke(props, 'onSelectionIndicatorClick', e, props);
-  };
+  const selectionIndicatorOverrideProps = (predefinedProps: BoxProps) => ({
+    onClick: (e: React.SyntheticEvent) => {
+      _.invoke(props, 'onSelectionIndicatorClick', e);
+      _.invoke(predefinedProps, 'onClick', e);
+    },
+  });
 
   const selectIndicator = Box.create(selectionIndicator, {
     defaultProps: () => ({
@@ -191,9 +194,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         styles: resolvedStyles.selectionIndicator,
       }),
     }),
-    overrideProps: {
-      onClick: handleSelectionIndicatorClick,
-    },
+    overrideProps: selectionIndicatorOverrideProps,
   });
 
   const element = (

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -217,10 +217,10 @@ describe('Tree', () => {
     it('should expand on click when TreeTitle renders children components ', () => {
       const wrapper = mountWithProvider(<Tree items={items} />);
 
+      // open title '2'
       getTitles(wrapper)
-        .at(1) // title '2'
+        .at(1)
         .simulate('click');
-      checkOpenTitles(wrapper, ['1', '2', '21', '22', '3']);
 
       // click on icon of title '21'
       const icon = wrapper.find(`.${svgIconClassName}`).filterWhere(n => typeof n.type() === 'string');

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -214,7 +214,7 @@ describe('Tree', () => {
       );
     });
 
-    it("should contain index of item open at clicking the title's children", () => {
+    it("should expand on click when TreeTitle renders children components ", () => {
       const wrapper = mountWithProvider(<Tree items={items} />);
 
       getTitles(wrapper)

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -7,6 +7,7 @@ import { Tree } from 'src/components/Tree/Tree';
 import { treeTitleClassName } from 'src/components/Tree/TreeTitle';
 import { treeItemClassName } from 'src/components/Tree/TreeItem';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
+import { TriangleDownIcon, TriangleEndIcon, svgIconClassName } from '@fluentui/react-icons-northstar';
 
 const items = [
   {
@@ -35,7 +36,15 @@ const items = [
     items: [
       {
         id: '21',
-        title: '21',
+        title: {
+          content: '21',
+          children: (Component, { content, expanded, hasSubtree, ...restProps }) => (
+            <Component expanded={expanded} hasSubtree={hasSubtree} {...restProps}>
+              {expanded ? <TriangleDownIcon /> : <TriangleEndIcon />}
+              {content}
+            </Component>
+          ),
+        },
         items: [
           {
             id: '211',
@@ -203,6 +212,20 @@ describe('Tree', () => {
         expect.objectContaining({ type: 'click' }),
         expect.objectContaining({ activeItemIds: expect.arrayContaining(['2', '21', '1']) }),
       );
+    });
+
+    it("should contain index of item open at clicking the title's children", () => {
+      const wrapper = mountWithProvider(<Tree items={items} />);
+
+      getTitles(wrapper)
+        .at(1) // title '2'
+        .simulate('click');
+      checkOpenTitles(wrapper, ['1', '2', '21', '22', '3']);
+
+      // click on icon of title '21'
+      const icon = wrapper.find(`.${svgIconClassName}`).filterWhere(n => typeof n.type() === 'string');
+      icon.simulate('click');
+      checkOpenTitles(wrapper, ['1', '2', '21', '211', '22', '3']);
     });
   });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -214,7 +214,7 @@ describe('Tree', () => {
       );
     });
 
-    it("should expand on click when TreeTitle renders children components ", () => {
+    it('should expand on click when TreeTitle renders children components ', () => {
       const wrapper = mountWithProvider(<Tree items={items} />);
 
       getTitles(wrapper)


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When treeTitle has children, expand/collapse doesn't work.
PR #16157 address the same issue, but this PR is preferred solution

#### Focus areas to test

(optional)
