### PR TITLE
fix(doc site): ensure Typography example text scrolls in Firefox

### DIFF
--- a/apps/public-docsite/src/pages/Styles/TypographyPage/TypographyPage.module.scss
+++ b/apps/public-docsite/src/pages/Styles/TypographyPage/TypographyPage.module.scss
@@ -1,6 +1,7 @@
 .example {
   line-height: 1;
   max-width: 580px;
-  // overflow: hidden;
+  overflow-x: auto;
+  padding-bottom: 14px;
   white-space: nowrap;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16385
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Small style changes to allow the table cells with large text example to scroll in Firefox (see #16385).

I added a little bit of padding (that matches table cell padding) so that there's a little space between the example text and the horizontal scrollbar.

This change allows text to overflow correctly in Firefox, though it does change the div so that there is no longer 100% implicit height in Edge or Chrome. I did look at alternatives to avoid this, but I couldn't find anything minimal that would both solve the overflow bug in Firefox and also keep height implicitly at 100% (unless you want to set a min-height, or something like that). I think this is a pretty good trade off though to make the page readable in Firefox, but please let me know if you disagree or have suggestions -- thank you!

#### Focus areas to test

Review the Typography page of the doc site in Firefox.
