### PR TITLE
(7.0)feat: add new property onRenderStar for Rating 

### DIFF
--- a/change/office-ui-fabric-react-2021-01-13-17-23-30-feat-rating-7.0.json
+++ b/change/office-ui-fabric-react-2021-01-13-17-23-30-feat-rating-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "(7.0)feat: add new property onRenderStar for Rating",
+  "packageName": "office-ui-fabric-react",
+  "email": "qiuya@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-13T09:23:30.977Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6899,12 +6899,29 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
     onChange?: (event: React.FocusEvent<HTMLElement>, rating?: number) => void;
     // @deprecated (undocumented)
     onChanged?: (rating: number) => void;
+    onRenderStar?: IRenderFunction<IRatingStarProps>;
     rating?: number;
     readOnly?: boolean;
     size?: RatingSize;
     styles?: IStyleFunctionOrObject<IRatingStyleProps, IRatingStyles>;
     theme?: ITheme;
     unselectedIcon?: string;
+}
+
+// @public (undocumented)
+export interface IRatingStarProps extends React.AllHTMLAttributes<HTMLElement> {
+    // (undocumented)
+    classNames: IProcessedStyleSet<IRatingStyles>;
+    // (undocumented)
+    disabled?: boolean;
+    // (undocumented)
+    fillPercentage: number;
+    // (undocumented)
+    icon?: string;
+    // (undocumented)
+    readOnly?: boolean;
+    // (undocumented)
+    starNum?: number;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -12,17 +12,9 @@ import {
 import { IProcessedStyleSet } from '../../Styling';
 import { Icon } from '../../Icon';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
-import { IRatingProps, RatingSize, IRatingStyleProps, IRatingStyles } from './Rating.types';
+import { IRatingProps, RatingSize, IRatingStyleProps, IRatingStyles, IRatingStarProps } from './Rating.types';
 
 const getClassNames = classNamesFunction<IRatingStyleProps, IRatingStyles>();
-
-interface IRatingStarProps extends React.AllHTMLAttributes<HTMLElement> {
-  fillPercentage: number;
-  disabled?: boolean;
-  readOnly?: boolean;
-  classNames: IProcessedStyleSet<IRatingStyles>;
-  icon?: string;
-}
 
 export interface IRatingState {
   rating: number | null | undefined;
@@ -86,6 +78,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       theme,
       icon = 'FavoriteStarFill',
       unselectedIcon = 'FavoriteStar',
+      onRenderStar,
     } = this.props;
 
     const id = this._id;
@@ -100,6 +93,9 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       theme: theme!,
     });
 
+    const renderStar = (starProps: IRatingStarProps, renderer?: IRatingProps['onRenderStar']) =>
+      renderer ? renderer(starProps) : <RatingStar key={starProps.starNum + 'rating'} {...starProps} />;
+
     for (let i = this._min as number; i <= (max as number); i++) {
       if (i !== 0) {
         const fillPercentage = this._getFillingPercentage(i);
@@ -108,6 +104,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
           disabled,
           classNames: this._classNames,
           icon: fillPercentage > 0 ? icon : unselectedIcon,
+          starNum: i,
         };
 
         starIds.push(this._getStarId(i - 1));
@@ -128,7 +125,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             type="button"
           >
             {this._getLabel(i)}
-            <RatingStar key={i + 'rating'} {...ratingStarProps} />
+            {renderStar(ratingStarProps, onRenderStar)}
           </button>,
         );
       }

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -1,11 +1,20 @@
 import * as React from 'react';
-import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IStyle, ITheme, IProcessedStyleSet } from '../../Styling';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * {@docCategory Rating}
  */
 export interface IRating {}
+
+export interface IRatingStarProps extends React.AllHTMLAttributes<HTMLElement> {
+  fillPercentage: number;
+  disabled?: boolean;
+  readOnly?: boolean;
+  classNames: IProcessedStyleSet<IRatingStyles>;
+  icon?: string;
+  starNum?: number;
+}
 
 /**
  * Rating component props.
@@ -50,6 +59,11 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
    * @defaultvalue FavoriteStar
    */
   unselectedIcon?: string;
+
+  /**
+   * Optional custom renderer for the star component.
+   */
+  onRenderStar?: IRenderFunction<IRatingStarProps>;
 
   /**
    * Size of rating, defaults to small


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a new property `onRenderStart` to customize star renderring.

#### Focus areas to test

(optional)
It's a cherry-pick of this PR: https://github.com/microsoft/fluentui/pull/15994