### PR TITLE
fix (web components): text-field label hidden styles ordering

### DIFF
--- a/change/@fluentui-web-components-2021-01-04-11-24-25-users-v-sedono-fix-text-field-label-hidden-styles.json
+++ b/change/@fluentui-web-components-2021-01-04-11-24-25-users-v-sedono-fix-text-field-label-hidden-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "move text-field label__hidden styles below main label styles for proper order",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-04T19:24:25.182Z"
+}

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -55,11 +55,6 @@ export const TextFieldStyles = css`
         outline: none;
     }
 
-    .label__hidden {
-        display: none;
-        visibility: hidden;
-    }
-
     .label {
         display: block;
         color: ${neutralForegroundRestBehavior.var};
@@ -67,6 +62,11 @@ export const TextFieldStyles = css`
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
         margin-bottom: 4px;
+    }
+   
+    .label__hidden {
+      display: none;
+      visibility: hidden;
     }
 
     .start,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Moves text-field label__hidden styles below main label styles for proper ordering so the styles are applied correctly.