### PR TITLE
[UPP] Use Segoe UI font in picker input

### DIFF
--- a/change/@fluentui-react-experiments-2020-12-15-10-44-07-upp-autofill-font-segoe.json
+++ b/change/@fluentui-react-experiments-2020-12-15-10-44-07-upp-autofill-font-segoe.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "[UPP] Use Segoe UI font in picker input",
+  "packageName": "@fluentui/react-experiments",
+  "email": "chrp@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-15T18:44:06.957Z"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -80,10 +80,15 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
                 ms-BasePicker-input
                 ms-UnifiedPicker-input
                 {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   border: none;
                   display: flex;
                   flex-grow: 1;
                   flex: 1 1 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   height: 34px;
                   margin-bottom: 1px;
                   margin-left: 1px;
@@ -839,10 +844,15 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                 ms-BasePicker-input
                 ms-UnifiedPicker-input
                 {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   border: none;
                   display: flex;
                   flex-grow: 1;
                   flex: 1 1 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   height: 34px;
                   margin-bottom: 1px;
                   margin-left: 1px;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
@@ -23,7 +23,7 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
     throw new Error('theme is undefined or null in Editing item getStyles function.');
   }
 
-  // const { semanticColors } = theme;
+  const { fonts } = theme;
   const { neutralTertiary, themeLight } = theme.palette;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -49,6 +49,7 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
     ],
     pickerInput: [
       classNames.pickerInput,
+      fonts.medium,
       {
         display: 'flex',
         flex: '1 1 auto',

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -80,10 +80,15 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
                 ms-BasePicker-input
                 ms-UnifiedPicker-input
                 {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   border: none;
                   display: flex;
                   flex-grow: 1;
                   flex: 1 1 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   height: 34px;
                   margin-bottom: 1px;
                   margin-left: 1px;
@@ -219,10 +224,15 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
                 ms-BasePicker-input
                 ms-UnifiedPicker-input
                 {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   border: none;
                   display: flex;
                   flex-grow: 1;
                   flex: 1 1 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   height: 34px;
                   margin-bottom: 1px;
                   margin-left: 1px;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

UnifiedPicker style was overriding BasePicker's style which used `fonts.medium` on the input. Added it back.

#### Focus areas to test

(optional)
