### PR TITLE
fix(Checkbox): Wrong grid template in checkbox for label end

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -61,6 +61,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `variables` not being propagated in `Carousel` @assuncaocharles ([#16084](https://github.com/microsoft/fluentui/pull/16084))
 - Fix `Carousel` `onActiveIndexChange` to contain `activeIndex` @assuncaocharles ([#16118](https://github.com/microsoft/fluentui/pull/16118))
 - Fix `Tree` behavior adding `shouldFocusInnerElementWhenReceivedFocus` to avoid root element to be focused @assuncaocharles ([#16145](https://github.com/microsoft/fluentui/pull/16145))
+- Fix wrong grid template in `Checkbox` for `label` end @jurokapsiar ([#16208](https://github.com/microsoft/fluentui/pull/16208))
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/docs/src/examples/components/Checkbox/Visual/CheckboxExampleLabelFlexColumn.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Checkbox/Visual/CheckboxExampleLabelFlexColumn.shorthand.tsx
@@ -1,0 +1,11 @@
+import { Checkbox, Flex } from '@fluentui/react-northstar';
+import * as React from 'react';
+
+const CheckboxExampleLabelFlexColumn = () => (
+  <Flex column>
+    <Checkbox label="At start" labelPosition="start" />
+    <Checkbox label="At end" />
+  </Flex>
+);
+
+export default CheckboxExampleLabelFlexColumn;

--- a/packages/fluentui/docs/src/examples/components/Checkbox/Visual/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Checkbox/Visual/index.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
 import NonPublicSection from '../../../../components/ComponentDoc/NonPublicSection';
 
-const Types = () => (
+const Visual = () => (
   <NonPublicSection title="Visual tests">
     <ComponentExample examplePath="components/Checkbox/Visual/CheckboxExampleLabelFlexColumn" />
   </NonPublicSection>
 );
 
-export default Types;
+export default Visual;

--- a/packages/fluentui/docs/src/examples/components/Checkbox/Visual/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Checkbox/Visual/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
+import NonPublicSection from '../../../../components/ComponentDoc/NonPublicSection';
+
+const Types = () => (
+  <NonPublicSection title="Visual tests">
+    <ComponentExample examplePath="components/Checkbox/Visual/CheckboxExampleLabelFlexColumn" />
+  </NonPublicSection>
+);
+
+export default Types;

--- a/packages/fluentui/docs/src/examples/components/Checkbox/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Checkbox/index.tsx
@@ -4,6 +4,7 @@ import Rtl from './Rtl';
 import Slots from './Slots';
 import States from './States';
 import Types from './Types';
+import Visual from './Visual';
 
 const CheckboxExamples = () => (
   <>
@@ -11,6 +12,7 @@ const CheckboxExamples = () => (
     <States />
     <Slots />
     <Rtl />
+    <Visual />
   </>
 );
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
@@ -19,7 +19,7 @@ export const checkboxStyles: ComponentSlotStylesPrepared<CheckboxStylesProps, Ch
     position: 'relative',
 
     display: ['inline-grid', '-ms-inline-grid'],
-    gridTemplateColumns: `1fr ${v.gap} auto`,
+    gridTemplateColumns: `auto ${v.gap} 1fr`,
     // IE11: Gap is done via virtual column as in autoprefixer
     msGridColumns: `auto ${v.gap} 1fr`,
 


### PR DESCRIPTION
#### Description of changes

There is a typo in the grid template for Checkbox, leading to wrong layout when checkbox is inside of a column Flex
 