### PR TITLE
Updateselectedpeoplelistexamples7.0

### DIFF
--- a/change/@fluentui-react-examples-2021-01-08-10-11-21-updateselectedpeoplelistexamples7.0.json
+++ b/change/@fluentui-react-examples-2021-01-08-10-11-21-updateselectedpeoplelistexamples7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update SelectedPeopleList edit examples to use hooks",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-08T18:11:21.453Z"
+}

--- a/change/@fluentui-react-examples-2021-01-08-10-11-21-updateselectedpeoplelistexamples7.0.json
+++ b/change/@fluentui-react-examples-2021-01-08-10-11-21-updateselectedpeoplelistexamples7.0.json
@@ -1,8 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update SelectedPeopleList edit examples to use hooks",
-  "packageName": "@fluentui/react-examples",
-  "email": "elvonspa@microsoft.com",
-  "dependentChangeType": "none",
-  "date": "2021-01-08T18:11:21.453Z"
-}

--- a/change/@fluentui-react-examples-2021-01-08-11-33-26-updateselectedpeoplelistexamples7.0.json
+++ b/change/@fluentui-react-examples-2021-01-08-11-33-26-updateselectedpeoplelistexamples7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update SelectedItemsList and UnifiedPicker edit examples with the new picker",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-08T19:33:26.107Z"
+}

--- a/change/@uifabric-experiments-2021-01-08-11-33-26-updateselectedpeoplelistexamples7.0.json
+++ b/change/@uifabric-experiments-2021-01-08-11-33-26-updateselectedpeoplelistexamples7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update the DefaultEditingItem in the SelectedItemsList to use FloatingSuggestionsComposite",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-08T19:32:59.037Z"
+}

--- a/packages/experiments/src/UnifiedPicker.ts
+++ b/packages/experiments/src/UnifiedPicker.ts
@@ -1,2 +1,1 @@
-export * from './components/UnifiedPicker/UnifiedPicker';
-export * from './components/UnifiedPicker/UnifiedPicker.types';
+export * from './components/UnifiedPicker/index';

--- a/packages/experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
@@ -7,6 +7,7 @@ export type EditingItemComponentProps<T> = {
   item: T;
   onEditingComplete: (oldItem: T, newItem: T) => void;
   onDismiss?: () => void;
+  createGenericItem?: (input: string) => T;
 };
 
 /**
@@ -39,6 +40,7 @@ export const EditableItem = <T extends any>(editableItemProps: EditableItemProps
         item={selectedItemProps.item}
         onEditingComplete={onItemEdited}
         onDismiss={setEditingFalse}
+        createGenericItem={selectedItemProps.createGenericItem}
       />
     ) : (
       <ItemComponent {...selectedItemProps} onTrigger={setEditingTrue} />

--- a/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 import { KeyCodes, getId, getNativeProps, inputProperties, css } from 'office-ui-fabric-react/lib/Utilities';
-import { FloatingSuggestions } from '../../../FloatingSuggestions/FloatingSuggestions';
-import { IFloatingSuggestionsProps } from '../../../FloatingSuggestions/FloatingSuggestions.types';
+import {
+  IBaseFloatingSuggestionsProps,
+  IBaseFloatingPickerHeaderFooterProps,
+} from '../../../FloatingSuggestionsComposite/FloatingSuggestions.types';
+import { IFloatingSuggestionItemProps } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { EditingItemComponentProps } from '../EditableItem';
+import { useFloatingSuggestionItems } from '../../../UnifiedPicker/hooks/useFloatingSuggestionItems';
 
 import * as styles from './DefaultEditingItem.scss';
 
@@ -41,118 +45,214 @@ export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttribut
    * Callback used by the EditingItem to populate the initial value of the editing item
    */
   getEditingItemText: (item: TItem) => string;
+
+  /**
+   * Callback used to retrieve the suggestions to show in the floating suggestions
+   */
+  getSuggestions: (value: string) => IFloatingSuggestionItemProps<TItem>[];
+
+  /**
+   * The header and footer props for the floating picker
+   * This should be set here instead of in onRenderFloatingPicker if you want them to be keyboard selectable
+   */
+  pickerSuggestionsProps?: IBaseFloatingPickerHeaderFooterProps;
+
+  /**
+   * Function that specifies how arbitrary text entered into the edit input is handled.
+   */
+  createGenericItem?: (input: string) => TItem;
 }
 
 export type EditingItemInnerFloatingPickerProps<T> = Pick<
-  IFloatingSuggestionsProps<T>,
-  'componentRef' | 'onSuggestionSelected' | 'inputElement' | 'onRemoveSuggestion' | 'onSuggestionsHidden'
+  IBaseFloatingSuggestionsProps<T>,
+  | 'componentRef'
+  | 'suggestions'
+  | 'onSuggestionSelected'
+  | 'targetElement'
+  | 'onRemoveSuggestion'
+  | 'onFloatingSuggestionsDismiss'
+  | 'onKeyDown'
+  | 'selectedSuggestionIndex'
+  | 'selectedHeaderIndex'
+  | 'selectedFooterIndex'
+  | 'pickerSuggestionsProps'
 >;
 
 /**
  * Wrapper around an item in a selection well that renders an item with a context menu for
  * replacing that item with another item.
  */
-export class DefaultEditingItemInner<TItem> extends React.PureComponent<IDefaultEditingItemInnerProps<TItem>> {
-  private _editingInput: HTMLInputElement;
-  private _editingFloatingPicker = React.createRef<FloatingSuggestions<TItem>>();
+export const DefaultEditingItemInner = <TItem extends any>(
+  props: IDefaultEditingItemInnerProps<TItem>,
+): JSX.Element => {
+  const editingInput = React.useRef<any>();
+  const editingFloatingPicker = React.createRef<any>();
+  const [editingSuggestions, setEditingSuggestions] = React.useState<IFloatingSuggestionItemProps<TItem>[]>([]);
+  const [inputValue, setInputValue] = React.useState<string>('');
 
-  constructor(props: IDefaultEditingItemInnerProps<TItem>) {
-    super(props);
-  }
+  const {
+    item,
+    onEditingComplete,
+    getSuggestions,
+    onRemoveItem,
+    createGenericItem,
+    getEditingItemText,
+    pickerSuggestionsProps,
+  } = props;
 
-  public componentDidMount(): void {
-    const itemText: string = this.props.getEditingItemText(this.props.item);
+  const {
+    focusItemIndex,
+    suggestionItems,
+    footerItemIndex,
+    footerItems,
+    headerItemIndex,
+    headerItems,
+    selectPreviousSuggestion,
+    selectNextSuggestion,
+  } = useFloatingSuggestionItems(
+    editingSuggestions,
+    pickerSuggestionsProps?.footerItemsProps,
+    pickerSuggestionsProps?.headerItemsProps,
+  );
 
-    this._editingFloatingPicker.current && this._editingFloatingPicker.current.onQueryStringChanged(itemText);
-    this._editingInput.value = itemText;
-    this._editingInput.focus();
-  }
+  React.useEffect(() => {
+    const itemText: string = getEditingItemText(props.item);
+    setEditingSuggestions(getSuggestions(itemText));
+    if (editingInput.current) {
+      editingInput.current.value = itemText;
+      setInputValue(itemText);
+      editingInput.current.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // We only want to run this once
 
-  public render(): JSX.Element {
-    const itemId = getId();
-    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
-    return (
-      <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
-        <input
-          {...nativeProps}
-          ref={this._resolveInputRef}
-          autoCapitalize={'off'}
-          autoComplete={'off'}
-          onChange={this._onInputChange}
-          onKeyDown={this._onInputKeyDown}
-          onBlur={this._onInputBlur}
-          onClick={this._onInputClick}
-          data-lpignore={true}
-          className={styles.editingInput}
-          id={itemId}
-        />
-        {this._renderEditingSuggestions()}
-      </span>
-    );
-  }
-
-  private _renderEditingSuggestions = (): JSX.Element => {
-    const FloatingPicker = this.props.onRenderFloatingPicker;
+  const _renderEditingSuggestions = (): JSX.Element => {
+    const FloatingPicker = props.onRenderFloatingPicker;
     if (!FloatingPicker) {
       return <></>;
     }
     return (
       <FloatingPicker
-        componentRef={this._editingFloatingPicker}
-        onSuggestionSelected={this._onSuggestionSelected}
-        inputElement={this._editingInput}
-        onRemoveSuggestion={this.props.onRemoveItem}
-        onSuggestionsHidden={this.props.onDismiss}
+        componentRef={editingFloatingPicker}
+        onSuggestionSelected={_onSuggestionSelected}
+        targetElement={editingInput.current}
+        onRemoveSuggestion={_onRemoveItem}
+        onFloatingSuggestionsDismiss={props.onDismiss}
+        suggestions={suggestionItems}
+        selectedSuggestionIndex={focusItemIndex}
+        selectedHeaderIndex={headerItemIndex}
+        selectedFooterIndex={footerItemIndex}
+        pickerSuggestionsProps={pickerSuggestionsProps}
       />
     );
   };
 
-  private _resolveInputRef = (ref: HTMLInputElement): void => {
-    this._editingInput = ref;
-
-    this.forceUpdate(() => {
-      this._editingInput.focus();
-    });
-  };
-
-  private _onInputClick = (): void => {
-    this._editingFloatingPicker.current && this._editingFloatingPicker.current.showPicker(true /*updatevalue*/);
-  };
-
-  private _onInputBlur = (ev: React.FocusEvent<HTMLElement>): void => {
-    if (this._editingFloatingPicker.current && ev.relatedTarget !== null) {
-      const target = ev.relatedTarget as HTMLElement;
-      if (
-        target.className.indexOf('ms-Suggestions-itemButton') === -1 &&
-        target.className.indexOf('ms-Suggestions-sectionButton') === -1
-      ) {
-        this._editingFloatingPicker.current.forceResolveSuggestion();
+  const _onInputBlur = React.useCallback(
+    (ev: React.FocusEvent<HTMLElement>): void => {
+      if (focusItemIndex >= 0) {
+        _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+      } else if (createGenericItem) {
+        onEditingComplete(item, createGenericItem(inputValue));
       }
-    }
-  };
+      // else, we come out of editing mode
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- these are the only dependencies which matter
+    [suggestionItems, focusItemIndex, item, createGenericItem, inputValue, onEditingComplete],
+  );
 
-  private _onInputChange = (ev: React.FormEvent<HTMLElement>): void => {
-    const value: string = (ev.target as HTMLInputElement).value;
+  const _onInputChange = React.useCallback(
+    (ev: React.FormEvent<HTMLElement>): void => {
+      const value: string = (ev.target as HTMLInputElement).value;
+      setInputValue(value);
 
-    if (value === '') {
-      if (this.props.onRemoveItem) {
-        this.props.onRemoveItem(this.props.item);
+      if (value === '') {
+        if (onRemoveItem) {
+          onRemoveItem(item);
+        }
+      } else {
+        setEditingSuggestions(getSuggestions(value));
       }
-    } else {
-      this._editingFloatingPicker.current && this._editingFloatingPicker.current.onQueryStringChanged(value);
-    }
-  };
+    },
+    [onRemoveItem, getSuggestions, item],
+  );
 
-  private _onInputKeyDown(ev: React.KeyboardEvent<HTMLInputElement>): void {
-    if (ev.which === KeyCodes.backspace || ev.which === KeyCodes.del) {
-      ev.stopPropagation();
-    }
-  }
+  const _onInputKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLInputElement>): void => {
+      const keyCode = ev.which;
+      switch (keyCode) {
+        case KeyCodes.backspace:
+        case KeyCodes.del:
+          ev.stopPropagation();
+          break;
+        case KeyCodes.enter:
+        case KeyCodes.tab:
+          if (!ev.shiftKey && !ev.ctrlKey && (focusItemIndex >= 0 || footerItemIndex >= 0 || headerItemIndex >= 0)) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            if (focusItemIndex >= 0) {
+              // Get the focused element and add it to selectedItemsList
+              _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+            } else if (footerItemIndex >= 0) {
+              // execute the footer action
+              footerItems![footerItemIndex].onExecute!();
+            } else if (headerItemIndex >= 0) {
+              // execute the header action
+              headerItems![headerItemIndex].onExecute!();
+            }
+          }
+          break;
+        case KeyCodes.up:
+          ev.preventDefault();
+          ev.stopPropagation();
+          selectPreviousSuggestion();
+          break;
+        case KeyCodes.down:
+          ev.preventDefault();
+          ev.stopPropagation();
+          selectNextSuggestion();
+          break;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- these are the only dependencies which matter
+    [suggestionItems, focusItemIndex, footerItems, footerItemIndex, headerItems, headerItemIndex],
+  );
 
-  private _onSuggestionSelected = (item: TItem): void => {
-    this.props.onEditingComplete(this.props.item, item);
-  };
-}
+  const _onSuggestionSelected = React.useCallback(
+    (ev: any, itemProps: IFloatingSuggestionItemProps<TItem>) => {
+      onEditingComplete(item, itemProps.item);
+    },
+    [onEditingComplete, item],
+  );
+
+  const _onRemoveItem = React.useCallback(
+    (ev: any, itemProps: IFloatingSuggestionItemProps<TItem>) => {
+      if (onRemoveItem) {
+        onRemoveItem(itemProps.item);
+      }
+    },
+    [onRemoveItem],
+  );
+
+  const itemId = getId();
+  const nativeProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(props, inputProperties);
+  return (
+    <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
+      <input
+        {...nativeProps}
+        ref={editingInput}
+        autoCapitalize={'off'}
+        autoComplete={'off'}
+        onChange={_onInputChange}
+        onKeyDown={_onInputKeyDown}
+        onBlur={_onInputBlur}
+        data-lpignore={true}
+        className={styles.editingInput}
+        id={itemId}
+      />
+      {_renderEditingSuggestions()}
+    </span>
+  );
+};
 
 type EditingItemProps<T> = Pick<
   IDefaultEditingItemInnerProps<T>,

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -77,6 +77,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
                 onItemChange={_replaceItem}
                 dragDropEvents={dragDropEvents}
                 dragDropHelper={dragDropHelper}
+                createGenericItem={props.createGenericItem}
               />
             ))}
         </div>

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IPickerItemProps, ISuggestionModel, ValidationState } from 'office-ui-fabric-react/lib/Pickers';
+import { IPickerItemProps } from 'office-ui-fabric-react/lib/Pickers';
 import { IRefObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IDragDropEvents, IDragDropHelper } from 'office-ui-fabric-react/lib/utilities/dragdrop/index';
 export interface ISelectedItemsList<T> {
@@ -50,6 +50,11 @@ export interface ISelectedItemProps<T> extends IPickerItemProps<T> {
    * A list of events to register
    */
   eventsToRegister?: { eventName: string; callback: (item?: any, index?: number, event?: any) => void }[];
+
+  /**
+   * Function that specifies how arbitrary text entered into the edit input is handled.
+   */
+  createGenericItem?: (input: string) => T;
 }
 
 export type BaseSelectedItem = {
@@ -84,7 +89,7 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
   /**
    * Function that specifies how arbitrary text entered into the well is handled.
    */
-  createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T>;
+  createGenericItem?: (input: string) => T;
   /**
    * The items that the base picker should currently display as selected. If this is provided then the picker will
    * act as a controlled component.

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -55,11 +55,11 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     selectNextSuggestion,
   } = useFloatingSuggestionItems(
     suggestions,
+    pickerSuggestionsProps?.footerItemsProps,
+    pickerSuggestionsProps?.headerItemsProps,
     selectedSuggestionIndex,
     selectedFooterIndex,
-    pickerSuggestionsProps?.footerItemsProps,
     selectedHeaderIndex,
-    pickerSuggestionsProps?.headerItemsProps,
     isSuggestionsVisible,
   );
 

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -25,11 +25,11 @@ export interface IUseFloatingSuggestionItems<T> {
 
 export const useFloatingSuggestionItems = <T extends {}>(
   floatingSuggestionItems: T[],
+  footerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
+  headerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   focusSuggestionIndex?: number,
   focusFooterIndex?: number,
-  footerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   focusHeaderIndex?: number,
-  headerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   isSuggestionsVisible?: boolean,
 ) => {
   const [focusItemIndex, setFocusItemIndex] = React.useState(focusSuggestionIndex || -1);

--- a/packages/experiments/src/components/UnifiedPicker/index.ts
+++ b/packages/experiments/src/components/UnifiedPicker/index.ts
@@ -1,0 +1,3 @@
+export * from './UnifiedPicker';
+export * from './UnifiedPicker.types';
+export * from './hooks/useFloatingSuggestionItems';

--- a/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
+++ b/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
@@ -11,14 +11,27 @@ import {
   DefaultEditingItem,
   EditingItemInnerFloatingPickerProps,
 } from '@uifabric/experiments/lib/SelectedItemsList';
-import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestions';
-import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
+import {
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+  IFloatingSuggestionItemProps,
+} from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 
 export const SelectedPeopleListWithEditExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
+
+  const _startsWith = (text: string, filterText: string): boolean => {
+    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
+  };
+
+  const _getSuggestions = (value: string): IFloatingSuggestionItemProps<IPersonaProps>[] => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
 
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
@@ -27,12 +40,9 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
     itemComponent: TriggerOnContextMenu(SelectedPersona),
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
+      getSuggestions: _getSuggestions,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
   });
@@ -85,60 +95,3 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
     </div>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
+++ b/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
@@ -12,15 +12,26 @@ import {
   DefaultEditingItem,
   EditingItemInnerFloatingPickerProps,
 } from '@uifabric/experiments/lib/SelectedItemsList';
-import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestions';
-import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
+import {
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+} from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 
 export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
 
+  const _startsWith = (text: string, filterText: string): boolean => {
+    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
+  };
+
+  const _getSuggestions = (value: string) => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
   /**
    * Build a custom selected item capable of being edited with a dropdown and capable of editing
    */
@@ -28,12 +39,9 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: (persona: IPersonaProps) => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
+      getSuggestions: _getSuggestions,
     }),
     itemComponent: ItemWithContextMenu<IPersona>({
       menuItems: (item, onTrigger) => [
@@ -134,60 +142,3 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
     </div>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
+++ b/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
@@ -15,29 +15,23 @@ import {
 import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestions';
 import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
 
-export interface IPeopleSelectedItemsListExampleState {
-  currentSelectedItems: IPersonaProps[];
-}
-
-export class SelectedPeopleListWithEditInContextMenuExample extends React.Component<
-  {},
-  IPeopleSelectedItemsListExampleState
-> {
+export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element => {
+  const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
   // Used to resolve suggestions on the editableItem
-  private model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  private suggestionsStore = new SuggestionsStore<IPersonaProps>();
+  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
+  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
 
   /**
    * Build a custom selected item capable of being edited with a dropdown and capable of editing
    */
-  private EditableItemWithContextMenu = EditableItem({
+  const EditableItemWithContextMenu = EditableItem({
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: (persona: IPersonaProps) => persona.text || '',
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
         <FloatingPeopleSuggestions
           {...props}
-          suggestionsStore={this.suggestionsStore}
-          onResolveSuggestions={this.model.resolveSuggestions}
+          suggestionsStore={suggestionsStore}
+          onResolveSuggestions={model.resolveSuggestions}
         />
       ),
     }),
@@ -47,14 +41,14 @@ export class SelectedPeopleListWithEditInContextMenuExample extends React.Compon
           key: 'remove',
           text: 'Remove',
           onClick: () => {
-            this._onItemsRemoved([item]);
+            _onItemsRemoved([item]);
           },
         },
         {
           key: 'copy',
           text: 'Copy',
           onClick: () => {
-            this._copyToClipboard(this._getCopyItemsText([item]));
+            _copyToClipboard(_getCopyItemsText([item]));
           },
         },
         {
@@ -67,53 +61,37 @@ export class SelectedPeopleListWithEditInContextMenuExample extends React.Compon
     }),
   });
 
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      currentSelectedItems: [people[40]],
-    };
-  }
-
-  public render(): JSX.Element {
-    return (
-      <div className={'ms-BasePicker-text'}>
-        Right click any persona to open the context menu
-        <br />
-        <PrimaryButton text="Add another item" onClick={this._onAddItemButtonClicked} />
-        {this._renderExtendedPicker()}
-      </div>
-    );
-  }
-  private _renderExtendedPicker(): JSX.Element {
-    return (
-      <div>
-        <SelectedPeopleList
-          key={'normal'}
-          removeButtonAriaLabel={'Remove'}
-          selectedItems={[...this.state.currentSelectedItems]}
-          onRenderItem={this.EditableItemWithContextMenu}
-          onItemsRemoved={this._onItemsRemoved}
-        />
-      </div>
-    );
-  }
-
-  private _onAddItemButtonClicked = (): void => {
+  const _onAddItemButtonClicked = React.useCallback(() => {
     const randomPerson = people[Math.floor(Math.random() * (people.length - 1))];
-    this.setState({ currentSelectedItems: [...this.state.currentSelectedItems, randomPerson] });
-  };
+    setCurrentSelectedItems([...currentSelectedItems, randomPerson]);
+  }, [currentSelectedItems]);
 
-  private _onItemsRemoved = (items: IPersona[]): void => {
-    const currentSelectedItemsCopy = [...this.state.currentSelectedItems];
-    items.forEach(item => {
-      const indexToRemove = currentSelectedItemsCopy.indexOf(item);
-      currentSelectedItemsCopy.splice(indexToRemove, 1);
-      this.setState({ currentSelectedItems: [...currentSelectedItemsCopy] });
-    });
-  };
+  const _onItemsRemoved = React.useCallback(
+    (items: IPersona[]): void => {
+      const currentSelectedItemsCopy = [...currentSelectedItems];
+      items.forEach(item => {
+        const indexToRemove = currentSelectedItemsCopy.indexOf(item);
+        currentSelectedItemsCopy.splice(indexToRemove, 1);
+        setCurrentSelectedItems([...currentSelectedItemsCopy]);
+      });
+    },
+    [currentSelectedItems],
+  );
 
-  private _copyToClipboard = (copyString: string): void => {
+  const _replaceItem = React.useCallback(
+    (newItem: IPersonaProps | IPersona[], index: number): void => {
+      const newItemsArray = !Array.isArray(newItem) ? [newItem] : newItem;
+
+      if (index >= 0) {
+        const newItems: IPersonaProps[] = [...currentSelectedItems];
+        newItems.splice(index, 1, ...newItemsArray);
+        setCurrentSelectedItems(newItems);
+      }
+    },
+    [currentSelectedItems],
+  );
+
+  const _copyToClipboard = (copyString: string): void => {
     navigator.clipboard.writeText(copyString).then(
       () => {
         /* clipboard successfully set */
@@ -125,7 +103,7 @@ export class SelectedPeopleListWithEditInContextMenuExample extends React.Compon
     );
   };
 
-  private _getCopyItemsText(items: IPersonaProps[]): string {
+  const _getCopyItemsText = (items: IPersonaProps[]): string => {
     let copyText = '';
     items.forEach((item: IPersonaProps, index: number) => {
       copyText += item.text;
@@ -136,8 +114,26 @@ export class SelectedPeopleListWithEditInContextMenuExample extends React.Compon
     });
 
     return copyText;
-  }
-}
+  };
+
+  return (
+    <div className={'ms-BasePicker-text'}>
+      Right click any persona to open the context menu
+      <br />
+      <PrimaryButton text="Add another item" onClick={_onAddItemButtonClicked} />
+      <div>
+        <SelectedPeopleList
+          key={'normal'}
+          removeButtonAriaLabel={'Remove'}
+          selectedItems={currentSelectedItems}
+          onRenderItem={EditableItemWithContextMenu}
+          onItemsRemoved={_onItemsRemoved}
+          replaceItem={_replaceItem}
+        />
+      </div>
+    </div>
+  );
+};
 
 type IBaseExampleType = {
   text?: string;

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useConst } from '@fluentui/react-hooks';
 import {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,
@@ -17,8 +18,7 @@ import {
   ItemWithContextMenu,
 } from '@uifabric/experiments/lib/SelectedItemsList';
 import { IInputProps } from 'office-ui-fabric-react';
-import { SuggestionsStore } from '@uifabric/experiments/lib/FloatingSuggestions';
-import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestions';
+import { FloatingPeopleSuggestions } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 
 const _suggestions = [
   {
@@ -72,9 +72,58 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
 
   const ref = React.useRef<any>();
 
-  // Used to resolve suggestions on the editableItem
-  const model = new ExampleSuggestionsModel<IPersonaProps>(people);
-  const suggestionsStore = new SuggestionsStore<IPersonaProps>();
+  const suggestionProps = useConst(() => {
+    return {
+      // uncomment below section to see any example of a selectable header item
+      headerItemsProps: [
+        {
+          renderItem: () => {
+            return <>People Suggestions</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          /*onExecute: () => {
+            alert('People suggestions selected');
+          },*/
+        },
+      ],
+      footerItemsProps: [
+        {
+          renderItem: () => {
+            return <>Showing {peopleSuggestions.length} results</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          // uncomment to see an example of multiple selectable footer items
+          /*onExecute: () => {
+            alert('Showing people suggestions executed');
+          },*/
+        },
+        {
+          renderItem: () => {
+            return <>Select to log out to console</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            console.log(peopleSuggestions);
+          },
+        },
+      ],
+    };
+  });
+
+  const _getSuggestions = (value: string): IFloatingSuggestionItemProps<IPersonaProps>[] => {
+    const allPeople = people;
+    const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', value));
+    const suggestionList = suggestions.map(item => {
+      return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+    });
+    return suggestionList;
+  };
 
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
@@ -82,12 +131,10 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
   const SelectedItem = EditableItem({
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',
+      getSuggestions: _getSuggestions,
+      pickerSuggestionsProps: suggestionProps,
       onRenderFloatingPicker: (props: EditingItemInnerFloatingPickerProps<IPersonaProps>) => (
-        <FloatingPeopleSuggestions
-          {...props}
-          suggestionsStore={suggestionsStore}
-          onResolveSuggestions={model.resolveSuggestions}
-        />
+        <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
     itemComponent: ItemWithContextMenu<IPersona>({
@@ -215,6 +262,10 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     }
   };
 
+  const _createGenericItem = (input: string): IPersona => {
+    return { text: input };
+  };
+
   const _onInputChange = (filterText: string): void => {
     // Clear the input if the user types a semicolon or comma
     // This is meant to be an example of using the forward ref,
@@ -258,6 +309,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     getItemCopyText: _getItemsCopyText,
     onRenderItem: SelectedItem,
     replaceItem: _replaceItem,
+    createGenericItem: _createGenericItem,
   } as ISelectedPeopleListProps<IPersonaProps>;
 
   const inputProps = {
@@ -280,60 +332,3 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     </>
   );
 };
-
-type IBaseExampleType = {
-  text?: string;
-  name?: string;
-};
-
-class ExampleSuggestionsModel<T extends IBaseExampleType> {
-  private suggestionsData: T[];
-
-  public constructor(data: T[]) {
-    this.suggestionsData = [...data];
-  }
-
-  public resolveSuggestions = (filterText: string, currentItems?: T[]): Promise<T[]> => {
-    let filteredItems: T[] = [];
-    if (filterText) {
-      filteredItems = this._filterItemsByText(filterText);
-      filteredItems = this._removeDuplicates(filteredItems, currentItems || []);
-    }
-
-    return this._convertResultsToPromise(filteredItems);
-  };
-
-  public removeSuggestion(item: T) {
-    const index = this.suggestionsData.indexOf(item);
-    console.log('removing', item, 'at', index);
-    if (index !== -1) {
-      this.suggestionsData.splice(index, 1);
-    }
-  }
-
-  private _filterItemsByText(filterText: string): T[] {
-    return this.suggestionsData.filter((item: T) => {
-      const itemText = item.text || item.name;
-      return itemText ? this._doesTextStartWith(itemText, filterText) : false;
-    });
-  }
-
-  private _doesTextStartWith(text: string, filterText: string): boolean {
-    return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
-  }
-
-  private _removeDuplicates(items: T[], possibleDupes: T[]): T[] {
-    return items.filter((item: T) => !this._listContainsItem(item, possibleDupes));
-  }
-
-  private _listContainsItem(item: T, Items: T[]): boolean {
-    if (!Items || !Items.length || Items.length === 0) {
-      return false;
-    }
-    return Items.filter((i: T) => (i.text || i.name) === (item.text || item.name)).length > 0;
-  }
-
-  private _convertResultsToPromise(results: T[]): Promise<T[]> {
-    return new Promise<T[]>(resolve => setTimeout(() => resolve(results), 150));
-  }
-}

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConst } from '@fluentui/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 import {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 - #16168 

Updated this to use the new picker. These are both used in the UnifiedPicker, but previously the input was using the new FloatingSuggestionsComposite, while editing items were using the old picker. Now they're both using the new picker.

The three editing examples are updated SelectedItemsList with edit, with edit in context menu, UnifiedPeoplePicker with edit. The unified people picker edit picker has headers and footers.
