### PR TITLE
Run yarn with timeout and retries

### DIFF
--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -22,7 +22,8 @@ steps:
     displayName: 'Check targetNpmVersion is valid semver'
 
   - task: Bash@3
-    filePath: yarn-ci.sh
+    inputs:
+      filePath: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -21,8 +21,8 @@ steps:
       node -e "let semver = require('semver');if(semver.valid('$(targetNpmVersion)') === null){ throw new Error('Invalid version specified'); }"
     displayName: 'Check targetNpmVersion is valid semver'
 
-  - bash: yarn-ci.sh
-    targetType: filePath
+  - task: Bash@3
+    filePath: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -22,6 +22,7 @@ steps:
     displayName: 'Check targetNpmVersion is valid semver'
 
   - bash: yarn-ci.sh
+    targetType: filePath
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -21,8 +21,7 @@ steps:
       node -e "let semver = require('semver');if(semver.valid('$(targetNpmVersion)') === null){ throw new Error('Invalid version specified'); }"
     displayName: 'Check targetNpmVersion is valid semver'
 
-  - script: |
-      npx midgard-yarn install
+  - bash: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -18,8 +18,7 @@ workspace:
 steps:
   - template: .devops/templates/tools.yml
 
-  - script: |
-      npx midgard-yarn install
+  - bash: yarn-ci.sh
     displayName: yarn
 
   # @fluentui/perf-test needs build and bundle steps

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -19,7 +19,8 @@ steps:
   - template: .devops/templates/tools.yml
 
   - task: Bash@3
-    filePath: yarn-ci.sh
+    inputs:
+      filePath: yarn-ci.sh
     displayName: yarn
 
   # @fluentui/perf-test needs build and bundle steps

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -19,6 +19,7 @@ steps:
   - template: .devops/templates/tools.yml
 
   - bash: yarn-ci.sh
+    targetType: filePath
     displayName: yarn
 
   # @fluentui/perf-test needs build and bundle steps

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -18,8 +18,8 @@ workspace:
 steps:
   - template: .devops/templates/tools.yml
 
-  - bash: yarn-ci.sh
-    targetType: filePath
+  - task: Bash@3
+    filePath: yarn-ci.sh
     displayName: yarn
 
   # @fluentui/perf-test needs build and bundle steps

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -33,8 +33,8 @@ steps:
       git config user.email "fluentui-internal@service.microsoft.com"
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
-  - bash: yarn-ci.sh
-    targetType: filePath
+  - task: Bash@3
+    filePath: yarn-ci.sh
     displayName: yarn
   - script: |
       PRODUCTION=true yarn build

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -34,7 +34,8 @@ steps:
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
   - task: Bash@3
-    filePath: yarn-ci.sh
+    inputs:
+      filePath: yarn-ci.sh
     displayName: yarn
   - script: |
       PRODUCTION=true yarn build

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -34,6 +34,7 @@ steps:
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
   - bash: yarn-ci.sh
+    targetType: filePath
     displayName: yarn
   - script: |
       PRODUCTION=true yarn build

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -33,8 +33,7 @@ steps:
       git config user.email "fluentui-internal@service.microsoft.com"
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
-  - script: |
-      npx midgard-yarn install
+  - bash: yarn-ci.sh
     displayName: yarn
   - script: |
       PRODUCTION=true yarn build

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -31,8 +31,8 @@ steps:
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
 
-  - bash: yarn-ci.sh
-    targetType: filePath
+  - task: Bash@3
+    filePath: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -32,7 +32,8 @@ steps:
     displayName: Authenticate git for pushes
 
   - task: Bash@3
-    filePath: yarn-ci.sh
+    inputs:
+      filePath: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -31,8 +31,7 @@ steps:
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
 
-  - script: |
-      npx midgard-yarn install
+  - bash: yarn-ci.sh
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -32,6 +32,7 @@ steps:
     displayName: Authenticate git for pushes
 
   - bash: yarn-ci.sh
+    targetType: filePath
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,9 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - task: Bash@3
-        filePath: yarn-ci.sh
+        inputs:
+          inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: |
@@ -72,7 +74,8 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - task: Bash@3
-        filePath: yarn-ci.sh
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       ## only do scoped bundle with PRs
@@ -139,7 +142,8 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - task: Bash@3
-        filePath: yarn-ci.sh
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: yarn workspace @fluentui/docs vr:build
@@ -169,7 +173,8 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - task: Bash@3
-        filePath: yarn-ci.sh
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: yarn-ci.sh
+        targetType: filePath
         displayName: yarn
 
       - script: |
@@ -71,6 +72,7 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: yarn-ci.sh
+        targetType: filePath
         displayName: yarn
 
       ## only do scoped bundle with PRs
@@ -137,6 +139,7 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: yarn-ci.sh
+        targetType: filePath
         displayName: yarn
 
       - script: yarn workspace @fluentui/docs vr:build
@@ -166,6 +169,7 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: yarn-ci.sh
+        targetType: filePath
         displayName: yarn
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - bash: yarn-ci.sh
-        targetType: filePath
+      - task: Bash@3
+        filePath: yarn-ci.sh
         displayName: yarn
 
       - script: |
@@ -71,8 +71,8 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - bash: yarn-ci.sh
-        targetType: filePath
+      - task: Bash@3
+        filePath: yarn-ci.sh
         displayName: yarn
 
       ## only do scoped bundle with PRs
@@ -138,8 +138,8 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - bash: yarn-ci.sh
-        targetType: filePath
+      - task: Bash@3
+        filePath: yarn-ci.sh
         displayName: yarn
 
       - script: yarn workspace @fluentui/docs vr:build
@@ -168,8 +168,8 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - bash: yarn-ci.sh
-        targetType: filePath
+      - task: Bash@3
+        filePath: yarn-ci.sh
         displayName: yarn
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - bash: yarn-ci.sh
         displayName: yarn
 
       - script: |
@@ -70,7 +70,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - bash: yarn-ci.sh
         displayName: yarn
 
       ## only do scoped bundle with PRs
@@ -136,7 +136,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - bash: yarn-ci.sh
         displayName: yarn
 
       - script: yarn workspace @fluentui/docs vr:build
@@ -165,7 +165,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - bash: yarn-ci.sh
         displayName: yarn
 
       - script: |

--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -7,11 +7,11 @@ MAX_TIME=5
 MAX_RETRIES=3
 # `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
 # https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
-while timeout -k "$((MAX_TIME+1)m" "$MAX_TIMEm" -- npx midgard-yarn install; [ $? = 124 ]; do
+while timeout -k "$((MAX_TIME+1))m" "$MAX_TIMEm" npx midgard-yarn install; [ $? = 124 ]; do
   if [ $attempt -lt $MAX_RETRIES ]; then
     printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
   else
-    printf "\n\#\#vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
+    printf "\n##vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
     exit 1
   fi
 done

--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Shell script (Linux only) to run yarn with a timeout and retries.
+# This is to address the issue where sometimes postinstall hangs forever.
+attempt=1
+MAX_TIME=5
+MAX_RETRIES=3
+# `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
+# https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
+while timeout -k "$((MAX_TIME+1)m" "$MAX_TIMEm" -- npx midgard-yarn install; [ $? = 124 ]; do
+  if [ $attempt -lt $MAX_RETRIES ]; then
+    printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
+  else
+    printf "\n##vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
+    exit 1
+  fi
+done

--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -7,7 +7,7 @@ MAX_TIME=5
 MAX_RETRIES=3
 # `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
 # https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
-while timeout -k "$((MAX_TIME+1))m" "$MAX_TIMEm" npx midgard-yarn install; [ $? = 124 ]; do
+while timeout -k "$((MAX_TIME+1))m" "${MAX_TIME}m" npx midgard-yarn install; [ $? = 124 ]; do
   if [ $attempt -lt $MAX_RETRIES ]; then
     printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
   else

--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -11,7 +11,7 @@ while timeout -k "$((MAX_TIME+1)m" "$MAX_TIMEm" -- npx midgard-yarn install; [ $
   if [ $attempt -lt $MAX_RETRIES ]; then
     printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
   else
-    printf "\n##vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
+    printf "\n\#\#vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
     exit 1
   fi
 done


### PR DESCRIPTION
We've had quite a few builds fail due to yarn timing out on postinstall. The easiest way to work around this is to add a wrapper script with a timeout and retries. Currently the timeout is set at 5 minutes (with 3 attempts) but we can tweak that if needed.

The approach I took only works on Linux, but I haven't seen this error recently in Size Auditor and that's our only Windows-based PR/CI build currently.

(Ideally we should find out which package's postinstall script is causing the hang and get that fixed, but there's not good logging for postinstall scripts, and even if we could find and report the issue it would likely take some time for a fix to be available.)