### PR TITLE
Azure theme fix: MessageBar, Callout and TeachingBubble

### DIFF
--- a/change/@fluentui-react-examples-2021-01-03-17-32-17-jackieg-control-style-fixes.json
+++ b/change/@fluentui-react-examples-2021-01-03-17-32-17-jackieg-control-style-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "callout, messagebar and teachingbubble style updatets",
+  "packageName": "@fluentui/react-examples",
+  "email": "jagaheri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-04T01:32:17.361Z"
+}

--- a/change/@uifabric-azure-themes-2021-01-03-17-32-17-jackieg-control-style-fixes.json
+++ b/change/@uifabric-azure-themes-2021-01-03-17-32-17-jackieg-control-style-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "callout, messagebar and teachingbubble style updates ",
+  "packageName": "@uifabric/azure-themes",
+  "email": "jagaheri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-04T01:31:54.840Z"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -252,6 +252,7 @@ export const DarkSemanticColors: IAzureSemanticColors = {
   },
   controlOutlines: {
     rest: BaseColors.GRAY_808080,
+    background: BaseColors.GRAY_252423,
     disabled: BaseColors.GRAY_808080_070,
     hover: BaseColors.WHITE,
     accent: BaseColors.BLUE_106EBE,
@@ -431,6 +432,7 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
   },
   controlOutlines: {
     rest: BaseColors.WHITE,
+    background: BaseColors.GRAY_111111,
     disabled: BaseColors.GRAY_808080_070,
     hover: BaseColors.WHITE,
     accent: BaseColors.BLUE_00FFFF,
@@ -610,6 +612,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
   },
   controlOutlines: {
     rest: BaseColors.GRAY_323130,
+    background: BaseColors.WHITE,
     disabled: BaseColors.GRAY_F3F2F1,
     hover: BaseColors.GRAY_605E5C,
     accent: BaseColors.BLUE_0078D4,
@@ -789,6 +792,7 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
   },
   controlOutlines: {
     rest: BaseColors.BLACK,
+    background: BaseColors.WHITE,
     disabled: BaseColors.GRAY_F3F2F1,
     hover: BaseColors.GRAY_605E5C,
     accent: BaseColors.PURPLE_800080,

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -312,6 +312,7 @@ export const DarkSemanticColors: IAzureSemanticColors = {
   teachingBubble: {
     rest: {
       background: BaseColors.BLUE_2899F5,
+      border: BaseColors.BLUE_2899F5,
       text: BaseColors.BLACK,
       secondaryBackround: BaseColors.BLACK,
     },
@@ -492,6 +493,7 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
   teachingBubble: {
     rest: {
       background: BaseColors.BLUE_00FFFF,
+      border: BaseColors.BLUE_00FFFF,
       text: BaseColors.BLACK,
       secondaryBackround: BaseColors.BLACK,
     },
@@ -672,6 +674,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
   teachingBubble: {
     rest: {
       background: BaseColors.BLUE_0078D4,
+      border: BaseColors.BLUE_0078D4,
       text: BaseColors.WHITE,
       secondaryBackround: BaseColors.WHITE,
     },
@@ -852,6 +855,7 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
   teachingBubble: {
     rest: {
       background: BaseColors.PURPLE_800080,
+      border: BaseColors.PURPLE_800080,
       text: BaseColors.WHITE,
       secondaryBackround: BaseColors.WHITE,
     },

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -89,6 +89,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
 
   // extended
   controlAccent: DarkSemanticColors.controlOutlines.accent,
+  controlBackground: DarkSemanticColors.controlOutlines.background,
   controlOutline: DarkSemanticColors.controlOutlines.rest,
   controlOutlineDisabled: DarkSemanticColors.controlOutlines.disabled,
   controlOutlineHovered: DarkSemanticColors.controlOutlines.hover,
@@ -120,6 +121,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
 
   // temporary work around for high contrast themes
   choiceGroupContainerBorder: '0px',
+  callOutBorderStyle: 'solid',
   choiceGroupContainerBorderStyle: 'solid',
   listUnderline: 'none',
   linkBorderStyle: 'dashed',

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -114,6 +114,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   statusWarningText: DarkSemanticColors.text.body,
   statusWarningIcon: DarkSemanticColors.statusBar.icon.warning,
   teachingBubbleBackground: DarkSemanticColors.teachingBubble.rest.background,
+  teachingBubbleBorder: DarkSemanticColors.teachingBubble.rest.border,
   teachingBubblePrimaryButtonHover: DarkSemanticColors.teachingBubble.hover.primaryButtonBackground,
   teachingBubbleSecondaryBackground: DarkSemanticColors.teachingBubble.rest.secondaryBackround,
   teachingBubbleText: DarkSemanticColors.teachingBubble.rest.text,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -88,6 +88,7 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
   controlAccent: HighContrastDarkSemanticColors.controlOutlines.accent,
+  controlBackground: HighContrastDarkSemanticColors.controlOutlines.background,
   controlOutline: HighContrastDarkSemanticColors.controlOutlines.rest,
   controlOutlineDisabled: HighContrastDarkSemanticColors.controlOutlines.disabled,
   controlOutlineHovered: HighContrastDarkSemanticColors.controlOutlines.hover,
@@ -120,6 +121,7 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
 
   // temporary work around for high contrast themes
   choiceGroupContainerBorder: '1px',
+  callOutBorderStyle: 'solid',
   choiceGroupContainerBorderStyle: 'solid',
   listUnderline: 'underline',
   linkBorderStyle: 'dashed',

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -114,6 +114,7 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   statusWarningText: HighContrastDarkSemanticColors.text.body,
   statusWarningIcon: HighContrastDarkSemanticColors.statusBar.icon.warning,
   teachingBubbleBackground: HighContrastDarkSemanticColors.teachingBubble.rest.background,
+  teachingBubbleBorder: HighContrastDarkSemanticColors.teachingBubble.rest.border,
   teachingBubblePrimaryButtonHover: HighContrastDarkSemanticColors.teachingBubble.hover.primaryButtonBackground,
   teachingBubbleSecondaryBackground: HighContrastDarkSemanticColors.teachingBubble.rest.secondaryBackround,
   teachingBubbleText: HighContrastDarkSemanticColors.teachingBubble.rest.text,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -115,6 +115,7 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   statusWarningText: HighContrastLightSemanticColors.text.body,
   statusWarningIcon: HighContrastLightSemanticColors.statusBar.icon.warning,
   teachingBubbleBackground: HighContrastLightSemanticColors.teachingBubble.rest.background,
+  teachingBubbleBorder: HighContrastLightSemanticColors.teachingBubble.rest.border,
   teachingBubblePrimaryButtonHover: HighContrastLightSemanticColors.teachingBubble.hover.primaryButtonBackground,
   teachingBubbleSecondaryBackground: HighContrastLightSemanticColors.teachingBubble.rest.secondaryBackround,
   teachingBubbleText: HighContrastLightSemanticColors.teachingBubble.rest.text,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -89,6 +89,7 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   variantBorder: HighContrastLightSemanticColors.controlOutlines.rest,
   // extended
   controlAccent: HighContrastLightSemanticColors.controlOutlines.accent,
+  controlBackground: HighContrastLightSemanticColors.controlOutlines.background,
   controlOutline: HighContrastLightSemanticColors.controlOutlines.rest,
   controlOutlineDisabled: HighContrastLightSemanticColors.controlOutlines.disabled,
   controlOutlineHovered: HighContrastLightSemanticColors.controlOutlines.hover,
@@ -121,6 +122,7 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
 
   // temporary work around for high contrast themes
   choiceGroupContainerBorder: '1px',
+  callOutBorderStyle: 'solid',
   choiceGroupContainerBorderStyle: 'dashed',
   listUnderline: 'underline',
   linkBorderStyle: 'dashed',

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -114,6 +114,7 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   statusWarningText: LightSemanticColors.text.body,
   statusWarningIcon: LightSemanticColors.statusBar.icon.warning,
   teachingBubbleBackground: LightSemanticColors.teachingBubble.rest.background,
+  teachingBubbleBorder: LightSemanticColors.teachingBubble.rest.border,
   teachingBubblePrimaryButtonHover: LightSemanticColors.teachingBubble.hover.primaryButtonBackground,
   teachingBubbleSecondaryBackground: LightSemanticColors.teachingBubble.rest.secondaryBackround,
   teachingBubbleText: LightSemanticColors.teachingBubble.rest.text,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -88,6 +88,7 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
   controlAccent: LightSemanticColors.controlOutlines.accent,
+  controlBackground: LightSemanticColors.controlOutlines.background,
   controlOutline: LightSemanticColors.controlOutlines.rest,
   controlOutlineDisabled: LightSemanticColors.controlOutlines.disabled,
   controlOutlineHovered: LightSemanticColors.controlOutlines.hover,
@@ -120,6 +121,7 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
 
   // temporary work around for high contrast themes
   choiceGroupContainerBorder: '0px',
+  callOutBorderStyle: 'solid',
   choiceGroupContainerBorderStyle: 'solid',
   listUnderline: 'none',
   linkBorderStyle: 'dashed',

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -169,6 +169,7 @@ export interface IAzureSemanticColors {
   teachingBubble: {
     rest: {
       background: string;
+      border: string;
       text: string;
       secondaryBackround: string;
     };

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -109,6 +109,7 @@ export interface IAzureSemanticColors {
   };
   controlOutlines: {
     rest: string;
+    background: string;
     disabled: string;
     hover: string;
     accent: string; // button in radio, check, et. al.

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -30,11 +30,13 @@ export interface IExtendedSemanticColors extends ISemanticColors {
   checkBoxDisabled: string;
   checkBoxIndeterminateBackground: string;
   checkBoxIndeterminateDefaultChecked: string;
+  callOutBorderStyle: string;
   choiceGroupContainerBorder: string;
   choiceGroupContainerBorderStyle: string;
   choiceGroupUncheckedDotHover: string;
   commandBarBorder: string;
   controlAccent: string;
+  controlBackground: string;
   controlOutline: string;
   controlOutlineDisabled: string;
   controlOutlineHovered: string;

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -115,6 +115,7 @@ export interface IExtendedSemanticColors extends ISemanticColors {
   textFieldBorderDisabled: string;
   tabHover: string;
   teachingBubbleBackground: string;
+  teachingBubbleBorder: string;
   teachingBubblePrimaryButtonHover: string;
   teachingBubbleSecondaryBackground: string;
   teachingBubbleText: string;

--- a/packages/azure-themes/src/azure/styles/Callout.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Callout.styles.ts
@@ -1,9 +1,11 @@
 import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
 import { Depths } from '../AzureDepths';
+import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;
   const { semanticColors } = theme;
+  const extendedSemanticColors = semanticColors as IExtendedSemanticColors;
 
   return {
     root: {
@@ -12,6 +14,16 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<
     calloutMain: {
       color: semanticColors.bodyText,
       fontSize: theme.fonts.medium.fontSize,
+      backgroundColor: extendedSemanticColors.controlBackground,
+      border: `${extendedSemanticColors.choiceGroupContainerBorder}
+      ${extendedSemanticColors.callOutBorderStyle}
+      ${extendedSemanticColors.primaryButtonBorder}`,
+    },
+    beak: {
+      backgroundColor: extendedSemanticColors.controlBackground,
+      border: `${extendedSemanticColors.choiceGroupContainerBorder}
+      ${extendedSemanticColors.callOutBorderStyle}
+      ${extendedSemanticColors.primaryButtonBorder}`,
     },
   };
 };

--- a/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
+++ b/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
@@ -39,7 +39,7 @@ const IconButtonStyles = (props: IMessageBarStyleProps): IStyle => {
     (messageBarType === MessageBarType.warning || messageBarType === MessageBarType.blocked) &&
       generateBaseStyle(semanticColors.statusWarningBackground, semanticColors.statusWarningText),
 
-    !messageBarType && generateBaseStyle(semanticColors.bodyBackground, semanticColors.bodyText),
+    typeof messageBarType !== 'number' && generateBaseStyle(semanticColors.bodyBackground, semanticColors.bodyText),
   ];
 };
 

--- a/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
@@ -12,7 +12,6 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
   return {
     bodyContent: {
       color: extendedSemanticColors.teachingBubbleText,
-      border: `1px solid ${extendedSemanticColors.teachingBubbleBorder}`,
       selectors: {
         '.ms-TeachingBubble-subText': {
           fontSize: FontSizes.size14,
@@ -51,14 +50,14 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
     subComponentStyles: {
       callout: {
         root: {
-          borderColor: extendedSemanticColors.teachingBubbleBorder,
-          borderStyle: StyleConstants.borderSolid,
-          borderWidth: StyleConstants.borderWidth,
-          borderRadius: '4px',
           boxShadow: Depths.depth8,
           selectors: {
+            '.ms-Callout-main': {
+              border: 0,
+            },
             '.ms-Callout-beak': {
               backgroundColor: extendedSemanticColors.teachingBubbleBackground,
+              border: 0,
             },
           },
         },
@@ -77,7 +76,7 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
       },
     },
     primaryButton: {
-      // backgroundColor and border color requires !important to override primary color
+      // backgroundColor and border color requires !important to override primary btn color
       backgroundColor: `${extendedSemanticColors.teachingBubbleSecondaryBackground} !important`,
       borderColor: `${extendedSemanticColors.teachingBubbleSecondaryBackground} !important`,
       selectors: {

--- a/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
@@ -12,7 +12,7 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
   return {
     bodyContent: {
       color: extendedSemanticColors.teachingBubbleText,
-      border: `1px solid ${extendedSemanticColors.teachingBubbleBackground}`,
+      border: `1px solid ${extendedSemanticColors.teachingBubbleBorder}`,
       selectors: {
         '.ms-TeachingBubble-subText': {
           fontSize: FontSizes.size14,
@@ -51,9 +51,10 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
     subComponentStyles: {
       callout: {
         root: {
-          borderColor: semanticColors.inputBorder,
+          borderColor: extendedSemanticColors.teachingBubbleBorder,
           borderStyle: StyleConstants.borderSolid,
           borderWidth: StyleConstants.borderWidth,
+          borderRadius: '4px',
           boxShadow: Depths.depth8,
           selectors: {
             '.ms-Callout-beak': {
@@ -76,7 +77,9 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
       },
     },
     primaryButton: {
-      backgroundColor: extendedSemanticColors.teachingBubbleSecondaryBackground,
+      // backgroundColor and border color requires !important to override primary color
+      backgroundColor: `${extendedSemanticColors.teachingBubbleSecondaryBackground} !important`,
+      borderColor: `${extendedSemanticColors.teachingBubbleSecondaryBackground} !important`,
       selectors: {
         '&:focus': {
           backgroundColor: extendedSemanticColors.teachingBubblePrimaryButtonHover,
@@ -101,10 +104,10 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
           fontSize: theme.fonts.medium.fontSize,
         },
         '&:hover': {
-          backgroundColor: extendedSemanticColors.primaryButtonBackgroundPressed,
+          backgroundColor: extendedSemanticColors.primaryButtonBackgroundHovered,
         },
         '&:focus': {
-          backgroundColor: extendedSemanticColors.primaryButtonBackgroundPressed,
+          backgroundColor: extendedSemanticColors.teachingBubbleBackground,
         },
       },
     },

--- a/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
@@ -1,7 +1,6 @@
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
 import { Depths } from '../AzureDepths';
 import { FontSizes } from '../AzureType';
-import * as StyleConstants from '../Constants';
 import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {

--- a/packages/react-examples/src/azure-themes/stories/components/TeachingBubble.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/TeachingBubble.stories.tsx
@@ -9,6 +9,7 @@ const examplePrimaryButtonProps: IButtonProps = {
 
 export const TeachingBubbleBasicExample: React.FunctionComponent = () => {
   const [teachingBubbleVisible, { toggle: toggleTeachingBubbleVisible }] = useBoolean(false);
+
   const exampleSecondaryButtonProps: IButtonProps = React.useMemo(
     () => ({
       children: 'Maybe later',
@@ -28,10 +29,10 @@ export const TeachingBubbleBasicExample: React.FunctionComponent = () => {
       {teachingBubbleVisible && (
         <TeachingBubble
           target="#targetButton"
+          hasCondensedHeadline={true}
           primaryButtonProps={examplePrimaryButtonProps}
           secondaryButtonProps={exampleSecondaryButtonProps}
           onDismiss={toggleTeachingBubbleVisible}
-          hasCloseButton={true}
           headline="Discover what’s trending around you"
         >
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni

--- a/packages/react-examples/src/azure-themes/stories/components/messageBar.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/messageBar.stories.tsx
@@ -31,8 +31,8 @@ const choiceGroupStyles = {
   },
 };
 
-const DefaultExample = () => (
-  <MessageBar>
+const DefaultExample = (p: IExampleProps) => (
+  <MessageBar onDismiss={p.resetChoice}>
     Info/Default MessageBar.
     <Link href="www.bing.com" target="_blank">
       Visit our website.
@@ -173,7 +173,7 @@ export const MessageBarBasicExample: React.FunctionComponent = () => {
         />
       </StackItem>
       <Stack {...verticalStackProps}>
-        {(choice === 'default' || showAll) && <DefaultExample />}
+        {(choice === 'default' || showAll) && <DefaultExample resetChoice={resetChoice} />}
 
         {(choice === 'error' || showAll) && <ErrorExample resetChoice={resetChoice} />}
 


### PR DESCRIPTION
### Pull request checklist

- [ x ] Addresses an existing issue: Fixes #0000
- [ x ] Include a change request file using `$ yarn change`

### Description of changes
#### 1. MessageBar: dismiss bug fixed
before: 
![image](https://user-images.githubusercontent.com/30805892/103496150-010d3800-4df2-11eb-85d9-3896c38e074a.png)
after
![image](https://user-images.githubusercontent.com/30805892/103496164-0b2f3680-4df2-11eb-878b-49803aa032f4.png)


#### 2. Callout: dark theme contrast

before (dark theme bug, no contrast between callout and background):
<img src="https://user-images.githubusercontent.com/30805892/103494547-3dd63080-4dec-11eb-8497-b4ae9a4dceb4.png" width="400px">

after:
<img src="https://user-images.githubusercontent.com/30805892/103494560-4dee1000-4dec-11eb-8134-bb345fc55b2f.png" width="400px">

#### 3. TeachingBubble: default and primary buttons 
before:
<img src="https://user-images.githubusercontent.com/30805892/103495011-184a2680-4dee-11eb-9dce-d00ec57ba5d3.png" width="400px">

after: 
<img src="https://user-images.githubusercontent.com/30805892/103495044-34e65e80-4dee-11eb-9c2f-dc05a27a6a4a.png" width="400px">

### (Extra) Components in each sub theme with changes
MessageBar
![image](https://user-images.githubusercontent.com/30805892/103496422-074fe400-4df3-11eb-91cf-824af301979b.png)
![image](https://user-images.githubusercontent.com/30805892/103496425-09b23e00-4df3-11eb-9c40-23a54f2719d6.png)
![image](https://user-images.githubusercontent.com/30805892/103496426-0b7c0180-4df3-11eb-869c-6b15dfc8e883.png)
![image](https://user-images.githubusercontent.com/30805892/103496429-0dde5b80-4df3-11eb-8071-6a7d6922ad4b.png)


Callout
<div>
<img src="https://user-images.githubusercontent.com/30805892/103495248-fdc47d00-4dee-11eb-9411-6ab994c6c294.png" width="200px" display="inline">
<img src="https://user-images.githubusercontent.com/30805892/103495274-116fe380-4def-11eb-8543-642cf3983c98.png" width="200px" display="inline">
<img src="https://user-images.githubusercontent.com/30805892/103495203-d2da2900-4dee-11eb-9fe6-3623229d071c.png" width="200px" display="inline">
<img src="https://user-images.githubusercontent.com/30805892/103495180-bb9b3b80-4dee-11eb-89f9-46a515ee7f35.png" width="200px" display="inline">
</div>

example of high contrast lines appearing live in portal: 
<img src="https://user-images.githubusercontent.com/30805892/103495235-f2715180-4dee-11eb-99d0-0ba038fb6a7f.png" width="400px" display="inline">



TeachingBubble
<img src="https://user-images.githubusercontent.com/30805892/103497538-ac1ff080-4df6-11eb-808a-371008a341df.png" width="400px">
<img src="https://user-images.githubusercontent.com/30805892/103497559-c2c64780-4df6-11eb-8cc9-78b1e8cd2a13.png" width="400px">
<img src="https://user-images.githubusercontent.com/30805892/103497521-9ca0a780-4df6-11eb-9b07-462f869042da.png" width="400px">
<img src="(https://user-images.githubusercontent.com/30805892/103497507-91e61280-4df6-11eb-97cc-9bef2d50aa87.png" width="400px">

<img src="" width="400px">