### PR TITLE
chore(Backport): Add `unstable_disableTether` prop to configure `Popper` (#16214)

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export missing type `SplitButtonToggleStyleProps` @ling1726 ([#16215](https://github.com/microsoft/fluentui/pull/16215))
 - Fix wrong grid template in `Checkbox` for `label` end @jurokapsiar ([#16208](https://github.com/microsoft/fluentui/pull/16208))
 - Remove `inline-block` from `Menu` root slot @assuncaocharles ([#16222](https://github.com/microsoft/fluentui/pull/16222))
+- Add `unstable_disableTether` prop to configure `Popper`'s behavior for elements outside of a viewport @ling1726 @layershifter ([#16214](https://github.com/microsoft/fluentui/pull/16214))
 
 <!--------------------------------[ v0.51.2 ]------------------------------- -->
 ## [v0.51.2](https://github.com/microsoft/fluentui/tree/'@fluentui/react-northstar_v'0.51.2) (2020-09-25)

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -401,6 +401,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
     styles,
     toggleIndicator,
     triggerButton,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   } = props;
@@ -636,6 +637,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
           rtl={context.rtl}
           enabled={open}
           targetRef={containerRef}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
           positioningDependencies={[items.length]}
           {...positioningProps}
@@ -1665,6 +1667,7 @@ Dropdown.propTypes = {
   searchInput: customPropTypes.itemShorthand,
   toggleIndicator: customPropTypes.shorthandAllowingChildren,
   triggerButton: customPropTypes.itemShorthand,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   value: PropTypes.oneOfType([customPropTypes.itemShorthand, customPropTypes.collectionShorthand]),
 };

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -136,6 +136,7 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     tabbableTrigger,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   } = props;
@@ -197,6 +198,7 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     styles: props.styles,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
     variables,
   };
@@ -328,6 +330,7 @@ MenuButton.propTypes = {
   target: PropTypes.any,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
   tabbableTrigger: PropTypes.bool,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   menu: PropTypes.oneOfType([
     customPropTypes.itemShorthandWithoutJSX,

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -146,6 +146,7 @@ export const Popup: React.FC<PopupProps> &
     target,
     trapFocus,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -523,6 +524,7 @@ export const Popup: React.FC<PopupProps> &
           offset={offset}
           overflowBoundary={overflowBoundary}
           rtl={context.rtl}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
           targetRef={rightClickReferenceObject.current || target || triggerRef}
         >
@@ -589,6 +591,7 @@ Popup.propTypes = {
   target: PropTypes.any,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.any]),
   tabbableTrigger: PropTypes.bool,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   content: customPropTypes.shorthandAllowingChildren,
   contentRef: customPropTypes.ref,

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -126,6 +126,7 @@ export const SplitButton: ComponentWithAs<'div', SplitButtonProps> &
     popperRef,
     positionFixed,
     offset,
+    unstable_disableTether,
     unstable_pinned,
     className,
     design,
@@ -227,6 +228,7 @@ export const SplitButton: ComponentWithAs<'div', SplitButtonProps> &
                 popperRef,
                 positionFixed,
                 offset,
+                unstable_disableTether,
                 unstable_pinned,
               }),
             overrideProps: handleMenuButtonOverrides,
@@ -301,6 +303,7 @@ SplitButton.propTypes = {
     PropTypes.func,
     PropTypes.arrayOf(PropTypes.number) as PropTypes.Requireable<[number, number]>,
   ]),
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
 };
 

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -113,6 +113,7 @@ export const Tooltip: React.FC<TooltipProps> &
     positionFixed,
     target,
     trigger,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -243,6 +244,7 @@ export const Tooltip: React.FC<TooltipProps> &
           rtl={context.rtl}
           targetRef={target || triggerRef}
           children={renderPopperChildren}
+          unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
         />
       </PortalInner>
@@ -284,6 +286,7 @@ Tooltip.propTypes = {
   target: customPropTypes.domNode,
   trigger: customPropTypes.every([customPropTypes.disallow(['children']), PropTypes.element]),
   content: customPropTypes.shorthandAllowingChildren,
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   popperRef: customPropTypes.ref,
   flipBoundary: PropTypes.oneOfType([

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -178,6 +178,7 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     positioningDependencies = [],
     rtl,
     targetRef,
+    unstable_disableTether,
     unstable_pinned,
   } = props;
 
@@ -269,6 +270,16 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
           },
         },
 
+        /**
+         * This modifier is necessary to retain behaviour from popper v1 where untethered poppers are allowed by
+         * default. i.e. popper is still rendered fully in the viewport even if anchor element is no longer in the
+         * viewport.
+         */
+        unstable_disableTether && {
+          name: 'preventOverflow',
+          options: { altAxis: unstable_disableTether === 'all', tether: false },
+        },
+
         flipBoundary && {
           name: 'flip',
           options: {
@@ -307,6 +318,7 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     positionFixed,
     proposedPlacement,
     targetRef,
+    unstable_disableTether,
     unstable_pinned,
     popperInitialPositionFix,
   ]);

--- a/packages/fluentui/react-northstar/src/utils/positioner/types.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/types.ts
@@ -111,6 +111,12 @@ export interface PositioningProps {
   offset?: Offset;
 
   /**
+   * When the reference element or the viewport is outside viewport allows a popper element to be fully in viewport.
+   * "all" enables this behavior for all axis.
+   */
+  unstable_disableTether?: boolean | 'all';
+
+  /**
    * Disables automatic repositioning of the component; it will always be placed according to the values of `align` and
    * `position` props, regardless of the size of the component, the reference element or the viewport.
    */

--- a/packages/fluentui/react-northstar/test/specs/commonTests/implementsPopperProps.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/implementsPopperProps.tsx
@@ -15,6 +15,7 @@ export const positioningProps: Required<PositioningProps> = {
   popperRef: React.createRef(),
   position: 'above',
   positionFixed: true,
+  unstable_disableTether: 'all',
   unstable_pinned: true,
 };
 


### PR DESCRIPTION
* Untether popper by default like in v1

* update changelong

* make tether configurable via prop

* update changelog

* fix deps for a hook

Co-authored-by: Lingfan Gao <lingfan.gao@microsoft.com>
Co-authored-by: Oleksandr Fediashov <olfedias@microsoft.com>

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
