### PR TITLE
(7.0) ComboBox: fix multi-select checkbox role; improve docs and examples

### DIFF
--- a/change/office-ui-fabric-react-2020-12-30-03-22-23-combobox-checkbox-option-7.json
+++ b/change/office-ui-fabric-react-2020-12-30-03-22-23-combobox-checkbox-option-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: fix multi-select checkbox role; improve docs and examples",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-30T09:22:16.015Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1460,7 +1460,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           onMouseLeave={this._onOptionMouseLeave}
           role="option"
           // aria-selected should only be applied to checked items, not hovered items
-          aria-selected={isSelected ? 'true' : 'false'}
+          aria-selected={isChecked ? 'true' : 'false'}
           ariaLabel={item.ariaLabel}
           disabled={item.disabled}
           title={title}
@@ -1476,20 +1476,23 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           id={id + '-list' + item.index}
           ariaLabel={item.ariaLabel}
           key={item.key}
-          data-index={item.index}
           styles={optionStyles}
           className={'ms-ComboBox-option'}
-          data-is-focusable={true}
           onChange={this._onItemClick(item)}
           label={item.text}
-          role="option"
           checked={isChecked}
           title={title}
           disabled={item.disabled}
           // eslint-disable-next-line react/jsx-no-bind
           onRenderLabel={onRenderCheckboxLabel}
           inputProps={{
-            'aria-selected': isSelected ? 'true' : 'false',
+            // aria-selected should only be applied to checked items, not hovered items
+            'aria-selected': isChecked ? 'true' : 'false',
+            role: 'option',
+            ...({
+              'data-index': item.index,
+              'data-is-focusable': true,
+            } as any),
           }}
         />
       );

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -14,19 +14,19 @@ import { IButtonProps } from '../Button/Button.types';
  */
 export interface IComboBox {
   /**
-   * All selected options
+   * All selected options.
    */
   readonly selectedOptions: IComboBoxOption[];
 
   /**
-   * If there is a menu open this will dismiss the menu
+   * If there is a menu open this will dismiss the menu.
    */
   dismissMenu: () => void;
 
   /**
-   * Sets focus to the input in the comboBox
-   * @param shouldOpenOnFocus - Determines if we should open the ComboBox menu when the input gets focus
-   * @param useFocusAsync - Determines if we should focus the input asynchronously
+   * Sets focus to the input in the ComboBox
+   * @param shouldOpenOnFocus - Determines if we should open the ComboBox menu when the input gets focus.
+   * @param useFocusAsync - Determines if we should focus the input asynchronously.
    * @returns True if focus could be set, false if no operation was taken.
    */
   focus(shouldOpenOnFocus?: boolean, useFocusAsync?: boolean): boolean;
@@ -37,16 +37,14 @@ export interface IComboBox {
  */
 export interface IComboBoxOption extends ISelectableOption {
   /**
-   * Specific styles for each comboBox option. If you intend to give
-   * common styles to all comboBox option please use
-   * the prop comboBoxOptionStyles
+   * Specific styles for each ComboBox option. To give common styles to all options, use
+   * `IComboBoxProps.comboBoxOptionStyles` instead.
    */
   styles?: Partial<IComboBoxOptionStyles>;
 
   /**
-   * In scenarios where embedded data is used at the text prop, we will use the ariaLabel prop
-   * to set the aria-label and preview text. Default to false
-   * @defaultvalue false;
+   * Whether to use the `ariaLabel` prop instead of the `text` prop to set the preview text as well
+   * as the `aria-label`. This is for scenarios where the `text` prop is used for embedded data.
    */
   useAriaLabelAsText?: boolean;
 }
@@ -56,31 +54,31 @@ export interface IComboBoxOption extends ISelectableOption {
  */
 export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox, IComboBox> {
   /**
-   * Optional callback to access the IComboBox interface. Use this instead of ref for accessing
+   * Optional callback to access the `IComboBox` interface. Use this instead of `ref` for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<IComboBox>;
 
   /**
-   * Collection of options for this ComboBox
+   * Collection of options for this ComboBox.
    */
   options: IComboBoxOption[];
 
   /**
-   * Callback issued when a ComboBox item is clicked.
+   * Callback for when a ComboBox item is clicked.
    */
   onItemClick?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number) => void;
 
   /**
-   * Callback issued when either:
-   * 1) the selected option changes
-   * 2) a manually edited value is submitted. In this case there may not be a matched option if allowFreeform
-   *    is also true (and hence only value would be true, the other parameter would be null in this case)
+   * Callback for when either:
+   * 1) The selected option changes.
+   * 2) A manually edited value is submitted. In this case there may not be a matched option if `allowFreeform`
+   *    is also true (and hence only `value` would be provided; the other parameters would be unspecified).
    */
   onChange?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) => void;
 
   /**
-   * Callback issued when the user changes the pending value in ComboBox.
+   * Callback for when the user changes the pending value in ComboBox.
    * This will be called any time the component is updated and there is a current
    * pending value. Option, index, and value will all be undefined if no change
    * has taken place and the previously entered pending value is still valid.
@@ -88,64 +86,64 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
   onPendingValueChanged?: (option?: IComboBoxOption, index?: number, value?: string) => void;
 
   /**
-   * Function that gets invoked when the ComboBox menu is launched
+   * Callback for when the ComboBox menu is launched.
    */
   onMenuOpen?: () => void;
 
   /**
-   * Function that gets invoked when the ComboBox menu is dismissed
+   * Callback for when the ComboBox menu is dismissed.
    */
   onMenuDismissed?: () => void;
 
   /**
-   * Function that gets invoked before the menu gets dismissed
+   * Callback for before the menu gets dismissed.
    */
   onMenuDismiss?: () => void;
 
   /**
-   * Callback issued when the options should be resolved, if they have been updated or
-   * if they need to be passed in the first time
+   * Callback for when the options should be resolved, if they have been updated or
+   * if they need to be passed in the first time.
    */
   onResolveOptions?: (options: IComboBoxOption[]) => IComboBoxOption[] | PromiseLike<IComboBoxOption[]>;
 
   /**
-   * Callback issued when the ComboBox requests the list to scroll to a specific element
+   * Callback for when the ComboBox requests the list to scroll to a specific element.
    */
   onScrollToItem?: (itemIndex: number) => void;
 
   /**
-   * Whether the ComboBox is free form, meaning that the user input is not bound to provided options. Defaults to false.
+   * Whether the ComboBox allows freeform user input, rather than restricting to the provided options.
    */
   allowFreeform?: boolean;
 
   /**
-   * Whether the ComboBox auto completes. As the user is inputing text, it will be suggested potential matches from
-   * the list of options. If the combo box is expanded, this will also scroll to the suggested option, and give it a
-   * selected style.
+   * Whether the ComboBox auto completes. As the user is entering text, potential matches will be
+   * suggested from the list of options. If the ComboBox is expanded, this will also scroll to the
+   * suggested option and give it a selected style.
    *
    * @defaultvalue "on"
    */
   autoComplete?: 'on' | 'off';
 
   /**
-   * Value to show in the input, does not have to map to a combobox option
+   * Value to show in the input (does not have to map to a ComboBox option).
    */
   text?: string;
 
   /**
-   * When multiple items are selected, this will be used to separate values in the combobox input.
+   * When multiple items are selected, this will be used to separate values in the ComboBox input.
    *
    * @defaultvalue ", "
    */
   multiSelectDelimiter?: string;
 
   /**
-   * The IconProps to use for the button aspect of the combobox
+   * The IconProps to use for the caret button of the ComboBox.
    */
   buttonIconProps?: IIconProps;
 
   /**
-   * The AutofillProps to be passed into the Autofill component inside combobox
+   * Props to pass through to the Autofill component (the input field) inside the ComboBox.
    */
   autofill?: IAutofillProps;
 
@@ -155,7 +153,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
   theme?: ITheme;
 
   /**
-   * Custom styles for this component
+   * Custom styles for this component.
    */
   styles?: Partial<IComboBoxStyles>;
 
@@ -180,80 +178,78 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
   caretDownButtonStyles?: Partial<IButtonStyles>;
 
   /**
-   * Default styles that should be applied to ComboBox options,
-   * in case an option does not come with user-defined custom styles
+   * Default styles that should be applied to ComboBox options.
    */
   comboBoxOptionStyles?: Partial<IComboBoxOptionStyles>;
 
   /**
-   * When options are scrollable the selected option is positioned at the top of the callout when it is opened
-   * (unless it has reached the end of the scrollbar).
+   * When the options list is scrollable, whether to position the selected option at the top of the
+   * callout when it is opened (unless it has reached the end of the scrollbar).
    * @defaultvalue false;
    */
   scrollSelectedToTop?: boolean;
 
   /**
-   * Add additional content above the callout list.
+   * Add additional content above the option list in the callout.
    */
   onRenderUpperContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-   * Add additional content below the callout list.
+   * Add additional content below the option list in the callout.
    */
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-   * Custom width for dropdown (unless useComboBoxAsMenuWidth is undefined or false)
+   * Custom width for options list dropdown. Mutually exclusive with `useComboBoxAsMenuWidth`.
    */
   dropdownWidth?: number;
 
   /**
-   * Whether to use the ComboBoxes width as the menu's width
+   * Whether to use the ComboBox field width as the menu's width.
    */
   useComboBoxAsMenuWidth?: boolean;
 
   /**
-   * Custom max width for dropdown
+   * Custom max width for the options list dropdown.
    */
   dropdownMaxWidth?: number;
 
   /**
-   * Sets the 'aria-hidden' attribute on the ComboBox's button element instructing screen readers how to handle
-   * the element. This element is hidden by default because all functionality is handled by the input element and
+   * Sets the `aria-hidden` attribute on the ComboBox's caret button element. This element is hidden
+   * from screen readers by default because all functionality is handled by the input element and
    * the arrow button is only meant to be decorative.
    * @defaultvalue true
    */
   isButtonAriaHidden?: boolean;
 
   /**
-   * Optional prop to add a string id that can be referenced inside the aria-describedby attribute
+   * Optional ID of an element providing a description of the ComboBox for screen reader users.
    */
   ariaDescribedBy?: string;
 
   /**
-   * Optional keytip for this combo box
+   * Optional keytip for this ComboBox.
    */
   keytipProps?: IKeytipProps;
 
   /**
-   * Menu will not be created or destroyed when opened or closed, instead it
-   * will be hidden. This will improve perf of the menu opening but could potentially
-   * impact overall perf by having more elements in the dom. Should only be used
-   * when perf is important.
-   * Note: This may increase the amount of time it takes for the comboBox itself to mount.
+   * Whether to show/hide the menu when it's opened/closed (rather than creating/destroying it).
+   * This will improve perf of the menu opening but could potentially have a negative impact on
+   * overall perf by increasing initial render time (since the ComboBox will render the menu hidden
+   * on mount) and keeping more elements in the DOM. Should only be used when perf to open/close
+   * the menu is important.
    */
   persistMenu?: boolean;
 
   /**
-   * When specified, determines whether the callout (the menu which drops down) should
-   * restore the focus after being dismissed or not.  If false, then the menu will not try
-   * to set focus to whichever element had focus before the menu was opened.
+   * Whether the options list callout should restore focus after being dismissed. Set to false to
+   * prevent the menu from trying to re-focus the element that had focus before the menu was opened.
    * @defaultvalue true;
    */
   shouldRestoreFocus?: boolean;
 
   /**
-   * Optional iconButton props on combo box
+   * Additional props for the caret button.
    */
   iconButtonProps?: IButtonProps;
 
@@ -268,12 +264,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
  */
 export interface IOnRenderComboBoxLabelProps {
   /**
-   * Props to render the combobox.
+   * Props to render the ComboBox.
    */
   props: IComboBoxProps;
 
   /**
-   * Accessible text for label when combobox is multiselected.
+   * Accessible text for label when ComboBox is multiselected.
    */
   multiselectAccessibleText?: string;
 }
@@ -283,7 +279,8 @@ export interface IOnRenderComboBoxLabelProps {
  */
 export interface IComboBoxStyles {
   /**
-   * Style for the container which has the ComboBox and the label
+   * Style for the container which has the ComboBox and the label.
+   * (In most other components this would be called `root`.)
    */
   container: IStyle;
 
@@ -298,57 +295,64 @@ export interface IComboBoxStyles {
   labelDisabled: IStyle;
 
   /**
-   * Base styles for the root element of all ComboBoxes.
+   * Base styles for the wrapper element containing the input field and caret button, applied to
+   * all state variants.
+   *
+   * Unlike in most components, this is NOT the actual root element which also contains the label
+   * as well as the field; for that, use `container`.
    */
   root: IStyle;
 
   /**
-   * Styles for the root element for variant of ComboBox with an errorMessage in the props.
+   * Styles for the wrapper element containing the input field and caret button, applied when
+   * the ComboBox has an error message.
    */
   rootError: IStyle;
 
   /**
-   * Styles for variant of ComboBox where allowFreeForm is false in the props.
+   * Styles for the wrapper element containing the input field and caret button, applied when
+   * `IComboBoxProps.allowFreeform` is false.
    */
   rootDisallowFreeForm: IStyle;
 
   /**
-   * Styles for when the ComboBox is hovered. These styles are applied for all comboBoxes except when
-   * the comboBox is disabled.
+   * Styles for the wrapper element containing the input field and caret button, applied any time
+   * the ComboBox is hovered (unless it's disabled).
    */
   rootHovered: IStyle;
 
   /**
-   * Styles for when the ComboBox is active. These styles are applied for all comboBoxes except when
-   * the comboBox is disabled.
+   * Styles for the wrapper element containing the input field and caret button, applied any time
+   * the ComboBox is active (unless it's disabled).
    */
   rootPressed: IStyle;
 
   /**
-   * Styles for when the ComboBox is focused. These styles are applied for all comboBoxes except when
-   * the comboBox is disabled.
+   * Styles for the wrapper element containing the input field and caret button, applied any time
+   * the ComboBox is focused (unless it's disabled).
    */
   rootFocused: IStyle;
 
   /**
-   * Styles for when the comboBox is disabled. These styles override all the other styles.
-   * NOTE : Hover (or) Focused (or) active styles are not applied for disabled comboBoxes.
+   * Styles for the wrapper element containing the input field and caret button, applied when the
+   * ComboBox is disabled. These override all the other styles.
+   *
+   * NOTE: Hover/focused/active styles are not applied for disabled ComboBoxes.
    */
   rootDisabled: IStyle;
 
   /**
-   * Base styles for the input element - which contains the currently selected
-   * option.
+   * Base styles for the input element which contains the currently selected option.
    */
   input: IStyle;
 
   /**
-   * Style override for the input element when comboBox is disabled.
+   * Style override for the input element when ComboBox is disabled.
    */
   inputDisabled: IStyle;
 
   /**
-   * Styles for the error Message text of the comboBox.
+   * Styles for the error message text of the ComboBox.
    */
   errorMessage: IStyle;
 
@@ -358,12 +362,12 @@ export interface IComboBoxStyles {
   callout: IStyle;
 
   /**
-   * Styles for the optionsContainerWrapper.
+   * Styles for the options list container element.
    */
   optionsContainerWrapper: IStyle;
 
   /**
-   * Styles for the container of all the Combobox options
+   * Styles for the container of all the ComboBox options.
    * Includes the headers and dividers.
    */
   optionsContainer: IStyle;
@@ -389,15 +393,13 @@ export interface IComboBoxStyles {
  */
 export interface IComboBoxOptionStyles extends IButtonStyles {
   /**
-   * Styles for the text inside the comboBox option.
-   * This should be used instead of the description
-   * inside IButtonStyles because we custom render the text
-   * in the comboBox options.
+   * Styles for the text inside the ComboBox option. This should be used instead of the description
+   * in IButtonStyles because we custom render the text in the ComboBox options.
    */
   optionText: IStyle;
 
   /**
-   * Styles for the comboBox option text's wrapper.
+   * Styles for the ComboBox option text's wrapper.
    */
   optionTextWrapper: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -363,6 +363,1640 @@ exports[`ComboBox Renders correctly 1`] = `
 </div>
 `;
 
+exports[`ComboBox Renders correctly when open 1`] = `
+<div
+  class="ms-ComboBox-container "
+>
+  <div
+    class=
+        ms-ComboBox
+        is-open
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-color: #0078d4;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: text;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-left: 0;
+          outline: 0;
+          padding-left: 9px;
+          padding-right: 32px;
+          position: relative;
+          text-overflow: ellipsis;
+          user-select: none;
+          white-space: nowrap;
+        }
+        & .ms-Label {
+          display: inline-block;
+          margin-bottom: 8px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+          border-color: Highlight;
+        }
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          border: 2px solid #0078d4;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        & .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+          border-color: Highlight;
+        }
+        &:active {
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+          border-color: Highlight;
+        }
+        &:focus {
+          border-color: #0078d4;
+        }
+        &:focus .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+          border-color: Highlight;
+        }
+        &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #0078d4;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+    id="ComboBox0wrapper"
+  >
+    <input
+      aria-activedescendant="ComboBox0-list3"
+      aria-autocomplete="both"
+      aria-expanded="true"
+      aria-owns="ComboBox0-list"
+      autocapitalize="off"
+      autocomplete="off"
+      class=
+          ms-ComboBox-Input
+          {
+            background-color: #ffffff;
+            border-style: none;
+            box-sizing: border-box;
+            color: #323130;
+            font: inherit;
+            height: 100%;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            width: 100%;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+            color: GrayText;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+            color: GrayText;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+            color: GrayText;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+      data-is-interactable="true"
+      data-lpignore="true"
+      id="ComboBox0-input"
+      role="combobox"
+      spellcheck="false"
+      type="text"
+      value="Option 2"
+    />
+    <button
+      aria-hidden="true"
+      class=
+          ms-Button
+          ms-Button--icon
+          is-checked
+          ms-ComboBox-CaretDown-button
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #edebe9;
+            border-radius: 2px;
+            border: none;
+            box-sizing: border-box;
+            color: #201f1e;
+            cursor: default;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            height: 100%;
+            line-height: 30px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: absolute;
+            text-align: center;
+            text-decoration: none;
+            top: 0px;
+            user-select: none;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid transparent;
+            bottom: 2px;
+            content: "";
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          &:hover {
+            background-color: #e1dfdd;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+      data-is-focusable="false"
+      role="presentation"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <i
+          aria-hidden="true"
+          class=
+              ms-Icon
+              ms-Button-icon
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                flex-shrink: 0;
+                font-size: 12px;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                text-align: center;
+              }
+          data-icon-name="ChevronDown"
+          style="font-family: \\"FabricMDL2Icons\\";"
+        >
+          
+        </i>
+      </span>
+    </button>
+  </div>
+  <span
+    class="ms-layer"
+  >
+    <div
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+    >
+      <div
+        class=
+            ms-Callout-container
+            {
+              position: relative;
+            }
+      >
+        <div
+          class=
+              ms-Callout
+              ms-ComboBox-callout
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 2px;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                position: absolute;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border-color: WindowText;
+                border-style: solid;
+                border-width: 1px;
+              }
+              &::-moz-focus-inner {
+                border: 0px;
+              }
+          style="opacity: 0; filter: opacity(0); pointer-events: none;"
+          tabindex="-1"
+        >
+          <div
+            class=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            style="outline: none; max-height: 752px;"
+          >
+            <div
+              class="ms-ComboBox-optionsContainerWrapper "
+            >
+              <div
+                class=
+                    ms-ComboBox-optionsContainer
+                    {
+                      display: block;
+                    }
+                id="ComboBox0header-list"
+                role="listbox"
+              >
+                <div
+                  aria-labelledby="ComboBox0header"
+                  role="group"
+                >
+                  <div
+                    class=
+                        ms-ComboBox-header
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: none;
+                          border-style: none;
+                          color: #0078d4;
+                          cursor: default;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 600;
+                          height: 36px;
+                          line-height: 36px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-align: left;
+                          user-select: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          color: GrayText;
+                          forced-color-adjust: none;
+                        }
+                    id="ComboBox0header"
+                  >
+                    <span
+                      class=
+                          ms-ComboBox-optionText
+                          {
+                            display: inline-block;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      Header
+                    </span>
+                  </div>
+                  <button
+                    aria-selected="false"
+                    class=
+                        ms-Button
+                        ms-Button--action
+                        ms-Button--command
+                        ms-ComboBox-option
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-color: transparent;
+                          border-radius: 0px;
+                          border-style: solid;
+                          border-width: 1px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #323130;
+                          cursor: pointer;
+                          display: block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: auto;
+                          line-height: 20px;
+                          min-height: 36px;
+                          outline: transparent;
+                          overflow-wrap: break-word;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: left;
+                          text-decoration: none;
+                          user-select: none;
+                          width: 100%;
+                          word-wrap: break-word;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid transparent;
+                          bottom: 2px;
+                          content: "";
+                          left: 2px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 2px;
+                          top: 2px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          border-color: Background;
+                          border: none;
+                        }
+                        &.ms-Checkbox {
+                          align-items: center;
+                          display: flex;
+                        }
+                        &.ms-Button--command:hover:active {
+                          background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
+                        &:hover {
+                          background-color: #f3f2f1;
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          border-color: Highlight;
+                          color: Highlight;
+                        }
+                        &:hover .ms-Button-icon {
+                          color: #0078d4;
+                        }
+                        &:focus {
+                          background-color: #f3f2f1;
+                        }
+                        &:active {
+                          color: #000000;
+                        }
+                        &:active .ms-Button-icon {
+                          color: #004578;
+                        }
+                    data-index="1"
+                    data-is-focusable="true"
+                    id="ComboBox0-list1"
+                    role="option"
+                    title="Option 1"
+                    type="button"
+                  >
+                    <span
+                      class=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: flex-start;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <span
+                        class=
+
+                            {
+                              align-items: center;
+                              display: flex;
+                              max-width: 100%;
+                            }
+                      >
+                        <span
+                          class=
+                              ms-ComboBox-optionText
+                              {
+                                display: inline-block;
+                                max-width: 100%;
+                                min-width: 0px;
+                                overflow-wrap: break-word;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                word-wrap: break-word;
+                              }
+                        >
+                          Option 1
+                        </span>
+                      </span>
+                    </span>
+                  </button>
+                  <div
+                    class=
+                        ms-ComboBox-divider
+                        {
+                          background-color: #edebe9;
+                          height: 1px;
+                        }
+                    role="separator"
+                  />
+                </div>
+                <button
+                  aria-selected="false"
+                  class=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      is-checked
+                      ms-ComboBox-option
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-color: transparent;
+                        border-radius: 0px;
+                        border-style: solid;
+                        border-width: 1px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #201f1e;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: auto;
+                        line-height: 20px;
+                        min-height: 36px;
+                        outline: transparent;
+                        overflow-wrap: break-word;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        user-select: none;
+                        width: 100%;
+                        word-wrap: break-word;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid transparent;
+                        bottom: 2px;
+                        content: "";
+                        left: 2px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 2px;
+                        top: 2px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        border: none;
+                        color: HighlightText;
+                        forced-color-adjust: none;
+                      }
+                      &.ms-Checkbox {
+                        align-items: center;
+                        display: flex;
+                      }
+                      &.ms-Button--command:hover:active {
+                        background-color: #edebe9;
+                      }
+                      & .ms-Checkbox-label {
+                        width: 100%;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                        forced-color-adjust: none;
+                      }
+                      .ms-Fabric--isFocusVisible &:after {
+                        border: 1px solid #ffffff;
+                        bottom: 0px;
+                        content: "";
+                        left: 0px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 0px;
+                        top: 0px;
+                        z-index: 1;
+                      }
+                  data-index="3"
+                  data-is-focusable="true"
+                  id="ComboBox0-list3"
+                  role="option"
+                  title="Option 2"
+                  type="button"
+                >
+                  <span
+                    class=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <span
+                      class=
+
+                          {
+                            align-items: center;
+                            display: flex;
+                            max-width: 100%;
+                          }
+                    >
+                      <span
+                        class=
+                            ms-ComboBox-optionText
+                            {
+                              display: inline-block;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
+                      >
+                        Option 2
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
+<div
+  class="ms-ComboBox-container "
+>
+  <div
+    class=
+        ms-ComboBox
+        is-open
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-color: #0078d4;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: text;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-left: 0;
+          outline: 0;
+          padding-left: 9px;
+          padding-right: 32px;
+          position: relative;
+          text-overflow: ellipsis;
+          user-select: none;
+          white-space: nowrap;
+        }
+        & .ms-Label {
+          display: inline-block;
+          margin-bottom: 8px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+          border-color: Highlight;
+        }
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          border: 2px solid #0078d4;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        & .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+          border-color: Highlight;
+        }
+        &:active {
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+          border-color: Highlight;
+        }
+        &:focus {
+          border-color: #0078d4;
+        }
+        &:focus .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+          border-color: Highlight;
+        }
+        &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #0078d4;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+    id="ComboBox0wrapper"
+  >
+    <input
+      aria-activedescendant="ComboBox0-list3"
+      aria-autocomplete="both"
+      aria-expanded="true"
+      aria-owns="ComboBox0-list"
+      autocapitalize="off"
+      autocomplete="off"
+      class=
+          ms-ComboBox-Input
+          {
+            background-color: #ffffff;
+            border-style: none;
+            box-sizing: border-box;
+            color: #323130;
+            font: inherit;
+            height: 100%;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            width: 100%;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+            color: GrayText;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+            color: GrayText;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+            color: GrayText;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+      data-is-interactable="true"
+      data-lpignore="true"
+      id="ComboBox0-input"
+      placeholder="Option 2"
+      role="combobox"
+      spellcheck="false"
+      type="text"
+      value=""
+    />
+    <button
+      aria-hidden="true"
+      class=
+          ms-Button
+          ms-Button--icon
+          is-checked
+          ms-ComboBox-CaretDown-button
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #edebe9;
+            border-radius: 2px;
+            border: none;
+            box-sizing: border-box;
+            color: #201f1e;
+            cursor: default;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            height: 100%;
+            line-height: 30px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: absolute;
+            text-align: center;
+            text-decoration: none;
+            top: 0px;
+            user-select: none;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid transparent;
+            bottom: 2px;
+            content: "";
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          &:hover {
+            background-color: #e1dfdd;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+      data-is-focusable="false"
+      role="presentation"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <i
+          aria-hidden="true"
+          class=
+              ms-Icon
+              ms-Button-icon
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                flex-shrink: 0;
+                font-size: 12px;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                text-align: center;
+              }
+          data-icon-name="ChevronDown"
+          style="font-family: \\"FabricMDL2Icons\\";"
+        >
+          
+        </i>
+      </span>
+    </button>
+  </div>
+  <span
+    class="ms-layer"
+  >
+    <div
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+    >
+      <div
+        class=
+            ms-Callout-container
+            {
+              position: relative;
+            }
+      >
+        <div
+          class=
+              ms-Callout
+              ms-ComboBox-callout
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 2px;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                position: absolute;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border-color: WindowText;
+                border-style: solid;
+                border-width: 1px;
+              }
+              &::-moz-focus-inner {
+                border: 0px;
+              }
+          style="opacity: 0; filter: opacity(0); pointer-events: none;"
+          tabindex="-1"
+        >
+          <div
+            class=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            style="outline: none; max-height: 752px;"
+          >
+            <div
+              class="ms-ComboBox-optionsContainerWrapper "
+            >
+              <div
+                class=
+                    ms-ComboBox-optionsContainer
+                    {
+                      display: block;
+                    }
+                id="ComboBox0header-list"
+                role="listbox"
+              >
+                <div
+                  aria-labelledby="ComboBox0header"
+                  role="group"
+                >
+                  <div
+                    class=
+                        ms-ComboBox-header
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: none;
+                          border-style: none;
+                          color: #0078d4;
+                          cursor: default;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 600;
+                          height: 36px;
+                          line-height: 36px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-align: left;
+                          user-select: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          color: GrayText;
+                          forced-color-adjust: none;
+                        }
+                    id="ComboBox0header"
+                  >
+                    <span
+                      class=
+                          ms-ComboBox-optionText
+                          {
+                            display: inline-block;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      Header
+                    </span>
+                  </div>
+                  <div
+                    class=
+                        ms-Checkbox
+                        is-enabled
+                        ms-ComboBox-option
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-color: transparent;
+                          border-radius: 0px;
+                          border-style: solid;
+                          border-width: 1px;
+                          box-sizing: border-box;
+                          cursor: pointer;
+                          display: block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: auto;
+                          line-height: 20px;
+                          min-height: 36px;
+                          overflow-wrap: break-word;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: left;
+                          width: 100%;
+                          word-wrap: break-word;
+                        }
+                        &:hover .ms-Checkbox-checkbox {
+                          border-color: #323130;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                          border-color: Highlight;
+                        }
+                        &:focus .ms-Checkbox-checkbox {
+                          border-color: #323130;
+                        }
+                        &:hover .ms-Checkbox-checkmark {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                          color: Highlight;
+                        }
+                        &:hover .ms-Checkbox-text {
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+                          color: WindowText;
+                        }
+                        &:focus .ms-Checkbox-text {
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+                          color: WindowText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          border-color: Background;
+                          border: none;
+                        }
+                        &.ms-Checkbox {
+                          align-items: center;
+                          display: flex;
+                        }
+                        &.ms-Button--command:hover:active {
+                          background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
+                    title="Option 1"
+                  >
+                    <input
+                      aria-checked="false"
+                      aria-label="Option 1"
+                      aria-selected="false"
+                      class=
+
+                          {
+                            background: none;
+                            opacity: 0;
+                            position: absolute;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus + label::before {
+                            outline-offset: 2px;
+                            outline: 1px solid #605e5c;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                            outline: 1px solid WindowText;
+                          }
+                      data-index="1"
+                      data-is-focusable="true"
+                      id="ComboBox0-list1"
+                      role="option"
+                      title="Option 1"
+                      type="checkbox"
+                    />
+                    <label
+                      class=
+                          ms-Checkbox-label
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            align-items: center;
+                            cursor: pointer;
+                            display: flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            position: relative;
+                            user-select: none;
+                          }
+                          &::before {
+                            bottom: 0px;
+                            content: "";
+                            left: 0px;
+                            pointer-events: none;
+                            position: absolute;
+                            right: 0px;
+                            top: 0px;
+                          }
+                      for="ComboBox0-list1"
+                    >
+                      <div
+                        class=
+                            ms-Checkbox-checkbox
+                            {
+                              align-items: center;
+                              border-radius: 2px;
+                              border: 1px solid #323130;
+                              box-sizing: border-box;
+                              display: flex;
+                              flex-shrink: 0;
+                              height: 20px;
+                              justify-content: center;
+                              margin-right: 4px;
+                              overflow: hidden;
+                              position: relative;
+                              transition-duration: 200ms;
+                              transition-property: background, border, border-color;
+                              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                              width: 20px;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
+                              border-color: WindowText;
+                              forced-color-adjust: none;
+                            }
+                      >
+                        <i
+                          aria-hidden="true"
+                          class=
+                              ms-Checkbox-checkmark
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                color: #ffffff;
+                                display: inline-block;
+                                font-family: "FabricMDL2Icons";
+                                font-style: normal;
+                                font-weight: normal;
+                                opacity: 0;
+                                speak: none;
+                              }
+                              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                -ms-high-contrast-adjust: none;
+                                color: Window;
+                                forced-color-adjust: none;
+                              }
+                          data-icon-name="CheckMark"
+                        >
+                          
+                        </i>
+                      </div>
+                      <span
+                        class=
+                            ms-ComboBox-optionText
+                            {
+                              display: inline-block;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
+                      >
+                        Option 1
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    class=
+                        ms-ComboBox-divider
+                        {
+                          background-color: #edebe9;
+                          height: 1px;
+                        }
+                    role="separator"
+                  />
+                </div>
+                <div
+                  class=
+                      ms-Checkbox
+                      is-checked
+                      is-enabled
+                      ms-ComboBox-option
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-color: transparent;
+                        border-radius: 0px;
+                        border-style: solid;
+                        border-width: 1px;
+                        box-sizing: border-box;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: auto;
+                        line-height: 20px;
+                        min-height: 36px;
+                        overflow-wrap: break-word;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        width: 100%;
+                        word-wrap: break-word;
+                      }
+                      &:hover .ms-Checkbox-checkbox {
+                        background: #005a9e;
+                        border-color: #005a9e;
+                      }
+                      &:focus .ms-Checkbox-checkbox {
+                        background: #005a9e;
+                        border-color: #005a9e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        border-color: Background;
+                        border: none;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                        background: Highlight;
+                        border-color: Highlight;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+                        background: Highlight;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+                        background: Highlight;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+                        color: Window;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                        color: Window;
+                      }
+                      &:hover .ms-Checkbox-text {
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+                        color: WindowText;
+                      }
+                      &:focus .ms-Checkbox-text {
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+                        color: WindowText;
+                      }
+                      &.ms-Checkbox {
+                        align-items: center;
+                        display: flex;
+                      }
+                      &.ms-Button--command:hover:active {
+                        background-color: #edebe9;
+                      }
+                      & .ms-Checkbox-label {
+                        width: 100%;
+                      }
+                  title="Option 2"
+                >
+                  <input
+                    aria-checked="true"
+                    aria-label="Option 2"
+                    aria-selected="true"
+                    checked=""
+                    class=
+
+                        {
+                          background: none;
+                          opacity: 0;
+                          position: absolute;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus + label::before {
+                          outline-offset: 2px;
+                          outline: 1px solid #605e5c;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                          outline: 1px solid WindowText;
+                        }
+                    data-index="3"
+                    data-is-focusable="true"
+                    id="ComboBox0-list3"
+                    role="option"
+                    title="Option 2"
+                    type="checkbox"
+                  />
+                  <label
+                    class=
+                        ms-Checkbox-label
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          align-items: center;
+                          cursor: pointer;
+                          display: flex;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                          user-select: none;
+                        }
+                        &::before {
+                          bottom: 0px;
+                          content: "";
+                          left: 0px;
+                          pointer-events: none;
+                          position: absolute;
+                          right: 0px;
+                          top: 0px;
+                        }
+                    for="ComboBox0-list3"
+                  >
+                    <div
+                      class=
+                          ms-Checkbox-checkbox
+                          {
+                            align-items: center;
+                            background: #0078d4;
+                            border-color: #0078d4;
+                            border-radius: 2px;
+                            border: 1px solid #323130;
+                            box-sizing: border-box;
+                            display: flex;
+                            flex-shrink: 0;
+                            height: 20px;
+                            justify-content: center;
+                            margin-right: 4px;
+                            overflow: hidden;
+                            position: relative;
+                            transition-duration: 200ms;
+                            transition-property: background, border, border-color;
+                            transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                            width: 20px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            -ms-high-contrast-adjust: none;
+                            background: Highlight;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
+                          }
+                    >
+                      <i
+                        aria-hidden="true"
+                        class=
+                            ms-Checkbox-checkmark
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              color: #ffffff;
+                              display: inline-block;
+                              font-family: "FabricMDL2Icons";
+                              font-style: normal;
+                              font-weight: normal;
+                              opacity: 1;
+                              speak: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
+                              color: Window;
+                              forced-color-adjust: none;
+                            }
+                        data-icon-name="CheckMark"
+                      >
+                        
+                      </i>
+                    </div>
+                    <span
+                      class=
+                          ms-ComboBox-optionText
+                          {
+                            display: inline-block;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      Option 2
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
 exports[`ComboBox renders with a Keytip correctly 1`] = `
 <div
   className="ms-ComboBox-container "

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -730,8 +730,6 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       <Checkbox
         id={this._listId + item.index}
         key={item.key}
-        data-index={item.index}
-        data-is-focusable={!item.disabled}
         disabled={item.disabled}
         onChange={this._onItemClick(item)}
         inputProps={{
@@ -740,6 +738,10 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
           onMouseLeave: this._onMouseItemLeave.bind(this, item),
           onMouseMove: this._onItemMouseMove.bind(this, item),
           role: 'option',
+          ...({
+            'data-index': item.index,
+            'data-is-focusable': !item.disabled,
+          } as any),
         }}
         label={item.text}
         title={title}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -21,6 +21,13 @@ const DEFAULT_OPTIONS: IDropdownOption[] = [
   { key: '6', text: '6' },
 ];
 
+const RENDER_OPTIONS: IDropdownOption[] = [
+  { key: 'Header1', text: 'Header 1', itemType: DropdownMenuItemType.Header },
+  { key: '1', text: '1', selected: true },
+  { key: 'Divider1', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: '2', text: '2', title: 'test' },
+];
+
 describe('Dropdown', () => {
   let component: renderer.ReactTestRenderer | undefined;
   let wrapper: ReactWrapper | undefined;
@@ -43,10 +50,25 @@ describe('Dropdown', () => {
   });
 
   describe('single-select', () => {
-    it('Renders single-select Dropdown correctly', () => {
+    it('Renders correctly', () => {
       component = renderer.create(<Dropdown options={DEFAULT_OPTIONS} />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('Renders correctly when open', () => {
+      // Mock createPortal so that the options list ends up inside the wrapper for snapshotting.
+      // Since this is the first test to call mount(), we have to mount something with the real
+      // version of createPortal first to allow some global setup to run properly.
+      wrapper = mount(<div />);
+      wrapper.unmount();
+      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+
+      const ref = React.createRef<IDropdown>();
+      wrapper = mount(<Dropdown options={RENDER_OPTIONS} componentRef={ref} />);
+      ref.current!.focus(true);
+      wrapper.update();
+      expect(wrapper.getDOMNode()).toMatchSnapshot();
     });
 
     it('Renders groups based on header start and divider end', () => {
@@ -441,10 +463,20 @@ describe('Dropdown', () => {
   });
 
   describe('multi-select', () => {
-    it('Renders multiselect Dropdown correctly', () => {
+    it('Renders correctly', () => {
       component = renderer.create(<Dropdown options={DEFAULT_OPTIONS} multiSelect />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('Renders correctly when open', () => {
+      // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
+      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      const ref = React.createRef<IDropdown>();
+      wrapper = mount(<Dropdown multiSelect options={RENDER_OPTIONS} componentRef={ref} />);
+      ref.current!.focus(true);
+      wrapper.update();
+      expect(wrapper.getDOMNode()).toMatchSnapshot();
     });
 
     it('Renders multiselect Dropdown correctly when options change', () => {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
+exports[`Dropdown multi-select Renders correctly 1`] = `
 <div
   className="ms-Dropdown-container"
 >
@@ -175,7 +175,845 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 </div>
 `;
 
-exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
+exports[`Dropdown multi-select Renders correctly when open 1`] = `
+<div
+  class="ms-Dropdown-container"
+>
+  <div
+    aria-activedescendant="Dropdown0-list1"
+    aria-controls="Dropdown0-list"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    class=
+        ms-Dropdown
+        is-open
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border-color: #605e5c;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          user-select: none;
+        }
+        &:hover .ms-Dropdown-title {
+          border-color: #605e5c;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Dropdown-title {
+          border-color: Highlight;
+        }
+        &:focus .ms-Dropdown-title {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-title {
+          color: Highlight;
+        }
+        &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #0078d4;
+          box-sizing: border-box;
+          content: '';
+          height: 100%;
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+          color: Highlight;
+        }
+        &:active .ms-Dropdown-title {
+          border-color: #0078d4;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Dropdown-title {
+          border-color: Highlight;
+        }
+        &:hover .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        &:focus .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+          color: Highlight;
+        }
+        &:active .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        &:hover .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:focus .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:active .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:hover .ms-Dropdown-title--hasError {
+          border-color: #a4262c;
+        }
+        &:active .ms-Dropdown-title--hasError {
+          border-color: #a4262c;
+        }
+    data-is-focusable="true"
+    id="Dropdown0"
+    role="combobox"
+    tabindex="0"
+  >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class=
+          ms-Dropdown-title
+          {
+            background-color: #ffffff;
+            border-color: #605e5c;
+            border-radius: 0 0 2px 2px;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: block;
+            height: 32px;
+            line-height: 30px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow: hidden;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 28px;
+            padding-top: 0;
+            position: relative;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      id="Dropdown0-option"
+    >
+      1
+    </span>
+    <span
+      class=
+          ms-Dropdown-caretDownWrapper
+          {
+            cursor: pointer;
+            height: 32px;
+            line-height: 30px;
+            position: absolute;
+            right: 8px;
+            top: 1px;
+          }
+    >
+      <i
+        aria-hidden="true"
+        class=
+            ms-Dropdown-caretDown
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              pointer-events: none;
+              speak: none;
+            }
+        data-icon-name="ChevronDown"
+      >
+        
+      </i>
+    </span>
+  </div>
+  <span
+    class="ms-layer"
+  >
+    <div
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+    >
+      <div
+        class=
+            ms-Callout-container
+            {
+              position: relative;
+            }
+      >
+        <div
+          class=
+              ms-Callout
+              ms-Dropdown-callout
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 2px 2px 0 0;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                position: absolute;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border-color: WindowText;
+                border-style: solid;
+                border-width: 1px;
+              }
+              &::-moz-focus-inner {
+                border: 0px;
+              }
+              & .ms-Callout-main {
+                border-radius: 2px 2px 0 0;
+              }
+          style="opacity: 0; filter: opacity(0); pointer-events: none;"
+          tabindex="-1"
+        >
+          <div
+            class=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            style="outline: none; max-height: 752px;"
+          >
+            <div
+              class=
+
+                  &:focus {
+                    outline: 0px;
+                  }
+              tabindex="0"
+            >
+              <div
+                aria-multiselectable="true"
+                class=
+                    ms-FocusZone
+                    ms-Dropdown-items
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: block;
+                    }
+                data-focuszone-id="FocusZone1"
+                id="Dropdown0-list"
+                role="listbox"
+              >
+                <div
+                  aria-labelledby="Dropdown0Header1"
+                  role="group"
+                >
+                  <div
+                    class=
+                        ms-Dropdown-header
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border: none;
+                          color: #0078d4;
+                          cursor: default;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 600;
+                          height: 36px;
+                          line-height: 36px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-align: left;
+                          user-select: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          color: GrayText;
+                          forced-color-adjust: none;
+                        }
+                    id="Dropdown0Header1"
+                  >
+                    <span
+                      class=
+                          ms-Dropdown-optionText
+                          {
+                            margin-bottom: 1px;
+                            margin-left: 1px;
+                            margin-right: 1px;
+                            margin-top: 1px;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      Header 1
+                    </span>
+                  </div>
+                  <div
+                    class=
+                        ms-Checkbox
+                        is-checked
+                        is-enabled
+                        ms-Dropdown-item
+                        {
+                          align-items: center;
+                          background-color: #edebe9;
+                          border-radius: 0px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #201f1e;
+                          cursor: pointer;
+                          display: flex;
+                          height: 0px;
+                          line-height: 20px;
+                          min-height: 36px;
+                          overflow-wrap: break-word;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
+                          text-align: left;
+                          width: 100%;
+                          word-wrap: break-word;
+                        }
+                        &:hover .ms-Checkbox-checkbox {
+                          background: #005a9e;
+                          border-color: #005a9e;
+                        }
+                        &:focus .ms-Checkbox-checkbox {
+                          background: #005a9e;
+                          border-color: #005a9e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          border: none;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                          background: Highlight;
+                          border-color: Highlight;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+                          background: Highlight;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+                          background: Highlight;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+                          color: Window;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                          color: Window;
+                        }
+                        &:hover .ms-Checkbox-text {
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+                          color: WindowText;
+                        }
+                        &:focus .ms-Checkbox-text {
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+                          color: WindowText;
+                        }
+                        & .ms-Button-flexContainer {
+                          width: 100%;
+                        }
+                        &:hover:focus {
+                          background-color: #edebe9;
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:focus {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:hover:focus {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        &:focus {
+                          background-color: #edebe9;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:focus {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        &:active {
+                          background-color: #f3f2f1;
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:active {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: 0px;
+                          left: 0px;
+                          right: 0px;
+                          top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    title="1"
+                  >
+                    <input
+                      aria-checked="true"
+                      aria-label="1"
+                      aria-posinset="1"
+                      aria-selected="true"
+                      aria-setsize="2"
+                      checked=""
+                      class=
+
+                          {
+                            background: none;
+                            opacity: 0;
+                            position: absolute;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus + label::before {
+                            outline-offset: 2px;
+                            outline: 1px solid #605e5c;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                            outline: 1px solid WindowText;
+                          }
+                      data-index="1"
+                      data-is-focusable="true"
+                      id="Dropdown0-list1"
+                      role="option"
+                      tabindex="0"
+                      title="1"
+                      type="checkbox"
+                    />
+                    <label
+                      class=
+                          ms-Checkbox-label
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            align-items: center;
+                            align-self: stretch;
+                            cursor: pointer;
+                            display: flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            position: relative;
+                            user-select: none;
+                            width: 100%;
+                          }
+                          &::before {
+                            bottom: 0px;
+                            content: "";
+                            left: 0px;
+                            pointer-events: none;
+                            position: absolute;
+                            right: 0px;
+                            top: 0px;
+                          }
+                      for="Dropdown0-list1"
+                    >
+                      <div
+                        class=
+                            ms-Checkbox-checkbox
+                            {
+                              align-items: center;
+                              background: #0078d4;
+                              border-color: #0078d4;
+                              border-radius: 2px;
+                              border: 1px solid #323130;
+                              box-sizing: border-box;
+                              display: flex;
+                              flex-shrink: 0;
+                              height: 20px;
+                              justify-content: center;
+                              margin-right: 4px;
+                              overflow: hidden;
+                              position: relative;
+                              transition-duration: 200ms;
+                              transition-property: background, border, border-color;
+                              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                              width: 20px;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
+                              background: Highlight;
+                              border-color: Highlight;
+                              forced-color-adjust: none;
+                            }
+                      >
+                        <i
+                          aria-hidden="true"
+                          class=
+                              ms-Checkbox-checkmark
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                color: #ffffff;
+                                display: inline-block;
+                                font-family: "FabricMDL2Icons";
+                                font-style: normal;
+                                font-weight: normal;
+                                opacity: 1;
+                                speak: none;
+                              }
+                              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                -ms-high-contrast-adjust: none;
+                                color: Window;
+                                forced-color-adjust: none;
+                              }
+                          data-icon-name="CheckMark"
+                        >
+                          
+                        </i>
+                      </div>
+                      <span
+                        class=
+                            ms-Dropdown-optionText
+                            {
+                              margin-bottom: 1px;
+                              margin-left: 1px;
+                              margin-right: 1px;
+                              margin-top: 1px;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
+                      >
+                        1
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    class=
+                        ms-Dropdown-divider
+                        {
+                          background-color: #edebe9;
+                          height: 1px;
+                        }
+                    role="separator"
+                  />
+                </div>
+                <div
+                  class=
+                      ms-Checkbox
+                      is-enabled
+                      ms-Dropdown-item
+                      {
+                        align-items: center;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        cursor: pointer;
+                        display: flex;
+                        height: 0px;
+                        line-height: 20px;
+                        min-height: 36px;
+                        overflow-wrap: break-word;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        text-align: left;
+                        width: 100%;
+                        word-wrap: break-word;
+                      }
+                      &:hover .ms-Checkbox-checkbox {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                        border-color: Highlight;
+                      }
+                      &:focus .ms-Checkbox-checkbox {
+                        border-color: #323130;
+                      }
+                      &:hover .ms-Checkbox-checkmark {
+                        color: #605e5c;
+                        opacity: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                        color: Highlight;
+                      }
+                      &:hover .ms-Checkbox-text {
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+                        color: WindowText;
+                      }
+                      &:focus .ms-Checkbox-text {
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+                        color: WindowText;
+                      }
+                      & .ms-Button-flexContainer {
+                        width: 100%;
+                      }
+                      &:hover:focus {
+                        background-color: #f3f2f1;
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:focus {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:hover:focus {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      &:focus {
+                        background-color: transparent;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:focus {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      &:active {
+                        background-color: #ffffff;
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:active {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        bottom: 0px;
+                        left: 0px;
+                        right: 0px;
+                        top: 0px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        border: none;
+                      }
+                  title="test"
+                >
+                  <input
+                    aria-checked="false"
+                    aria-label="2"
+                    aria-posinset="2"
+                    aria-selected="false"
+                    aria-setsize="2"
+                    class=
+
+                        {
+                          background: none;
+                          opacity: 0;
+                          position: absolute;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus + label::before {
+                          outline-offset: 2px;
+                          outline: 1px solid #605e5c;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                          outline: 1px solid WindowText;
+                        }
+                    data-index="3"
+                    data-is-focusable="true"
+                    id="Dropdown0-list3"
+                    role="option"
+                    tabindex="-1"
+                    title="test"
+                    type="checkbox"
+                  />
+                  <label
+                    class=
+                        ms-Checkbox-label
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          align-items: center;
+                          align-self: stretch;
+                          cursor: pointer;
+                          display: flex;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          position: relative;
+                          user-select: none;
+                          width: 100%;
+                        }
+                        &::before {
+                          bottom: 0px;
+                          content: "";
+                          left: 0px;
+                          pointer-events: none;
+                          position: absolute;
+                          right: 0px;
+                          top: 0px;
+                        }
+                    for="Dropdown0-list3"
+                  >
+                    <div
+                      class=
+                          ms-Checkbox-checkbox
+                          {
+                            align-items: center;
+                            border-radius: 2px;
+                            border: 1px solid #323130;
+                            box-sizing: border-box;
+                            display: flex;
+                            flex-shrink: 0;
+                            height: 20px;
+                            justify-content: center;
+                            margin-right: 4px;
+                            overflow: hidden;
+                            position: relative;
+                            transition-duration: 200ms;
+                            transition-property: background, border, border-color;
+                            transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                            width: 20px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            -ms-high-contrast-adjust: none;
+                            border-color: WindowText;
+                            forced-color-adjust: none;
+                          }
+                    >
+                      <i
+                        aria-hidden="true"
+                        class=
+                            ms-Checkbox-checkmark
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              color: #ffffff;
+                              display: inline-block;
+                              font-family: "FabricMDL2Icons";
+                              font-style: normal;
+                              font-weight: normal;
+                              opacity: 0;
+                              speak: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
+                              color: Window;
+                              forced-color-adjust: none;
+                            }
+                        data-icon-name="CheckMark"
+                      >
+                        
+                      </i>
+                    </div>
+                    <span
+                      class=
+                          ms-Dropdown-optionText
+                          {
+                            margin-bottom: 1px;
+                            margin-left: 1px;
+                            margin-right: 1px;
+                            margin-top: 1px;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      2
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Dropdown single-select Renders correctly 1`] = `
 <div
   className="ms-Dropdown-container"
 >
@@ -347,5 +1185,678 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
       </i>
     </span>
   </div>
+</div>
+`;
+
+exports[`Dropdown single-select Renders correctly when open 1`] = `
+<div
+  class="ms-Dropdown-container"
+>
+  <div
+    aria-activedescendant="Dropdown0-list1"
+    aria-controls="Dropdown0-list"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    class=
+        ms-Dropdown
+        is-open
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border-color: #605e5c;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          user-select: none;
+        }
+        &:hover .ms-Dropdown-title {
+          border-color: #605e5c;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Dropdown-title {
+          border-color: Highlight;
+        }
+        &:focus .ms-Dropdown-title {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-title {
+          color: Highlight;
+        }
+        &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #0078d4;
+          box-sizing: border-box;
+          content: '';
+          height: 100%;
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+          color: Highlight;
+        }
+        &:active .ms-Dropdown-title {
+          border-color: #0078d4;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Dropdown-title {
+          border-color: Highlight;
+        }
+        &:hover .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        &:focus .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+          color: Highlight;
+        }
+        &:active .ms-Dropdown-caretDown {
+          color: #323130;
+        }
+        &:hover .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:focus .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:active .ms-Dropdown-titleIsPlaceHolder {
+          color: #323130;
+        }
+        &:hover .ms-Dropdown-title--hasError {
+          border-color: #a4262c;
+        }
+        &:active .ms-Dropdown-title--hasError {
+          border-color: #a4262c;
+        }
+    data-is-focusable="true"
+    id="Dropdown0"
+    role="combobox"
+    tabindex="0"
+  >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class=
+          ms-Dropdown-title
+          {
+            background-color: #ffffff;
+            border-color: #605e5c;
+            border-radius: 0 0 2px 2px;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: block;
+            height: 32px;
+            line-height: 30px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow: hidden;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 28px;
+            padding-top: 0;
+            position: relative;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      id="Dropdown0-option"
+    >
+      1
+    </span>
+    <span
+      class=
+          ms-Dropdown-caretDownWrapper
+          {
+            cursor: pointer;
+            height: 32px;
+            line-height: 30px;
+            position: absolute;
+            right: 8px;
+            top: 1px;
+          }
+    >
+      <i
+        aria-hidden="true"
+        class=
+            ms-Dropdown-caretDown
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              pointer-events: none;
+              speak: none;
+            }
+        data-icon-name="ChevronDown"
+      >
+        
+      </i>
+    </span>
+  </div>
+  <span
+    class="ms-layer"
+  >
+    <div
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+    >
+      <div
+        class=
+            ms-Callout-container
+            {
+              position: relative;
+            }
+      >
+        <div
+          class=
+              ms-Callout
+              ms-Dropdown-callout
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 2px 2px 0 0;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                position: absolute;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border-color: WindowText;
+                border-style: solid;
+                border-width: 1px;
+              }
+              &::-moz-focus-inner {
+                border: 0px;
+              }
+              & .ms-Callout-main {
+                border-radius: 2px 2px 0 0;
+              }
+          style="opacity: 0; filter: opacity(0); pointer-events: none;"
+          tabindex="-1"
+        >
+          <div
+            class=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            style="outline: none; max-height: 752px;"
+          >
+            <div
+              class=
+
+                  &:focus {
+                    outline: 0px;
+                  }
+              tabindex="0"
+            >
+              <div
+                class=
+                    ms-FocusZone
+                    ms-Dropdown-items
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: block;
+                    }
+                data-focuszone-id="FocusZone1"
+                id="Dropdown0-list"
+                role="listbox"
+              >
+                <div
+                  aria-labelledby="Dropdown0Header1"
+                  role="group"
+                >
+                  <div
+                    class=
+                        ms-Dropdown-header
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border: none;
+                          color: #0078d4;
+                          cursor: default;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 600;
+                          height: 36px;
+                          line-height: 36px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-align: left;
+                          user-select: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          color: GrayText;
+                          forced-color-adjust: none;
+                        }
+                    id="Dropdown0Header1"
+                  >
+                    <span
+                      class=
+                          ms-Dropdown-optionText
+                          {
+                            margin-bottom: 1px;
+                            margin-left: 1px;
+                            margin-right: 1px;
+                            margin-top: 1px;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      Header 1
+                    </span>
+                  </div>
+                  <button
+                    aria-posinset="1"
+                    aria-selected="true"
+                    aria-setsize="2"
+                    class=
+                        ms-Button
+                        ms-Button--action
+                        ms-Button--command
+                        ms-Dropdown-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          align-items: center;
+                          background-color: #edebe9;
+                          border-radius: 0px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #201f1e;
+                          cursor: pointer;
+                          display: flex;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 0px;
+                          line-height: 20px;
+                          min-height: 36px;
+                          outline: transparent;
+                          overflow-wrap: break-word;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: left;
+                          text-decoration: none;
+                          user-select: none;
+                          width: 100%;
+                          word-wrap: break-word;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid transparent;
+                          bottom: 0px;
+                          content: "";
+                          left: 0px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 0px;
+                          top: 0px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        &:hover {
+                          color: #0078d4;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          border-color: Highlight;
+                          color: Highlight;
+                        }
+                        &:hover .ms-Button-icon {
+                          color: #0078d4;
+                        }
+                        &:focus {
+                          background-color: #edebe9;
+                        }
+                        &:active {
+                          background-color: #f3f2f1;
+                          color: #201f1e;
+                        }
+                        &:active .ms-Button-icon {
+                          color: #004578;
+                        }
+                        & .ms-Button-flexContainer {
+                          width: 100%;
+                        }
+                        &:hover:focus {
+                          background-color: #edebe9;
+                          color: #201f1e;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:focus {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:hover:focus {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:focus {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:active {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          border: none;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-index="1"
+                    data-is-focusable="true"
+                    id="Dropdown0-list1"
+                    role="option"
+                    tabindex="0"
+                    title="1"
+                    type="button"
+                  >
+                    <span
+                      class=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: flex-start;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <span
+                        class=
+                            ms-Dropdown-optionText
+                            {
+                              margin-bottom: 1px;
+                              margin-left: 1px;
+                              margin-right: 1px;
+                              margin-top: 1px;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
+                      >
+                        1
+                      </span>
+                    </span>
+                  </button>
+                  <div
+                    class=
+                        ms-Dropdown-divider
+                        {
+                          background-color: #edebe9;
+                          height: 1px;
+                        }
+                    role="separator"
+                  />
+                </div>
+                <button
+                  aria-posinset="2"
+                  aria-selected="false"
+                  aria-setsize="2"
+                  class=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Dropdown-item
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        align-items: center;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
+                        display: flex;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 0px;
+                        line-height: 20px;
+                        min-height: 36px;
+                        outline: transparent;
+                        overflow-wrap: break-word;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        user-select: none;
+                        width: 100%;
+                        word-wrap: break-word;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid transparent;
+                        bottom: 0px;
+                        content: "";
+                        left: 0px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 0px;
+                        top: 0px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:focus {
+                        background-color: transparent;
+                      }
+                      &:active {
+                        background-color: #ffffff;
+                        color: #201f1e;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      & .ms-Button-flexContainer {
+                        width: 100%;
+                      }
+                      &:hover:focus {
+                        background-color: #f3f2f1;
+                        color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:focus {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:hover:focus {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:focus {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                        background-color: Highlight;
+                        border-color: Highlight;
+                        color: HighlightText;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active), screen and (-ms-high-contrast: black-on-white), (forced-colors: black-on-white){&:active {
+                        -ms-high-contrast-adjust: none;
+                        forced-color-adjust: none;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        border: none;
+                      }
+                  data-index="3"
+                  data-is-focusable="true"
+                  id="Dropdown0-list3"
+                  role="option"
+                  tabindex="-1"
+                  title="test"
+                  type="button"
+                >
+                  <span
+                    class=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <span
+                      class=
+                          ms-Dropdown-optionText
+                          {
+                            margin-bottom: 1px;
+                            margin-left: 1px;
+                            margin-right: 1px;
+                            margin-top: 1px;
+                            max-width: 100%;
+                            min-width: 0px;
+                            overflow-wrap: break-word;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            word-wrap: break-word;
+                          }
+                    >
+                      2
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -13,28 +13,28 @@ import { ISelectableOption } from '../../utilities/selectableOption/SelectableOp
 export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
   extends React.HTMLAttributes<TListenerElement> {
   /**
-   * Optional callback to access the ISelectableDroppableText interface. Use this instead of ref for accessing
-   * the public methods and properties of the component.
+   * Optional callback to access the component interface (usually `IDropdown` or `IComboBox`).
+   * Use this instead of `ref` for accessing the public methods and properties of the component.
    */
   componentRef?: IRefObject<TComponent>;
 
   /**
-   * Descriptive label for the ISelectableDroppableText
+   * Descriptive label for the field
    */
   label?: string;
 
   /**
-   * Aria Label for the ISelectableDroppableText for screen reader users.
+   * Aria Label for the field for screen reader users.
    */
   ariaLabel?: string;
 
   /**
-   * Id of the ISelectableDroppableText
+   * ID of the field
    */
   id?: string;
 
   /**
-   * If provided, additional class name to provide on the root element.
+   * Additional class name for the root element.
    */
   className?: string;
 
@@ -42,7 +42,7 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
    * The key(s) that will be initially used to set a selected item.
    *
    * Mutually exclusive with `selectedKey`.
-   * For Dropdown in multi-select mode, use `defaultSelectedKeys` instead.
+   * For Dropdown (but not ComboBox) in multi-select mode, use `defaultSelectedKeys` instead.
    */
   defaultSelectedKey?: string | number | string[] | number[] | null;
 
@@ -52,68 +52,69 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
    * Note that passing in `null` will cause selection to be reset.
    *
    * Mutually exclusive with `defaultSelectedKey`.
-   * For Dropdown in multi-select mode, use `selectedKeys` instead.
+   * For Dropdown (but not ComboBox) in multi-select mode, use `selectedKeys` instead.
    */
   selectedKey?: string | number | string[] | number[] | null;
 
   /**
-   * Optional prop that indicates if multi-choice selections are allowed or not.
+   * Whether multi-choice selections are allowed or not.
    * @defaultvalue false
    */
   multiSelect?: boolean;
 
   /**
-   * Collection of options for this ISelectableDroppableText
+   * Collection of options for this field
    */
   options?: any;
 
   /**
-   * Optional custom renderer for the ISelectableDroppableText container
+   * Optional custom renderer for the option list container
    */
   onRenderContainer?: IRenderFunction<ISelectableDroppableTextProps<TComponent, TListenerElement>>;
 
   /**
-   * Optional custom renderer for the ISelectableDroppableText list
+   * Optional custom renderer for the option list
    */
   onRenderList?: IRenderFunction<ISelectableDroppableTextProps<TComponent, TListenerElement>>;
 
   /**
-   * Optional custom renderer for the ISelectableDroppableText options
+   * Optional custom renderer for all items, including headers and dividers as well as normal options.
    */
   onRenderItem?: IRenderFunction<ISelectableOption>;
 
   /**
-   * Optional custom renderer for the ISelectableDroppableText option content
+   * Optional custom renderer for normal options only.
+   * Use `onRenderItem` to control rendering for separators and headers as well.
    */
   onRenderOption?: IRenderFunction<ISelectableOption>;
 
   /**
-   * Callback that is issued when the options callout is dismissed
+   * Callback for when the options list callout is dismissed
    */
   onDismiss?: () => void;
 
   /**
-   * Whether or not the ISelectableDroppableText is disabled.
+   * Whether or not the field is disabled.
    */
   disabled?: boolean;
 
   /**
-   * Whether or not the ISelectableDroppableText is required.
+   * Whether or not the field is required.
    */
   required?: boolean;
 
   /**
-   * Custom properties for ISelectableDroppableText's Callout used to render options.
+   * Custom properties for the Callout used to render the option list.
    */
   calloutProps?: ICalloutProps;
 
   /**
-   * Custom properties for ISelectableDroppableText's Panel used to render options on small devices.
+   * Custom properties for the Panel used to render the option list on small devices.
    */
   panelProps?: IPanelProps;
 
   /**
-   * Descriptive label for the ISelectableDroppableText Error Message
+   * Error message for the field.
    */
   errorMessage?: string;
 

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Basic.Example.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import {
   ComboBox,
+  IButtonStyles,
   IComboBox,
   IComboBoxOption,
+  IComboBoxStyles,
   PrimaryButton,
   SelectableOptionMenuItemType,
-} from 'office-ui-fabric-react/lib/index';
+} from 'office-ui-fabric-react';
 
-const comboBoxBasicOptions: IComboBoxOption[] = [
+const options: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
@@ -22,10 +24,11 @@ const comboBoxBasicOptions: IComboBoxOption[] = [
   { key: 'I', text: 'Option I' },
   { key: 'J', text: 'Option J' },
 ];
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const buttonStyles: Partial<IButtonStyles> = { root: { display: 'block', margin: '10px 0 20px' } };
 
-const comboBoxMultiStyle = { maxWidth: 300, display: 'block', marginTop: '10px' };
-
-export const ComboBoxBasicExample: React.FC = () => {
+export const ComboBoxBasicExample: React.FunctionComponent = () => {
   const comboBoxRef = React.useRef<IComboBox>(null);
   const onOpenClick = React.useCallback(() => comboBoxRef.current?.focus(true), []);
 
@@ -34,12 +37,19 @@ export const ComboBoxBasicExample: React.FC = () => {
       <ComboBox
         componentRef={comboBoxRef}
         defaultSelectedKey="C"
-        label="Basic ComboBox"
-        allowFreeform
-        autoComplete="on"
-        options={comboBoxBasicOptions}
+        label="Basic single-select ComboBox"
+        options={options}
+        styles={comboBoxStyles}
       />
-      <PrimaryButton text="Open ComboBox" style={comboBoxMultiStyle} onClick={onOpenClick} />
+      <PrimaryButton text="Open first ComboBox" onClick={onOpenClick} styles={buttonStyles} />
+
+      <ComboBox
+        defaultSelectedKey="C"
+        label="Basic multi-select ComboBox"
+        multiSelect
+        options={options}
+        styles={comboBoxStyles}
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Controlled.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Controlled.Example.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
-import { ComboBox, IComboBoxOption, IComboBox, SelectableOptionMenuItemType } from 'office-ui-fabric-react/lib/index';
+import {
+  ComboBox,
+  IComboBoxOption,
+  IComboBox,
+  SelectableOptionMenuItemType,
+  IComboBoxStyles,
+  IStackTokens,
+  Stack,
+  Toggle,
+} from 'office-ui-fabric-react';
+import { useBoolean } from '@uifabric/react-hooks';
 
-const items: IComboBoxOption[] = [
+const INITIAL_OPTIONS: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
@@ -16,28 +26,44 @@ const items: IComboBoxOption[] = [
   { key: 'I', text: 'Option I' },
   { key: 'J', text: 'Option J' },
 ];
+let newKey = 1;
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const stackTokens: Partial<IStackTokens> = { childrenGap: 20 };
 
-const comboBoxStyle = { maxWidth: 300 };
-
-export const ComboBoxControlledExample: React.FC = () => {
+export const ComboBoxControlledExample: React.FunctionComponent = () => {
   const [selectedKey, setSelectedKey] = React.useState<string | number | undefined>('C');
+  // Manually updating the options list is only necessary when allowFreeform is true
+  const [options, setOptions] = React.useState(INITIAL_OPTIONS);
+  const [allowFreeform, { toggle: toggleAllowFreeform }] = useBoolean(true);
 
   const onChange = React.useCallback(
-    (ev: React.FormEvent<IComboBox>, option?: IComboBoxOption): void => {
-      setSelectedKey(option?.key);
+    (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string): void => {
+      let key = option?.key;
+      if (allowFreeform && !option && value) {
+        // If allowFreeform is true, the newly selected option might be something the user typed that
+        // doesn't exist in the options list yet. So there's extra work to manually add it.
+        key = `${newKey++}`;
+        setOptions(prevOptions => [...prevOptions, { key: key!, text: value }]);
+      }
+
+      setSelectedKey(key);
     },
-    [setSelectedKey],
+    [allowFreeform],
   );
 
   return (
-    <ComboBox
-      style={comboBoxStyle}
-      selectedKey={selectedKey}
-      label="Controlled single-select ComboBox (allowFreeform: T)"
-      allowFreeform
-      autoComplete="on"
-      options={items}
-      onChange={onChange}
-    />
+    <Stack horizontal tokens={stackTokens}>
+      <ComboBox
+        selectedKey={selectedKey}
+        label="Controlled single-select ComboBox"
+        autoComplete="on"
+        allowFreeform={allowFreeform}
+        options={options}
+        onChange={onChange}
+        styles={comboBoxStyles}
+      />
+      <Toggle label="Allow freeform" checked={allowFreeform} onChange={toggleAllowFreeform} />
+    </Stack>
   );
 };

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ControlledMulti.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ControlledMulti.Example.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
-import { ComboBox, IComboBoxOption, IComboBox, SelectableOptionMenuItemType } from 'office-ui-fabric-react/lib/index';
+import {
+  ComboBox,
+  IComboBoxOption,
+  SelectableOptionMenuItemType,
+  Toggle,
+  IComboBox,
+  IComboBoxStyles,
+  IStackTokens,
+  Stack,
+} from 'office-ui-fabric-react';
+import { useBoolean } from '@uifabric/react-hooks';
 
-const items: IComboBoxOption[] = [
+const INITIAL_OPTIONS: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
@@ -16,31 +26,49 @@ const items: IComboBoxOption[] = [
   { key: 'I', text: 'Option I' },
   { key: 'J', text: 'Option J' },
 ];
+let newKey = 1;
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const stackTokens: Partial<IStackTokens> = { childrenGap: 20 };
 
-const comboBoxMultiStyle = { maxWidth: 300 };
-
-export const ComoBoxControlledMultiExample: React.FC = () => {
+export const ComboBoxControlledMultiExample: React.FunctionComponent = () => {
   const [selectedKeys, setSelectedKeys] = React.useState<string[]>(['C', 'D']);
+  // Manually updating the options list is only necessary when allowFreeform is true
+  const [options, setOptions] = React.useState(INITIAL_OPTIONS);
+  const [allowFreeform, { toggle: toggleAllowFreeform }] = useBoolean(true);
 
   const onChange = React.useCallback(
-    (ev: React.FormEvent<IComboBox>, option?: IComboBoxOption): void => {
-      setSelectedKeys(
-        option?.selected ? [...selectedKeys, option.key as string] : selectedKeys.filter(key => key !== option?.key),
-      );
+    (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string): void => {
+      let selected = option?.selected;
+      if (allowFreeform && !option && value) {
+        // If allowFreeform is true, the newly selected option might be something the user typed that
+        // doesn't exist in the options list yet. So there's extra work to manually add it.
+        selected = true;
+        option = { key: `${newKey++}`, text: value };
+        setOptions(prevOptions => [...prevOptions, option!]);
+      }
+
+      if (option) {
+        setSelectedKeys(prevSelectedKeys =>
+          selected ? [...prevSelectedKeys, option!.key as string] : prevSelectedKeys.filter(k => k !== option!.key),
+        );
+      }
     },
-    [selectedKeys],
+    [allowFreeform],
   );
 
   return (
-    <ComboBox
-      multiSelect
-      style={comboBoxMultiStyle}
-      selectedKey={selectedKeys}
-      label="Controlled multi-select ComboBox (allowFreeform: T)"
-      allowFreeform
-      autoComplete="on"
-      options={items}
-      onChange={onChange}
-    />
+    <Stack horizontal tokens={stackTokens}>
+      <ComboBox
+        multiSelect
+        selectedKey={selectedKeys}
+        label="Controlled multi-select ComboBox"
+        allowFreeform={allowFreeform}
+        options={options}
+        onChange={onChange}
+        styles={comboBoxStyles}
+      />
+      <Toggle label="Allow freeform" checked={allowFreeform} onChange={toggleAllowFreeform} />
+    </Stack>
   );
 };

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.CustomStyled.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.CustomStyled.Example.tsx
@@ -3,16 +3,10 @@ import {
   ComboBox,
   IComboBoxOption,
   SelectableOptionMenuItemType,
-  Fabric,
-  mergeStyles,
-} from 'office-ui-fabric-react/lib/index';
-
-const wrapperClassName = mergeStyles({
-  selectors: {
-    '& > *': { marginBottom: '20px' },
-    '& .ms-ComboBox': { maxWidth: '300px' },
-  },
-});
+  IComboBoxStyles,
+  Stack,
+  IStackTokens,
+} from 'office-ui-fabric-react';
 
 const fontMapping: { [fontName: string]: string } = {
   ['Arial Black']: '"Arial Black", "Arial Black_MSFontService", sans-serif',
@@ -23,18 +17,16 @@ const fontMapping: { [fontName: string]: string } = {
 
 const fonts = Object.keys(fontMapping);
 
-const ComboBoxCustomStyledExampleStyles = {
-  container: {
-    maxWidth: '300px',
-  },
+const customStyles: Partial<IComboBoxStyles> = {
+  // Note that this is actually the wrapper of the input and caret (doesn't include the label)
   root: {
+    maxWidth: '300px',
     backgroundColor: '#b4a0ff',
   },
   input: {
     backgroundColor: '#b4a0ff',
   },
 };
-
 const optionsWithCustomStyling: IComboBoxOption[] = fonts.map((fontName: string) => ({
   key: fontName,
   text: fontName,
@@ -46,10 +38,10 @@ const optionsWithCustomStyling: IComboBoxOption[] = fonts.map((fontName: string)
 }));
 
 const optionsForCustomRender: IComboBoxOption[] = [
-  { key: 'header1', text: 'Theme Fonts', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'header1', text: 'Theme fonts', itemType: SelectableOptionMenuItemType.Header },
   ...fonts.map((fontName: string) => ({ key: fontName, text: fontName })),
   { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
-  { key: 'header2', text: 'Other Options', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'header2', text: 'Other options', itemType: SelectableOptionMenuItemType.Header },
 ];
 
 const onRenderOption = (item: IComboBoxOption) => {
@@ -70,21 +62,28 @@ const onRenderOption = (item: IComboBoxOption) => {
   }
 };
 
-export const ComboBoxCustomStyledExample: React.FC = () => (
-  <Fabric className={wrapperClassName}>
-    <ComboBox
-      defaultSelectedKey="Calibri"
-      label="Custom styled ComboBox"
-      options={optionsWithCustomStyling}
-      styles={ComboBoxCustomStyledExampleStyles}
-    />
-    <ComboBox
-      defaultSelectedKey="Calibri"
-      label={'ComboBox with custom option rendering (type the name of a font and the option will render in that font)'}
-      allowFreeform
-      autoComplete="on"
-      options={optionsForCustomRender}
-      onRenderOption={onRenderOption}
-    />
-  </Fabric>
-);
+// Basic styling to make the example look nicer
+const basicStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const stackTokens: Partial<IStackTokens> = { childrenGap: 20 };
+
+export const ComboBoxCustomStyledExample: React.FunctionComponent = () => {
+  return (
+    <Stack tokens={stackTokens}>
+      <ComboBox
+        defaultSelectedKey="Calibri"
+        label="Custom styled ComboBox"
+        options={optionsWithCustomStyling}
+        styles={customStyles}
+      />
+      <ComboBox
+        defaultSelectedKey="Calibri"
+        label="ComboBox with custom option rendering (type the name of a font and the option will render in that font)"
+        allowFreeform
+        autoComplete="on"
+        options={optionsForCustomRender}
+        onRenderOption={onRenderOption}
+        styles={basicStyles}
+      />
+    </Stack>
+  );
+};

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ErrorHandling.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ErrorHandling.Example.tsx
@@ -4,9 +4,12 @@ import {
   IComboBoxProps,
   IComboBoxOption,
   SelectableOptionMenuItemType,
-} from 'office-ui-fabric-react/lib/index';
+  IComboBoxStyles,
+  IStackTokens,
+  Stack,
+} from 'office-ui-fabric-react';
 
-const comboBoxBasicOptions: IComboBoxOption[] = [
+const options: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
@@ -21,28 +24,33 @@ const comboBoxBasicOptions: IComboBoxOption[] = [
   { key: 'I', text: 'Option I' },
   { key: 'J', text: 'Option J' },
 ];
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const stackTokens: Partial<IStackTokens> = { childrenGap: 20 };
 
-export const ComboBoxErrorHandlingExample: React.FC = () => {
+export const ComboBoxErrorHandlingExample: React.FunctionComponent = () => {
   const [selectedKey, setSelectedKey] = React.useState<string | undefined>('');
   const onChange: IComboBoxProps['onChange'] = (event, option) => setSelectedKey(option!.key as string);
 
   return (
-    <div>
+    <Stack tokens={stackTokens}>
       <ComboBox
         label="ComboBox with static error message"
         defaultSelectedKey="B"
         errorMessage="Oh no! This ComboBox has an error!"
-        options={comboBoxBasicOptions}
+        options={options}
+        styles={comboBoxStyles}
       />
 
       <ComboBox
         label="ComboBox that errors when Option B is selected"
-        options={comboBoxBasicOptions}
+        options={options}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onChange}
         selectedKey={selectedKey}
         errorMessage={selectedKey === 'B' ? 'B is not an allowed option' : undefined}
+        styles={comboBoxStyles}
       />
-    </div>
+    </Stack>
   );
 };

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Toggles.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Toggles.Example.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import {
   ComboBox,
-  Fabric,
+  Stack,
   IComboBoxOption,
-  mergeStyles,
   SelectableOptionMenuItemType,
   Toggle,
-} from 'office-ui-fabric-react/lib/index';
+  IStackTokens,
+  IComboBoxStyles,
+} from 'office-ui-fabric-react';
 import { useBoolean } from '@uifabric/react-hooks';
 
-const INITIAL_OPTIONS: IComboBoxOption[] = [
+const options: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
@@ -24,30 +25,27 @@ const INITIAL_OPTIONS: IComboBoxOption[] = [
   { key: 'I', text: 'Option I' },
   { key: 'J', text: 'Option J' },
 ];
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+const stackTokens: Partial<IStackTokens> = { childrenGap: 20 };
 
-const wrapperClassName = mergeStyles({
-  display: 'flex',
-  selectors: {
-    '& > *': { marginRight: '20px' },
-    '& .ms-ComboBox': { maxWidth: '300px' },
-  },
-});
-
-export const ComboBoxTogglesExample: React.FC = () => {
-  const [autoComplete, { toggle: ToggleAutoComplete }] = useBoolean(false);
-  const [allowFreeform, { toggle: ToggleAllowFreeform }] = useBoolean(true);
+export const ComboBoxTogglesExample: React.FunctionComponent = () => {
+  const [autoComplete, { toggle: toggleAutoComplete }] = useBoolean(false);
+  const [allowFreeform, { toggle: toggleAllowFreeform }] = useBoolean(true);
 
   return (
-    <Fabric className={wrapperClassName}>
+    <Stack horizontal tokens={stackTokens}>
       <ComboBox
         label="ComboBox with toggleable freeform/auto-complete"
-        key={'' + autoComplete + allowFreeform}
         allowFreeform={allowFreeform}
         autoComplete={autoComplete ? 'on' : 'off'}
-        options={INITIAL_OPTIONS}
+        options={options}
+        styles={comboBoxStyles}
+        // Force re-creating the component when the toggles change (for demo purposes)
+        key={'' + autoComplete + allowFreeform}
       />
-      <Toggle label="Allow freeform" checked={allowFreeform} onChange={ToggleAllowFreeform} />
-      <Toggle label="Auto-complete" checked={autoComplete} onChange={ToggleAutoComplete} />
-    </Fabric>
+      <Toggle label="Allow freeform" checked={allowFreeform} onChange={toggleAllowFreeform} />
+      <Toggle label="Auto-complete" checked={autoComplete} onChange={toggleAutoComplete} />
+    </Stack>
   );
 };

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Virtualized.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Virtualized.Example.tsx
@@ -1,24 +1,26 @@
 import * as React from 'react';
-import { IComboBoxOption, IComboBoxStyles, VirtualizedComboBox, Fabric } from 'office-ui-fabric-react';
+import { IComboBoxOption, IComboBoxStyles, VirtualizedComboBox } from 'office-ui-fabric-react';
 
-const comboBoxOption: IComboBoxOption[] = Array.from({ length: 1000 }).map((x, i) => ({
-  key: `${i}`,
-  text: `Option ${i}`,
-}));
-
+const options: IComboBoxOption[] = [];
+for (let i = 0; i < 1000; i++) {
+  options.push({
+    key: `${i}`,
+    text: `Option ${i}`,
+  });
+}
 const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: '300px' } };
 
-export const ComboBoxVirtualizedExample: React.FC = () => (
-  <Fabric className="ms-ComboBoxExample">
+export const ComboBoxVirtualizedExample: React.FunctionComponent = () => {
+  return (
     <VirtualizedComboBox
-      styles={comboBoxStyles}
       defaultSelectedKey="547"
       label="Scaled/virtualized example with 1000 items"
       allowFreeform
       autoComplete="on"
-      options={comboBoxOption}
+      options={options}
       dropdownMaxWidth={200}
       useComboBoxAsMenuWidth
+      styles={comboBoxStyles}
     />
-  </Fabric>
-);
+  );
+};

--- a/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.doc.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.doc.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ComboBoxBasicExample } from './ComboBox.Basic.Example';
 import { ComboBoxTogglesExample } from './ComboBox.Toggles.Example';
 import { ComboBoxControlledExample } from './ComboBox.Controlled.Example';
+import { ComboBoxControlledMultiExample } from './ComboBox.ControlledMulti.Example';
 import { ComboBoxVirtualizedExample } from './ComboBox.Virtualized.Example';
 import { ComboBoxErrorHandlingExample } from './ComboBox.ErrorHandling.Example';
 import { ComboBoxCustomStyledExample } from './ComboBox.CustomStyled.Example';
@@ -9,15 +10,11 @@ import { ComboBoxCustomStyledExample } from './ComboBox.CustomStyled.Example';
 import { IDocPageProps } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 const ComboBoxBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Basic.Example.tsx') as string;
-
 const ComboBoxTogglesExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Toggles.Example.tsx') as string;
-
 const ComboBoxControlledExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Controlled.Example.tsx') as string;
-
+const ComboBoxControlledMultiExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ControlledMulti.Example.tsx') as string;
 const ComboBoxVirtualizedExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.Virtualized.Example.tsx') as string;
-
 const ComboBoxErrorHandlingExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.ErrorHandling.Example.tsx') as string;
-
 const ComboBoxCustomStyledExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/ComboBox/ComboBox.CustomStyled.Example.tsx') as string;
 
 export const ComboBoxPageProps: IDocPageProps = {
@@ -40,6 +37,11 @@ export const ComboBoxPageProps: IDocPageProps = {
       title: 'Controlled ComboBox',
       code: ComboBoxControlledExampleCode,
       view: <ComboBoxControlledExample />,
+    },
+    {
+      title: 'Controlled multi-select ComboBox',
+      code: ComboBoxControlledMultiExampleCode,
+      view: <ComboBoxControlledMultiExample />,
     },
     {
       title: 'VirtualizedComboBox',

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -31,7 +31,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
       id="ComboBox0-label"
     >
-      Basic ComboBox
+      Basic single-select ComboBox
     </label>
     <div
       className=
@@ -50,6 +50,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;
@@ -170,7 +171,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       id="ComboBox0wrapper"
     >
       <input
-        aria-autocomplete="inline"
+        aria-autocomplete="both"
         aria-expanded={false}
         aria-labelledby="ComboBox0-label"
         autoCapitalize="off"
@@ -404,11 +405,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           box-sizing: border-box;
           color: #ffffff;
           cursor: pointer;
-          display: inline-block;
+          display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
           height: 32px;
+          margin-bottom: 20px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
           min-width: 80px;
           outline: transparent;
           padding-bottom: 0;
@@ -483,13 +488,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    style={
-      Object {
-        "display": "block",
-        "marginTop": "10px",
-        "maxWidth": 300,
-      }
-    }
     type="button"
   >
     <span
@@ -526,10 +524,421 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               }
           id="id__4"
         >
-          Open ComboBox
+          Open first ComboBox
         </span>
       </span>
     </span>
   </button>
+  <div
+    className="ms-ComboBox-container "
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      id="ComboBox7-label"
+    >
+      Basic multi-select ComboBox
+      <span
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              width: 1px;
+            }
+      >
+        Option C
+      </span>
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            max-width: 300px;
+            outline: 0;
+            padding-left: 9px;
+            padding-right: 32px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
+            border-color: #323130;
+          }
+          &:hover .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+            color: GrayText;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: GrayText;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
+            border-color: Highlight;
+          }
+          &:active {
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+            border-color: Highlight;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          &:focus .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+            border-color: Highlight;
+          }
+          &:focus:after {
+            border-radius: 2px;
+            border: 2px solid #0078d4;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      id="ComboBox7wrapper"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-expanded={false}
+        aria-labelledby="ComboBox7-label"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #323130;
+              font: inherit;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="ComboBox7-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value="Option C"
+      />
+      <button
+        aria-hidden={true}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 100%;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              text-align: center;
+              text-decoration: none;
+              top: 0px;
+              user-select: none;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+              forced-color-adjust: none;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 12px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                }
+            data-icon-name="ChevronDown"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -2,397 +2,551 @@
 
 exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`] = `
 <div
-  className="ms-ComboBox-container "
-  style={
-    Object {
-      "maxWidth": 300,
-    }
-  }
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-left: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-    id="ComboBox0-label"
-  >
-    Controlled single-select ComboBox (allowFreeform: T)
-  </label>
   <div
-    className=
-        ms-ComboBox
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #ffffff;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          cursor: text;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          margin-left: 0;
-          outline: 0;
-          padding-left: 9px;
-          padding-right: 32px;
-          position: relative;
-          text-overflow: ellipsis;
-          user-select: none;
-          white-space: nowrap;
-        }
-        & .ms-Label {
-          display: inline-block;
-          margin-bottom: 8px;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
-          border-color: Highlight;
-        }
-        &:after {
-          border-color: #605e5c;
-          border-radius: 2px;
-          border-style: solid;
-          border-width: 1px;
-          bottom: 0px;
-          content: '';
-          left: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-        }
-        &:hover:after {
-          border-color: #323130;
-        }
-        &:hover .ms-ComboBox-Input {
-          color: #201f1e;
-        }
-        &:hover .ms-ComboBox-Input::placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
-          color: GrayText;
-        }
-        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: GrayText;
-        }
-        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: GrayText;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: WindowText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
-          border-color: Highlight;
-        }
-        &:active {
-          position: relative;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
-          border-color: Highlight;
-        }
-        &:focus {
-          border-color: #0078d4;
-        }
-        &:focus .ms-ComboBox-Input {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: WindowText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
-          border-color: Highlight;
-        }
-        &:focus:after {
-          border-radius: 2px;
-          border: 2px solid #0078d4;
-          bottom: 0px;
-          content: '';
-          left: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-        }
-    id="ComboBox0wrapper"
+    className="ms-ComboBox-container "
   >
-    <input
-      aria-autocomplete="inline"
-      aria-expanded={false}
-      aria-labelledby="ComboBox0-label"
-      autoCapitalize="off"
-      autoComplete="off"
+    <label
       className=
-          ms-ComboBox-Input
+          ms-Label
           {
-            background-color: #ffffff;
-            border-style: none;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            font: inherit;
-            height: 100%;
-            outline: none;
-            padding-bottom: 0;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
             padding-left: 0;
             padding-right: 0;
-            padding-top: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      id="ComboBox0-label"
+    >
+      Controlled single-select ComboBox
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            max-width: 300px;
+            outline: 0;
+            padding-left: 9px;
+            padding-right: 32px;
+            position: relative;
             text-overflow: ellipsis;
-            width: 100%;
+            user-select: none;
+            white-space: nowrap;
           }
-          &::placeholder {
-            color: #605e5c;
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
+            border-color: #323130;
+          }
+          &:hover .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
             color: GrayText;
           }
-          &:-ms-input-placeholder {
-            color: #605e5c;
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: GrayText;
           }
-          &::-ms-input-placeholder {
-            color: #605e5c;
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: GrayText;
           }
-          &::-ms-clear {
-            display: none;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-      data-is-interactable={true}
-      data-lpignore={true}
-      id="ComboBox0-input"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onCompositionEnd={[Function]}
-      onCompositionStart={[Function]}
-      onCompositionUpdate={[Function]}
-      onFocus={[Function]}
-      onInput={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onTouchStart={[Function]}
-      role="combobox"
-      spellCheck={false}
-      type="text"
-      value="Option C"
-    />
-    <button
-      aria-hidden={true}
-      className=
-          ms-Button
-          ms-Button--icon
-          ms-ComboBox-CaretDown-button
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background-color: transparent;
-            border-radius: 2px;
-            border: none;
-            box-sizing: border-box;
-            color: #605e5c;
-            cursor: default;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            height: 100%;
-            line-height: 30px;
-            outline: transparent;
-            padding-bottom: 0;
-            padding-left: 4px;
-            padding-right: 4px;
-            padding-top: 0;
-            position: absolute;
-            text-align: center;
-            text-decoration: none;
-            top: 0px;
-            user-select: none;
-            width: 32px;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid transparent;
-            bottom: 2px;
-            content: "";
-            left: 2px;
-            outline: 1px solid #605e5c;
-            position: absolute;
-            right: 2px;
-            top: 2px;
-            z-index: 1;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-            bottom: -2px;
-            left: -2px;
-            outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
-          }
-          &:active > * {
-            left: 0px;
-            position: relative;
-            top: 0px;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            -ms-high-contrast-adjust: none;
-            background-color: ButtonFace;
-            border-color: ButtonText;
-            color: ButtonText;
-            forced-color-adjust: none;
-          }
-          &:hover {
-            background-color: #f3f2f1;
-            color: #201f1e;
-            cursor: pointer;
-          }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            background-color: Highlight;
-            border-color: Highlight;
+            background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            background-color: #edebe9;
-            color: #201f1e;
+            position: relative;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
-            background-color: Highlight;
-            border-color: Highlight;
+            background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-      data-is-focusable={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onKeyPress={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="presentation"
-      tabIndex={-1}
-      type="button"
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+            border-color: Highlight;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          &:focus .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+            border-color: Highlight;
+          }
+          &:focus:after {
+            border-radius: 2px;
+            border: 2px solid #0078d4;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      id="ComboBox0wrapper"
     >
-      <span
+      <input
+        aria-autocomplete="inline"
+        aria-expanded={false}
+        aria-labelledby="ComboBox0-label"
+        autoCapitalize="off"
+        autoComplete="off"
         className=
-            ms-Button-flexContainer
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #323130;
+              font: inherit;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="ComboBox0-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value="Option C"
+      />
+      <button
+        aria-hidden={true}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 100%;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              text-align: center;
+              text-decoration: none;
+              top: 0px;
+              user-select: none;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+              forced-color-adjust: none;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 12px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                }
+            data-icon-name="ChevronDown"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle4"
+      id="Toggle4-label"
+    >
+      Allow freeform
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={true}
+        aria-labelledby="Toggle4-label"
+        checked={true}
+        className=
+            ms-Toggle-background
             {
               align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
               display: flex;
-              flex-wrap: nowrap;
-              height: 100%;
-              justify-content: center;
+              font-size: 20px;
+              height: 20px;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
             }
-        data-automationid="splitbuttonprimary"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #005a9e;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={true}
+        id="Toggle4"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
       >
-        <i
-          aria-hidden={true}
+        <span
           className=
-              ms-Icon
-              ms-Button-icon
+              ms-Toggle-thumb
               {
-                display: inline-block;
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: 6px;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
               }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Window;
+                border-color: Window;
               }
-              {
-                flex-shrink: 0;
-                font-size: 12px;
-                height: 16px;
-                line-height: 16px;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
-                text-align: center;
-              }
-          data-icon-name="ChevronDown"
-          style={
-            Object {
-              "fontFamily": "\\"FabricMDL2Icons\\"",
-            }
-          }
-        >
-          
-        </i>
-      </span>
-    </button>
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
@@ -2,418 +2,572 @@
 
 exports[`Component Examples renders ComboBox.ControlledMulti.Example.tsx correctly 1`] = `
 <div
-  className="ms-ComboBox-container "
-  style={
-    Object {
-      "maxWidth": 300,
-    }
-  }
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-left: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-    id="ComboBox0-label"
-  >
-    Controlled multi-select ComboBox (allowFreeform: T)
-    <span
-      className=
-
-          {
-            border: 0px;
-            height: 1px;
-            margin-bottom: -1px;
-            margin-left: -1px;
-            margin-right: -1px;
-            margin-top: -1px;
-            overflow: hidden;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: absolute;
-            width: 1px;
-          }
-    >
-      Option C, Option D
-    </span>
-  </label>
   <div
-    className=
-        ms-ComboBox
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #ffffff;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          cursor: text;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          margin-left: 0;
-          outline: 0;
-          padding-left: 9px;
-          padding-right: 32px;
-          position: relative;
-          text-overflow: ellipsis;
-          user-select: none;
-          white-space: nowrap;
-        }
-        & .ms-Label {
-          display: inline-block;
-          margin-bottom: 8px;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
-          border-color: Highlight;
-        }
-        &:after {
-          border-color: #605e5c;
-          border-radius: 2px;
-          border-style: solid;
-          border-width: 1px;
-          bottom: 0px;
-          content: '';
-          left: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-        }
-        &:hover:after {
-          border-color: #323130;
-        }
-        &:hover .ms-ComboBox-Input {
-          color: #201f1e;
-        }
-        &:hover .ms-ComboBox-Input::placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
-          color: GrayText;
-        }
-        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: GrayText;
-        }
-        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: GrayText;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: WindowText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
-          border-color: Highlight;
-        }
-        &:active {
-          position: relative;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
-          border-color: Highlight;
-        }
-        &:focus {
-          border-color: #0078d4;
-        }
-        &:focus .ms-ComboBox-Input {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: WindowText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
-          -ms-high-contrast-adjust: none;
-          background-color: Window;
-          color: HighlightText;
-          forced-color-adjust: none;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
-          border-color: Highlight;
-        }
-        &:focus:after {
-          border-radius: 2px;
-          border: 2px solid #0078d4;
-          bottom: 0px;
-          content: '';
-          left: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-        }
-    id="ComboBox0wrapper"
+    className="ms-ComboBox-container "
   >
-    <input
-      aria-autocomplete="inline"
-      aria-expanded={false}
-      aria-labelledby="ComboBox0-label"
-      autoCapitalize="off"
-      autoComplete="off"
+    <label
       className=
-          ms-ComboBox-Input
+          ms-Label
           {
-            background-color: #ffffff;
-            border-style: none;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            font: inherit;
-            height: 100%;
-            outline: none;
-            padding-bottom: 0;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
             padding-left: 0;
             padding-right: 0;
-            padding-top: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      id="ComboBox0-label"
+    >
+      Controlled multi-select ComboBox
+      <span
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              width: 1px;
+            }
+      >
+        Option C, Option D
+      </span>
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            max-width: 300px;
+            outline: 0;
+            padding-left: 9px;
+            padding-right: 32px;
+            position: relative;
             text-overflow: ellipsis;
-            width: 100%;
+            user-select: none;
+            white-space: nowrap;
           }
-          &::placeholder {
-            color: #605e5c;
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
+            border-color: #323130;
+          }
+          &:hover .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
             color: GrayText;
           }
-          &:-ms-input-placeholder {
-            color: #605e5c;
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: GrayText;
           }
-          &::-ms-input-placeholder {
-            color: #605e5c;
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: GrayText;
           }
-          &::-ms-clear {
-            display: none;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-      data-is-interactable={true}
-      data-lpignore={true}
-      id="ComboBox0-input"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onCompositionEnd={[Function]}
-      onCompositionStart={[Function]}
-      onCompositionUpdate={[Function]}
-      onFocus={[Function]}
-      onInput={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onTouchStart={[Function]}
-      role="combobox"
-      spellCheck={false}
-      type="text"
-      value="Option C, Option D"
-    />
-    <button
-      aria-hidden={true}
-      className=
-          ms-Button
-          ms-Button--icon
-          ms-ComboBox-CaretDown-button
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background-color: transparent;
-            border-radius: 2px;
-            border: none;
-            box-sizing: border-box;
-            color: #605e5c;
-            cursor: default;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            height: 100%;
-            line-height: 30px;
-            outline: transparent;
-            padding-bottom: 0;
-            padding-left: 4px;
-            padding-right: 4px;
-            padding-top: 0;
-            position: absolute;
-            text-align: center;
-            text-decoration: none;
-            top: 0px;
-            user-select: none;
-            width: 32px;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid transparent;
-            bottom: 2px;
-            content: "";
-            left: 2px;
-            outline: 1px solid #605e5c;
-            position: absolute;
-            right: 2px;
-            top: 2px;
-            z-index: 1;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-            bottom: -2px;
-            left: -2px;
-            outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
-          }
-          &:active > * {
-            left: 0px;
-            position: relative;
-            top: 0px;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            -ms-high-contrast-adjust: none;
-            background-color: ButtonFace;
-            border-color: ButtonText;
-            color: ButtonText;
-            forced-color-adjust: none;
-          }
-          &:hover {
-            background-color: #f3f2f1;
-            color: #201f1e;
-            cursor: pointer;
-          }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            background-color: Highlight;
-            border-color: Highlight;
+            background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            background-color: #edebe9;
-            color: #201f1e;
+            position: relative;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
-            background-color: Highlight;
-            border-color: Highlight;
+            background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-      data-is-focusable={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onKeyPress={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="presentation"
-      tabIndex={-1}
-      type="button"
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+            border-color: Highlight;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          &:focus .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+            border-color: Highlight;
+          }
+          &:focus:after {
+            border-radius: 2px;
+            border: 2px solid #0078d4;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      id="ComboBox0wrapper"
     >
-      <span
+      <input
+        aria-autocomplete="inline"
+        aria-expanded={false}
+        aria-labelledby="ComboBox0-label"
+        autoCapitalize="off"
+        autoComplete="off"
         className=
-            ms-Button-flexContainer
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #323130;
+              font: inherit;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="ComboBox0-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value="Option C, Option D"
+      />
+      <button
+        aria-hidden={true}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 100%;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              text-align: center;
+              text-decoration: none;
+              top: 0px;
+              user-select: none;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+              forced-color-adjust: none;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 12px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                }
+            data-icon-name="ChevronDown"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle4"
+      id="Toggle4-label"
+    >
+      Allow freeform
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={true}
+        aria-labelledby="Toggle4-label"
+        checked={true}
+        className=
+            ms-Toggle-background
             {
               align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
               display: flex;
-              flex-wrap: nowrap;
-              height: 100%;
-              justify-content: center;
+              font-size: 20px;
+              height: 20px;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
             }
-        data-automationid="splitbuttonprimary"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #005a9e;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={true}
+        id="Toggle4"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
       >
-        <i
-          aria-hidden={true}
+        <span
           className=
-              ms-Icon
-              ms-Button-icon
+              ms-Toggle-thumb
               {
-                display: inline-block;
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: 6px;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
               }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Window;
+                border-color: Window;
               }
-              {
-                flex-shrink: 0;
-                font-size: 12px;
-                height: 16px;
-                line-height: 16px;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
-                text-align: center;
-              }
-          data-icon-name="ChevronDown"
-          style={
-            Object {
-              "fontFamily": "\\"FabricMDL2Icons\\"",
-            }
-          }
-        >
-          
-        </i>
-      </span>
-    </button>
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -3,37 +3,27 @@
 exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 1`] = `
 <div
   className=
-      ms-Fabric
+      ms-Stack
       {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
       }
       & > * {
-        margin-bottom: 20px;
+        text-overflow: ellipsis;
       }
-      & .ms-ComboBox {
-        max-width: 300px;
+      & > *:not(:first-child) {
+        margin-top: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
       }
 >
   <div
-    className=
-        ms-ComboBox-container
-        {
-          max-width: 300px;
-        }
+    className="ms-ComboBox-container "
   >
     <label
       className=
@@ -80,6 +70,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;
@@ -469,6 +460,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly 1`] = `
-<div>
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
+>
   <div
     className="ms-ComboBox-container "
   >
@@ -50,6 +70,7 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;
@@ -392,6 +413,7 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -3,30 +3,23 @@
 exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] = `
 <div
   className=
-      ms-Fabric
+      ms-Stack
       {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
+        box-sizing: border-box;
         display: flex;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
       }
       & > * {
-        margin-right: 20px;
+        text-overflow: ellipsis;
       }
-      & .ms-ComboBox {
-        max-width: 300px;
+      & > *:not(:first-child) {
+        margin-left: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
       }
 >
   <div
@@ -77,6 +70,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             font-weight: 400;
             height: 32px;
             margin-left: 0;
+            max-width: 300px;
             outline: 0;
             padding-left: 9px;
             padding-right: 32px;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -2,416 +2,393 @@
 
 exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1`] = `
 <div
-  className=
-      ms-Fabric
-      ms-ComboBoxExample
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
-      }
+  className="ms-ComboBox-container "
 >
-  <div
-    className="ms-ComboBox-container "
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+    id="ComboBox0-label"
   >
-    <label
+    Scaled/virtualized example with 1000 items
+  </label>
+  <div
+    className=
+        ms-ComboBox
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: text;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-left: 0;
+          max-width: 300px;
+          outline: 0;
+          padding-left: 9px;
+          padding-right: 32px;
+          position: relative;
+          text-overflow: ellipsis;
+          user-select: none;
+          white-space: nowrap;
+        }
+        & .ms-Label {
+          display: inline-block;
+          margin-bottom: 8px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+          border-color: Highlight;
+        }
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        &:hover:after {
+          border-color: #323130;
+        }
+        &:hover .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        &:hover .ms-ComboBox-Input::placeholder {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+          color: GrayText;
+        }
+        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: GrayText;
+        }
+        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          color: GrayText;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
+          border-color: Highlight;
+        }
+        &:active {
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+          border-color: Highlight;
+        }
+        &:focus {
+          border-color: #0078d4;
+        }
+        &:focus .ms-ComboBox-Input {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: WindowText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          color: HighlightText;
+          forced-color-adjust: none;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+          border-color: Highlight;
+        }
+        &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #0078d4;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+    id="ComboBox0wrapper"
+  >
+    <input
+      aria-autocomplete="inline"
+      aria-expanded={false}
+      aria-labelledby="ComboBox0-label"
+      autoCapitalize="off"
+      autoComplete="off"
       className=
-          ms-Label
+          ms-ComboBox-Input
           {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: #ffffff;
+            border-style: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
+            font: inherit;
+            height: 100%;
+            outline: none;
+            padding-bottom: 0;
             padding-left: 0;
             padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      id="ComboBox0-label"
-    >
-      Scaled/virtualized example with 1000 items
-    </label>
-    <div
-      className=
-          ms-ComboBox
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background-color: #ffffff;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            cursor: text;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: 32px;
-            margin-left: 0;
-            max-width: 300px;
-            outline: 0;
-            padding-left: 9px;
-            padding-right: 32px;
-            position: relative;
+            padding-top: 0;
             text-overflow: ellipsis;
-            user-select: none;
-            white-space: nowrap;
+            width: 100%;
           }
-          & .ms-Label {
-            display: inline-block;
-            margin-bottom: 8px;
+          &::placeholder {
+            color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
-            -ms-high-contrast-adjust: none;
-            background-color: Window;
-            color: HighlightText;
-            forced-color-adjust: none;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
-            border-color: Highlight;
-          }
-          &:after {
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
-            bottom: 0px;
-            content: '';
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
-          &:hover:after {
-            border-color: #323130;
-          }
-          &:hover .ms-ComboBox-Input {
-            color: #201f1e;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #201f1e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
             color: GrayText;
           }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #201f1e;
+          &:-ms-input-placeholder {
+            color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
             color: GrayText;
           }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #201f1e;
+          &::-ms-input-placeholder {
+            color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
             color: GrayText;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
+          &::-ms-clear {
+            display: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
+          }
+      data-is-interactable={true}
+      data-lpignore={true}
+      id="ComboBox0-input"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onCompositionEnd={[Function]}
+      onCompositionStart={[Function]}
+      onCompositionUpdate={[Function]}
+      onFocus={[Function]}
+      onInput={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onTouchStart={[Function]}
+      role="combobox"
+      spellCheck={false}
+      type="text"
+      value="Option 547"
+    />
+    <button
+      aria-hidden={true}
+      className=
+          ms-Button
+          ms-Button--icon
+          ms-ComboBox-CaretDown-button
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 2px;
+            border: none;
+            box-sizing: border-box;
+            color: #605e5c;
+            cursor: default;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            height: 100%;
+            line-height: 30px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: absolute;
+            text-align: center;
+            text-decoration: none;
+            top: 0px;
+            user-select: none;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid transparent;
+            bottom: 2px;
+            content: "";
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: ButtonFace;
+            border-color: ButtonText;
+            color: ButtonText;
+            forced-color-adjust: none;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            background-color: Window;
+            background-color: Highlight;
+            border-color: Highlight;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
-            border-color: Highlight;
-          }
           &:active {
-            position: relative;
+            background-color: #edebe9;
+            color: #201f1e;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
-            background-color: Window;
+            background-color: Highlight;
+            border-color: Highlight;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
-            border-color: Highlight;
-          }
-          &:focus {
-            border-color: #0078d4;
-          }
-          &:focus .ms-ComboBox-Input {
-            color: #201f1e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
-            -ms-high-contrast-adjust: none;
-            background-color: Window;
-            color: WindowText;
-            forced-color-adjust: none;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
-            -ms-high-contrast-adjust: none;
-            background-color: Window;
-            color: HighlightText;
-            forced-color-adjust: none;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
-            border-color: Highlight;
-          }
-          &:focus:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: 0px;
-            content: '';
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
-      id="ComboBox0wrapper"
+      data-is-focusable={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="presentation"
+      tabIndex={-1}
+      type="button"
     >
-      <input
-        aria-autocomplete="inline"
-        aria-expanded={false}
-        aria-labelledby="ComboBox0-label"
-        autoCapitalize="off"
-        autoComplete="off"
+      <span
         className=
-            ms-ComboBox-Input
+            ms-Button-flexContainer
             {
-              background-color: #ffffff;
-              border-style: none;
-              box-sizing: border-box;
-              color: #323130;
-              font: inherit;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
               height: 100%;
-              outline: none;
-              padding-bottom: 0;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
+              justify-content: center;
             }
-            &::placeholder {
-              color: #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              -ms-high-contrast-adjust: none;
-              background-color: Window;
-              color: WindowText;
-              forced-color-adjust: none;
-            }
-        data-is-interactable={true}
-        data-lpignore={true}
-        id="ComboBox0-input"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onCompositionEnd={[Function]}
-        onCompositionStart={[Function]}
-        onCompositionUpdate={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onTouchStart={[Function]}
-        role="combobox"
-        spellCheck={false}
-        type="text"
-        value="Option 547"
-      />
-      <button
-        aria-hidden={true}
-        className=
-            ms-Button
-            ms-Button--icon
-            ms-ComboBox-CaretDown-button
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 2px;
-              border: none;
-              box-sizing: border-box;
-              color: #605e5c;
-              cursor: default;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              height: 100%;
-              line-height: 30px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 4px;
-              padding-right: 4px;
-              padding-top: 0;
-              position: absolute;
-              text-align: center;
-              text-decoration: none;
-              top: 0px;
-              user-select: none;
-              width: 32px;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid transparent;
-              bottom: 2px;
-              content: "";
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: absolute;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              -ms-high-contrast-adjust: none;
-              background-color: ButtonFace;
-              border-color: ButtonText;
-              color: ButtonText;
-              forced-color-adjust: none;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-              -ms-high-contrast-adjust: none;
-              background-color: Highlight;
-              border-color: Highlight;
-              color: HighlightText;
-              forced-color-adjust: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
-              -ms-high-contrast-adjust: none;
-              background-color: Highlight;
-              border-color: Highlight;
-              color: HighlightText;
-              forced-color-adjust: none;
-            }
-        data-is-focusable={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="presentation"
-        tabIndex={-1}
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
-        <span
+        <i
+          aria-hidden={true}
           className=
-              ms-Button-flexContainer
+              ms-Icon
+              ms-Button-icon
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: center;
+                display: inline-block;
               }
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className=
-                ms-Icon
-                ms-Button-icon
-                {
-                  display: inline-block;
-                }
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                {
-                  flex-shrink: 0;
-                  font-size: 12px;
-                  height: 16px;
-                  line-height: 16px;
-                  margin-bottom: 0;
-                  margin-left: 4px;
-                  margin-right: 4px;
-                  margin-top: 0;
-                  text-align: center;
-                }
-            data-icon-name="ChevronDown"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
               }
+              {
+                flex-shrink: 0;
+                font-size: 12px;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                text-align: center;
+              }
+          data-icon-name="ChevronDown"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
             }
-          >
-            
-          </i>
-        </span>
-      </button>
-    </div>
+          }
+        >
+          
+        </i>
+      </span>
+    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #16307, fixes #15223, fixes #15224
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ComboBox tries to pass `role="option"` and some `data-*` props as top-level props to an option Checkbox in multi-select mode. As documented in #16307, Checkbox currently doesn't apply most native props, so these props aren't applied. This is definitely a problem (Accessibility Insights flags it) but probably got missed since none of the ComboBox examples on the website used multi-select.

Related changes:
- Fix a minor version of this issue in Dropdown, where `data-*` props are passed as top-level props to the Checkbox (the more significant issue with the role had already been fixed)
- Add multi-select ComboBox examples on the website, and fix the controlled examples to actually work with freeform mode
- Add snapshot tests for ComboBox and Dropdown's open states

(master version: #16331)