### PR TITLE
Tooltip: Fix positioning issues that can cause tooltip to flash/not render

### DIFF
--- a/change/office-ui-fabric-react-2021-01-12-17-49-23-FixTooltipV7.json
+++ b/change/office-ui-fabric-react-2021-01-12-17-49-23-FixTooltipV7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tooltip: Fix positioning issues that can cause tooltip to flash/not render",
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-13T01:49:23.643Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -47,7 +47,7 @@ const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // filter needs to be added as an additional way to set opacity.
 // Also set pointer-events: none so that the callout will not occlude the element it is
 // going to be positioned against
-const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)', pointerEvents: 'none' };
+const OFF_SCREEN_STYLE: React.CSSProperties = { opacity: 0, filter: 'opacity(0)', pointerEvents: 'none' };
 // role and role description go hand-in-hand. Both would be included by spreading getNativeProps for a basic element
 // This constant array can be used to filter these out of native props spread on callout root and apply them together on
 // calloutMain (the Popup component within the callout)

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -45,7 +45,9 @@ const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // Microsoft Edge will overwrite inline styles if there is an animation pertaining to that style.
 // To help ensure that edge will respect the offscreen style opacity
 // filter needs to be added as an additional way to set opacity.
-const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)' };
+// Also set pointer-events: none so that the callout will not occlude the element it is
+// going to be positioned against
+const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)', pointerEvents: 'none' };
 // role and role description go hand-in-hand. Both would be included by spreading getNativeProps for a basic element
 // This constant array can be used to filter these out of native props spread on callout root and apply them together on
 // calloutMain (the Popup component within the callout)

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Callout renders Callout correctly 1`] = `
       Object {
         "filter": "opacity(0)",
         "opacity": 0,
+        "pointerEvents": "none",
       }
     }
     tabIndex={-1}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -228,6 +228,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
               Object {
                 "filter": "opacity(0)",
                 "opacity": 0,
+                "pointerEvents": "none",
               }
             }
             tabIndex={-1}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           Object {
             "filter": "opacity(0)",
             "opacity": 0,
+            "pointerEvents": "none",
           }
         }
         tabIndex={-1}
@@ -260,6 +261,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           Object {
             "filter": "opacity(0)",
             "opacity": 0,
+            "pointerEvents": "none",
           }
         }
         tabIndex={-1}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
       Object {
         "filter": "opacity(0)",
         "opacity": 0,
+        "pointerEvents": "none",
       }
     }
     tabIndex={-1}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -6,7 +6,9 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
   const { semanticColors, fonts, effects } = theme;
 
   // The math here is done to account for the 45 degree rotation of the beak
-  const tooltipGapSpace = -(Math.sqrt((beakWidth * beakWidth) / 2) + gapSpace);
+  // and sub-pixel rounding that differs across browsers, which is more noticeable when
+  // the device pixel ratio is larger
+  const tooltipGapSpace = -(Math.sqrt((beakWidth * beakWidth) / 2) + gapSpace) + 1 / window.devicePixelRatio;
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
           Object {
             "filter": "opacity(0)",
             "opacity": 0,
+            "pointerEvents": "none",
           }
         }
         tabIndex={-1}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Prior to this change there were cases where the tooltip may occlude its targetElement which could cause the tooltip to flash or potentially not appear at all. The issue becomes more prominent if one of more of the follow ins is present:
1. The contents of the tooltip are large (and the targetElement is near the top left corner of the window, so that it will be occluded by the tooltip before updatePosition is run)
2. The `tooltipGapSpace` is not a whole number of pixels, this is exacerbated the larger the user's devicePixelRatio which can lead to an overlap at the bottom of the targetElement (because the `::after` element is slightly occluding the bottom of the targetElement)

To fix these issues I've made two fixes:
1. When the callout is "hidden" it sets `OFF_SCREEN_STYLE` which sets the opacity, but the callout can still occlude the targetElement. I'm adding pointerEvents: none to the styling that is applied in this case so that it will not fire mouse events
2. Update the `tooltipGapSpace` calculation to take into account the user's `devicePixelRatio` and compensate for the sub-pixel rounding



#### Focus areas to test
Verified that there is no functional behavior change outside of the fact that the targetElement is no longer occluded all the way up to 500% browser zoom across IE11, Edge, Chrome, FF, and Safari on Mac
