### PR TITLE
fix: design parity update to web-components for matching with fast

### DIFF
--- a/change/@fluentui-web-components-2020-12-30-13-58-55-users-v-sedono-fix-design-parody-misc-fixes.json
+++ b/change/@fluentui-web-components-2020-12-30-13-58-55-users-v-sedono-fix-design-parody-misc-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "misc design parody updates to match FAST",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-30T21:58:55.120Z"
+}

--- a/packages/web-components/.storybook/manager.js
+++ b/packages/web-components/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import theme from './theme';
+
+addons.setConfig({
+  theme,
+});

--- a/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
@@ -106,6 +106,7 @@ export const AccordionItemStyles = css`
     .start {
         display: flex;
         align-items: center;
+        padding-inline-start: calc(var(--design-unit) * 1px);
         justify-content: center;
         grid-column: 1;
         z-index: 2;

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -15,7 +15,7 @@ export const MenuItemStyles = css`
         outline: none;
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        grid-template-columns: 42px auto 42px;
+        grid-template-columns: minmax(42px, auto) 1fr minmax(42px, auto);
         grid-template-rows: auto;
         justify-items: center;
         align-items: center;
@@ -72,6 +72,7 @@ export const MenuItemStyles = css`
             replace when adaptive typography is figured out */ ''
         } width: 16px;
         height: 16px;
+        display: flex;
     }
 
     :host(:hover) .start,

--- a/packages/web-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/src/menu/fixtures/menu.html
@@ -4,10 +4,11 @@
   <fluent-menu>
     <fluent-menu-item>Menu item 1</fluent-menu-item>
     <fluent-menu-item>Menu item 2</fluent-menu-item>
-    <fluent-menu-item>Menu item 3</fluent-menu-item>
+    <fluent-menu-item disabled>Menu item 3 Disabled</fluent-menu-item>
+    <fluent-menu-item>Menu item 4</fluent-menu-item>
   </fluent-menu>
 
-  <h4>With seperator</h4>
+  <h4>With Separator</h4>
   <fluent-menu>
     <fluent-menu-item role="menuitem">Menu item 1</fluent-menu-item>
     <fluent-menu-item role="menuitem">Menu item 2</fluent-menu-item>

--- a/packages/web-components/src/select/select.styles.ts
+++ b/packages/web-components/src/select/select.styles.ts
@@ -25,8 +25,10 @@ export const SelectStyles = css`
         background: ${neutralFillInputRestBehavior.var};
         border-radius: calc(var(--corner-radius) * 1px);
         border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
+        box-sizing: border-box;
         color: ${neutralForegroundRestBehavior.var};
         contain: contents;
+        height: calc(${heightNumber} * 1px);
         position: relative;
         user-select: none;
         min-width: 250px;

--- a/packages/web-components/src/select/select.styles.ts
+++ b/packages/web-components/src/select/select.styles.ts
@@ -166,6 +166,7 @@ export const SelectStyles = css`
     .start,
     .end,
     .indicator,
+    .select-indicator,
     ::slotted(svg) {
         ${`` /* Glyph size is temporary - replace when glyph-size var is added */}
         fill: currentcolor;

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -81,7 +81,7 @@ export const SliderStyles = css`
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+        margin-inline-start: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         width: calc(var(--track-width) * 1px);
         height: 100%;
     }

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -95,7 +95,10 @@ export const BaseButtonStyles: ElementStyles = css`
     }
 
     .start,
-    .end,
+    .end {
+        display: flex;
+    }
+
     ::slotted(svg) {
         ${
           /* Glyph size and margin-left is temporary -
@@ -260,6 +263,7 @@ export const HypertextStyles = css`
         font-size: inherit;
         line-height: inherit;
         background: transparent;
+        min-width: 0;
     }
 
     :host(.hypertext) .control {

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -105,6 +105,8 @@ export const SwitchStyles = css`
         color: ${neutralForegroundRestBehavior.var};
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
+        margin-inline-end: calc(var(--design-unit) * 2px + 2px);
+        cursor: pointer;
     }
 
     ::slotted(*) {

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -71,13 +71,15 @@ export const TextFieldStyles = css`
 
     .start,
     .end {
-        ${
-          /* Glyph size and margin-left is temporary -
-            replace when adaptive typography is figured out */ ''
-        } width: 16px;
-        height: 16px;
         margin: auto;
-        fill: ${neutralForegroundRestBehavior.var};
+        fill: currentcolor;
+    }
+    
+    ::slotted(svg) {      ${
+      /* Glyph size and margin-left is temporary -
+            replace when adaptive typography is figured out */ ''
+    } width: 16px;
+        height: 16px;
     }
 
     .start {

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -55,11 +55,6 @@ export const TextFieldStyles = css`
         outline: none;
     }
 
-    .label__hidden {
-        display: none;
-        visibility: hidden;
-    }
-
     .label {
         display: block;
         color: ${neutralForegroundRestBehavior.var};
@@ -67,6 +62,11 @@ export const TextFieldStyles = css`
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
         margin-bottom: 4px;
+    }
+   
+    .label__hidden {
+      display: none;
+      visibility: hidden;
     }
 
     .start,

--- a/packages/web-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/src/tree-item/tree-item.styles.ts
@@ -147,10 +147,14 @@ export const TreeItemStyles = css`
     }
     .start,
     .end {
+        display: flex;
+        fill: currentcolor;
+    }
+
+     ::slotted(svg) {
         ${/* Glyph size is temporary -
             replace when glyph-size var is added */ ''} width: 16px;
         height: 16px;
-        fill: ${neutralForegroundRestBehavior.var};
     }
 
     .start {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
These changes are to catch a few design parody discrepancies between Fluent Web Components and FAST.
The updates are as follows with related PRs if applicable:
•	Select glyph sizing, [PR #4171](https://github.com/microsoft/fast/pull/4171)
•	Select box sizing and height clamp [PR #4153](https://github.com/microsoft/fast/pull/4153)
•	Menu Item - Needs *disabled* example in fixtures
•	Text Field - label__hidden styles re-order so hidden styles take precedence
•	Switch - no padding between label and switch, cursor should be pointer
•	Accordion – focus border overlap of start, [PR #3994](https://github.com/microsoft/fast/pull/3994)
•	Slider - use of margin inline start for RTL, [PR #3830](https://github.com/microsoft/fast/pull/3830)
•	Anchor – hypertext, reset min-width, [PR #3708](https://github.com/microsoft/fast/pull/3708)
•	Update Start and End slot to remove fixed width and height, [PR #4081](https://github.com/microsoft/fast/pull/4081)

This also fixes the _theme_ for storybook as it was missing the _manager.js_ file