### PR TITLE
fix(azure-themes): dark mode themes are now correctly set as inverted

### DIFF
--- a/change/@fluentui-azure-themes-2021-01-05-13-52-11-daparks-fixinverted.json
+++ b/change/@fluentui-azure-themes-2021-01-05-13-52-11-daparks-fixinverted.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix(azure-themes): dark mode themes are now correctly set as inverted",
+  "packageName": "@fluentui/azure-themes",
+  "email": "daparks@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-05T21:52:11.737Z"
+}

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -148,6 +148,7 @@ export const AzureThemeDark: Theme = createTheme({
     white: DarkSemanticColors.background, // shimmer elements
   },
   semanticColors: darkExtendedSemanticColors,
+  isInverted: true,
 });
 
 AzureThemeDark.components = AzureStyleSettings(AzureThemeDark);

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -148,6 +148,7 @@ export const AzureThemeHighContrastDark: Theme = createTheme({
     white: HighContrastDarkSemanticColors.background, // shimmer elements
   },
   semanticColors: highContrastDarkExtendedSemanticColors,
+  isInverted: true,
 });
 
 AzureThemeHighContrastDark.components = AzureStyleSettings(AzureThemeHighContrastDark);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16376
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Sets `isInverted` to true for dark mode azure themes.
