### PR TITLE
Added foreground and background color token pairs into Teams theme v1 and v2

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -116,6 +116,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `WhiteboardIcon`. @TanelVari ([#16164](https://github.com/microsoft/fluentui/pull/16164))
 - Added `TvIcon`. @TanelVari ([#16207](https://github.com/microsoft/fluentui/pull/16207))
 - Added `CalendarAgendaIcon`, `ImageLibraryIcon`. @TanelVari ([#16293](https://github.com/microsoft/fluentui/pull/16293))
+- Added color tokens to be used for search term highlighting. Added default foreground7 and default background6 into Teams theme v1 and v2. @TanelVari ([#16391](https://github.com/microsoft/fluentui/pull/16391))
 
 ### Documentation
 - Fix sticky tree's hidden item + focus loss when last sticky header collapsed @yuanboxue-amber ([#16341](https://github.com/microsoft/fluentui/pull/16341))

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
@@ -9,7 +9,7 @@ export const colorScheme = {
     foreground2: colors.grey['310'],
     foreground3: colors.white,
     foreground4: colors.white,
-    foreground7: colors.white, // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1 (might be used in same place)
+    foreground7: colors.white, // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1
 
     background: colors.grey['700'],
     background1: colors.grey['750'],
@@ -17,7 +17,6 @@ export const colorScheme = {
     background3: colors.grey['870'],
     background4: colors.grey['550'],
     background5: colors.grey['600'],
-    background6: colors.brand['900'], // keeping background6 name consistent with teams-theme-v1 (might be used in same place)
 
     border: colors.grey['450'],
     border1: colors.grey['850'],
@@ -67,6 +66,7 @@ export const colorScheme = {
     background2: colors.brand['900'],
     background3: colors.brand['1000'],
     background4: colors.grey['910'],
+    background5: colors.brand['900'],
 
     foreground: colors.brand['450'],
     foreground1: colors.brand['450'],

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
@@ -9,6 +9,7 @@ export const colorScheme = {
     foreground2: colors.grey['310'],
     foreground3: colors.white,
     foreground4: colors.white,
+    foreground7: colors.white, // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1 (might be used in same place)
 
     background: colors.grey['700'],
     background1: colors.grey['750'],
@@ -16,6 +17,7 @@ export const colorScheme = {
     background3: colors.grey['870'],
     background4: colors.grey['550'],
     background5: colors.grey['600'],
+    background6: colors.brand['900'], // keeping background6 name consistent with teams-theme-v1 (might be used in same place)
 
     border: colors.grey['450'],
     border1: colors.grey['850'],

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
@@ -12,6 +12,7 @@ export const colorScheme: ColorSchemeMapping = {
     foreground4: colors.white,
     foreground5: colors.grey[450],
     foreground6: colors.grey[550],
+    foreground7: colors.white,
 
     background: colors.grey[650],
     background1: colors.grey[700],
@@ -19,6 +20,7 @@ export const colorScheme: ColorSchemeMapping = {
     background3: colors.grey[550],
     background4: colors.grey[600],
     background5: colors.grey[250],
+    background6: colors.brand[900],
 
     border: colors.grey[450], // buttons
     border1: colors.grey[850],

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
@@ -20,7 +20,6 @@ export const colorScheme: ColorSchemeMapping = {
     background3: colors.grey[550],
     background4: colors.grey[600],
     background5: colors.grey[250],
-    background6: colors.brand[900],
 
     border: colors.grey[450], // buttons
     border1: colors.grey[850],
@@ -93,6 +92,7 @@ export const colorScheme: ColorSchemeMapping = {
     background2: colors.brand[900],
     background3: colors.brand[1000],
     background4: colors.grey[650],
+    background5: colors.brand[900],
 
     border: colors.grey[450],
     border1: colors.brand[800],

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
@@ -61,7 +61,6 @@ export const colorScheme: ColorSchemeMapping = {
     background3: colors.black,
     background4: colors.black,
     background5: accessibleYellow,
-    background6: colors.white,
 
     border: colors.white,
     border1: colors.white,
@@ -133,6 +132,7 @@ export const colorScheme: ColorSchemeMapping = {
     background2: colors.black,
     background3: colors.black,
     background4: colors.black,
+    background5: colors.white,
 
     border: colors.white, // buttons
     border1: colors.white,

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
@@ -53,6 +53,7 @@ export const colorScheme: ColorSchemeMapping = {
     foreground4: colors.black,
     foreground5: colors.grey[600],
     foreground6: colors.grey[750],
+    foreground7: colors.black,
 
     background: colors.black,
     background1: colors.black,
@@ -60,6 +61,7 @@ export const colorScheme: ColorSchemeMapping = {
     background3: colors.black,
     background4: colors.black,
     background5: accessibleYellow,
+    background6: colors.white,
 
     border: colors.white,
     border1: colors.white,

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
@@ -54,7 +54,7 @@ export const colorScheme = {
     foreground2: colors.grey['450'],
     foreground3: colors.white,
     foreground4: colors.white,
-    foreground7: colors.grey['750'], // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1 (might be used in same place)
+    foreground7: colors.grey['750'], // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1
 
     background: colors.white,
     background1: colors.grey['25'],
@@ -62,7 +62,6 @@ export const colorScheme = {
     background3: colors.grey['100'],
     background4: colors.grey['150'],
     background5: colors.grey['200'],
-    background6: colors.brand['100'], // keeping background6 name consistent with teams-theme-v1 (might be used in same place)
 
     border: colors.grey['230'],
     border1: colors.grey['100'],
@@ -112,6 +111,7 @@ export const colorScheme = {
     background2: colors.brand['900'],
     background3: colors.brand['1000'],
     background4: colors.brand['800'],
+    background5: colors.brand['100'],
 
     foreground: colors.brand['600'],
     foreground1: colors.brand['600'],

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
@@ -54,6 +54,7 @@ export const colorScheme = {
     foreground2: colors.grey['450'],
     foreground3: colors.white,
     foreground4: colors.white,
+    foreground7: colors.grey['750'], // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1 (might be used in same place)
 
     background: colors.white,
     background1: colors.grey['25'],
@@ -61,6 +62,7 @@ export const colorScheme = {
     background3: colors.grey['100'],
     background4: colors.grey['150'],
     background5: colors.grey['200'],
+    background6: colors.brand['100'], // keeping background6 name consistent with teams-theme-v1 (might be used in same place)
 
     border: colors.grey['230'],
     border1: colors.grey['100'],

--- a/packages/fluentui/react-northstar/src/themes/teams/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/colors.ts
@@ -227,7 +227,6 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
     background3: colors.grey[150],
     background4: colors.grey[100],
     background5: colors.grey[350],
-    background6: colors.brand[100],
 
     border: colors.grey[200], // buttons
     border1: colors.grey[150],
@@ -300,6 +299,7 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
     background2: colors.brand[900],
     background3: colors.brand[1000],
     background4: colors.brand[800],
+    background5: colors.brand[100],
 
     border: colors.grey[200],
     border1: colors.brand[200],

--- a/packages/fluentui/react-northstar/src/themes/teams/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/colors.ts
@@ -219,6 +219,7 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
     foreground4: colors.white,
     foreground5: colors.grey[100],
     foreground6: colors.grey[200],
+    foreground7: colors.grey[750],
 
     background: colors.white,
     background1: colors.grey[50],
@@ -226,6 +227,7 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
     background3: colors.grey[150],
     background4: colors.grey[100],
     background5: colors.grey[350],
+    background6: colors.brand[100],
 
     border: colors.grey[200], // buttons
     border1: colors.grey[150],


### PR DESCRIPTION

Added color tokens to be used for search term highlight.
Added default foreground7 and default background6

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
