### PR TITLE
fix(react-examples): Add tooltips to DetailsList documents example

### DIFF
--- a/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
@@ -96,7 +96,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
         maxWidth: 16,
         onColumnClick: this._onColumnClick,
         onRender: (item: IDocument) => (
-          <TooltipHost content={`${item.fileType} file`} id={`file-type-tooltip-${item.key}`}>
+          <TooltipHost content={`${item.fileType} file`}>
             <img src={item.iconName} className={classNames.fileIconImg} alt={`${item.fileType} file icon`} />
           </TooltipHost>
         ),

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
@@ -6,6 +6,7 @@ import { Announced } from '@fluentui/react/lib/Announced';
 import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
+import { TooltipHost } from '@fluentui/react';
 
 const classNames = mergeStyleSets({
   fileIconHeaderIcon: {
@@ -94,9 +95,11 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
         minWidth: 16,
         maxWidth: 16,
         onColumnClick: this._onColumnClick,
-        onRender: (item: IDocument) => {
-          return <img src={item.iconName} className={classNames.fileIconImg} alt={item.fileType + ' file icon'} />;
-        },
+        onRender: (item: IDocument) => (
+          <TooltipHost content={`${item.fileType} file`} id={`file-type-tooltip-${item.key}`}>
+            <img src={item.iconName} className={classNames.fileIconImg} alt={`${item.fileType} file icon`} />
+          </TooltipHost>
+        ),
       },
       {
         key: 'column2',

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1536,17 +1536,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -1765,7 +1778,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone9"
+                        data-focuszone-id="FocusZone10"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
@@ -1856,17 +1869,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -2085,7 +2111,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone10"
+                        data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
@@ -2176,17 +2202,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -2405,7 +2444,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone11"
+                        data-focuszone-id="FocusZone14"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
@@ -2496,17 +2535,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -2725,7 +2777,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone12"
+                        data-focuszone-id="FocusZone16"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
@@ -2816,17 +2868,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -3045,7 +3110,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone13"
+                        data-focuszone-id="FocusZone18"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
@@ -3136,17 +3201,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -3365,7 +3443,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone14"
+                        data-focuszone-id="FocusZone20"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
@@ -3456,17 +3534,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -3685,7 +3776,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone15"
+                        data-focuszone-id="FocusZone22"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
@@ -3776,17 +3867,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -4005,7 +4109,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone16"
+                        data-focuszone-id="FocusZone24"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
@@ -4096,17 +4200,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}
@@ -4325,7 +4442,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone17"
+                        data-focuszone-id="FocusZone26"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
@@ -4416,17 +4533,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             }
                           >
-                            <img
-                              alt="accdb file icon"
+                            <div
                               className=
-
+                                  ms-TooltipHost
                                   {
-                                    max-height: 16px;
-                                    max-width: 16px;
-                                    vertical-align: middle;
+                                    display: inline;
                                   }
-                              src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
-                            />
+                              onBlurCapture={[Function]}
+                              onFocusCapture={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <img
+                                alt="accdb file icon"
+                                className=
+
+                                    {
+                                      max-height: 16px;
+                                      max-width: 16px;
+                                      vertical-align: middle;
+                                    }
+                                src="https://static2.sharepointonline.com/files/fabric/assets/item-types/16/accdb.svg"
+                              />
+                            </div>
                           </div>
                           <div
                             aria-colindex={2}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [microsoftdesign/fluentui#10255](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10255)
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Add missing tooltip to the file icons in the DetailsList with documents example. Also added an `alt` to the image itself.