### PR TITLE
fix(Tree): cannot expand/collapse when treeTitle has children

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix shorthand `id` prop not being passed to control in `FormField` component @assuncaocharles ([#16003](https://github.com/microsoft/fluentui/pull/16003))
 - Add cleanup to Fela renderer to avoid memory leaks @layershifter @miroslavstastny ([#15211](https://github.com/microsoft/fluentui/pull/15211))
 - Fix `Attachment` to pass `actionable` to accessibility behaviors @layershifter ([#16023](https://github.com/microsoft/fluentui/pull/16023))
-
+- Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16199](https://github.com/microsoft/fluentui/pull/16199))
 
 <!--------------------------------[ v0.51.2 ]------------------------------- -->
 ## [v0.51.2](https://github.com/microsoft/fluentui/tree/'@fluentui/react-northstar_v'0.51.2) (2020-09-25)

--- a/packages/fluentui/react-northstar/jest.config.js
+++ b/packages/fluentui/react-northstar/jest.config.js
@@ -1,15 +1,13 @@
 const commonConfig = require('@uifabric/build/jest');
 
-module.exports = {
-  ...commonConfig,
+const config = commonConfig({
   name: 'react',
   moduleNameMapper: {
-    ...require('lerna-alias').jest({
-      directory: require('@uifabric/build/monorepo/findGitRoot')(),
-    }),
     // Legacy aliases, they should not be used in new tests
     '^src/(.*)$': `<rootDir>/src/$1`,
     'test/(.*)$': `<rootDir>/test/$1`,
   },
-  setupFilesAfterEnv: [...commonConfig.setupFilesAfterEnv, './test/setup.ts'],
-};
+});
+config.setupFilesAfterEnv = [...config.setupFilesAfterEnv, './test/setup.ts'];
+
+module.exports = config;

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -297,7 +297,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
         return;
       }
 
-      if (treeItemHasSubtree && !executeSelection && e.target === e.currentTarget) {
+      if (treeItemHasSubtree && !executeSelection) {
         expandItems(e, treeItemProps);
       }
 
@@ -307,8 +307,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
           return;
         }
 
-        // if the target is equal to currentTarget it means treeItem should be collapsed, not procced with selection
-        if (treeItemHasSubtree && e.target === e.currentTarget && !executeSelection) {
+        if (treeItemHasSubtree && !executeSelection) {
           return;
         }
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -30,7 +30,7 @@ import {
   ShorthandCollection,
   FluentComponentStaticProps,
 } from '../../types';
-import { TreeTitle, TreeTitleProps } from './TreeTitle';
+import { TreeTitle, TreeTitleProps, treeTitleSlotClassNames } from './TreeTitle';
 import { BoxProps } from '../Box/Box';
 import { hasSubtree, TreeContext } from './utils';
 
@@ -230,8 +230,12 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     onSiblingsExpand(e, props);
   };
   const handleTitleOverrides = (predefinedProps: TreeTitleProps) => ({
-    onClick: (e, titleProps) => {
-      handleTitleClick(e);
+    onClick: (e: React.SyntheticEvent, titleProps) => {
+      if (selectable && (e?.target as HTMLElement)?.className?.includes(treeTitleSlotClassNames.indicator)) {
+        handleSelection(e);
+      } else {
+        handleTitleClick(e);
+      }
       _.invoke(predefinedProps, 'onClick', e, titleProps);
     },
   });

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -165,6 +165,14 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     _.invoke(props, 'onClick', e, props);
   };
 
+  const selectionIndicatorOverrideProps = (predefinedProps: BoxProps) => ({
+    onClick: (e: React.SyntheticEvent) => {
+      e.stopPropagation(); // otherwise onClick on title will also be executed
+      handleClick(e);
+      _.invoke(predefinedProps, 'onClick', e);
+    },
+  });
+
   const selectIndicator = Box.create(selectionIndicator, {
     defaultProps: () => ({
       as: 'span',
@@ -178,6 +186,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
           }),
       }),
     }),
+    overrideProps: selectionIndicatorOverrideProps,
   });
 
   const element = (

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -7,6 +7,7 @@ import { Tree } from 'src/components/Tree/Tree';
 import { treeTitleClassName } from 'src/components/Tree/TreeTitle';
 import { treeItemClassName } from 'src/components/Tree/TreeItem';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
+import { TriangleDownIcon, TriangleEndIcon, svgIconClassName } from '@fluentui/react-icons-northstar';
 
 const items = [
   {
@@ -35,7 +36,15 @@ const items = [
     items: [
       {
         id: '21',
-        title: '21',
+        title: {
+          content: '21',
+          children: (Component, { content, expanded, hasSubtree, ...restProps }) => (
+            <Component expanded={expanded} hasSubtree={hasSubtree} {...restProps}>
+              {expanded ? <TriangleDownIcon /> : <TriangleEndIcon />}
+              {content}
+            </Component>
+          ),
+        },
         items: [
           {
             id: '211',
@@ -181,6 +190,37 @@ describe('Tree', () => {
       itemsClone[0]['items'][1]['expanded'] = true;
       const wrapper = mountWithProvider(<Tree items={itemsClone} activeItemIds={['2', '21']} />);
 
+      checkOpenTitles(wrapper, ['1', '2', '21', '211', '22', '3']);
+    });
+
+    it('should propagate correct items through onActiveItemIdsChange', () => {
+      const itemsClone = JSON.parse(JSON.stringify(items));
+      const onActiveItemIdsChange = jest.fn();
+      const wrapper = mountWithProvider(
+        <Tree items={itemsClone} activeItemIds={['2', '21']} onActiveItemIdsChange={onActiveItemIdsChange} />,
+      );
+
+      getTitles(wrapper)
+        .at(0) // title 1
+        .simulate('click');
+
+      expect(onActiveItemIdsChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'click' }),
+        expect.objectContaining({ activeItemIds: expect.arrayContaining(['2', '21', '1']) }),
+      );
+    });
+
+    it('should expand on click when TreeTitle renders children components ', () => {
+      const wrapper = mountWithProvider(<Tree items={items} />);
+
+      // open title '2'
+      getTitles(wrapper)
+        .at(1)
+        .simulate('click');
+
+      // click on icon of title '21'
+      const icon = wrapper.find(`.${svgIconClassName}`).filterWhere(n => typeof n.type() === 'string');
+      icon.simulate('click');
       checkOpenTitles(wrapper, ['1', '2', '21', '211', '22', '3']);
     });
   });

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -193,23 +193,6 @@ describe('Tree', () => {
       checkOpenTitles(wrapper, ['1', '2', '21', '211', '22', '3']);
     });
 
-    it('should propagate correct items through onActiveItemIdsChange', () => {
-      const itemsClone = JSON.parse(JSON.stringify(items));
-      const onActiveItemIdsChange = jest.fn();
-      const wrapper = mountWithProvider(
-        <Tree items={itemsClone} activeItemIds={['2', '21']} onActiveItemIdsChange={onActiveItemIdsChange} />,
-      );
-
-      getTitles(wrapper)
-        .at(0) // title 1
-        .simulate('click');
-
-      expect(onActiveItemIdsChange).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'click' }),
-        expect.objectContaining({ activeItemIds: expect.arrayContaining(['2', '21', '1']) }),
-      );
-    });
-
     it('should expand on click when TreeTitle renders children components ', () => {
       const wrapper = mountWithProvider(<Tree items={items} />);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

when tree title has children, it cannot be expand/collapsed when click happens on children

BACKPORT of #16199 

#### Focus areas to test

(optional)
