### PR TITLE
fix(react-examples): Add focus to DatePicker examples when clicking the Clear button

### DIFF
--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatePicker } from '@fluentui/react-date-time';
+import { DatePicker, IDatePicker } from '@fluentui/react-date-time';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
 
@@ -14,9 +14,11 @@ const onFormatDate = (date?: Date): string => {
 
 export const DatePickerFormatExample: React.FunctionComponent = () => {
   const [value, setValue] = React.useState<Date | undefined>();
+  const datePickerRef = React.useRef<IDatePicker>(null);
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
+    datePickerRef.current?.focus();
   }, []);
 
   const onParseDateFromString = React.useCallback(
@@ -46,6 +48,7 @@ export const DatePickerFormatExample: React.FunctionComponent = () => {
         example, we are formatting and parsing dates as dd/MM/yy.
       </div>
       <DatePicker
+        componentRef={datePickerRef}
         label="Start date"
         allowTextInput
         ariaLabel="Select a date. Input format is day slash month slash year."

--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
@@ -14,6 +14,7 @@ export const DatePickerInputExample: React.FunctionComponent = () => {
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
+    datePickerRef.current?.focus();
   }, []);
 
   return (
@@ -24,12 +25,12 @@ export const DatePickerInputExample: React.FunctionComponent = () => {
         pressing Enter will open the DatePicker.
       </div>
       <DatePicker
+        componentRef={datePickerRef}
         label="Start date"
         allowTextInput
         ariaLabel="Select a date"
         value={value}
         onSelectDate={setValue as (date: Date | null | undefined) => void}
-        componentRef={datePickerRef}
         className={styles.control}
       />
       <DefaultButton onClick={onClick} text="Clear" />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [microsoftdesign/fluentui#10249](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10249)
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Pressing the `Clear` button will now also focus the DatePicker input, so that user can know that the date has been cleared, when navigating with the Narrator.
Applied this to both `DatePicker allows input date string` and `DatePicker allows dates to be formatted` examples, as they both contain the `Clear` button