### PR TITLE
(7.0) swapping arrows for decade picker, which were backwards

### DIFF
--- a/change/@uifabric-date-time-2020-12-30-15-48-21-7.0.json
+++ b/change/@uifabric-date-time-2020-12-30-15-48-21-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "cherry picking and merging 6537ee66190784eb1a04bd765546efff09d451a1 from master",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-30T23:48:21.758Z"
+}

--- a/change/@uifabric-date-time-2020-12-30-15-48-21-7.0.json
+++ b/change/@uifabric-date-time-2020-12-30-15-48-21-7.0.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "cherry picking and merging 6537ee66190784eb1a04bd765546efff09d451a1 from master",
+  "comment": "swapping arrows for decade picker, which were backwards",
   "packageName": "@uifabric/date-time",
   "email": "lorejoh12@gmail.com",
   "dependentChangeType": "patch",

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -261,6 +261,11 @@ const CalendarYearNavArrow = React.forwardRef(
       }
     };
 
+    // can be condensed, but leaving verbose for clarity due to regressions
+    const isLeftNavigation = getRTL()
+      ? direction === CalendarYearNavDirection.Next
+      : direction === CalendarYearNavDirection.Previous;
+
     return (
       <button
         className={css(classNames.navigationButton, {
@@ -273,13 +278,7 @@ const CalendarYearNavArrow = React.forwardRef(
         disabled={disabled}
         ref={forwardedRef}
       >
-        <Icon
-          iconName={
-            (direction === CalendarYearNavDirection.Previous) !== getRTL()
-              ? iconStrings.rightNavigation
-              : iconStrings.leftNavigation
-          }
-        />
+        <Icon iconName={isLeftNavigation ? iconStrings.leftNavigation : iconStrings.rightNavigation} />
       </button>
     );
   },

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -248,7 +248,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   ): JSX.Element => {
     const { minDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
-    const leftNavigationIcon = navigationIcons!.leftNavigation;
+    const leftNavigationIcon = getRTL() ? navigationIcons!.rightNavigation : navigationIcons!.leftNavigation;
 
     // determine if previous week in bounds
     const prevWeekInBounds = minDate
@@ -275,7 +275,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   private _renderNextWeekNavigationButton = (classNames: IProcessedStyleSet<IWeeklyDayPickerStyles>): JSX.Element => {
     const { maxDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
-    const rightNavigationIcon = navigationIcons!.rightNavigation;
+    const rightNavigationIcon = getRTL() ? navigationIcons!.leftNavigation : navigationIcons!.rightNavigation;
 
     // determine if next week in bounds
     const nextWeekInBounds = maxDate


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

cherry picking and merging 6537ee66190784eb1a04bd765546efff09d451a1 from master to 7.0, driven by PR https://github.com/microsoft/fluentui/pull/16227

#### Focus areas to test

(optional)
