### PR TITLE
Add `unstable_disableTether` prop to configure `Popper`

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -66,7 +66,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix wrong grid template in `Checkbox` for `label` end @jurokapsiar ([#16208](https://github.com/microsoft/fluentui/pull/16208))
 - Export missing type `SplitButtonToggleStyleProps` @ling1726 ([#16215](https://github.com/microsoft/fluentui/pull/16215))
 - Remove `inline-block` from `Menu` root slot @assuncaocharles ([#16222](https://github.com/microsoft/fluentui/pull/16222))
-- Make untethered poppers default again like in Popper v1 @ling1726 ([#16214](https://github.com/microsoft/fluentui/pull/16214))
+- Add `unstable_disableTether` prop to configure `Popper`'s behavior for elements outside of a viewport @ling1726 @layershifter ([#16214](https://github.com/microsoft/fluentui/pull/16214))
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -64,6 +64,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Carousel` `onActiveIndexChange` to contain `activeIndex` @assuncaocharles ([#16118](https://github.com/microsoft/fluentui/pull/16118))
 - Fix `Tree` behavior adding `shouldFocusInnerElementWhenReceivedFocus` to avoid root element to be focused @assuncaocharles ([#16145](https://github.com/microsoft/fluentui/pull/16145))
 - Fix wrong grid template in `Checkbox` for `label` end @jurokapsiar ([#16208](https://github.com/microsoft/fluentui/pull/16208))
+- Make untethered poppers default again like in Popper v1 @ling1726 ([#16214])(https://github.com/microsoft/fluentui/pull/16214)
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -406,6 +406,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
     styles,
     toggleIndicator,
     triggerButton,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   } = props;
@@ -642,6 +643,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
           rtl={context.rtl}
           enabled={open}
           targetRef={containerRef}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
           positioningDependencies={[items.length]}
           {...positioningProps}
@@ -1679,6 +1681,7 @@ Dropdown.propTypes = {
   searchInput: customPropTypes.itemShorthand,
   toggleIndicator: customPropTypes.shorthandAllowingChildren,
   triggerButton: customPropTypes.itemShorthand,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   value: PropTypes.oneOfType([customPropTypes.itemShorthand, customPropTypes.collectionShorthand]),
 };

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -136,6 +136,7 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     tabbableTrigger,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   } = props;
@@ -197,6 +198,7 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     styles: props.styles,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   };
@@ -328,6 +330,7 @@ MenuButton.propTypes = {
   target: PropTypes.any,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
   tabbableTrigger: PropTypes.bool,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   menu: PropTypes.oneOfType([
     customPropTypes.itemShorthandWithoutJSX,

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -147,6 +147,7 @@ export const Popup: React.FC<PopupProps> &
     target,
     trapFocus,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -550,6 +551,7 @@ export const Popup: React.FC<PopupProps> &
           offset={offset}
           overflowBoundary={overflowBoundary}
           rtl={context.rtl}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
           targetRef={rightClickReferenceObject.current || target || triggerRef}
         >
@@ -616,6 +618,7 @@ Popup.propTypes = {
   target: PropTypes.any,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
   tabbableTrigger: PropTypes.bool,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   content: customPropTypes.shorthandAllowingChildren,
   contentRef: customPropTypes.ref,

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -126,6 +126,7 @@ export const SplitButton: ComponentWithAs<'div', SplitButtonProps> &
     popperRef,
     positionFixed,
     offset,
+    unstable_disableTether,
     unstable_pinned,
     className,
     design,
@@ -227,6 +228,7 @@ export const SplitButton: ComponentWithAs<'div', SplitButtonProps> &
                 popperRef,
                 positionFixed,
                 offset,
+                unstable_disableTether,
                 unstable_pinned,
               }),
             overrideProps: handleMenuButtonOverrides,
@@ -301,6 +303,7 @@ SplitButton.propTypes = {
     PropTypes.func,
     PropTypes.arrayOf(PropTypes.number) as PropTypes.Requireable<[number, number]>,
   ]),
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
 };
 

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -113,6 +113,7 @@ export const Tooltip: React.FC<TooltipProps> &
     positionFixed,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -243,6 +244,7 @@ export const Tooltip: React.FC<TooltipProps> &
           rtl={context.rtl}
           targetRef={target || triggerRef}
           children={renderPopperChildren}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
         />
       </PortalInner>
@@ -284,6 +286,7 @@ Tooltip.propTypes = {
   target: customPropTypes.domNode,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.element]),
   content: customPropTypes.shorthandAllowingChildren,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   popperRef: customPropTypes.ref,
   flipBoundary: PropTypes.oneOfType([

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -318,6 +318,7 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     positionFixed,
     proposedPlacement,
     targetRef,
+    unstable_disableTether,
     unstable_pinned,
     popperInitialPositionFix,
   ]);

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -269,6 +269,18 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
           },
         },
 
+        /**
+         * This modifier is necessary to retain behaviour from popper v1 where untethered poppers are allowed by
+         * default. i.e. popper is still rendered fully in the viewport even if anchor element is no longer in the
+         * viewport
+         */
+        {
+          name: 'preventOverflow',
+          options: {
+            tether: false,
+          },
+        },
+
         flipBoundary && {
           name: 'flip',
           options: {

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -178,6 +178,7 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     positioningDependencies = [],
     rtl,
     targetRef,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -272,13 +273,11 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
         /**
          * This modifier is necessary to retain behaviour from popper v1 where untethered poppers are allowed by
          * default. i.e. popper is still rendered fully in the viewport even if anchor element is no longer in the
-         * viewport
+         * viewport.
          */
-        {
+        unstable_disableTether && {
           name: 'preventOverflow',
-          options: {
-            tether: false,
-          },
+          options: { altAxis: unstable_disableTether === 'all', tether: false },
         },
 
         flipBoundary && {

--- a/packages/fluentui/react-northstar/src/utils/positioner/types.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/types.ts
@@ -111,6 +111,12 @@ export interface PositioningProps {
   offset?: Offset;
 
   /**
+   * When the reference element or the viewport is outside viewport allows a popper element to be fully in viewport.
+   * "all" enables this behavior for all axis.
+   */
+  unstable_disableTether?: boolean | 'all';
+
+  /**
    * Disables automatic repositioning of the component; it will always be placed according to the values of `align` and
    * `position` props, regardless of the size of the component, the reference element or the viewport.
    */

--- a/packages/fluentui/react-northstar/test/specs/commonTests/implementsPopperProps.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/implementsPopperProps.tsx
@@ -15,6 +15,7 @@ export const positioningProps: Required<PositioningProps> = {
   popperRef: React.createRef(),
   position: 'above',
   positionFixed: true,
+  unstable_disableTether: 'all',
   unstable_pinned: true,
 };
 


### PR DESCRIPTION
This PR Add `unstable_disableTether` prop to configure `Popper`'s behavior for elements outside of a viewport, this can be added by default as will break the behavior of other Popper consumers:

![tether](https://user-images.githubusercontent.com/14183168/102212075-e28fdd00-3ed4-11eb-88fd-5c91b380e44c.gif)

---

`unstable_disableTether='all'` allows to include `altAxis`, see https://github.com/popperjs/popper-core/issues/989.