### PR TITLE
fix(Popup): use proper window from useWindow() hook

### DIFF
--- a/change/@fluentui-react-internal-2021-01-06-13-24-14-fix-win-popup.json
+++ b/change/@fluentui-react-internal-2021-01-06-13-24-14-fix-win-popup.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Popup): use proper window from useWindow() hook",
+  "packageName": "@fluentui/react-internal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-06T12:24:14.813Z"
+}

--- a/packages/react-internal/src/components/Popup/Popup.tsx
+++ b/packages/react-internal/src/components/Popup/Popup.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../Utilities';
 import { IPopupProps, IPopupRestoreFocusParams } from './Popup.types';
 import { useMergedRefs, useAsync, useOnEvent } from '@fluentui/react-hooks';
+import { useWindow } from '@fluentui/react-window-provider';
 
 function useScrollbarAsync(props: IPopupProps, root: React.RefObject<HTMLDivElement | undefined>) {
   const async = useAsync();
@@ -152,7 +153,8 @@ export const Popup: React.FunctionComponent<IPopupProps> = React.forwardRef<HTML
       [onDismiss],
     );
 
-    useOnEvent(getWindow(root.current), 'keydown', onKeyDown as (ev: Event) => void);
+    const win = useWindow();
+    useOnEvent(win, 'keydown', onKeyDown as (ev: Event) => void);
 
     return (
       <div


### PR DESCRIPTION
Fixes #14108.

---

`useWindow()` looks like the SSOT for components and already is used in other places:

https://github.com/microsoft/fluentui/blob/e5a8a3b99533fa971eecf9b11803885d75dbfba3/packages/react-internal/src/components/ResizeGroup/ResizeGroup.base.tsx#L5
https://github.com/microsoft/fluentui/blob/e5a8a3b99533fa971eecf9b11803885d75dbfba3/packages/react-internal/src/components/Modal/Modal.base.tsx#L22

With this change the reported issue will be fixed as we will not rely on `root.current` anymore.
