### PR TITLE
fix(MenuStyles): revert fix for IE11

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -65,6 +65,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tree` behavior adding `shouldFocusInnerElementWhenReceivedFocus` to avoid root element to be focused @assuncaocharles ([#16145](https://github.com/microsoft/fluentui/pull/16145))
 - Fix wrong grid template in `Checkbox` for `label` end @jurokapsiar ([#16208](https://github.com/microsoft/fluentui/pull/16208))
 - Export missing type `SplitButtonToggleStyleProps` @ling1726 ([#16215](https://github.com/microsoft/fluentui/pull/16215))
+- Remove `inline-block` from `Menu` root slot @assuncaocharles ([#16222](https://github.com/microsoft/fluentui/pull/16222))
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuStyles.ts
@@ -17,6 +17,7 @@ export const menuStyles: ComponentSlotStylesPrepared<MenuStylesProps, MenuVariab
       color: v.color,
       backgroundColor: v.backgroundColor || 'inherit',
       listStyleType: 'none',
+
       ...(iconOnly && { alignItems: 'center' }),
       ...(vertical && {
         flexDirection: 'column',
@@ -25,7 +26,7 @@ export const menuStyles: ComponentSlotStylesPrepared<MenuStylesProps, MenuVariab
         ...(submenu && {
           boxShadow: v.verticalBoxShadow,
         }),
-        ...(!fluid && !submenu && { width: ['fit-content', 'auto'] }),
+        ...(!fluid && !submenu && { width: 'fit-content' }),
         ...(iconOnly && {
           display: 'inline-block',
           width: 'auto',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuStyles.ts
@@ -25,7 +25,7 @@ export const menuStyles: ComponentSlotStylesPrepared<MenuStylesProps, MenuVariab
         ...(submenu && {
           boxShadow: v.verticalBoxShadow,
         }),
-        ...(!fluid && !submenu && { width: ['fit-content', 'auto'], display: 'inline-block' }),
+        ...(!fluid && !submenu && { width: ['fit-content', 'auto'] }),
         ...(iconOnly && {
           display: 'inline-block',
           width: 'auto',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16216
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In the PR #13506 we introduced `display: inline-block` for the root slot of `Menu`, this fixed a spacing problem in IE11. Recently we noticed that it created a new issue, see #16216 .  We are reverting it here since we do not support IE11 anymore and it fixes the current issue. 

#### Focus areas to test

(optional)
