### PR TITLE
fix(react-examples): Add narrator cue for cleaning action in Date Picker examples

### DIFF
--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Announced } from '@fluentui/react';
 import { DatePicker } from '@fluentui/react-date-time';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
@@ -15,11 +14,9 @@ const onFormatDate = (date?: Date): string => {
 
 export const DatePickerFormatExample: React.FunctionComponent = () => {
   const [value, setValue] = React.useState<Date | undefined>();
-  const [clearedAnnounced, setClearedAnnounced] = React.useState<JSX.Element | undefined>();
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
-    setClearedAnnounced(<Announced message="Input field cleared" aria-live="assertive" />);
   }, []);
 
   const onParseDateFromString = React.useCallback(
@@ -58,8 +55,7 @@ export const DatePickerFormatExample: React.FunctionComponent = () => {
         parseDateFromString={onParseDateFromString}
         className={styles.control}
       />
-      {clearedAnnounced}
-      <DefaultButton onClick={onClick} text="Clear" />
+      <DefaultButton aria-label="Clear the date input" onClick={onClick} text="Clear" />
       <div>Selected date: {(value || '').toString()}</div>
     </div>
   );

--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Format.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Announced } from '@fluentui/react';
 import { DatePicker } from '@fluentui/react-date-time';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
@@ -14,9 +15,11 @@ const onFormatDate = (date?: Date): string => {
 
 export const DatePickerFormatExample: React.FunctionComponent = () => {
   const [value, setValue] = React.useState<Date | undefined>();
+  const [clearedAnnounced, setClearedAnnounced] = React.useState<JSX.Element | undefined>();
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
+    setClearedAnnounced(<Announced message="Input field cleared" aria-live="assertive" />);
   }, []);
 
   const onParseDateFromString = React.useCallback(
@@ -55,6 +58,7 @@ export const DatePickerFormatExample: React.FunctionComponent = () => {
         parseDateFromString={onParseDateFromString}
         className={styles.control}
       />
+      {clearedAnnounced}
       <DefaultButton onClick={onClick} text="Clear" />
       <div>Selected date: {(value || '').toString()}</div>
     </div>

--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Announced } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 import { DatePicker, IDatePicker } from '@fluentui/react-date-time';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
@@ -11,9 +12,11 @@ const styles = mergeStyleSets({
 export const DatePickerInputExample: React.FunctionComponent = () => {
   const [value, setValue] = React.useState<Date | undefined>();
   const datePickerRef = React.useRef<IDatePicker>(null);
+  const [clearedAnnounced, setClearedAnnounced] = React.useState<JSX.Element | undefined>();
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
+    setClearedAnnounced(<Announced message="Input field cleared" aria-live="assertive" />);
   }, []);
 
   return (
@@ -32,6 +35,7 @@ export const DatePickerInputExample: React.FunctionComponent = () => {
         componentRef={datePickerRef}
         className={styles.control}
       />
+      {clearedAnnounced}
       <DefaultButton onClick={onClick} text="Clear" />
     </div>
   );

--- a/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
+++ b/packages/react-examples/src/react-date-time/DatePicker/DatePicker.Input.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Announced } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/compat/Button';
 import { DatePicker, IDatePicker } from '@fluentui/react-date-time';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
@@ -12,11 +11,9 @@ const styles = mergeStyleSets({
 export const DatePickerInputExample: React.FunctionComponent = () => {
   const [value, setValue] = React.useState<Date | undefined>();
   const datePickerRef = React.useRef<IDatePicker>(null);
-  const [clearedAnnounced, setClearedAnnounced] = React.useState<JSX.Element | undefined>();
 
   const onClick = React.useCallback((): void => {
     setValue(undefined);
-    setClearedAnnounced(<Announced message="Input field cleared" aria-live="assertive" />);
   }, []);
 
   return (
@@ -35,8 +32,7 @@ export const DatePickerInputExample: React.FunctionComponent = () => {
         componentRef={datePickerRef}
         className={styles.control}
       />
-      {clearedAnnounced}
-      <DefaultButton onClick={onClick} text="Clear" />
+      <DefaultButton aria-label="Clear the date input" onClick={onClick} text="Clear" />
     </div>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [microsoftdesign/fluentui#10254](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10254/)
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Added an `Announced` component for when the user presses the `Clear` button on the `Date Picker Input` and `Date Picker Required` examples