### PR TITLE
feat(AvatarIcon): add AvatarIcon

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` slots were moved to exact components (`AvatarStatus`, `AvatarStatusIcon`) @assuncaocharles ([#16382](https://github.com/microsoft/fluentui/pull/16382))
 - Styles from `Avatar` image slot were moved to exact component `AvatarImage` @assuncaocharles ([#16409](https://github.com/microsoft/fluentui/pull/16409))
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
+- Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
 
 
 ### Fixes

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -120,6 +120,8 @@ export const Avatar: ComponentWithAs<'div', AvatarProps> &
       getA11Props('icon', {
         title: name,
         styles: resolvedStyles.icon,
+        size,
+        square,
       }),
   });
 

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -13,13 +13,12 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
-import { Box, BoxProps } from '../Box/Box';
-
 import { ShorthandValue, FluentComponentStaticProps } from '../../types';
 import { createShorthandFactory, UIComponentProps, commonPropTypes, SizeValue, createShorthand } from '../../utils';
 import { AvatarStatusProps, AvatarStatus } from './AvatarStatus';
 import { AvatarImage, AvatarImageProps } from './AvatarImage';
 import { AvatarStatusIcon } from './AvatarStatusIcon';
+import { AvatarIcon, AvatarIconProps } from './AvatarIcon';
 import { AvatarLabel, AvatarLabelProps } from './AvatarLabel';
 
 export interface AvatarProps extends UIComponentProps {
@@ -29,7 +28,7 @@ export interface AvatarProps extends UIComponentProps {
   accessibility?: Accessibility<never>;
 
   /** Avatar can contain icon. It will be rendered only if the image is not present. */
-  icon?: ShorthandValue<BoxProps>;
+  icon?: ShorthandValue<AvatarIconProps>;
 
   /** Shorthand for the image. */
   image?: ShorthandValue<AvatarImageProps>;
@@ -65,6 +64,7 @@ export const Avatar: ComponentWithAs<'div', AvatarProps> &
     StatusIcon: typeof AvatarStatusIcon;
     Image: typeof AvatarImage;
     Label: typeof AvatarLabel;
+    Icon: typeof AvatarIcon;
   } = props => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(Avatar.displayName, context.telemetry);
@@ -115,7 +115,7 @@ export const Avatar: ComponentWithAs<'div', AvatarProps> &
       }),
   });
 
-  const iconElement = Box.create(icon, {
+  const iconElement = createShorthand(AvatarIcon, icon, {
     defaultProps: () =>
       getA11Props('icon', {
         title: name,
@@ -207,6 +207,7 @@ Avatar.Status = AvatarStatus;
 Avatar.StatusIcon = AvatarStatusIcon;
 Avatar.Image = AvatarImage;
 Avatar.Label = AvatarLabel;
+Avatar.Icon = AvatarIcon;
 
 Avatar.handledProps = Object.keys(Avatar.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -94,5 +94,3 @@ AvatarIcon.defaultProps = {
 AvatarIcon.shorthandConfig = {
   mappedProp: 'content',
 };
-
-AvatarIcon.create = createShorthandFactory({ Component: AvatarIcon });

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import {
+  useFluentContext,
+  useTelemetry,
+  useStyles,
+  useAccessibility,
+  getElementType,
+  useUnhandledProps,
+  ComponentWithAs,
+} from '@fluentui/react-bindings';
+import * as customPropTypes from '@fluentui/react-proptypes';
+import * as PropTypes from 'prop-types';
+import {
+  commonPropTypes,
+  UIComponentProps,
+  SizeValue,
+  ContentComponentProps,
+  ChildrenComponentProps,
+} from '../../utils';
+import { FluentComponentStaticProps } from '../../types';
+import { Accessibility } from '@fluentui/accessibility';
+
+export interface AvatarIconProps extends UIComponentProps, ContentComponentProps, ChildrenComponentProps {
+  /** Accessibility behavior if overridden by the user. */
+  accessibility?: Accessibility<never>;
+
+  /** The avatar icon can have a square shape. */
+  square?: boolean;
+
+  /** Size multiplier. */
+  size?: SizeValue;
+}
+
+export type AvatarIconStylesProps = Required<Pick<AvatarIconProps, 'size' | 'square'>>;
+export const avatarIconClassName = 'ui-avatar__icon';
+
+/**
+ * A AvatarIcon provides a status icon for the Avatar.
+ */
+export const AvatarIcon: ComponentWithAs<'span', AvatarIconProps> &
+  FluentComponentStaticProps<AvatarIconProps> = props => {
+  const context = useFluentContext();
+  const { setStart, setEnd } = useTelemetry(AvatarIcon.displayName, context.telemetry);
+  setStart();
+
+  const { className, children, design, styles, variables, size, square } = props;
+
+  const { classes } = useStyles<AvatarIconStylesProps>(AvatarIcon.displayName, {
+    className: avatarIconClassName,
+    mapPropsToStyles: () => ({
+      size,
+      square,
+    }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
+
+  const getA11Props = useAccessibility(props.accessibility, {
+    debugName: AvatarIcon.displayName,
+    rtl: context.rtl,
+  });
+
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(AvatarIcon.handledProps, props);
+
+  const element = (
+    <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>{children}</ElementType>
+  );
+  setEnd();
+
+  return element;
+};
+
+AvatarIcon.displayName = 'AvatarIcon';
+AvatarIcon.propTypes = {
+  ...commonPropTypes.createCommon(),
+  square: PropTypes.bool,
+  size: customPropTypes.size,
+};
+AvatarIcon.handledProps = Object.keys(AvatarIcon.propTypes) as any;
+AvatarIcon.defaultProps = {
+  as: 'span',
+};
+
+AvatarIcon.shorthandConfig = {
+  mappedProp: 'content',
+};

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -16,6 +16,8 @@ import {
   SizeValue,
   ContentComponentProps,
   ChildrenComponentProps,
+  createShorthandFactory,
+  childrenExist,
 } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';
 import { Accessibility } from '@fluentui/accessibility';
@@ -43,7 +45,7 @@ export const AvatarIcon: ComponentWithAs<'span', AvatarIconProps> &
   const { setStart, setEnd } = useTelemetry(AvatarIcon.displayName, context.telemetry);
   setStart();
 
-  const { className, children, design, styles, variables, size, square } = props;
+  const { className, children, design, styles, variables, size, square, content } = props;
 
   const { classes } = useStyles<AvatarIconStylesProps>(AvatarIcon.displayName, {
     className: avatarIconClassName,
@@ -69,7 +71,9 @@ export const AvatarIcon: ComponentWithAs<'span', AvatarIconProps> &
   const unhandledProps = useUnhandledProps(AvatarIcon.handledProps, props);
 
   const element = (
-    <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>{children}</ElementType>
+    <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>
+      {childrenExist(children) ? children : content}
+    </ElementType>
   );
   setEnd();
 
@@ -90,3 +94,5 @@ AvatarIcon.defaultProps = {
 AvatarIcon.shorthandConfig = {
   mappedProp: 'content',
 };
+
+AvatarIcon.create = createShorthandFactory({ Component: AvatarIcon });

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -16,7 +16,6 @@ import {
   SizeValue,
   ContentComponentProps,
   ChildrenComponentProps,
-  createShorthandFactory,
   childrenExist,
 } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';

--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -42,6 +42,7 @@ export * from './components/Avatar/Avatar';
 export * from './components/Avatar/AvatarStatus';
 export * from './components/Avatar/AvatarStatusIcon';
 export * from './components/Avatar/AvatarImage';
+export * from './components/Avatar/AvatarIcon';
 
 export * from './components/Box/Box';
 

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -16,6 +16,7 @@ export { avatarStyles as Avatar } from './components/Avatar/avatarStyles';
 export { avatarStatusStyles as AvatarStatus } from './components/Avatar/avatarStatusStyles';
 export { avatarStatusIconStyles as AvatarStatusIcon } from './components/Avatar/avatarStatusIconStyles';
 export { avatarImageStyles as AvatarImage } from './components/Avatar/avatarImageStyles';
+export { avatarIconStyles as AvatarIcon } from './components/Avatar/avatarIconStyles';
 
 export { buttonStyles as Button } from './components/Button/buttonStyles';
 export { buttonGroupStyles as ButtonGroup } from './components/Button/buttonGroupStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
@@ -15,6 +15,7 @@ export { avatarVariables as Avatar } from './components/Avatar/avatarVariables';
 export { avatarStatusVariables as AvatarStatus } from './components/Avatar/avatarStatusVariables';
 export { avatarStatusIconVariables as AvatarStatusIcon } from './components/Avatar/avatarStatusIconVariables';
 export { avatarImageVariables as AvatarImage } from './components/Avatar/avatarImageVariables';
+export { avatarIconVariables as AvatarIcon } from './components/Avatar/avatarIconVariables';
 
 export { buttonVariables as Button } from './components/Button/buttonVariables';
 export { buttonGroupVariables as ButtonGroup } from './components/Button/buttonGroupVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarIconStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarIconStyles.ts
@@ -1,0 +1,53 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { AvatarIconStylesProps } from '../../../../components/Avatar/AvatarIcon';
+import { AvatarVariables } from './avatarVariables';
+import { pxToRem, SizeValue } from '../../../../utils';
+
+const sizeToPxValue: Record<SizeValue, number> = {
+  smallest: 20,
+  smaller: 24,
+  small: 28,
+  medium: 32,
+  large: 44,
+  larger: 64,
+  largest: 96,
+};
+
+const iconSizeToPxValue: Record<SizeValue, number> = {
+  smallest: 10,
+  smaller: 12,
+  small: 16,
+  medium: 16,
+  large: 20,
+  larger: 32,
+  largest: 40,
+};
+
+export const avatarIconStyles: ComponentSlotStylesPrepared<AvatarIconStylesProps, AvatarVariables> = {
+  root: ({ variables: v, props: p }): ICSSInJSStyle => {
+    const sizeInRem = pxToRem(sizeToPxValue[p.size]);
+    const iconsizeInRem = pxToRem(iconSizeToPxValue[p.size]);
+
+    return {
+      color: v.iconColor,
+      background: v.iconBackgroundColor,
+      width: sizeInRem,
+      height: sizeInRem,
+      borderRadius: '50%',
+      display: 'inline-flex',
+      alignItems: 'center',
+      ...(p.square && {
+        borderRadius: v.squareAvatarBorderRadius,
+      }),
+      '& > :first-child': {
+        margin: '0 auto',
+        width: iconsizeInRem,
+        height: iconsizeInRem,
+        '& svg': {
+          width: '100%',
+          height: '100%',
+        },
+      },
+    };
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarIconVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarIconVariables.ts
@@ -1,0 +1,1 @@
+export { avatarVariables as avatarIconVariables } from './avatarVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarStyles.ts
@@ -13,16 +13,6 @@ const sizeToPxValue: Record<SizeValue, number> = {
   largest: 96,
 };
 
-const iconSizeToPxValue: Record<SizeValue, number> = {
-  smallest: 10,
-  smaller: 12,
-  small: 16,
-  medium: 16,
-  large: 20,
-  larger: 32,
-  largest: 40,
-};
-
 export const avatarStyles: ComponentSlotStylesPrepared<AvatarStylesProps, AvatarVariables> = {
   root: ({ props: { size } }): ICSSInJSStyle => {
     const sizeInRem = pxToRem(sizeToPxValue[size]);
@@ -34,32 +24,6 @@ export const avatarStyles: ComponentSlotStylesPrepared<AvatarStylesProps, Avatar
       verticalAlign: 'middle',
       height: sizeInRem,
       width: sizeInRem,
-    };
-  },
-  icon: ({ props: p, variables: v }) => {
-    const sizeInRem = pxToRem(sizeToPxValue[p.size]);
-    const iconsizeInRem = pxToRem(iconSizeToPxValue[p.size]);
-
-    return {
-      color: v.iconColor,
-      background: v.iconBackgroundColor,
-      width: sizeInRem,
-      height: sizeInRem,
-      borderRadius: '50%',
-      display: 'inline-flex',
-      alignItems: 'center',
-      ...(p.square && {
-        borderRadius: v.squareAvatarBorderRadius,
-      }),
-      '& > :first-child': {
-        margin: '0 auto',
-        width: iconsizeInRem,
-        height: iconsizeInRem,
-        '& svg': {
-          width: '100%',
-          height: '100%',
-        },
-      },
     };
   },
 };

--- a/packages/fluentui/react-northstar/test/specs/components/Avatar/AvatarStatus-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Avatar/AvatarStatus-test.tsx
@@ -1,6 +1,0 @@
-import { isConformant } from 'test/specs/commonTests';
-import { AvatarStatus } from 'src/components/Avatar/AvatarStatus';
-
-describe('AvatarStatus', () => {
-  isConformant(AvatarStatus, { testPath: __filename, constructorName: 'AvatarStatus' });
-});

--- a/packages/fluentui/react-northstar/test/specs/components/Avatar/AvatarStatus-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Avatar/AvatarStatus-test.tsx
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import { AvatarStatus } from 'src/components/Avatar/AvatarStatus';
+
+describe('AvatarStatus', () => {
+  isConformant(AvatarStatus, { testPath: __filename, constructorName: 'AvatarStatus' });
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGE

Avatar `icon` slot  were moved to separated component `AvatarIcon`

## Styles 

`AvatarIcon` has its own styles now as separated component with its own styles props being 

```typescript
export type AvatarIconStylesProps = Required<Pick<AvatarIconProps, 'size' | 'square'>>;
```

Custom variables set directly to `Icon` component will no long work, please use `AvatarIcon` instead

```jsx
<Provider
    theme={{
      componentStyles: {
        Icon: {
          root: ({ variables: v }) => ({ ...(v.isFoo && { color: 'red' }) }),
        },
      },
    }}
  >
    <Avatar
      label={{
        // This is will no longer work
        variables: { isFoo: true },
        content: '...',
      }}
    />
  </Provider>
```

## Deprecation

We want to remove `icon` slot in the future so please prefer

```jsx
 <Provider
    theme={{
      componentStyles: {
        AvatarIcon: {
          root: ({ variables: v }) => ({ ...(v.isFoo && { height: 200 }) }),
        },
      },
    }}
  >
    <Avatar
      icon={{...}}
    />
    <Avatar
      icon={{...}}
      variables={{ isFoo: true }}
    />
  </Provider>
```

Over 

```jsx
 <Provider
    theme={{
      componentStyles: {
        Avatar: {
          icon: ({ variables: v }) => ({ ...(v.isFoo && { backgroundColor: 'red' }) }),
        },
      },
    }}
  >
    <Avatar
        icon={{...}}
    />
    <Avatar
      icon={{...}}
      variables={{ isFoo: true }}
    />
  </Provider>
```

#### Focus areas to test

(optional)
