### PR TITLE
Destructure snapToStep correctly for useSlider

### DIFF
--- a/change/@fluentui-react-slider-2021-01-25-15-51-47-snapToStep.json
+++ b/change/@fluentui-react-slider-2021-01-25-15-51-47-snapToStep.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Destructure snapToStep correctly for useSlider",
+  "packageName": "@fluentui/react-slider",
+  "email": "chengshi1219@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-25T14:51:47.198Z"
+}

--- a/packages/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-slider/src/components/Slider/useSlider.ts
@@ -127,7 +127,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
   };
 
   const updateValue = (valueProp: number, renderedValueProp: number): void => {
-    const snapToStep = props;
+    const { snapToStep } = props;
     let numDec = 0;
     if (isFinite(step!)) {
       while (Math.round(step! * Math.pow(10, numDec)) / Math.pow(10, numDec) !== step!) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
In `updateValue` function of `useSlider`, it looks like the code intended to use `snapToStep` prop in the if statement but it didn't destructure the prop correctly, so the if statement will be true forever
(give an overview)

#### Focus areas to test

(optional)
