### PR TITLE
chore(MenuButton):No aria-expanded for menuButton with contextMenu

### DIFF
--- a/packages/a11y-testing/src/definitions/MenuButton/menuButtonBehaviorDefinition.ts
+++ b/packages/a11y-testing/src/definitions/MenuButton/menuButtonBehaviorDefinition.ts
@@ -53,6 +53,9 @@ const menuButtonBehaviorDefinitionTriggerSlot: Rule[] = [
   BehaviorRule.slot('trigger')
     .hasAttribute('id', 'triggerElementID', true)
     .description(`if 'ID' is defined for the 'trigger' slot.`),
+  BehaviorRule.slot('trigger')
+    .forProps({ contextMenu: true, open: true })
+    .doesNotHaveAttribute('aria-expanded'),
 ];
 
 export const menuButtonBehaviorDefinitionTriggerSlotTabbable = menuButtonBehaviorDefinitionTriggerSlot.concat(

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -70,7 +70,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix a warning when the `fluid` or `resize` prop was used in `TextArea` @assuncaocharles ([#16393](https://github.com/microsoft/fluentui/pull/16393))
 - Fix implementation of getReactFiberFromNode to be compatible with React 17 @layershifter ([#16392](https://github.com/microsoft/fluentui/pull/16392))
 - Fix missing focus styles for carousel paddle @assuncaocharles ([#16460](https://github.com/microsoft/fluentui/pull/16460))
-
+- Do not add `aria-expanded="true"` for `trigger` slot when `MenuButton` has `contextMenu` @pompomon ([#16286](https://github.com/microsoft/fluentui/pull/16442))
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))
 - `Tree`: added `useVirtualTree` hook @yuanboxue-amber ([#16080](https://github.com/microsoft/fluentui/pull/16080))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -70,7 +70,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix a warning when the `fluid` or `resize` prop was used in `TextArea` @assuncaocharles ([#16393](https://github.com/microsoft/fluentui/pull/16393))
 - Fix implementation of getReactFiberFromNode to be compatible with React 17 @layershifter ([#16392](https://github.com/microsoft/fluentui/pull/16392))
 - Fix missing focus styles for carousel paddle @assuncaocharles ([#16460](https://github.com/microsoft/fluentui/pull/16460))
-- Do not add `aria-expanded="true"` for `trigger` slot when `MenuButton` has `contextMenu` @pompomon ([#16286](https://github.com/microsoft/fluentui/pull/16442))
+- Do not add `aria-expanded="true"` for `trigger` slot when `MenuButton` has `contextMenu` @pompomon ([#16442](https://github.com/microsoft/fluentui/pull/16442))
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))
 - `Tree`: added `useVirtualTree` hook @yuanboxue-amber ([#16080](https://github.com/microsoft/fluentui/pull/16080))

--- a/packages/fluentui/accessibility/src/behaviors/MenuButton/menuButtonBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/MenuButton/menuButtonBehavior.ts
@@ -15,7 +15,7 @@ export const menuButtonBehavior: Accessibility<MenuButtonBehaviorProps> = props 
     attributes: {
       trigger: {
         'aria-controls': props.open ? props.menuId : undefined,
-        'aria-expanded': props.open || undefined,
+        'aria-expanded': (props.open && !props.contextMenu) || undefined,
         'aria-haspopup': props.contextMenu ? undefined : 'true',
         id: props.triggerId,
         ...(!props.contextMenu && props.open && { tabIndex: -1 }),


### PR DESCRIPTION
#### Description of changes

Do not add `aria-expanded="true"` to the `trigger` slot for `<MenuButton contextMenu />`.
[WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#menubutton) recommends to add `aria-expended` to all menu tied to 
a button, but in case of context menu the popup is not directly linked to the MenuButton component, thus it makes less semantical sense to keep `aria-expanded`.

For example, tree list with items, which have context menu - https://codesandbox.io/s/fluent-ui-example-forked-q9kxp?file=/example.js
