### PR TITLE
Enable Dropdown component to adjust the width to fit content.

### DIFF
--- a/change/@fluentui-react-2020-12-25-15-17-03-master.json
+++ b/change/@fluentui-react-2020-12-25-15-17-03-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add a props for Dropdown component to enable adjust width to fit content",
+  "packageName": "@fluentui/react",
+  "email": "qizheqi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-25T07:17:03.663Z"
+}

--- a/change/@fluentui-react-internal-2020-12-25-15-17-03-master.json
+++ b/change/@fluentui-react-internal-2020-12-25-15-17-03-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add calloutMinWidth props for Callout component",
+  "packageName": "@fluentui/react-internal",
+  "email": "qizheqi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-25T07:16:55.108Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -1286,6 +1286,7 @@ export interface ICalloutContentStyleProps {
     backgroundColor?: string;
     beakWidth?: number;
     calloutMaxWidth?: number;
+    calloutMinWidth?: number;
     calloutWidth?: number;
     className?: string;
     overflowYHidden?: boolean;
@@ -1325,6 +1326,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
     bounds?: IRectangle | ((target?: Target, targetWindow?: Window) => IRectangle | undefined);
     calloutMaxHeight?: number;
     calloutMaxWidth?: number;
+    calloutMinWidth?: number;
     calloutWidth?: number;
     className?: string;
     coverTarget?: boolean;

--- a/packages/react-internal/src/components/Callout/Callout.types.ts
+++ b/packages/react-internal/src/components/Callout/Callout.types.ts
@@ -53,10 +53,16 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
   calloutWidth?: number;
 
   /**
-   * Custom width for callout including borders. If value is 0, no width is applied.
+   * Maximum width for callout including borders. If value is 0, no width is applied.
    * @defaultvalue 0
    */
   calloutMaxWidth?: number;
+
+  /**
+   * Minimum width for callout including borders. If value is 0, no width is applied.
+   * @defaultvalue 0
+   */
+  calloutMinWidth?: number;
 
   /**
    * The background color of the Callout in hex format ie. #ffffff.
@@ -313,6 +319,11 @@ export interface ICalloutContentStyleProps {
    * Max width for callout including borders.
    */
   calloutMaxWidth?: number;
+
+  /**
+   * Min width for callout including borders.
+   */
+  calloutMinWidth?: number;
 }
 
 /**

--- a/packages/react-internal/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react-internal/src/components/Callout/CalloutContent.base.tsx
@@ -427,6 +427,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       beakWidth,
       calloutWidth,
       calloutMaxWidth,
+      calloutMinWidth,
       finalHeight,
       hideOverflow = !!finalHeight,
       backgroundColor,
@@ -487,6 +488,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       beakWidth,
       backgroundColor,
       calloutMaxWidth,
+      calloutMinWidth,
     });
 
     const overflowStyle: React.CSSProperties = {

--- a/packages/react-internal/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/react-internal/src/components/Callout/CalloutContent.styles.ts
@@ -17,7 +17,16 @@ const GlobalClassNames = {
 };
 
 export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyles => {
-  const { theme, className, overflowYHidden, calloutWidth, beakWidth, backgroundColor, calloutMaxWidth } = props;
+  const {
+    theme,
+    className,
+    overflowYHidden,
+    calloutWidth,
+    beakWidth,
+    backgroundColor,
+    calloutMaxWidth,
+    calloutMinWidth,
+  } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -50,6 +59,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
       className,
       !!calloutWidth && { width: calloutWidth },
       !!calloutMaxWidth && { maxWidth: calloutMaxWidth },
+      !!calloutMinWidth && { minWidth: calloutMinWidth },
     ],
     beak: [
       classNames.beak,

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1498,6 +1498,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
     dropdownWidth?: number;
     // @deprecated
     isDisabled?: boolean;
+    isDropdownWidthFitContent?: boolean;
     multiSelectDelimiter?: string;
     notifyOnReselect?: boolean;
     onChange?: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, index?: number) => void;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1495,10 +1495,9 @@ export interface IDropdownOption extends ISelectableOption {
 // @public (undocumented)
 export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     defaultSelectedKeys?: string[] | number[];
-    dropdownWidth?: number;
+    dropdownWidth?: number | 'grow';
     // @deprecated
     isDisabled?: boolean;
-    isDropdownWidthFitContent?: boolean;
     multiSelectDelimiter?: string;
     notifyOnReselect?: boolean;
     onChange?: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, index?: number) => void;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1495,7 +1495,7 @@ export interface IDropdownOption extends ISelectableOption {
 // @public (undocumented)
 export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     defaultSelectedKeys?: string[] | number[];
-    dropdownWidth?: number | 'grow';
+    dropdownWidth?: number | 'auto';
     // @deprecated
     isDisabled?: boolean;
     multiSelectDelimiter?: string;

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -222,7 +222,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       });
 
       warnMutuallyExclusive(COMPONENT_NAME, props, {
-        dropdownWidth: 'isDropdownWidthFitContent',
         defaultSelectedKey: 'selectedKey',
         defaultSelectedKeys: 'selectedKeys',
         selectedKeys: 'selectedKey',
@@ -590,7 +589,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   /** Render Callout or Panel container and pass in list */
   private _onRenderContainer = (props: ISelectableDroppableTextProps<IDropdown, HTMLDivElement>): JSX.Element => {
     const { calloutProps, panelProps } = props;
-    const { responsiveMode, dropdownWidth, isDropdownWidthFitContent } = this.props;
+    const { responsiveMode, dropdownWidth } = this.props;
 
     const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
@@ -598,9 +597,10 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
       : undefined;
 
+    const isGrow = dropdownWidth === 'grow';
     const defaultCalloutWidth = dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0);
-    const calloutWidth = isDropdownWidthFitContent ? undefined : defaultCalloutWidth;
-    const calloutMinWidth = isDropdownWidthFitContent ? defaultCalloutWidth : undefined;
+    const calloutWidth = isGrow ? undefined : defaultCalloutWidth;
+    const calloutMinWidth = isGrow ? defaultCalloutWidth : undefined;
 
     return isSmall ? (
       <Panel

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -51,6 +51,7 @@ import { getPropsWithDefaults } from '@fluentui/utilities';
 import { useResponsiveMode } from '@fluentui/react-internal/lib/utilities/hooks/useResponsiveMode';
 import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
 
+const COMPONENT_NAME = 'Dropdown';
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
 /** Internal only props interface to support mixing in responsive mode */
@@ -213,17 +214,18 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const { multiSelect, selectedKey, selectedKeys, defaultSelectedKey, defaultSelectedKeys, options } = props;
 
     if (process.env.NODE_ENV !== 'production') {
-      warnDeprecations('Dropdown', props, {
+      warnDeprecations(COMPONENT_NAME, props, {
         isDisabled: 'disabled',
         onChanged: 'onChange',
         placeHolder: 'placeholder',
         onRenderPlaceHolder: 'onRenderPlaceholder',
       });
 
-      warnMutuallyExclusive('Dropdown', props, {
+      warnMutuallyExclusive(COMPONENT_NAME, props, {
         defaultSelectedKey: 'selectedKey',
         defaultSelectedKeys: 'selectedKeys',
         selectedKeys: 'selectedKey',
+        dropdownWidth: 'isDropdownWidthFitContent',
       });
 
       if (multiSelect) {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -614,13 +614,13 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         doNotLayer={false}
         directionalHintFixed={false}
         directionalHint={DirectionalHint.bottomLeftEdge}
+        calloutWidth={dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0)}
         {...calloutProps}
         className={this._classNames.callout}
         target={this._dropDown.current}
         onDismiss={this._onDismiss}
         onScroll={this._onScroll}
         onPositioned={this._onPositioned}
-        calloutWidth={dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0)}
       >
         {this._renderFocusableList(props)}
       </Callout>

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -588,13 +588,17 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   /** Render Callout or Panel container and pass in list */
   private _onRenderContainer = (props: ISelectableDroppableTextProps<IDropdown, HTMLDivElement>): JSX.Element => {
     const { calloutProps, panelProps } = props;
-    const { responsiveMode, dropdownWidth } = this.props;
+    const { responsiveMode, dropdownWidth, isDropdownWidthFitContent } = this.props;
 
     const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
     const panelStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
       : undefined;
+
+    const defaultCalloutWidth = dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0);
+    const calloutWidth = isDropdownWidthFitContent ? undefined : defaultCalloutWidth;
+    const calloutMinWidth = isDropdownWidthFitContent ? defaultCalloutWidth : undefined;
 
     return isSmall ? (
       <Panel
@@ -614,7 +618,8 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         doNotLayer={false}
         directionalHintFixed={false}
         directionalHint={DirectionalHint.bottomLeftEdge}
-        calloutWidth={dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0)}
+        calloutWidth={calloutWidth}
+        calloutMinWidth={calloutMinWidth}
         {...calloutProps}
         className={this._classNames.callout}
         target={this._dropDown.current}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -597,10 +597,13 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
       : undefined;
 
-    const isGrow = dropdownWidth === 'grow';
-    const defaultCalloutWidth = dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0);
-    const calloutWidth = isGrow ? undefined : defaultCalloutWidth;
-    const calloutMinWidth = isGrow ? defaultCalloutWidth : undefined;
+    let calloutWidth = undefined;
+    let calloutMinWidth = undefined;
+    if (dropdownWidth === 'grow') {
+      calloutMinWidth = this._dropDown.current ? this._dropDown.current.clientWidth : 0;
+    } else {
+      calloutWidth = dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0);
+    }
 
     return isSmall ? (
       <Panel

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -222,10 +222,10 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       });
 
       warnMutuallyExclusive(COMPONENT_NAME, props, {
+        dropdownWidth: 'isDropdownWidthFitContent',
         defaultSelectedKey: 'selectedKey',
         defaultSelectedKeys: 'selectedKeys',
         selectedKeys: 'selectedKey',
-        dropdownWidth: 'isDropdownWidthFitContent',
       });
 
       if (multiSelect) {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -599,7 +599,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     let calloutWidth = undefined;
     let calloutMinWidth = undefined;
-    if (dropdownWidth === 'grow') {
+    if (dropdownWidth === 'auto') {
       calloutMinWidth = this._dropDown.current ? this._dropDown.current.clientWidth : 0;
     } else {
       calloutWidth = dropdownWidth || (this._dropDown.current ? this._dropDown.current.clientWidth : 0);

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -85,6 +85,12 @@ export interface IDropdownProps
   dropdownWidth?: number;
 
   /**
+   * Adjust the width to fit the content. Cannot be used together with `dropdownWidth`.
+   * @defaultvalue false
+   */
+  isDropdownWidthFitContent?: boolean;
+
+  /**
    * Pass in ResponsiveMode to manually overwrite the way the Dropdown renders.
    * ResponsiveMode.large would, for instance, disable the behavior where Dropdown options
    * get rendered into a Panel while ResponsiveMode.small would result in the Dropdown

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -80,10 +80,10 @@ export interface IDropdownProps
 
   /**
    * Custom width for dropdown. If value is 0, width of the input field is used.
-   * If value is 'grow', width of the input field is used by default, and it can grow wider to fit the content.
+   * If value is 'auto', width of the input field is used by default, and it can grow wider to fit the content.
    * @defaultvalue 0
    */
-  dropdownWidth?: number | 'grow';
+  dropdownWidth?: number | 'auto';
 
   /**
    * Pass in ResponsiveMode to manually overwrite the way the Dropdown renders.

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -85,7 +85,8 @@ export interface IDropdownProps
   dropdownWidth?: number;
 
   /**
-   * Adjust the width to fit the content. Cannot be used together with `dropdownWidth`.
+   * Adjust the width to fit the content.
+   * Mutually exclusive with `dropdownWidth`.
    * @defaultvalue false
    */
   isDropdownWidthFitContent?: boolean;

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -80,16 +80,10 @@ export interface IDropdownProps
 
   /**
    * Custom width for dropdown. If value is 0, width of the input field is used.
+   * If value is 'grow', width of the input field is used by default, and it can grow wider to fit the content.
    * @defaultvalue 0
    */
-  dropdownWidth?: number;
-
-  /**
-   * Adjust the width to fit the content.
-   * Mutually exclusive with `dropdownWidth`.
-   * @defaultvalue false
-   */
-  isDropdownWidthFitContent?: boolean;
+  dropdownWidth?: number | 'grow';
 
   /**
    * Pass in ResponsiveMode to manually overwrite the way the Dropdown renders.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7215,9 +7215,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001093:
-  version "1.0.30001097"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001097.tgz#1129c40c9f5ee3282158da08fd915d301f4a9bd8"
-  integrity sha512-TeuSleKt/vWXaPkLVFqGDnbweYfq4IaZ6rUugFf3rWY6dlII8StUZ8Ddin0PkADfgYZ4wRqCdO2ORl4Rn5eZIA==
+  version "1.0.30001171"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz"
+  integrity sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16181
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Add `calloutMinWidth` props for Callout component
- Add a prop for the Dropdown component to enable adjust the width to fit content.

```jsx
<Dropdown
  placeholder="Select an Option"
  label="Basic example:"
  ariaLabel="Basic dropdown example"
  options={[
    { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
    { key: 'A', text: 'Option a' },
    { key: 'B', text: 'Option b' },
    { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
    { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
    { key: 'F', text: 'Option f', disabled: true },
    { key: 'G', text: 'Option g' },
    { key: 'Long', text: 'Option long long long long long long long long long' },
  ]}
  dropdownWidth={'grow'} // this one
/>
```
When `dropdownWidth='grow'`
![image](https://user-images.githubusercontent.com/19623228/103125258-788de980-46c5-11eb-930c-06e6c372c188.png)

When `dropdownWidth=undefined`
![image](https://user-images.githubusercontent.com/19623228/103125287-8b082300-46c5-11eb-8a6b-da7f7ee20fab.png)

