### PR TITLE
chore: use --passWithNoTests for update-snapshots

### DIFF
--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 const commonArgs = () => {
   return {
     ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME) && { runInBand: true }),
-    ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined),
+    ...(argv().u || argv().updateSnapshot ? { passWithNoTests: true, updateSnapshot: true } : undefined),
   };
 };
 


### PR DESCRIPTION
Related to https://github.com/microsoft/fluentui/pull/16370#issuecomment-756055193.

Without this change `update-snapshots` command will fail:

```
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In C:\Users\olfedias\WebstormProjects\office-ui-fabric-react\packages\react-shared-contexts
  41 files checked.
  testMatch:  - 0 matches
  testPathIgnorePatterns: \\node_modules\\ - 41 matches
  testRegex: (\\__tests__\\.*|\.(test|spec))\.(ts|tsx)$ - 0 matches
Pattern:  - 0 matches
[12:19:52 PM] x Error detected while running 'jest'
[12:19:52 PM] x ------------------------------------
```