### PR TITLE
7.0: UnifiedPicker: Drop to either side of items

### DIFF
--- a/change/@uifabric-experiments-2021-01-08-10-16-10-dropright7.0.json
+++ b/change/@uifabric-experiments-2021-01-08-10-16-10-dropright7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker drop to each side of item",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-08T18:16:10.340Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -19,6 +19,7 @@ import { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from '@uifabric/merge-styles';
 import { IDragDropContext } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
+import { getRTL } from 'office-ui-fabric-react/lib/Utilities';
 
 export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();
@@ -178,6 +179,21 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       );
     } else {
       insertIndex = selectedItems.indexOf(item);
+    }
+
+    // If the drop is in the right half of the item, we want to drop at index+1
+    if (event && event.currentTarget) {
+      const targetElement = event.currentTarget as HTMLElement;
+      const halfwayPoint = targetElement.offsetLeft + targetElement.offsetWidth / 2;
+      if (getRTL()) {
+        if (event.pageX < halfwayPoint) {
+          insertIndex++;
+        }
+      } else {
+        if (event.pageX > halfwayPoint) {
+          insertIndex++;
+        }
+      }
     }
 
     event?.preventDefault();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - #16236 

If you're dropping over an item, it is counter intuitive for it always to drop to the left. It makes more sense to drop left or right depending on what end the mouse is closer to.
