### PR TITLE
fix (web components): add padding for focus overlap of state in accordion item

### DIFF
--- a/change/@fluentui-web-components-2021-01-04-10-54-05-users-v-sedono-fix-margin-focus-overlap-accordion-item.json
+++ b/change/@fluentui-web-components-2021-01-04-10-54-05-users-v-sedono-fix-margin-focus-overlap-accordion-item.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "add margin for focus overlap of state in accordion item",
+  "comment": "add padding for focus overlap of state in accordion item",
   "packageName": "@fluentui/web-components",
   "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-web-components-2021-01-04-10-54-05-users-v-sedono-fix-margin-focus-overlap-accordion-item.json
+++ b/change/@fluentui-web-components-2021-01-04-10-54-05-users-v-sedono-fix-margin-focus-overlap-accordion-item.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add margin for focus overlap of state in accordion item",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-04T18:54:05.059Z"
+}

--- a/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
@@ -106,6 +106,7 @@ export const AccordionItemStyles = css`
     .start {
         display: flex;
         align-items: center;
+        padding-inline-start: calc(var(--design-unit) * 1px);
         justify-content: center;
         grid-column: 1;
         z-index: 2;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add padding for focus overlap in `Accordion Item`