### PR TITLE
RadioGroup visual polish 

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -73,6 +73,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix missing focus styles for carousel paddle @assuncaocharles ([#16460](https://github.com/microsoft/fluentui/pull/16460))
 - Do not add `aria-expanded="true"` for `trigger` slot when `MenuButton` has `contextMenu` @pompomon ([#16442](https://github.com/microsoft/fluentui/pull/16442))
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))
+- Fix RadioGroup visual issues. Add `RadioButtonIcon`. Fix vertical RadioGroup alignment issue with custom content. Fix focus frame alignment for bare indicator. @TanelVari ([#16478](https://github.com/microsoft/fluentui/pull/16478))
 
 ### Features
 - Add 2.0 light and dark themes @jurokapsiar ([#15867](https://github.com/microsoft/fluentui/pull/15867))

--- a/packages/fluentui/react-icons-northstar/src/components/RadioButtonIcon.tsx
+++ b/packages/fluentui/react-icons-northstar/src/components/RadioButtonIcon.tsx
@@ -1,0 +1,21 @@
+// This is Fluent-style icon
+import * as React from 'react';
+import cx from 'classnames';
+import { createSvgIcon } from '../utils/createSvgIcon';
+import { iconClassNames } from '../utils/iconClassNames';
+
+export const RadioButtonIcon = createSvgIcon({
+  svg: ({ classes }) => (
+    <svg role="presentation" focusable="false" viewBox="0 0 16 16" className={classes.svg}>
+      <path
+        className={cx(iconClassNames.outline, classes.outlinePart)}
+        d="M8,1A7,7,0,1,1,1,8,7.008,7.008,0,0,1,8,1M8,0a8,8,0,1,0,8,8A8,8,0,0,0,8,0Z"
+      />
+      <g className={cx(iconClassNames.filled, classes.filledPart)}>
+        <path d="M8,1A7,7,0,1,1,1,8,7.008,7.008,0,0,1,8,1M8,0a8,8,0,1,0,8,8A8,8,0,0,0,8,0Z" />
+        <circle cx="8" cy="8" r="5" />
+      </g>
+    </svg>
+  ),
+  displayName: 'RadioButtonIcon',
+});

--- a/packages/fluentui/react-icons-northstar/src/index.ts
+++ b/packages/fluentui/react-icons-northstar/src/index.ts
@@ -185,6 +185,7 @@ export { PresenterIcon } from './components/PresenterIcon';
 export { QnaIcon } from './components/QnaIcon';
 export { QuestionCircleIcon } from './components/QuestionCircleIcon';
 export { QuoteIcon } from './components/QuoteIcon';
+export { RadioButtonIcon } from './components/RadioButtonIcon';
 export { ReadAloudIcon } from './components/ReadAloudIcon';
 export { RaiseHandColoredIcon } from './components/RaiseHandColoredIcon';
 export { RaiseHandDisabledIcon } from './components/RaiseHandDisabledIcon';

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
@@ -52,7 +52,7 @@ export interface RadioGroupProps extends UIComponentProps, ChildrenComponentProp
 
 export const radioGroupClassName = 'ui-radiogroup';
 
-export type RadioGrouptStylesProps = never;
+export type RadioGroupStylesProps = Required<Pick<RadioGroupProps, 'vertical'>>;
 
 /**
  * A RadioGroup allows user to select a value from a small set of mutually exclusive options.
@@ -83,8 +83,11 @@ export const RadioGroup: ComponentWithAs<'div', RadioGroupProps> &
     rtl: context.rtl,
   });
 
-  const { classes } = useStyles<RadioGrouptStylesProps>(RadioGroup.displayName, {
+  const { classes } = useStyles<RadioGroupStylesProps>(RadioGroup.displayName, {
     className: radioGroupClassName,
+    mapPropsToStyles: () => ({
+      vertical,
+    }),
     mapPropsToInlineStyles: () => ({
       className,
       design,

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -27,6 +27,7 @@ import { RadioButtonIcon } from '@fluentui/react-icons-northstar';
 
 export interface RadioGroupItemSlotClassNames {
   indicator: string;
+  label: string;
 }
 
 export interface RadioGroupItemProps extends UIComponentProps, ChildrenComponentProps {
@@ -81,6 +82,7 @@ export interface RadioGroupItemProps extends UIComponentProps, ChildrenComponent
 export const radioGroupItemClassName = 'ui-radiogroup__item';
 export const radioGroupItemSlotClassNames: RadioGroupItemSlotClassNames = {
   indicator: `${radioGroupItemClassName}__indicator`,
+  label: `${radioGroupItemClassName}__label`,
 };
 
 export type RadioGroupItemStylesProps = Required<Pick<RadioGroupItemProps, 'disabled' | 'vertical' | 'checked'>>;
@@ -198,6 +200,8 @@ export const RadioGroupItem: ComponentWithAs<'div', RadioGroupItemProps> &
         {Box.create(label, {
           defaultProps: () => ({
             as: 'span',
+            className: radioGroupItemSlotClassNames.label,
+            styles: resolvedStyles.label,
           }),
         })}
       </ElementType>

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -23,7 +23,7 @@ import {
   useTelemetry,
   useUnhandledProps,
 } from '@fluentui/react-bindings';
-import { CircleIcon } from '@fluentui/react-icons-northstar';
+import { RadioButtonIcon } from '@fluentui/react-icons-northstar';
 
 export interface RadioGroupItemSlotClassNames {
   indicator: string;
@@ -229,8 +229,8 @@ RadioGroupItem.propTypes = {
 
 RadioGroupItem.defaultProps = {
   accessibility: radioGroupItemBehavior,
-  indicator: <CircleIcon outline size="small" />,
-  checkedIndicator: <CircleIcon size="small" />,
+  indicator: <RadioButtonIcon outline />,
+  checkedIndicator: <RadioButtonIcon />,
 };
 
 RadioGroupItem.handledProps = Object.keys(RadioGroupItem.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -101,6 +101,7 @@ export { popupContentStyles as PopupContent } from './components/Popup/popupCont
 
 export { providerStyles as Provider } from './components/Provider/providerStyles';
 
+export { radioGroupStyles as RadioGroup } from './components/RadioGroup/radioGroupStyles';
 export { radioGroupItemStyles as RadioGroupItem } from './components/RadioGroup/radioGroupItemStyles';
 
 export { segmentStyles as Segment } from './components/Segment/segmentStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -32,6 +32,7 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
     display: p.vertical ? 'flex' : 'inline-flex',
     fontSize: v.textFontSize,
     padding: v.padding,
+    margin: v.margin,
 
     ':hover': {
       color: v.textColorDefaultHoverFocus,
@@ -58,16 +59,11 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
       ...restHoverFocusTextColor(v.colorDisabled),
     }),
 
-    ...(p.vertical && {
-      marginTop: `${pxToRem(5)}`,
-      marginBottom: `${pxToRem(5)}`,
-    }),
-
     ...getBorderFocusStyles({ variables: siteVariables }),
   }),
 
   indicator: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    margin: `${pxToRem(2)} 0 ${pxToRem(2)} ${pxToRem(2)}`,
+    margin: `${pxToRem(2)} 0`,
     outline: 0,
     display: 'flex',
     alignItems: 'center',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -67,7 +67,7 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
   }),
 
   indicator: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    margin: `${pxToRem(2)}`,
+    margin: `${pxToRem(2)} 0 ${pxToRem(2)} ${pxToRem(2)}`,
     outline: 0,
     display: 'flex',
     alignItems: 'center',
@@ -87,6 +87,6 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
   }),
 
   label: (): ICSSInJSStyle => ({
-    margin: `0 0 0 ${pxToRem(10)}`,
+    margin: `0 0 0 ${pxToRem(12)}`,
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -67,13 +67,13 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
   }),
 
   indicator: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    margin: `0 ${pxToRem(12)} 0 0`,
+    margin: `${pxToRem(2)}`,
     outline: 0,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: pxToRem(12),
-    height: pxToRem(12),
+    width: pxToRem(16),
+    height: pxToRem(16),
     verticalAlign: 'midddle',
     color: v.indicatorColorDefault,
 
@@ -84,5 +84,9 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
     ...(p.disabled && {
       color: v.colorDisabled,
     }),
+  }),
+
+  label: (): ICSSInJSStyle => ({
+    margin: `0 0 0 ${pxToRem(10)}`,
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -58,6 +58,11 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
       ...restHoverFocusTextColor(v.colorDisabled),
     }),
 
+    ...(p.vertical && {
+      marginTop: `${pxToRem(5)}`,
+      marginBottom: `${pxToRem(5)}`,
+    }),
+
     ...getBorderFocusStyles({ variables: siteVariables }),
   }),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
@@ -16,6 +16,7 @@ export type RadioGroupItemVariables = {
   indicatorBackgroundColorChecked: string;
 
   padding: string;
+  margin: string;
 };
 
 export const radioGroupItemVariables = (siteVars: any): RadioGroupItemVariables => ({
@@ -33,5 +34,6 @@ export const radioGroupItemVariables = (siteVars: any): RadioGroupItemVariables 
 
   indicatorBackgroundColorChecked: siteVars.colors.brand[600],
 
-  padding: `0 ${pxToRem(4)} 0 ${pxToRem(2)}`,
+  padding: `0 ${pxToRem(2)}`,
+  margin: `${pxToRem(5)} ${pxToRem(8)} ${pxToRem(5)} ${pxToRem(2)}`,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemVariables.ts
@@ -33,5 +33,5 @@ export const radioGroupItemVariables = (siteVars: any): RadioGroupItemVariables 
 
   indicatorBackgroundColorChecked: siteVars.colors.brand[600],
 
-  padding: `0 ${pxToRem(4)}`,
+  padding: `0 ${pxToRem(4)} 0 ${pxToRem(2)}`,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupStyles.ts
@@ -1,0 +1,9 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { RadioGroupStylesProps } from '../../../../components/RadioGroup/RadioGroup';
+
+export const radioGroupStyles: ComponentSlotStylesPrepared<RadioGroupStylesProps> = {
+  root: ({ props: p }): ICSSInJSStyle => ({
+    display: 'flex',
+    flexDirection: p.vertical ? 'column' : 'row',
+  }),
+};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

- Added RadioButtonIcon from Fluent library which is used as a radio button indicator
- Fixed vertical RadioGroup aligment issues with custom content (Input)
- Fixed focus frame alignment for bare indicator 
