### PR TITLE
Rename Fabric component in export to codepen

### DIFF
--- a/change/@uifabric-tsx-editor-2020-12-29-18-13-37-fix-codepen.json
+++ b/change/@uifabric-tsx-editor-2020-12-29-18-13-37-fix-codepen.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rename Fabric component in export to codepen",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-30T00:13:37.485Z"
+}

--- a/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`example transform can return component 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -16,7 +16,7 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -25,7 +25,7 @@ return LabelBasicExampleWrapper;
 exports[`example transform can return component with transpiled example 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -35,7 +35,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -43,7 +43,7 @@ return LabelBasicExampleWrapper;
 
 exports[`example transform handles examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -67,7 +67,7 @@ class SpinButtonBasicExample extends React.Component<any, any> {
   }
 }
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
@@ -89,7 +89,7 @@ ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 
 exports[`example transform handles examples with custom supportedPackages and Fabric 1`] = `
 Object {
-  "output": "const { Stack, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Stack, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 const { FooLabel } = window.Foo;
 
 // Initialize icons in case this example uses them
@@ -103,14 +103,14 @@ const FooExample = () => {
   );
 };
 
-const FooExampleWrapper = () => <Fabric><FooExample /></Fabric>;
+const FooExampleWrapper = () => <FabricComponent><FooExample /></FabricComponent>;
 ReactDOM.render(<FooExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -123,14 +123,14 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -163,14 +163,14 @@ var SpinButtonBasicExample = /** @class */ (function (_super) {
 }(React.Component));
 { SpinButtonBasicExample };
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -180,7 +180,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;

--- a/packages/tsx-editor/src/transpiler/exampleTransform.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.ts
@@ -93,14 +93,21 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
     // and initialize icons in case the example uses them.
     finalComponent = component + 'Wrapper';
 
+    // rename to avoid conflict with window.Fabric
+    const renamedFabricComponent = 'FabricComponent';
+
     // If eval-ing the code, the component can't use JSX format
     const wrapperCode = returnFunction
-      ? `React.createElement(Fabric, null, React.createElement(${component}, null))`
-      : `<Fabric><${component} /></Fabric>`;
+      ? `React.createElement(${renamedFabricComponent}, null, React.createElement(${component}, null))`
+      : `<${renamedFabricComponent}><${component} /></${renamedFabricComponent}>`;
     lines.push('', `const ${finalComponent} = () => ${wrapperCode};`);
 
-    if (identifiersByGlobal.Fabric.indexOf('Fabric') === -1) {
-      identifiersByGlobal.Fabric.push('Fabric');
+    const fabricIndex = identifiersByGlobal.Fabric.indexOf('Fabric');
+    const renamedIdentifier = `Fabric: ${renamedFabricComponent}`;
+    if (fabricIndex === -1) {
+      identifiersByGlobal.Fabric.push(renamedIdentifier);
+    } else {
+      identifiersByGlobal.Fabric[fabricIndex] = renamedIdentifier;
     }
 
     if (identifiersByGlobal.Fabric.indexOf('initializeIcons') === -1) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #11773
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Codepen has once again changed the scope in which the example code is run, causing the global `window.Fabric` from our UMD bundle to conflict with local destructuring of the `Fabric` component. Workaround is to rename `Fabric` to `FabricComponent` when destructuring.

(Note that this change isn't needed in master since it wraps examples in `ThemeProvider` instead. It might be broken in 6, but that's a lower priority at this point.)