### PR TITLE
Charting: Tooltip dismiss on escape press

### DIFF
--- a/change/@uifabric-charting-2021-01-11-18-30-19-user-v-jasha-tooltipIssue.json
+++ b/change/@uifabric-charting-2021-01-11-18-30-19-user-v-jasha-tooltipIssue.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "tooltip disappear on escape",
+  "comment": "line chart - tooltip disappear on escape issue resolved",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2021-01-11T13:00:19.936Z"
 }

--- a/change/@uifabric-charting-2021-01-11-18-30-19-user-v-jasha-tooltipIssue.json
+++ b/change/@uifabric-charting-2021-01-11-18-30-19-user-v-jasha-tooltipIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "tooltip disappear on escape",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-01-11T13:00:19.936Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Axis as D3Axis } from 'd3-axis';
 import { select as d3Select } from 'd3-selection';
 import { ILegend, Legends } from '../Legends/index';
-import { classNamesFunction, getId, find } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, getId, find, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
 import {
   CartesianChart,
   IBasestate,
@@ -373,6 +373,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 circleId,
                 lineColor,
               )}
+              onKeyDown={this._onKeyDown.bind(this, circleId, lineColor)}
               opacity={1}
               fill={lineColor}
               stroke={lineColor}
@@ -400,6 +401,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                   lastCircleId,
                   lineColor,
                 )}
+                onKeyDown={this._onKeyDown.bind(this, circleId, lineColor)}
                 opacity={1}
                 fill={lineColor}
                 stroke={lineColor}
@@ -602,6 +604,18 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _onKeyDown = (circleId: string, lineColor: string, event: React.KeyboardEvent<SVGElement>) => {
+    if (event.keyCode === KeyCodes.escape) {
+      d3Select('#' + circleId)
+        .attr('fill', lineColor)
+        .attr('r', 0.2);
+      d3Select(`#${this._verticalLine}`).attr('visibility', 'hidden');
+      this.setState({
+        isCalloutVisible: false,
+      });
+    }
   };
 
   private _handleLegendClick = (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/16422
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Line chart: added a 'onKeyDown' event in line chart to dismiss tooltip, when accessing through keyboard
#### Focus areas to test

Line chart
