### PR TITLE
Refactor table event propagation logic

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
@@ -73,7 +73,10 @@ export const TableCell: ComponentWithAs<'div', TableCellProps> & FluentComponent
         cellRef.current.focus();
       },
       performClick: e => {
-        handleClick(e);
+        if (e.currentTarget === e.target) {
+          _.invoke(props, 'onClick', e, props);
+          e.preventDefault();
+        }
       },
     },
     rtl: context.rtl,
@@ -93,20 +96,12 @@ export const TableCell: ComponentWithAs<'div', TableCellProps> & FluentComponent
     rtl: context.rtl,
   });
 
-  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    if (e.currentTarget === e.target) {
-      _.invoke(props, 'onClick', e, props);
-      e.preventDefault();
-    }
-  };
-
   const element = (
     <Ref innerRef={cellRef}>
       {getA11yProps.unstable_wrapWithFocusZone(
         <ElementType
           {...getA11yProps('root', {
             className: classes.root,
-            onClick: handleClick,
             ...unhandledProps,
           })}
         >

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -15,7 +15,7 @@ import * as _ from 'lodash';
 
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { FluentComponentStaticProps, ShorthandCollection, ComponentEventHandler } from '../../types';
+import { FluentComponentStaticProps, ShorthandCollection } from '../../types';
 import { childrenExist, commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
 import { TableCell, TableCellProps } from './TableCell';
 
@@ -44,14 +44,6 @@ export interface TableRowProps extends UIComponentProps {
    * Whether a row is currently selected or not.
    */
   selected?: boolean;
-
-  /**
-   * Called on click.
-   *
-   * @param event - React's original SyntheticEvent.
-   * @param data - All props.
-   */
-  onClick?: ComponentEventHandler<TableRowProps>;
 }
 
 export const tableRowClassName = 'ui-table__row';
@@ -79,7 +71,10 @@ export const TableRow: ComponentWithAs<'div', TableRowProps> & FluentComponentSt
         rowRef.current.setAttribute('tabindex', '-1');
       },
       performClick: e => {
-        handleClick(e);
+        if (e.currentTarget === e.target) {
+          _.invoke(props, 'onClick', e, props);
+          e.preventDefault();
+        }
       },
     },
     mapPropsToBehavior: () => ({
@@ -104,13 +99,6 @@ export const TableRow: ComponentWithAs<'div', TableRowProps> & FluentComponentSt
     rtl: context.rtl,
   });
 
-  const handleClick = (e: React.SyntheticEvent) => {
-    if (e.currentTarget === e.target) {
-      _.invoke(props, 'onClick', e, props);
-      e.preventDefault();
-    }
-  };
-
   const renderCells = () => {
     return _.map(items, (item: TableCellProps) => {
       return TableCell.create(item, {
@@ -128,7 +116,6 @@ export const TableRow: ComponentWithAs<'div', TableRowProps> & FluentComponentSt
         <ElementType
           {...getA11yProps('root', {
             className: classes.root,
-            onClick: handleClick,
             ...unhandledProps,
           })}
         >
@@ -152,7 +139,6 @@ TableRow.propTypes = {
   header: PropTypes.bool,
   compact: PropTypes.bool,
   selected: PropTypes.bool,
-  onClick: PropTypes.func,
 };
 
 TableRow.handledProps = Object.keys(TableRow.propTypes) as any;


### PR DESCRIPTION
During the transition to functional components (PR #12797), a previously unused `handleClick` callback function was enabled by adding `onClick` as a handled prop to `TableRow`. The use of this `handleClick` actually creates a new bug since the `e.curentTarget === e.target` condition would swallow all click events on the row since clicks are always triggered from the lowest element of the DOM tree.

This PR refactors logic in `handleClick` and moves it purely to keyboard behaviours and removes `onClick` as a handled prop to `TableRow`, relying on native `onClick` again.