### PR TITLE
UnifiedPicker: Drop to either side of items

### DIFF
--- a/change/@fluentui-react-experiments-2020-12-15-11-05-24-dropright.json
+++ b/change/@fluentui-react-experiments-2020-12-15-11-05-24-dropright.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "UnifiedPicker drop to each side of item",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-15T19:05:24.161Z"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -180,6 +180,15 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       insertIndex = selectedItems.indexOf(item);
     }
 
+    // If the drop is in the right half of the item, we want to drop at index+1
+    if (event && event.currentTarget) {
+      const targetElement = event.currentTarget as HTMLElement;
+      // how does this math work for RTL?
+      if (event.pageX > targetElement.offsetLeft + targetElement.offsetWidth / 2) {
+        insertIndex++;
+      }
+    }
+
     event?.preventDefault();
     _onDropInner(event?.dataTransfer !== null ? event?.dataTransfer : undefined);
   };

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -11,6 +11,7 @@ import { useSelectedItems } from './hooks/useSelectedItems';
 import { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite';
 import { getTheme } from '@fluentui/react/lib/Styling';
 import { mergeStyles } from '@fluentui/merge-styles';
+import { getRTL } from '@fluentui/react/lib/Utilities';
 
 export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();
@@ -183,9 +184,15 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     // If the drop is in the right half of the item, we want to drop at index+1
     if (event && event.currentTarget) {
       const targetElement = event.currentTarget as HTMLElement;
-      // how does this math work for RTL?
-      if (event.pageX > targetElement.offsetLeft + targetElement.offsetWidth / 2) {
-        insertIndex++;
+      const halfwayPoint = targetElement.offsetLeft + targetElement.offsetWidth / 2;
+      if (getRTL()) {
+        if (event.pageX < halfwayPoint) {
+          insertIndex++;
+        }
+      } else {
+        if (event.pageX > halfwayPoint) {
+          insertIndex++;
+        }
       }
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If you're dropping over an item, it is counter intuitive for it always to drop to the left. It makes more sense to drop left or right depending on what end the mouse is closer to.

I tested RTL by setting the documentation to RTL and then going into that code. I'm new to this so if there's a better way to test that please let me know.
