### PR TITLE
chore(scripts): support opting out from opening browser for 'just dev'

### DIFF
--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -25,12 +25,12 @@ import { findGitRoot } from './monorepo/index';
 
 interface BasicPresetArgs extends Arguments {
   production: boolean;
-  webpackConfig: 'string';
+  webpackConfig: string;
   commonjs: boolean;
   cached: boolean;
   registry: string;
   push: boolean;
-  package: 'string';
+  package: string;
   min: boolean;
 }
 

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -90,7 +90,7 @@ export function preset() {
   task('eslint', eslint);
   task('ts:commonjs-only', ts.commonjsOnly);
   task('webpack', webpack);
-  task('webpack-dev-server', webpackDevServer());
+  task('webpack-dev-server', webpackDevServer(getJustArgv()));
   task('api-extractor:verify', verifyApiExtractor());
   task('api-extractor:update', updateApiExtractor());
   task('lint-imports', lintImports);
@@ -128,7 +128,7 @@ export function preset() {
   task('update-api', series('clean', 'copy', 'sass', 'ts', 'api-extractor:update'));
 
   task('dev:storybook', series('storybook:start'));
-  task('dev', series('copy', 'sass', webpackDevServer(getJustArgv())));
+  task('dev', series('copy', 'sass', 'webpack-dev-server'));
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs-only')).cached();
 

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -1,4 +1,5 @@
 import { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } from 'just-scripts';
+import { Arguments } from 'yargs-parser';
 
 import path from 'path';
 import fs from 'fs';
@@ -21,6 +22,21 @@ import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
 import { startStorybookTask, buildStorybookTask } from './tasks/storybook';
 import { fluentuiLernaPublish } from './tasks/fluentui-publish';
 import { findGitRoot } from './monorepo/index';
+
+interface BasicPresetArgs extends Arguments {
+  production: boolean;
+  webpackConfig: 'string';
+  commonjs: boolean;
+  cached: boolean;
+  registry: string;
+  push: boolean;
+  package: 'string';
+  min: boolean;
+}
+
+function getJustArgv() {
+  return argv() as Partial<BasicPresetArgs>;
+}
 
 /** Do only the bare minimum setup of options and resolve paths */
 function basicPreset() {
@@ -74,7 +90,7 @@ export function preset() {
   task('eslint', eslint);
   task('ts:commonjs-only', ts.commonjsOnly);
   task('webpack', webpack);
-  task('webpack-dev-server', webpackDevServer);
+  task('webpack-dev-server', webpackDevServer());
   task('api-extractor:verify', verifyApiExtractor());
   task('api-extractor:update', updateApiExtractor());
   task('lint-imports', lintImports);
@@ -88,12 +104,14 @@ export function preset() {
   task('fluentui:publish:minor', fluentuiLernaPublish('minor'));
 
   task('ts:compile', () => {
-    return argv().commonjs
+    const args = getJustArgv();
+
+    return args.commonjs
       ? 'ts:commonjs-only'
       : parallel(
-          condition('ts:commonjs', () => !argv().min),
+          condition('ts:commonjs', () => !args.min),
           'ts:esm',
-          condition('ts:amd', () => !!argv().production),
+          condition('ts:amd', () => !!args.production),
         );
   });
 
@@ -110,7 +128,7 @@ export function preset() {
   task('update-api', series('clean', 'copy', 'sass', 'ts', 'api-extractor:update'));
 
   task('dev:storybook', series('storybook:start'));
-  task('dev', series('copy', 'sass', 'webpack-dev-server'));
+  task('dev', series('copy', 'sass', webpackDevServer(getJustArgv())));
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs-only')).cached();
 
@@ -121,7 +139,7 @@ export function preset() {
       'copy',
       'sass',
       'ts',
-      condition('api-extractor:verify', () => !argv().min),
+      condition('api-extractor:verify', () => !getJustArgv().min),
     ),
   ).cached();
 

--- a/scripts/tasks/webpack.ts
+++ b/scripts/tasks/webpack.ts
@@ -1,33 +1,57 @@
-import { webpackCliTask, argv, logger } from 'just-scripts';
+import { webpackCliTask, argv, logger, option } from 'just-scripts';
 import * as path from 'path';
 import * as fs from 'fs';
 import execSync from '../exec-sync';
+import { Arguments } from 'yargs-parser';
+
+type JustArguments<T extends Record<string, unknown>> = Arguments & T;
 
 export function webpack() {
-  const args = argv();
+  const args: JustArguments<Partial<{ production: boolean }>> = argv();
   return webpackCliTask({
     webpackCliArgs: args.production ? ['--production'] : [],
     nodeArgs: ['--max-old-space-size=4096'],
   });
 }
 
-export async function webpackDevServer() {
-  const fp = (await import('find-free-port')).default;
-  const webpackConfigFilePath = argv().webpackConfig || 'webpack.serve.config.js';
-  const configPath = path.resolve(process.cwd(), webpackConfigFilePath);
-  const port = await fp(4322, 4400);
+export function webpackDevServer(
+  options: Partial<{
+    /**
+     * Open the default browser
+     * @default 'true'
+     */
+    open: 'true' | 'false';
+    /**
+     * @default 'webpack.serve.config.js'
+     */
+    webpackConfig: string;
+    /**
+     * @default false
+     */
+    cached: boolean;
+  }> = {},
+) {
+  return async () => {
+    const args = { ...argv(), ...options };
 
-  if (fs.existsSync(configPath)) {
-    const webpackDevServerPath = require.resolve('webpack-dev-server/bin/webpack-dev-server.js');
-    const cmd = `node ${webpackDevServerPath} --config ${configPath} --port ${port} --open`;
+    const fp = (await import('find-free-port')).default;
+    const webpackConfigFilePath = args.webpackConfig || 'webpack.serve.config.js';
+    const configPath = path.resolve(process.cwd(), webpackConfigFilePath);
+    const port = await fp(4322, 4400);
+    const openBrowser = args.open === 'false' ? '' : '--open';
 
-    logger.info(`Caching enabled: ${argv().cached}`);
-    logger.info('Running: ', cmd);
+    if (fs.existsSync(configPath)) {
+      const webpackDevServerPath = require.resolve('webpack-dev-server/bin/webpack-dev-server.js');
+      const cmd = `node ${webpackDevServerPath} --config ${configPath} --port ${port} ${openBrowser}`.trim();
 
-    process.env.cached = argv().cached;
+      logger.info(`Caching enabled: ${args.cached ? 'YES' : 'NO'}`);
+      logger.info('Running: ', cmd);
 
-    execSync(cmd);
-  }
+      process.env.cached = String(args.cached);
+
+      execSync(cmd);
+    }
+  };
 }
 
 let server;

--- a/scripts/tasks/webpack.ts
+++ b/scripts/tasks/webpack.ts
@@ -1,4 +1,4 @@
-import { webpackCliTask, argv, logger, option } from 'just-scripts';
+import { webpackCliTask, argv, logger } from 'just-scripts';
 import * as path from 'path';
 import * as fs from 'fs';
 import execSync from '../exec-sync';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change` - no publishable changes

#### Description of changes

**Before**
`just dev`  opens always new browser window. This can become quite annoying ( YMMV! )

**After**
You can now opt out by using `open` flag

`just dev --open false` will not open new window

#### Focus areas to test

(optional)
