### PR TITLE
docs(forms): changing examples to use Fluent UI Checkbox

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Form/Rtl/FormExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Rtl/FormExample.rtl.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Checkbox, Input } from '@fluentui/react-northstar';
 
 const FormExampleRtl = () => (
   <Form>
@@ -23,7 +23,7 @@ const FormExampleRtl = () => (
         showSuccessIndicator: false,
       }}
     />
-    <Form.Field label="أوافق على الشروط" control={{ as: 'input' }} type="checkbox" id="conditions" />
+    <Form.Field control={{ as: Checkbox, label: 'أوافق على الشروط' }} id="conditions" />
     <Form.Field control={{ as: Button, content: 'خضع' }} />
   </Form>
 );

--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Checkbox, Input } from '@fluentui/react-northstar';
 
 const fields = [
   {
@@ -25,9 +25,10 @@ const fields = [
     },
   },
   {
-    label: 'I agree to the Terms and Conditions',
-    control: { as: 'input' },
-    type: 'checkbox',
+    control: {
+      as: Checkbox,
+      label: 'I agree to the Terms and Conditions',
+    },
     id: 'conditions-shorthand',
     key: 'conditions',
   },

--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Checkbox, Input } from '@fluentui/react-northstar';
 
 const FormExample = () => (
   <Form
@@ -27,7 +27,7 @@ const FormExample = () => (
         showSuccessIndicator: false,
       }}
     />
-    <Form.Field label="I agree to the Terms and Conditions" control={{ as: 'input' }} type="checkbox" id="conditions" />
+    <Form.Field control={{ as: Checkbox, label: 'I agree to the Terms and Conditions' }} id="conditions" />
     <Form.Field control={{ as: Button, content: 'Submit' }} />
   </Form>
 );

--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Checkbox, Input } from '@fluentui/react-northstar';
 
 const fields = [
   {
@@ -27,9 +27,7 @@ const fields = [
     inline: true,
   },
   {
-    label: 'I agree to the Terms and Conditions',
-    control: { as: 'input' },
-    type: 'checkbox',
+    control: { as: Checkbox, label: 'I agree to the Terms and Conditions' },
     id: 'conditions-inline-shorthand',
     key: 'conditions',
   },

--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Checkbox, Input } from '@fluentui/react-northstar';
 
 const FormExample = () => (
   <Form
@@ -29,12 +29,7 @@ const FormExample = () => (
         showSuccessIndicator: false,
       }}
     />
-    <Form.Field
-      label="I agree to the Terms and Conditions"
-      control={{ as: 'input' }}
-      type="checkbox"
-      id="conditions-inline"
-    />
+    <Form.Field control={{ as: Checkbox, label: 'I agree to the Terms and Conditions' }} id="conditions-inline" />
     <Form.Field control={{ as: Button, content: 'Submit' }} />
   </Form>
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Several examples within Components/Form documentation erroneously used the HTML input checkbox rather than than the Fluent UI Checkbox component. This was leading to confusion with regard to which checkbox to use when referencing this example for forms.