### PR TITLE
fix (web components): slider disabled and readonly cursor

### DIFF
--- a/change/@fluentui-web-components-2021-01-05-13-44-17-users-v-sedono-fix-slider-disabled-cursor.json
+++ b/change/@fluentui-web-components-2021-01-05-13-44-17-users-v-sedono-fix-slider-disabled-cursor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix slider disabled and readonly cursor",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-05T21:44:17.903Z"
+}

--- a/packages/web-components/src/slider/fixtures/slider.html
+++ b/packages/web-components/src/slider/fixtures/slider.html
@@ -193,6 +193,43 @@
           100
         </fluent-slider-label>
       </fluent-slider>
+      <!-- Read Only -->
+      <h4 style="margin-top: 60px;">Read Only</h4>
+      <fluent-slider min="0" max="100" step="5" readonly>
+        <fluent-slider-label position="0">
+          0
+        </fluent-slider-label>
+        <fluent-slider-label position="10">
+          10
+        </fluent-slider-label>
+        <fluent-slider-label position="20">
+          20
+        </fluent-slider-label>
+        <fluent-slider-label position="30">
+          30
+        </fluent-slider-label>
+        <fluent-slider-label position="40">
+          40
+        </fluent-slider-label>
+        <fluent-slider-label position="50">
+          50
+        </fluent-slider-label>
+        <fluent-slider-label position="60">
+          60
+        </fluent-slider-label>
+        <fluent-slider-label position="70">
+          70
+        </fluent-slider-label>
+        <fluent-slider-label position="80">
+          80
+        </fluent-slider-label>
+        <fluent-slider-label position="90">
+          90
+        </fluent-slider-label>
+        <fluent-slider-label position="100">
+          100
+        </fluent-slider-label>
+      </fluent-slider>
     </div>
   </div>
 </fluent-design-system-provider>

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -94,10 +94,7 @@ export const SliderStyles = css`
         min-height: calc(var(--design-unit) * 60px);
         min-width: calc(var(--design-unit) * 20px);
     }
-    :host(.disabled) .label,
-    :host(.readonly) .label,
-    :host(.readonly) .slider,
-    :host(.disabled) .slider {
+    :host(.disabled), :host(.readonly) {
         cursor: ${disabledCursor};
     }
     :host(.disabled) {
@@ -132,9 +129,7 @@ export const SliderStyles = css`
             }
             :host(.disabled) {
                 opacity: 1;
-                cursor: ${disabledCursor};
             }
-            :host(.disabled) .slider,
             :host(.disabled) .track,
             :host(.disabled) .thumb-cursor {
                 forced-color-adjust: none;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16362
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fixes PR #16362 and addresses same issue with _readonly_ Slider

Note: There is no `.slider` class on this component's template, so the css `.slider ` selector was not targeting anything. The disabled cursor still works on the labels and the forcedColors cursor style can be removed with this change as well.

Before:


After:
<img width="508" alt="Screen Shot 2021-01-05 at 12 11 05 PM" src="https://user-images.githubusercontent.com/31681651/103694120-3ed3a300-4f4f-11eb-8fc4-e37cfaa9a98d.png">
<img width="508" alt="Screen Shot 2021-01-05 at 12 10 53 PM" src="https://user-images.githubusercontent.com/31681651/103694121-3f6c3980-4f4f-11eb-85bc-2a3972d8a87c.png">

High Contrast:
<img width="508" alt="Screen Shot 2021-01-05 at 12 26 02 PM" src="https://user-images.githubusercontent.com/31681651/103695347-4005cf80-4f51-11eb-93ee-7e549780fe9a.png">

