### PR TITLE
fix (web components): inline start margin rtl slider

### DIFF
--- a/change/@fluentui-web-components-2021-01-04-11-29-21-users-v-sedono-fix-inline-start-margin-rtl-slider.json
+++ b/change/@fluentui-web-components-2021-01-04-11-29-21-users-v-sedono-fix-inline-start-margin-rtl-slider.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add inline start margin for rtl to slider",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-04T19:29:21.433Z"
+}

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -81,7 +81,7 @@ export const SliderStyles = css`
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+        margin-inline-start: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         width: calc(var(--track-width) * 1px);
         height: 100%;
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adds inline-start-margin to `Slider` for RTL mode.