### PR TITLE
ScrollablePane example a11y-update

### DIFF
--- a/packages/react-examples/src/react/ScrollablePane/ScrollablePane.Default.Example.tsx
+++ b/packages/react-examples/src/react/ScrollablePane/ScrollablePane.Default.Example.tsx
@@ -46,7 +46,7 @@ const createContentArea = (item: IScrollablePaneExampleItem) => (
     }}
   >
     <Sticky stickyPosition={StickyPositionType.Both}>
-      <div role="heading" aria-level="1" className={classNames.sticky}>
+      <div role="heading" aria-level={1} className={classNames.sticky}>
         Sticky Component #{item.index + 1}
       </div>
     </Sticky>

--- a/packages/react-examples/src/react/ScrollablePane/ScrollablePane.Default.Example.tsx
+++ b/packages/react-examples/src/react/ScrollablePane/ScrollablePane.Default.Example.tsx
@@ -46,7 +46,9 @@ const createContentArea = (item: IScrollablePaneExampleItem) => (
     }}
   >
     <Sticky stickyPosition={StickyPositionType.Both}>
-      <div className={classNames.sticky}>Sticky Component #{item.index + 1}</div>
+      <div role="heading" aria-level="1" className={classNames.sticky}>
+        Sticky Component #{item.index + 1}
+      </div>
     </Sticky>
     <div className={classNames.textContent}>{item.text}</div>
   </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15913 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Heading level is not defined for "Sticky component #1" in Default example. This adds a header role and an aria-level prop to the Sticky in the default example
#### Focus areas to test

(optional)
