### PR TITLE
7.0: UnifiedPicker: Add ability to force resolve what is selected in the floating suggestions

### DIFF
--- a/change/@fluentui-react-examples-2021-01-08-10-41-26-forceresolve7.0.json
+++ b/change/@fluentui-react-examples-2021-01-08-10-41-26-forceresolve7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update UnifiedPeoplePicker edit example with force resolve example",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-08T18:41:26.037Z"
+}

--- a/change/@uifabric-experiments-2021-01-08-10-41-26-forceresolve7.0.json
+++ b/change/@uifabric-experiments-2021-01-08-10-41-26-forceresolve7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add a force resolve function to the UnifiedPicker",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-08T18:41:07.509Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -117,6 +117,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     getSelectedItems: () => {
       return getSelectedItems() as T[];
     },
+    forceResolve: () => {
+      if (focusItemIndex >= 0) {
+        _onSuggestionSelected(undefined, suggestionItems[focusItemIndex]);
+        return true;
+      } else {
+        return false;
+      }
+    },
   }));
 
   // All of the drag drop functions are the default behavior. Users can override that by setting the dragDropEvents prop

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -20,7 +20,7 @@ import {
 import { IInputProps } from 'office-ui-fabric-react';
 import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
 import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestions';
-import { KeyCodes } from '@fluentui/react-experiments/lib/Utilities';
+import { KeyCodes } from '@uifabric/experiments/lib/Utilities';
 
 const _suggestions = [
   {
@@ -228,6 +228,10 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
       newItems.splice(index, 1, ...newItemsArray);
       setPeopleSelectedItems(newItems);
     }
+  };
+
+  const _createGenericItem = (input: string): IPersona => {
+    return { text: input };
   };
 
   const _addGenericItem = (text: string) => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - #16209 

Add a force resolve function to the UnifiedPicker so that callers can resolve what is selected in the picker. This is for compatibility with the old picker.

Added code to run that in the UnifiedPeoplePicker with edit example, as well as code to add invalid recipients from the input.
