### PR TITLE
(7.0) TextField: set type="button" on reveal password button

### DIFF
--- a/change/@fluentui-react-avatar-2020-10-13-12-47-23-fix-button-hooks.json
+++ b/change/@fluentui-react-avatar-2020-10-13-12-47-23-fix-button-hooks.json
@@ -1,8 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Updating useStatus and useAvatar to return state only, exporting render functions separately.",
-  "packageName": "@fluentui/react-avatar",
-  "email": "dzearing@hotmail.com",
-  "dependentChangeType": "patch",
-  "date": "2020-10-13T19:47:23.741Z"
-}

--- a/change/@fluentui-react-examples-2020-12-23-19-50-18-textfield-button.json
+++ b/change/@fluentui-react-examples-2020-12-23-19-50-18-textfield-button.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "TextField: set type=\"button\" on reveal password button",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-12-24T01:50:18.290Z"
+}

--- a/change/office-ui-fabric-react-2020-12-23-19-50-18-textfield-button.json
+++ b/change/office-ui-fabric-react-2020-12-23-19-50-18-textfield-button.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: set type=\"button\" on reveal password button",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-24T01:50:13.658Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -241,7 +241,8 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {multiline ? this._renderTextArea() : this._renderInput()}
             {iconProps && <Icon className={classNames.icon} {...iconProps} />}
             {hasRevealButton && (
-              <button className={classNames.revealButton} onClick={this._onRevealButtonClick}>
+              // Explicitly set type="button" since the default button type within a form is "submit"
+              <button className={classNames.revealButton} onClick={this._onRevealButtonClick} type="button">
                 <span className={classNames.revealSpan}>
                   <Icon
                     className={classNames.revealIcon}

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1491,6 +1491,7 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
               outline: 0px;
             }
         onClick={[Function]}
+        type="button"
       >
         <span
           className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -2138,6 +2138,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   outline: 0px;
                 }
             onClick={[Function]}
+            type="button"
           >
             <span
               className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15729
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #15949: set `type="button"` on TextField's reveal password button so that pressing the button doesn't submit if the TextField is within a form.