### PR TITLE
fix(azure-themes): dark mode themes are now correctly set as inverted (v7)

### DIFF
--- a/change/@uifabric-azure-themes-2021-01-05-13-57-26-daparks-f7.json
+++ b/change/@uifabric-azure-themes-2021-01-05-13-57-26-daparks-f7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix(azure-themes): dark mode themes are now correctly set as inverted",
+  "packageName": "@uifabric/azure-themes",
+  "email": "daparks@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-05T21:57:26.519Z"
+}

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -150,6 +150,7 @@ export const AzureThemeDark: Theme = createTheme({
     white: DarkSemanticColors.background, // shimmer elements
   },
   semanticColors: darkExtendedSemanticColors,
+  isInverted: true,
 });
 
 AzureThemeDark.components = AzureStyleSettings(AzureThemeDark);

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -150,6 +150,7 @@ export const AzureThemeHighContrastDark: Theme = createTheme({
     white: HighContrastDarkSemanticColors.background, // shimmer elements
   },
   semanticColors: highContrastDarkExtendedSemanticColors,
+  isInverted: true,
 });
 
 AzureThemeHighContrastDark.components = AzureStyleSettings(AzureThemeHighContrastDark);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16376
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Sets `isInverted` to true for dark mode azure themes.
