### PR TITLE
swapping arrows for decade picker, which were backwards

### DIFF
--- a/change/@fluentui-react-date-time-2020-12-14-13-19-28-lorejoh12-swapArrowDirections.json
+++ b/change/@fluentui-react-date-time-2020-12-14-13-19-28-lorejoh12-swapArrowDirections.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "swapping arrows for decade picker, which were backwards",
+  "packageName": "@fluentui/react-date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-14T21:19:27.993Z"
+}

--- a/packages/react-date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react-date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -267,8 +267,8 @@ const CalendarYearNavArrow = React.forwardRef(
         <Icon
           iconName={
             (direction === CalendarYearNavDirection.Previous) !== getRTL()
-              ? navigationIcons.rightNavigation
-              : navigationIcons.leftNavigation
+              ? navigationIcons.leftNavigation
+              : navigationIcons.rightNavigation
           }
         />
       </button>

--- a/packages/react-date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react-date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -252,6 +252,11 @@ const CalendarYearNavArrow = React.forwardRef(
       }
     };
 
+    // can be condensed, but leaving verbose for clarity due to regressions
+    const isLeftNavigation = getRTL()
+      ? direction === CalendarYearNavDirection.Next
+      : direction === CalendarYearNavDirection.Previous;
+
     return (
       <button
         className={css(classNames.navigationButton, {
@@ -264,13 +269,7 @@ const CalendarYearNavArrow = React.forwardRef(
         disabled={disabled}
         ref={forwardedRef}
       >
-        <Icon
-          iconName={
-            (direction === CalendarYearNavDirection.Previous) !== getRTL()
-              ? navigationIcons.leftNavigation
-              : navigationIcons.rightNavigation
-          }
-        />
+        <Icon iconName={isLeftNavigation ? navigationIcons.leftNavigation : navigationIcons.rightNavigation} />
       </button>
     );
   },

--- a/packages/react-date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/react-date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -199,7 +199,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   ): JSX.Element => {
     const { minDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
-    const leftNavigationIcon = navigationIcons!.leftNavigation;
+    const leftNavigationIcon = getRTL() ? navigationIcons!.rightNavigation : navigationIcons!.leftNavigation;
 
     // determine if previous week in bounds
     const prevWeekInBounds = minDate
@@ -226,7 +226,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   private _renderNextWeekNavigationButton = (classNames: IProcessedStyleSet<IWeeklyDayPickerStyles>): JSX.Element => {
     const { maxDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
-    const rightNavigationIcon = navigationIcons!.rightNavigation;
+    const rightNavigationIcon = getRTL() ? navigationIcons!.leftNavigation : navigationIcons!.rightNavigation;
 
     // determine if next week in bounds
     const nextWeekInBounds = maxDate


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Noticed in OWA that the arrows for the decade picker were swapped in all views. Small fix to swap them back.

#### Focus areas to test

(optional)
