### PR TITLE
fix: update style on aria-current item and adjust margin on last item

### DIFF
--- a/change/@fluentui-web-components-2020-12-15-15-09-46-users-khamu-breadcrumb-aria-current.json
+++ b/change/@fluentui-web-components-2020-12-15-15-09-46-users-khamu-breadcrumb-aria-current.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update style on aria-current item and adjust margin on last item",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-15T23:09:46.906Z"
+}

--- a/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -74,13 +74,17 @@ export const BreadcrumbItemStyles = css`
         height: calc(var(--focus-outline-width) * 1px);
     }
 
-    :host(:not([href])) {
+    :host(:not([href])),
+    :host([aria-current]) .control  {
         font-weight: 600;
         color: ${neutralForegroundRestBehavior.var};
         fill: currentcolor;
-        margin-inline-start: 11px;
         cursor: default;
     }
+
+    :host([aria-current]) .control:hover .content::before {
+      background: ${neutralForegroundRestBehavior.var};
+  }
 
     .start {
         display: flex;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updated the style on the aria-current item to look like the no href item. 
The margin on the no href item was also removed.

#### Focus areas to test

(optional)
