### PR TITLE
fix(fontSizeUtility): fallback to a default pxToRem value

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -73,6 +73,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix the type for `onBlur`callback in the `Dropdown` component @ling1726 ([#16257](https://github.com/microsoft/fluentui/pull/16257))
 - Fix missing export for `AttachmentBodyStylesProps` @ling1726 ([#16260](https://github.com/microsoft/fluentui/pull/16260))
 - Fix throwing error when using `ChatMessage` with children without declaring the `header` prop @ling1726 ([#16321](https://github.com/microsoft/fluentui/pull/16321))
+- Fix throwing error in `fontSizeUtility` on CodeSandbox @layershifter ([#16368](https://github.com/microsoft/fluentui/pull/16368))
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/react-northstar/src/utils/fontSizeUtility.ts
+++ b/packages/fluentui/react-northstar/src/utils/fontSizeUtility.ts
@@ -4,11 +4,17 @@ const DEFAULT_REM_SIZE_IN_PX = 16;
 
 let _documentRemSize: number | null = null;
 
-const getDocumentRemSize = (): number => {
-  return isBrowser()
-    ? // eslint-disable-next-line no-undef
-      getFontSizeValue(getComputedStyle(document.documentElement).fontSize) || DEFAULT_REM_SIZE_IN_PX
-    : DEFAULT_REM_SIZE_IN_PX;
+export const getDocumentRemSize = (): number => {
+  if (isBrowser()) {
+    try {
+      // eslint-disable-next-line no-undef
+      return getFontSizeValue(getComputedStyle(document.documentElement).fontSize) || DEFAULT_REM_SIZE_IN_PX;
+    } catch (e) {
+      return DEFAULT_REM_SIZE_IN_PX;
+    }
+  }
+
+  return DEFAULT_REM_SIZE_IN_PX;
 };
 
 const getFontSizeValue = (size?: string | null): number | null => {

--- a/packages/fluentui/react-northstar/test/specs/utils/fontSizeUtility-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/utils/fontSizeUtility-test.ts
@@ -1,4 +1,4 @@
-import { pxToRem, round } from 'src/utils/fontSizeUtility';
+import { getDocumentRemSize, pxToRem, round } from 'src/utils/fontSizeUtility';
 
 describe('fontSizeUtility', () => {
   describe('round', () => {
@@ -11,28 +11,42 @@ describe('fontSizeUtility', () => {
   });
 
   describe('pxToRem', () => {
-    it('returns 1rem for 16px with a default HTML font size of 16px.', () => {
+    it('returns 1rem for 16px with a default HTML font size of 16px', () => {
       expect(pxToRem(16)).toEqual('1rem');
     });
 
-    it('returns 1rem with base font size of 10px.', () => {
+    it('returns 1rem with base font size of 10px', () => {
       expect(pxToRem(10, 10)).toEqual('1rem');
     });
 
-    it('returns 0.714rem with a base font size of 14px.', () => {
+    it('returns 0.714rem with a base font size of 14px', () => {
       expect(pxToRem(10, 14)).toEqual('0.7143rem');
     });
 
-    it('returns 1.25rem with a base font size of 8px.', () => {
+    it('returns 1.25rem with a base font size of 8px', () => {
       expect(pxToRem(10, 8)).toEqual('1.25rem');
     });
 
-    it('returns 0rem when pxToRem is called with 0.', () => {
+    it('returns 0rem when pxToRem is called with 0', () => {
       expect(pxToRem(0)).toEqual('0rem');
     });
 
-    it('should handle negative input values and return negative conversion result.', () => {
+    it('should handle negative input values and return negative conversion result', () => {
       expect(pxToRem(-16, 16)).toEqual('-1rem');
+    });
+  });
+
+  describe('getDocumentRemSize', () => {
+    it('fallbacks to a default value when "documentElement" contains an invalid entry', () => {
+      Object.defineProperty(document, 'documentElement', {
+        configurable: true,
+        get() {
+          return null;
+        },
+      });
+
+      expect(document.documentElement).toBe(null);
+      expect(getDocumentRemSize()).toEqual(16);
     });
   });
 });


### PR DESCRIPTION
Fixes #14049, see https://github.com/microsoft/fluentui/issues/14049#issuecomment-754545818.

---

There is a collision between native DOM and JSDOM as it provides own implementation of HTML elements, `Document` & `Window` objects:

```tsx
getComputedStyle === dom.window.getComputedStyle // false
dom.window.document.documentElement instanceof Element // 💣 false
```

As we are using `getComputedStyle()` directly it fails with:

```tsx
TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
```

It should not be an issue for Node environment, but can be annoying for CodeSandbox, a repro can be found on CSB:
https://codesandbox.io/s/fluent-ui-issue-14049-forked-sl7zo?file=/src/index.js