### PR TITLE
DetailsList: fix group chevron alignment in single select mode

### DIFF
--- a/change/@fluentui-react-2020-12-22-17-10-32-header-spacer.json
+++ b/change/@fluentui-react-2020-12-22-17-10-32-header-spacer.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "DetailsList: Fix group chevron alignment in single select mode",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-22T23:10:32.766Z"
+}

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -12,6 +12,7 @@ import {
   IGroupHeaderProps,
   IGroupHeaderCheckboxProps,
 } from './GroupHeader.types';
+import { CHECK_CELL_WIDTH } from '../DetailsList/DetailsRowCheck.styles';
 
 const getClassNames = classNamesFunction<IGroupHeaderStyleProps, IGroupHeaderStyles>();
 
@@ -137,7 +138,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
               </button>
             </div>
           ) : (
-            selectionMode !== SelectionMode.none && <GroupSpacer indentWidth={indentWidth} count={1} />
+            // To make the group header align properly with the column headers, this spacer
+            // needs to be the same width as the check cell in the column header.
+            selectionMode !== SelectionMode.none && <GroupSpacer indentWidth={CHECK_CELL_WIDTH} count={1} />
           )}
 
           <GroupSpacer indentWidth={indentWidth} count={groupLevel!} />

--- a/scripts/local-codepen.js
+++ b/scripts/local-codepen.js
@@ -3,16 +3,22 @@ const WebpackDevServer = require('webpack-dev-server');
 const path = require('path');
 const fs = require('fs');
 const yargs = require('yargs');
+const execSync = require('./exec-sync');
+const { findGitRoot } = require('./monorepo/index');
 
 const options = yargs.option('webpackConfig', { alias: 'w', type: 'string' }).argv;
 
 const webpackConfigFilePath = options.webpackConfig || 'webpack.codepen.config.js';
 
 const configPath = path.resolve(process.cwd(), webpackConfigFilePath);
+const gitRoot = findGitRoot();
 
 if (fs.existsSync(configPath)) {
   let ngrok;
   try {
+    console.log("Attempting to npm link globally installed ngrok so it can be require'd");
+    // This will probably install ngrok globally if it's not already present
+    execSync('npm link ngrok@3', undefined, gitRoot);
     ngrok = require('ngrok');
   } catch (err) {
     // ngrok has a postbuild step which was slowing down yarn install, so it's been removed


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16120
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In a grouped DetailsList in single select mode, the group header chevron is incorrectly aligned with the column header chevron. This is because the GroupSpacer used to compensate for the empty checkbox column is the wrong width. (In the screenshot, I highlighted the bad spacer in red and the group level spacers in green.)
![before, 1 level of groups](https://user-images.githubusercontent.com/5864305/102941800-73802e80-4468-11eb-81fc-d169743bd315.png)
![before, 3 levels of groups](https://user-images.githubusercontent.com/5864305/102942096-46804b80-4469-11eb-9b18-b5fc8b7b5748.png)

Fix is to hardcode the width of this particular spacer to be the same as the checkbox column width. This works fine even with nested groups since the extra spacers used for subsequent levels still use the custom width. Below is a screenshot of nested groups **after** the fix (the fixed spacer is blue and the unchanged group spacers are green).
![after, 1 level of groups](https://user-images.githubusercontent.com/5864305/102942078-39fbf300-4469-11eb-8cc4-20646f3a89c8.png)
![after, 3 levels of groups](https://user-images.githubusercontent.com/5864305/102942034-1b95f780-4469-11eb-966d-900873109f9e.png)

While trying to validate this fix in a [codepen](https://codepen.io/ecraig12345/pen/zYKEozM), I noticed that the `yarn codepen` script was broken due to being unable to find the globally installed `ngrok` dependency, so I fixed that too.