### PR TITLE
Remove react-theme-provider@v0 dependency from react-focus package

### DIFF
--- a/change/@fluentui-react-focus-2020-12-16-11-36-46-fix-dep.json
+++ b/change/@fluentui-react-focus-2020-12-16-11-36-46-fix-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Remove react-theme-provider@v0 dependency from react-focus package",
+  "packageName": "@fluentui/react-focus",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-16T19:36:46.684Z"
+}

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.12",
-    "@fluentui/react-theme-provider": "^0.18.0",
     "@uifabric/merge-styles": "^7.19.1",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.18",

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { ThemeContext, Theme } from '@fluentui/react-theme-provider';
 import { mergeStyles } from '@uifabric/merge-styles';
-import { getTheme } from '@uifabric/styling';
+import { getTheme, ITheme } from '@uifabric/styling';
 import {
   KeyCodes,
   css,
@@ -28,6 +27,7 @@ import {
   getWindow,
   findScrollableParent,
   createMergedRef,
+  useCustomizationSettings,
 } from '@uifabric/utilities';
 import { FocusZoneDirection, FocusZoneTabbableElements, IFocusZone, IFocusZoneProps } from './FocusZone.types';
 
@@ -254,7 +254,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     this._evaluateFocusBeforeRender();
 
     return (
-      <ThemeContext.Consumer>
+      <ThemeContextConsumer>
         {theme => (
           <Tag
             aria-labelledby={ariaLabelledBy}
@@ -282,7 +282,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
             {this.props.children}
           </Tag>
         )}
-      </ThemeContext.Consumer>
+      </ThemeContextConsumer>
     );
   }
 
@@ -574,7 +574,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   /**
    * Handle the keystrokes.
    */
-  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme: Theme): boolean | undefined => {
+  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme: ITheme): boolean | undefined => {
     if (this._portalContainsElement(ev.target as HTMLElement)) {
       // If the event target is inside a portal do not process the event.
       return;
@@ -992,7 +992,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusLeft(theme: Theme): boolean {
+  private _moveFocusLeft(theme: ITheme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
@@ -1034,7 +1034,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusRight(theme: Theme): boolean {
+  private _moveFocusRight(theme: ITheme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
@@ -1367,3 +1367,11 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return getDocument(this._root.current)!;
   }
 }
+
+// TODO: switch to use useTheme from react-theme-provider once it's officially released.
+const ThemeContextConsumer: React.FunctionComponent<{
+  children: (theme: ITheme | undefined) => JSX.Element;
+}> = props => {
+  const theme = useCustomizationSettings(['theme']).theme;
+  return props.children(theme);
+};

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -27,7 +27,6 @@ import {
   getWindow,
   findScrollableParent,
   createMergedRef,
-  useCustomizationSettings,
 } from '@uifabric/utilities';
 import { FocusZoneDirection, FocusZoneTabbableElements, IFocusZone, IFocusZoneProps } from './FocusZone.types';
 
@@ -253,36 +252,35 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // the case the element was removed.
     this._evaluateFocusBeforeRender();
 
+    // Only support RTL defined in global theme, not contextual theme/RTL.
+    const theme: ITheme = getTheme();
+
     return (
-      <ThemeContextConsumer>
-        {theme => (
-          <Tag
-            aria-labelledby={ariaLabelledBy}
-            aria-describedby={ariaDescribedBy}
-            {...divProps}
-            {
-              // root props has been deprecated and should get removed.
-              // it needs to be marked as "any" since root props expects a div element, but really Tag can
-              // be any native element so typescript rightly flags this as a problem.
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ...(rootProps as any)
-            }
-            // Once the getClassName correctly memoizes inputs this should
-            // be replaced so that className is passed to getRootClass and is included there so
-            // the class names will always be in the same order.
-            className={css(getRootClass(), className)}
-            // eslint-disable-next-line deprecation/deprecation
-            ref={this._mergedRef(this.props.elementRef, this._root)}
-            data-focuszone-id={this._id}
-            // eslint-disable-next-line react/jsx-no-bind
-            onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme || getTheme())}
-            onFocus={this._onFocus}
-            onMouseDownCapture={this._onMouseDown}
-          >
-            {this.props.children}
-          </Tag>
-        )}
-      </ThemeContextConsumer>
+      <Tag
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        {...divProps}
+        {
+          // root props has been deprecated and should get removed.
+          // it needs to be marked as "any" since root props expects a div element, but really Tag can
+          // be any native element so typescript rightly flags this as a problem.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(rootProps as any)
+        }
+        // Once the getClassName correctly memoizes inputs this should
+        // be replaced so that className is passed to getRootClass and is included there so
+        // the class names will always be in the same order.
+        className={css(getRootClass(), className)}
+        // eslint-disable-next-line deprecation/deprecation
+        ref={this._mergedRef(this.props.elementRef, this._root)}
+        data-focuszone-id={this._id}
+        // eslint-disable-next-line react/jsx-no-bind
+        onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme)}
+        onFocus={this._onFocus}
+        onMouseDownCapture={this._onMouseDown}
+      >
+        {this.props.children}
+      </Tag>
     );
   }
 
@@ -1367,11 +1365,3 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return getDocument(this._root.current)!;
   }
 }
-
-// TODO: switch to use useTheme from react-theme-provider once it's officially released.
-const ThemeContextConsumer: React.FunctionComponent<{
-  children: (theme: ITheme | undefined) => JSX.Element;
-}> = props => {
-  const theme = useCustomizationSettings(['theme']).theme;
-  return props.children(theme);
-};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Dependency of `@fluentui/react-theme-provider@v0` for `@fluentui/react-focus` was introduced from fix in #16016.
`react-focus` is a production package and it's dependency for suite package `@fluentui/react`. 
We should not let production package to depend on a beta package, which lead to package duplication issue for our partners. 
This change removes the dependency and have FocusZone to retrieve global theme/RTL applied using `loadTheme`. Since the original ask is to fix it to work with `loadTheme`, I decided to revoke the support for contextual theme/RTL to avoid unneeded runtime cost (we can add it when there is a real need).

#### Focus areas to test

(optional)
