### PR TITLE
add webpack bundles to react-icons-mdl2 and react-theme-provider

### DIFF
--- a/change/@fluentui-react-icons-mdl2-2021-01-11-10-21-25-webpack-bundle-add.json
+++ b/change/@fluentui-react-icons-mdl2-2021-01-11-10-21-25-webpack-bundle-add.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "add webpack bundles to react-icons-mdl2 and react-theme-provider",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-11T18:21:18.349Z"
+}

--- a/change/@fluentui-react-theme-provider-2021-01-11-10-21-25-webpack-bundle-add.json
+++ b/change/@fluentui-react-theme-provider-2021-01-11-10-21-25-webpack-bundle-add.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "add webpack bundles to react-icons-mdl2 and react-theme-provider",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-11T18:21:24.846Z"
+}

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-icons-mdl2/webpack.config.js
+++ b/packages/react-icons-mdl2/webpack.config.js
@@ -1,0 +1,5 @@
+const resources = require('../../scripts/webpack/webpack-resources');
+
+module.exports = resources.createBundleConfig({
+  output: 'FluentUIReactIconsMDL2',
+});

--- a/packages/react-theme-provider/package.json
+++ b/packages/react-theme-provider/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-theme-provider/webpack.config.js
+++ b/packages/react-theme-provider/webpack.config.js
@@ -1,0 +1,5 @@
+const resources = require('../../scripts/webpack/webpack-resources');
+
+module.exports = resources.createBundleConfig({
+  output: 'FluentUIReactThemeProvider',
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR is to add a webpack bundle to the `react-icons-mdl2` and `react-theme-provider` packages so they can be used in codepen

#### Focus areas to test

(optional)
