### PR TITLE
chore: update projects-test build script

### DIFF
--- a/packages/fluentui/projects-test/package.json
+++ b/packages/fluentui/projects-test/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --noEmit",
+    "build": "gulp bundle:package:no-umd",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
     "test": "node -r @fluentui/scripts/babel/register src/index.ts"

--- a/packages/fluentui/projects-test/tsconfig.json
+++ b/packages/fluentui/projects-test/tsconfig.json
@@ -4,7 +4,15 @@
     "allowSyntheticDefaultImports": true,
     "module": "esnext",
     "types": ["node"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist/dts",
+    "noEmit": true,
+    "composite": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../react-northstar"
+    }
+  ]
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The `yarn build:prod` script in the workspace does `npm run build -- --production` to the workspace. 
This cause problem with @fluentui/projects-test. Because it uses `tsc` as build script, which doesn't play well with `--production`. The build will fail with 
>unknown compiler option "—production"

#### Focus areas to test

(optional)
