### PR TITLE
Calendar: improve a11y of aria-label (#16072)

### DIFF
--- a/change/@fluentui-date-time-utilities-2021-01-13-14-13-53-calendar-a11y-aria-label.json
+++ b/change/@fluentui-date-time-utilities-2021-01-13-14-13-53-calendar-a11y-aria-label.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Calendar: improve a11y of aria-label (#16072)",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "jbright@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-13T19:13:45.401Z"
+}

--- a/change/@fluentui-react-date-time-2021-01-13-14-13-53-calendar-a11y-aria-label.json
+++ b/change/@fluentui-react-date-time-2021-01-13-14-13-53-calendar-a11y-aria-label.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Calendar: improve a11y of aria-label (#16072)",
+  "packageName": "@fluentui/react-date-time",
+  "email": "jbright@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-13T19:13:53.642Z"
+}

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -81,6 +81,9 @@ export enum FirstWeekOfYear {
 export const formatDay: (date: Date) => string;
 
 // @public
+export const formatDayMonthYear: (date: Date, strings: IDateGridStrings) => string;
+
+// @public
 export const formatMonthDayYear: (date: Date, strings: IDateGridStrings) => string;
 
 // @public
@@ -156,6 +159,7 @@ export interface ICalendarStrings extends IDateGridStrings {
 // @public (undocumented)
 export interface IDateFormatting {
     formatDay: (date: Date) => string;
+    formatDayMonthYear: (date: Date, strings: IDateGridStrings) => string;
     formatMonthDayYear: (date: Date, strings: IDateGridStrings) => string;
     formatMonthYear: (date: Date, strings: IDateGridStrings) => string;
     formatYear: (date: Date) => string;

--- a/packages/date-time-utilities/src/dateFormatting/dateFormatting.defaults.ts
+++ b/packages/date-time-utilities/src/dateFormatting/dateFormatting.defaults.ts
@@ -15,6 +15,14 @@ export const formatMonthDayYear = (date: Date, strings: IDateGridStrings) =>
   strings.months[date.getMonth()] + ' ' + date.getDate() + ', ' + date.getFullYear();
 
 /**
+ * Format date to a day-month-year string
+ * @param date - input date to format
+ * @param strings - localized strings
+ */
+export const formatDayMonthYear = (date: Date, strings: IDateGridStrings) =>
+  date.getDate() + ' ' + strings.months[date.getMonth()] + ' ' + date.getFullYear();
+
+/**
  * Format date to a month-year string
  * @param date - input date to format
  * @param strings - localized strings
@@ -52,6 +60,7 @@ export const DEFAULT_DATE_FORMATTING: IDateFormatting = {
   formatDay,
   formatYear,
   formatMonthDayYear,
+  formatDayMonthYear,
   formatMonthYear,
 };
 

--- a/packages/date-time-utilities/src/dateFormatting/dateFormatting.test.ts
+++ b/packages/date-time-utilities/src/dateFormatting/dateFormatting.test.ts
@@ -1,6 +1,7 @@
 import {
   formatDay,
   formatMonthDayYear,
+  formatDayMonthYear,
   formatMonthYear,
   formatYear,
   DEFAULT_DATE_GRID_STRINGS,
@@ -20,6 +21,13 @@ describe('formatMonthDayYear', () => {
   it('returns default format', () => {
     const result = formatMonthDayYear(date, DEFAULT_DATE_GRID_STRINGS);
     expect(result).toBe('April 1, 2016');
+  });
+});
+
+describe('formatDayMonthYear', () => {
+  it('returns default format', () => {
+    const result = formatDayMonthYear(date, DEFAULT_DATE_GRID_STRINGS);
+    expect(result).toBe('1 April 2016');
   });
 });
 

--- a/packages/date-time-utilities/src/dateFormatting/dateFormatting.types.ts
+++ b/packages/date-time-utilities/src/dateFormatting/dateFormatting.types.ts
@@ -47,6 +47,11 @@ export interface IDateFormatting {
   formatMonthDayYear: (date: Date, strings: IDateGridStrings) => string;
 
   /**
+   * Get a localized string for a day, month, and year.
+   */
+  formatDayMonthYear: (date: Date, strings: IDateGridStrings) => string;
+
+  /**
    * Get a localized string for a month and year.
    */
   formatMonthYear: (date: Date, strings: IDateGridStrings) => string;

--- a/packages/react-date-time/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
+++ b/packages/react-date-time/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
@@ -6,6 +6,7 @@ import { isConformant } from '../../common/isConformant';
 describe('CalendarDayGrid', () => {
   const timeFormatter = {
     formatMonthDayYear: (date: Date, strings?: ICalendarStrings) => 'm/d/y',
+    formatDayMonthYear: (date: Date, strings?: ICalendarStrings) => 'd/m/y',
     formatMonthYear: (date: Date, strings?: ICalendarStrings) => 'm/y',
     formatDay: (date: Date) => 'd',
     formatYear: (date: Date) => 'y',

--- a/packages/react-date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -201,7 +201,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
     }
   };
 
-  let ariaLabel = dateTimeFormatter.formatMonthDayYear(day.originalDate, strings);
+  let ariaLabel = dateTimeFormatter.formatDayMonthYear(day.originalDate, strings);
   if (day.isMarked) {
     ariaLabel = ariaLabel + ', ' + strings.dayMarkedAriaLabel;
   }

--- a/packages/react-date-time/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-date-time/src/components/DatePicker/DatePicker.test.tsx
@@ -336,6 +336,7 @@ describe('DatePicker', () => {
 
     const dateTimeFormatter: IDatePickerProps['dateTimeFormatter'] = {
       formatMonthDayYear: () => 'm/d/y',
+      formatDayMonthYear: () => 'd/m/y',
       formatMonthYear: () => 'm/y',
       formatDay: () => 'd',
       formatYear: () => 'y',

--- a/packages/react-date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react-date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -634,7 +634,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 21, 2018"
+              aria-label="21 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -746,7 +746,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 22, 2018"
+              aria-label="22 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -858,7 +858,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 23, 2018"
+              aria-label="23 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -970,7 +970,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 24, 2018"
+              aria-label="24 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1082,7 +1082,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 25, 2018"
+              aria-label="25 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1194,7 +1194,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 26, 2018"
+              aria-label="26 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1306,7 +1306,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 27, 2018"
+              aria-label="27 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1439,7 +1439,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 28, 2018"
+              aria-label="28 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1567,7 +1567,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 29, 2018"
+              aria-label="29 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1695,7 +1695,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 30, 2018"
+              aria-label="30 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1823,7 +1823,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 31, 2018"
+              aria-label="31 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1979,7 +1979,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="January 1, 2019"
+              aria-label="1 January 2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -2117,7 +2117,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="January 2, 2019"
+              aria-label="2 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2241,7 +2241,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="January 3, 2019"
+              aria-label="3 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2365,7 +2365,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 4, 2019"
+              aria-label="4 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2473,7 +2473,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 5, 2019"
+              aria-label="5 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2581,7 +2581,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 6, 2019"
+              aria-label="6 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2689,7 +2689,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 7, 2019"
+              aria-label="7 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2797,7 +2797,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 8, 2019"
+              aria-label="8 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2905,7 +2905,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 9, 2019"
+              aria-label="9 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3013,7 +3013,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 10, 2019"
+              aria-label="10 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3791,7 +3791,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 23, 2018"
+              aria-label="23 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3903,7 +3903,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 24, 2018"
+              aria-label="24 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4015,7 +4015,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 25, 2018"
+              aria-label="25 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4127,7 +4127,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 26, 2018"
+              aria-label="26 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4239,7 +4239,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 27, 2018"
+              aria-label="27 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4351,7 +4351,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 28, 2018"
+              aria-label="28 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4463,7 +4463,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 29, 2018"
+              aria-label="29 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4596,7 +4596,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="December 30, 2018"
+              aria-label="30 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4724,7 +4724,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="December 31, 2018"
+              aria-label="31 December 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4880,7 +4880,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="January 1, 2019"
+              aria-label="1 January 2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -5018,7 +5018,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 2, 2019"
+              aria-label="2 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5142,7 +5142,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 3, 2019"
+              aria-label="3 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5266,7 +5266,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 4, 2019"
+              aria-label="4 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5390,7 +5390,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 5, 2019"
+              aria-label="5 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5514,7 +5514,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 6, 2019"
+              aria-label="6 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5622,7 +5622,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 7, 2019"
+              aria-label="7 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5730,7 +5730,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 8, 2019"
+              aria-label="8 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5838,7 +5838,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 9, 2019"
+              aria-label="9 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5946,7 +5946,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 10, 2019"
+              aria-label="10 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6054,7 +6054,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 11, 2019"
+              aria-label="11 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6162,7 +6162,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 12, 2019"
+              aria-label="12 January 2019"
               aria-readonly={true}
               aria-selected={false}
               className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16072 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Add date formatting function, formatDayMonthYear, intended to be used for better a11y in use cases where the user is
likely to repeatedly navigate among multiple dates.  For example, tapping the rt-arrow key to find a particular day.
- Use formatDayMonthYear to build aria-label in CalendarGridDayCell.
