### PR TITLE
fix(Callout): merge Callout with FocusTrapCallout

### DIFF
--- a/change/@fluentui-react-internal-2021-01-12-16-59-42-fix-16383.json
+++ b/change/@fluentui-react-internal-2021-01-12-16-59-42-fix-16383.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Callout): merge Callout with FocusTrapCallout",
+  "packageName": "@fluentui/react-internal",
+  "email": "jakubkonka@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-12T15:59:42.291Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -768,7 +768,7 @@ export class FloatingPeoplePicker extends BaseFloatingPeoplePicker {
     static defaultProps: any;
 }
 
-// @public
+// @public @deprecated
 export const FocusTrapCallout: React.FunctionComponent<IFocusTrapCalloutProps>;
 
 // @public (undocumented)
@@ -1336,6 +1336,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
     directionalHintForRTL?: DirectionalHint;
     doNotLayer?: boolean;
     finalHeight?: number;
+    focusTrapProps?: IFocusTrapZoneProps;
     gapSpace?: number;
     hidden?: boolean;
     hideOverflow?: boolean;

--- a/packages/react-internal/src/components/Callout/Callout.types.ts
+++ b/packages/react-internal/src/components/Callout/Callout.types.ts
@@ -6,6 +6,7 @@ import { ICalloutPositionedInfo } from '../../Positioning';
 import { ILayerProps } from '../../Layer';
 import { Target } from '@fluentui/react-hooks';
 import { IPopupRestoreFocusParams } from '../../Popup';
+import { IFocusTrapZoneProps } from '../../FocusTrapZone';
 
 export { Target };
 
@@ -273,6 +274,11 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
    * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
   onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
+
+  /**
+   * Optional props to be passed on to FocusTrapZone
+   */
+  focusTrapProps?: IFocusTrapZoneProps;
 }
 
 /**

--- a/packages/react-internal/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react-internal/src/components/Callout/CalloutContent.base.tsx
@@ -27,6 +27,7 @@ import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import { AnimationClassNames } from '../../Styling';
 import { useMergedRefs, useAsync, useConst, useTarget } from '@fluentui/react-hooks';
+import { FocusTrapZone } from '../FocusTrapZone/index';
 
 const ANIMATIONS: { [key: number]: string | undefined } = {
   [RectangleEdge.top]: AnimationClassNames.slideUpIn10,
@@ -438,6 +439,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       target,
       hidden,
       onLayerMounted,
+      focusTrapProps,
     } = props;
 
     const hostElement = React.useRef<HTMLDivElement>(null);
@@ -497,7 +499,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       ...(overflowYHidden && { overflowY: 'hidden' }),
     };
 
-    const visibilityStyle: React.CSSProperties | undefined = props.hidden ? { visibility: 'hidden' } : undefined;
+    const visibilityStyle: React.CSSProperties | undefined = hidden ? { visibility: 'hidden' } : undefined;
     // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
     const content = (
       <div ref={rootRef} className={classNames.container} style={visibilityStyle}>
@@ -526,7 +528,15 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
             onMouseDown={mouseDownOnPopup}
             onMouseUp={mouseUpOnPopup}
           >
-            {children}
+            <FocusTrapZone disabled={hidden} {...focusTrapProps}>
+              <div
+                // Set tabindex to 0 to keep focus within the Popup's content.
+                // TODO This <div> element should probably have more props, styling, etc.
+                tabIndex={0}
+              >
+                {children}
+              </div>
+            </FocusTrapZone>
           </Popup>
         </div>
       </div>

--- a/packages/react-internal/src/components/Callout/FocusTrapCallout.tsx
+++ b/packages/react-internal/src/components/Callout/FocusTrapCallout.tsx
@@ -7,13 +7,15 @@ import { FocusTrapZone } from '../../FocusTrapZone';
 /**
  * A special Callout that uses FocusTrapZone to trap focus
  * @param props - Props for the component
+ * @deprecated Use Callout which includes FocusTrapZone by default
  */
 export const FocusTrapCallout: React.FunctionComponent<IFocusTrapCalloutProps> = (
   props: IFocusTrapCalloutProps,
 ): JSX.Element => {
+  const focusTrapProps = props.focusTrapProps;
   return (
     <Callout {...props}>
-      <FocusTrapZone disabled={props.hidden} {...props.focusTrapProps}>
+      <FocusTrapZone disabled={props.hidden} isClickableOutsideFocusTrap={true} {...focusTrapProps}>
         {props.children}
       </FocusTrapZone>
     </Callout>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16383
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This commit merges `Callout` with `FocusTrapCallout`, enabling
`FocusTrapZone` by default in `Callout`. This proposal fixes #16383.
However, I'd still welcome some guidance and critical eye verifying
the direction I took in trying to provide a fix for the referenced
issue.