### PR TITLE
Fix: Update Readme - removed duplicated link on README.md fixes  #15357

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Fluent UI web repository is home to 3 main projects today, the following tab
 | **Overview**    | Mature, refreshing with new concepts from react-northstar. | Newer, has concepts we're iterating on. | Web Component implementation of Fluent UI. |
 | **Used By**     | Office| Teams | Edge |
 | **Read Me**     | [README.md](/packages/react/README.md) | [README.md](/packages/fluentui/README.md) | [README.md](/packages/web-components/README.md) |
-| **Repo**        | [./packages/react](/packages/react) [./packages/react](/packages/react) | [./packages/fluentui/react-northstar](/packages/fluentui/react-northstar) | [./packages/web-components](/packages/web-components) |
+| **Repo**        | [./packages/react](/packages/react) | [./packages/fluentui/react-northstar](/packages/fluentui/react-northstar) | [./packages/web-components](/packages/web-components) |
 | **Quick Start** | [Quick Start](https://developer.microsoft.com/en-us/fluentui#/get-started/web) | [Quick Start](https://fluentsite.z22.web.core.windows.net/quick-start) | [See README.md](https://github.com/microsoft/fluentui/tree/master/packages/web-components/README.md) |
 | **Docs**        | aka.ms/fluentui-react | aka.ms/fluentui-react-northstar | aka.ms/fluentui-web-components |
 | **NPM**         | `@fluentui/react` | `@fluentui/react-northstar` | `@fluentui/web-components` |


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15357
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
On README.md there are duplicated link to /packages/react
- just updated README.md to remove the duplicated link to /packages/react

#### Focus areas to test
Check README.md and see if the duplicated link has been removed
