### PR TITLE
fix(Popup): Do not trigger popup on click when hover is used with context

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `selectableParent` prop in favor of `selectable` in `TreeItem` and make `selectionIndicator` visible only on focus or hover @assuncaocharles ([#15133](https://github.com/microsoft/fluentui/pull/15133))
 
 ### Fixes
+- Do not trigger `Popup` on `click` when `hover` is used with `context` @jurokapsiar ([#16286](https://github.com/microsoft/fluentui/pull/16286))
 - Fix selectable `Tree` where node with unselectable children displaying wrong selection state @yuanboxue-amber ([#16158](https://github.com/microsoft/fluentui/pull/16158))
 - Fix `Tree` cannot expand/collapse when treeTitle has children @yuanboxue-amber ([#16199](https://github.com/microsoft/fluentui/pull/16199))
 - Fix `Attachment` to pass `actionable` to accessibility behaviors @layershifter ([#16023](https://github.com/microsoft/fluentui/pull/16023))

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -318,10 +318,12 @@ export const Popup: React.FC<PopupProps> &
         setPopupOpen(false, e);
         _.invoke(triggerElement, 'props.onMouseLeave', e, ...args);
       };
-      triggerProps.onClick = (e, ...args) => {
-        setPopupOpen(true, e);
-        _.invoke(triggerElement, 'props.onClick', e, ...args);
-      };
+      if (!_.includes(normalizedOn, 'context')) {
+        triggerProps.onClick = (e, ...args) => {
+          setPopupOpen(true, e);
+          _.invoke(triggerElement, 'props.onClick', e, ...args);
+        };
+      }
       triggerProps.onBlur = (e, ...args) => {
         if (shouldBlurClose(e)) {
           trySetOpen(false, e);

--- a/packages/fluentui/react-northstar/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Popup/Popup-test.tsx
@@ -116,6 +116,16 @@ describe('Popup', () => {
       expect(spy.mock.calls[0][1]).toMatchObject({ open: true });
     });
 
+    test('is not called on click when on is contextmenu and hover', () => {
+      const spy = jest.fn();
+
+      mountWithProvider(<Popup trigger={<button />} content="Hi" onOpenChange={spy} on={['context', 'hover']} />)
+        .find('button')
+        .simulate('click');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     // https://github.com/microsoft/fluent-ui-react/pull/619
     test('is called on contextmenu when controlled', () => {
       const spy = jest.fn();


### PR DESCRIPTION
#### Description of changes

When `hover` and `context` are used in `Popup` `on` prop, there is no need to trigger popup on click as well.
