### PR TITLE
fix(react-examples v7): Change link text for clarity in Checkbox example

### DIFF
--- a/change/@fluentui-react-examples-2021-01-12-19-30-49-microsoftdesign-fluentui-10211.json
+++ b/change/@fluentui-react-examples-2021-01-12-19-30-49-microsoftdesign-fluentui-10211.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Change Checkbox \"Custom-rendered label with a link\" example's link to be more descriptive ",
+  "packageName": "@fluentui/react-examples",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-12T18:30:49.520Z"
+}

--- a/packages/react-examples/src/office-ui-fabric-react/Checkbox/Checkbox.Other.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Checkbox/Checkbox.Other.Example.tsx
@@ -34,9 +34,9 @@ export const CheckboxOtherExample: React.FunctionComponent = () => {
 function _renderLabelWithLink() {
   return (
     <span>
-      Custom-rendered label with a{' '}
+      Custom-rendered label with a link{' '}
       <Link href="https://www.microsoft.com" target="_blank">
-        link
+        go to Microsoft home page
       </Link>
     </span>
   );

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -653,7 +653,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span>
-        Custom-rendered label with a
+        Custom-rendered label with a link
          
         <a
           className=
@@ -710,7 +710,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           onClick={[Function]}
           target="_blank"
         >
-          link
+          go to Microsoft home page
         </a>
       </span>
     </label>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes microsoftdesign/fluentui#10211
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changed the link text of the Checkbox  "Custom-rendered label with a link" example to be more descriptive.

**Cherry-pick of [PR](https://github.com/microsoft/fluentui/pull/16423)**