### PR TITLE
fix(react-examples): Add aria-label to identify link in Checkbox example

### DIFF
--- a/packages/react-examples/src/react-checkbox/Checkbox/Checkbox.Other.Example.tsx
+++ b/packages/react-examples/src/react-checkbox/Checkbox/Checkbox.Other.Example.tsx
@@ -37,9 +37,9 @@ export const CheckboxOtherExample: React.FunctionComponent = () => {
 function _renderLabelWithLink() {
   return (
     <span>
-      Custom-rendered label with a{' '}
+      Custom-rendered label with a link{' '}
       <Link href="https://www.microsoft.com" target="_blank">
-        link
+        go to Microsoft home page
       </Link>
     </span>
   );

--- a/packages/react-examples/src/react-checkbox/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react-checkbox/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -655,7 +655,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span>
-        Custom-rendered label with a
+        Custom-rendered label with a link
          
         <a
           className=
@@ -712,7 +712,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           onClick={[Function]}
           target="_blank"
         >
-          link
+          go to Microsoft home page
         </a>
       </span>
     </label>


### PR DESCRIPTION
(microsoftdesign/fluentui#10211)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes microsoftdesign/fluentui#10211
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Added an aria-label to better identify the link used as example in the `Custom-rendered label with a link` example.