### PR TITLE
fix(react-examples): Add labels to Icon examples

### DIFF
--- a/packages/react-examples/src/react/Icon/Icon.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Basic.Example.tsx
@@ -12,6 +12,8 @@ const iconClass = mergeStyles({
 export const IconBasicExample: React.FunctionComponent = () => {
   // FontIcon is an optimized variant of standard Icon.
   // You could also use the standard Icon here.
+  // Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by text
+  // that conveys the same meaning.
   return (
     <div>
       <FontIcon aria-label="Compass icon" role="img" iconName="CompassNW" className={iconClass} />

--- a/packages/react-examples/src/react/Icon/Icon.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Basic.Example.tsx
@@ -14,9 +14,9 @@ export const IconBasicExample: React.FunctionComponent = () => {
   // You could also use the standard Icon here.
   return (
     <div>
-      <FontIcon iconName="CompassNW" className={iconClass} />
-      <FontIcon iconName="Dictionary" className={iconClass} />
-      <FontIcon iconName="TrainSolid" className={iconClass} />
+      <FontIcon aria-label="Compass icon" role="img" iconName="CompassNW" className={iconClass} />
+      <FontIcon aria-label="Dictionary icon" role="img" iconName="Dictionary" className={iconClass} />
+      <FontIcon aria-label="Train icon" role="img" iconName="TrainSolid" className={iconClass} />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Icon/Icon.Color.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Color.Example.tsx
@@ -19,9 +19,9 @@ export const IconColorExample: React.FunctionComponent = () => {
   // You could also use the standard Icon here.
   return (
     <div>
-      <FontIcon iconName="CompassNW" className={classNames.deepSkyBlue} />
-      <FontIcon iconName="Dictionary" className={classNames.greenYellow} />
-      <FontIcon iconName="TrainSolid" className={classNames.salmon} />
+      <FontIcon aria-label="Compass icon" role="img" iconName="CompassNW" className={classNames.deepSkyBlue} />
+      <FontIcon aria-label="Dictionary icon" role="img" iconName="Dictionary" className={classNames.greenYellow} />
+      <FontIcon aria-label="Train icon" role="img" iconName="TrainSolid" className={classNames.salmon} />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Icon/Icon.Color.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Color.Example.tsx
@@ -17,6 +17,8 @@ const classNames = mergeStyleSets({
 export const IconColorExample: React.FunctionComponent = () => {
   // FontIcon is an optimized variant of standard Icon.
   // You could also use the standard Icon here.
+  // Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by text
+  // that conveys the same meaning.
   return (
     <div>
       <FontIcon aria-label="Compass icon" role="img" iconName="CompassNW" className={classNames.deepSkyBlue} />

--- a/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
@@ -41,6 +41,8 @@ const classNames = mergeStyleSets({
 export const IconImageSheetExample: React.FunctionComponent = () => {
   // ImageIcon is an optimized variant of standard Icon.
   // You could also use the standard Icon here (adding the prop `iconType={IconType.image}`).
+  // Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by text
+  // that conveys the same meaning.
   return (
     <div>
       <ImageIcon

--- a/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
@@ -33,7 +33,7 @@ const classNames = mergeStyleSets({
     marginLeft: 65,
   },
   lockImage: {
-    width: -109,
+    left: -109,
     top: -5,
   },
 });
@@ -62,7 +62,7 @@ export const IconImageSheetExample: React.FunctionComponent = () => {
         }}
       />
       <ImageIcon
-        aria-label="OneNote file icon"
+        aria-label="Lock icon"
         role="img"
         className={classNames.lock}
         imageProps={{

--- a/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.ImageSheet.Example.tsx
@@ -44,6 +44,8 @@ export const IconImageSheetExample: React.FunctionComponent = () => {
   return (
     <div>
       <ImageIcon
+        aria-label="OneNote file icon"
+        role="img"
         className={classNames.one}
         imageProps={{
           src: TestImages.iconOne,
@@ -51,6 +53,8 @@ export const IconImageSheetExample: React.FunctionComponent = () => {
         }}
       />
       <ImageIcon
+        aria-label="Check icon"
+        role="img"
         className={classNames.check}
         imageProps={{
           src: TestImages.iconOne,
@@ -58,6 +62,8 @@ export const IconImageSheetExample: React.FunctionComponent = () => {
         }}
       />
       <ImageIcon
+        aria-label="OneNote file icon"
+        role="img"
         className={classNames.lock}
         imageProps={{
           src: TestImages.iconOne,

--- a/packages/react-examples/src/react/Icon/Icon.Svg.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Svg.Example.tsx
@@ -45,6 +45,8 @@ const BorderBlindsIcon: React.FunctionComponent<{ color1?: string; color2?: stri
 
   // FontIcon is an optimized variant of standard Icon.
   // You could also use the standard Icon here.
+  // Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by text
+  // that conveys the same meaning.
   return (
     <FontIcon
       aria-label="Map icon"

--- a/packages/react-examples/src/react/Icon/Icon.Svg.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.Svg.Example.tsx
@@ -47,6 +47,8 @@ const BorderBlindsIcon: React.FunctionComponent<{ color1?: string; color2?: stri
   // You could also use the standard Icon here.
   return (
     <FontIcon
+      aria-label="Map icon"
+      role="img"
       iconName="borderblinds-svg"
       className={mergeStyles(iconClass, {
         width: 50,
@@ -72,8 +74,10 @@ export const IconSvgExample: React.FunctionComponent = () => {
   // You could also use the standard Icon here.
   return (
     <div>
-      <FontIcon iconName="onedrive-svg" className={iconClass} />
+      <FontIcon aria-label="OneDrive logo" role="img" iconName="onedrive-svg" className={iconClass} />
       <FontIcon
+        aria-label="Yammer logo"
+        role="img"
         iconName="yammer-svg"
         className={mergeStyles(iconClass, {
           fill: 'red',

--- a/packages/react-examples/src/react/Icon/Icon.SvgFactory.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.SvgFactory.Example.tsx
@@ -69,6 +69,10 @@ export const IconSvgFactoryExample: React.FunctionComponent = () => {
           .slice((page - 1) * 100, (page - 1) * 100 + 100)
           .map((Icon: React.FunctionComponent<ReactIcons.ISvgIconProps>) => (
             <div key={Icon.displayName} className={classes.cell}>
+              {/*
+                Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by
+                text that conveys the same meaning.
+              */}
               <Icon aria-label={Icon.displayName} role="img" className={classes.icon} />
               <br />
               <code className={classes.code}>{Icon.displayName}</code>

--- a/packages/react-examples/src/react/Icon/Icon.SvgFactory.Example.tsx
+++ b/packages/react-examples/src/react/Icon/Icon.SvgFactory.Example.tsx
@@ -69,7 +69,7 @@ export const IconSvgFactoryExample: React.FunctionComponent = () => {
           .slice((page - 1) * 100, (page - 1) * 100 + 100)
           .map((Icon: React.FunctionComponent<ReactIcons.ISvgIconProps>) => (
             <div key={Icon.displayName} className={classes.cell}>
-              <Icon className={classes.icon} />
+              <Icon aria-label={Icon.displayName} role="img" className={classes.icon} />
               <br />
               <code className={classes.code}>{Icon.displayName}</code>
             </div>

--- a/packages/react-examples/src/react/Icon/docs/IconDos.md
+++ b/packages/react-examples/src/react/Icon/docs/IconDos.md
@@ -1,2 +1,3 @@
 - Adjust to proper size to highlight importance but not occupying too much space.
 - Be simple and concise.
+- Provide an `aria-label` (and set `role="img"`) for screen reader users if the icon is not accompanied by text that conveys the same meaning.

--- a/packages/react-examples/src/react/__snapshots__/Icon.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.Basic.Example.tsx.shot
@@ -3,7 +3,7 @@
 exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
 <div>
   <i
-    aria-hidden={true}
+    aria-label="Compass icon"
     className=
         ms-Icon
         {
@@ -27,7 +27,7 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="CompassNW"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-2\\"",
@@ -37,7 +37,7 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
     
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Dictionary icon"
     className=
         ms-Icon
         {
@@ -61,7 +61,7 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="Dictionary"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-1\\"",
@@ -71,7 +71,7 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
     
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Train icon"
     className=
         ms-Icon
         {
@@ -95,7 +95,7 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="TrainSolid"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-4\\"",

--- a/packages/react-examples/src/react/__snapshots__/Icon.Color.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.Color.Example.tsx.shot
@@ -3,7 +3,7 @@
 exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
 <div>
   <i
-    aria-hidden={true}
+    aria-label="Compass icon"
     className=
         ms-Icon
         {
@@ -28,7 +28,7 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="CompassNW"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-2\\"",
@@ -38,7 +38,7 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
     
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Dictionary icon"
     className=
         ms-Icon
         {
@@ -63,7 +63,7 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="Dictionary"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-1\\"",
@@ -73,7 +73,7 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
     
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Train icon"
     className=
         ms-Icon
         {
@@ -98,7 +98,7 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="TrainSolid"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": "\\"FabricMDL2Icons-4\\"",

--- a/packages/react-examples/src/react/__snapshots__/Icon.ImageSheet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.ImageSheet.Example.tsx.shot
@@ -115,7 +115,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    aria-label="OneNote file icon"
+    aria-label="Lock icon"
     className=
         ms-Icon
         ms-Icon-imageContainer
@@ -142,10 +142,10 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
+            left: -109px;
             overflow: hidden;
             position: relative;
             top: -5px;
-            width: -109px;
           }
       style={
         Object {

--- a/packages/react-examples/src/react/__snapshots__/Icon.ImageSheet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.ImageSheet.Example.tsx.shot
@@ -3,7 +3,7 @@
 exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = `
 <div>
   <div
-    aria-hidden={true}
+    aria-label="OneNote file icon"
     className=
         ms-Icon
         ms-Icon-imageContainer
@@ -18,7 +18,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
           margin-left: 27px;
           width: 48px;
         }
-    role="presentation"
+    role="img"
   >
     <div
       className=
@@ -59,7 +59,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    aria-hidden={true}
+    aria-label="Check icon"
     className=
         ms-Icon
         ms-Icon-imageContainer
@@ -74,7 +74,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
           margin-left: 55px;
           width: 35px;
         }
-    role="presentation"
+    role="img"
   >
     <div
       className=
@@ -115,7 +115,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    aria-hidden={true}
+    aria-label="OneNote file icon"
     className=
         ms-Icon
         ms-Icon-imageContainer
@@ -130,7 +130,7 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
           margin-left: 65px;
           width: 35px;
         }
-    role="presentation"
+    role="img"
   >
     <div
       className=

--- a/packages/react-examples/src/react/__snapshots__/Icon.Svg.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.Svg.Example.tsx.shot
@@ -3,7 +3,7 @@
 exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
 <div>
   <i
-    aria-hidden={true}
+    aria-label="OneDrive logo"
     className=
         ms-Icon
         {
@@ -19,7 +19,7 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
           width: 50px;
         }
     data-icon-name="onedrive-svg"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": undefined,
@@ -40,7 +40,7 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
     </svg>
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Yammer logo"
     className=
         ms-Icon
         {
@@ -60,7 +60,7 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
           fill: green;
         }
     data-icon-name="yammer-svg"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": undefined,
@@ -81,7 +81,7 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
     </svg>
   </i>
   <i
-    aria-hidden={true}
+    aria-label="Map icon"
     className=
         ms-Icon
         {
@@ -106,7 +106,7 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
           fill: pink;
         }
     data-icon-name="borderblinds-svg"
-    role="presentation"
+    role="img"
     style={
       Object {
         "fontFamily": undefined,

--- a/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
@@ -290,59 +290,6 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AADLogoIcon"
-        className=
-
-            {
-              font-size: 50px;
-            }
-        role="img"
-        style={Object {}}
-      >
-        <svg
-          viewBox="0 0 2048 2048"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-<<<<<<< HEAD
-=======
-            d="M2048 1310l-1024 598L0 1310 1024 140l1024 1170zm-526 60q30 0 57-11t46-31 31-47 12-57q0-30-11-56t-32-46-46-31-57-12q-32 0-62 14l-314-359q23-35 23-79 0-30-11-56t-31-46-46-31-57-12q-30 0-56 11t-47 31-31 46-12 57q0 21 6 41t18 38l-314 359q-30-14-62-14-30 0-56 11t-47 31-31 46-12 57q0 30 11 57t31 46 47 31 57 12q28 0 54-10t46-31l257 150q-5 20-5 36 0 30 11 56t32 47 46 31 57 12q30 0 56-11t47-32 31-46 12-57q0-16-5-36l256-150q20 20 46 30t55 11zM962 787l10 4q5 2 12 4v580q-35 11-61 35l-257-150q5-20 5-36 0-44-23-79l314-358zm438 358q-23 35-23 79 0 20 4 36l-256 150q-26-24-61-35V795q6-2 11-4t11-4l314 358z"
-          />
-        </svg>
-      </span>
-      <br />
-      <code
-        className=
-
-            {
-              background: #f2f2f2;
-              border-radius: 4px;
-              padding-bottom: 4px;
-              padding-left: 4px;
-              padding-right: 4px;
-              padding-top: 4px;
-            }
-      >
-        AADLogoIcon
-      </code>
-    </div>
-    <div
-      className=
-
-          {
-            align-items: center;
-            display: flex;
-            flex-direction: column;
-            float: left;
-            height: 50px;
-            margin-bottom: 80px;
-            margin-left: 80px;
-            margin-right: 80px;
-            margin-top: 80px;
-            width: 50px;
-          }
-    >
-      <span
         aria-label="AcceptIcon"
         className=
 
@@ -357,7 +304,6 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
->>>>>>> 4a0e2d340c (fix(react-examples): Add labels to Icon examples)
             d="M640 1755L19 1133l90-90 531 530L1939 275l90 90L640 1755z"
           />
         </svg>
@@ -1874,7 +1820,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminALogo32Icon"
+        aria-label="AirplaneIcon"
         className=
 
             {
@@ -1925,7 +1871,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminALogoFill32Icon"
+        aria-label="AirplaneSolidIcon"
         className=
 
             {
@@ -1976,7 +1922,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminALogoInverse32Icon"
+        aria-label="AirTicketsIcon"
         className=
 
             {
@@ -2027,7 +1973,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminCLogoInverse32Icon"
+        aria-label="AlarmClockIcon"
         className=
 
             {
@@ -2078,7 +2024,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminDLogoInverse32Icon"
+        aria-label="AlbumIcon"
         className=
 
             {
@@ -2129,7 +2075,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminELogoInverse32Icon"
+        aria-label="AlbumRemoveIcon"
         className=
 
             {
@@ -2180,7 +2126,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminIcon"
+        aria-label="AlertSettingsIcon"
         className=
 
             {
@@ -2231,7 +2177,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminLLogoInverse32Icon"
+        aria-label="AlertSolidIcon"
         className=
 
             {
@@ -2282,7 +2228,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminMLogoInverse32Icon"
+        aria-label="AlignCenterIcon"
         className=
 
             {
@@ -2333,7 +2279,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminOLogoInverse32Icon"
+        aria-label="AlignHorizontalCenterIcon"
         className=
 
             {
@@ -2384,7 +2330,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminPLogoInverse32Icon"
+        aria-label="AlignHorizontalLeftIcon"
         className=
 
             {
@@ -2435,7 +2381,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminSLogoInverse32Icon"
+        aria-label="AlignHorizontalRightIcon"
         className=
 
             {
@@ -2486,7 +2432,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AdminYLogoInverse32Icon"
+        aria-label="AlignJustifyIcon"
         className=
 
             {
@@ -2537,7 +2483,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AirplaneIcon"
+        aria-label="AlignLeftIcon"
         className=
 
             {
@@ -2588,7 +2534,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AirplaneSolidIcon"
+        aria-label="AlignRightIcon"
         className=
 
             {
@@ -2639,7 +2585,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AirTicketsIcon"
+        aria-label="AlignVerticalBottomIcon"
         className=
 
             {
@@ -2690,7 +2636,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlarmClockIcon"
+        aria-label="AlignVerticalCenterIcon"
         className=
 
             {
@@ -2741,7 +2687,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlbumIcon"
+        aria-label="AlignVerticalTopIcon"
         className=
 
             {
@@ -2792,7 +2738,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlbumRemoveIcon"
+        aria-label="AllAppsIcon"
         className=
 
             {
@@ -2843,7 +2789,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlertSettingsIcon"
+        aria-label="AllAppsMirroredIcon"
         className=
 
             {
@@ -2894,7 +2840,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlertSolidIcon"
+        aria-label="AllCurrencyIcon"
         className=
 
             {
@@ -2945,7 +2891,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignCenterIcon"
+        aria-label="AltTextIcon"
         className=
 
             {
@@ -2996,7 +2942,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignHorizontalCenterIcon"
+        aria-label="AmazonWebServicesLogoIcon"
         className=
 
             {
@@ -3047,7 +2993,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignHorizontalLeftIcon"
+        aria-label="AnalyticsQueryIcon"
         className=
 
             {
@@ -3098,7 +3044,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignHorizontalRightIcon"
+        aria-label="AnalyticsReportIcon"
         className=
 
             {
@@ -3149,7 +3095,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignJustifyIcon"
+        aria-label="AnalyticsViewIcon"
         className=
 
             {
@@ -3200,7 +3146,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignLeftIcon"
+        aria-label="AnchorLockIcon"
         className=
 
             {
@@ -3251,7 +3197,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignRightIcon"
+        aria-label="AndroidLogoIcon"
         className=
 
             {
@@ -3302,7 +3248,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignVerticalBottomIcon"
+        aria-label="AnnotationIcon"
         className=
 
             {
@@ -3353,7 +3299,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignVerticalCenterIcon"
+        aria-label="ApacheIvyLogo32Icon"
         className=
 
             {
@@ -3404,7 +3350,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AlignVerticalTopIcon"
+        aria-label="ApacheMavenLogoIcon"
         className=
 
             {
@@ -3455,7 +3401,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AllAppsIcon"
+        aria-label="ArchiveIcon"
         className=
 
             {
@@ -3506,7 +3452,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AllAppsMirroredIcon"
+        aria-label="ArchiveUndoIcon"
         className=
 
             {
@@ -3557,7 +3503,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AllCurrencyIcon"
+        aria-label="AreaChartIcon"
         className=
 
             {
@@ -3608,7 +3554,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AltTextIcon"
+        aria-label="ArrangeBringForwardIcon"
         className=
 
             {
@@ -3659,7 +3605,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AmazonWebServicesLogoIcon"
+        aria-label="ArrangeBringToFrontIcon"
         className=
 
             {
@@ -3710,7 +3656,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnalyticsLogoIcon"
+        aria-label="ArrangeByFromIcon"
         className=
 
             {
@@ -3761,7 +3707,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnalyticsQueryIcon"
+        aria-label="ArrangeSendBackwardIcon"
         className=
 
             {
@@ -3812,7 +3758,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnalyticsReportIcon"
+        aria-label="ArrangeSendToBackIcon"
         className=
 
             {
@@ -3863,7 +3809,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnalyticsViewIcon"
+        aria-label="ArrivalsIcon"
         className=
 
             {
@@ -3914,7 +3860,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnchorLockIcon"
+        aria-label="ArrowDownRight8Icon"
         className=
 
             {
@@ -3965,7 +3911,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AndroidLogoIcon"
+        aria-label="ArrowDownRightMirrored8Icon"
         className=
 
             {
@@ -4016,7 +3962,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AnnotationIcon"
+        aria-label="ArrowTallDownLeftIcon"
         className=
 
             {
@@ -4067,7 +4013,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ApacheIvyLogo32Icon"
+        aria-label="ArrowTallDownRightIcon"
         className=
 
             {
@@ -4118,7 +4064,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ApacheMavenLogoIcon"
+        aria-label="ArrowTallUpLeftIcon"
         className=
 
             {
@@ -4169,7 +4115,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AppIconDefaultAddIcon"
+        aria-label="ArrowTallUpRightIcon"
         className=
 
             {
@@ -4220,7 +4166,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AppIconDefaultIcon"
+        aria-label="ArrowUpRight8Icon"
         className=
 
             {
@@ -4271,7 +4217,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AppIconDefaultListIcon"
+        aria-label="ArrowUpRightIcon"
         className=
 
             {
@@ -4322,7 +4268,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArchiveIcon"
+        aria-label="ArrowUpRightMirrored8Icon"
         className=
 
             {
@@ -4373,7 +4319,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArchiveUndoIcon"
+        aria-label="ArticlesIcon"
         className=
 
             {
@@ -4424,7 +4370,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AreaChartIcon"
+        aria-label="AscendingIcon"
         className=
 
             {
@@ -4475,7 +4421,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrangeBringForwardIcon"
+        aria-label="AspectRatioIcon"
         className=
 
             {
@@ -4526,7 +4472,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrangeBringToFrontIcon"
+        aria-label="AssessmentGroupIcon"
         className=
 
             {
@@ -4577,7 +4523,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrangeByFromIcon"
+        aria-label="AssessmentGroupTemplateIcon"
         className=
 
             {
@@ -4628,7 +4574,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrangeSendBackwardIcon"
+        aria-label="AssetLibraryIcon"
         className=
 
             {
@@ -4679,7 +4625,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrangeSendToBackIcon"
+        aria-label="AssignIcon"
         className=
 
             {
@@ -4730,7 +4676,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrivalsIcon"
+        aria-label="AssignPolicyIcon"
         className=
 
             {
@@ -4781,7 +4727,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowDownRight8Icon"
+        aria-label="AsteriskIcon"
         className=
 
             {
@@ -4832,7 +4778,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowDownRightMirrored8Icon"
+        aria-label="AsteriskSolidIcon"
         className=
 
             {
@@ -4883,7 +4829,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowTallDownLeftIcon"
+        aria-label="AttachIcon"
         className=
 
             {
@@ -4934,7 +4880,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowTallDownRightIcon"
+        aria-label="AustralianRulesIcon"
         className=
 
             {
@@ -4985,7 +4931,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowTallUpLeftIcon"
+        aria-label="AutoDeploySettingsIcon"
         className=
 
             {
@@ -5036,7 +4982,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowTallUpRightIcon"
+        aria-label="AutoEnhanceOffIcon"
         className=
 
             {
@@ -5087,7 +5033,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowUpRight8Icon"
+        aria-label="AutoEnhanceOnIcon"
         className=
 
             {
@@ -5138,7 +5084,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowUpRightIcon"
+        aria-label="AutoFillTemplateIcon"
         className=
 
             {
@@ -5189,7 +5135,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArrowUpRightMirrored8Icon"
+        aria-label="AutoFitContentsIcon"
         className=
 
             {
@@ -5240,7 +5186,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="ArticlesIcon"
+        aria-label="AutoFitWindowIcon"
         className=
 
             {
@@ -5291,7 +5237,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AscendingIcon"
+        aria-label="AutoHeightIcon"
         className=
 
             {
@@ -5342,7 +5288,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-label="AspectRatioIcon"
+        aria-label="AutomateFlowIcon"
         className=
 
             {
@@ -5393,13 +5339,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AutoRacingIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg

--- a/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
@@ -290,13 +290,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AADLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -304,6 +304,60 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
+<<<<<<< HEAD
+=======
+            d="M2048 1310l-1024 598L0 1310 1024 140l1024 1170zm-526 60q30 0 57-11t46-31 31-47 12-57q0-30-11-56t-32-46-46-31-57-12q-32 0-62 14l-314-359q23-35 23-79 0-30-11-56t-31-46-46-31-57-12q-30 0-56 11t-47 31-31 46-12 57q0 21 6 41t18 38l-314 359q-30-14-62-14-30 0-56 11t-47 31-31 46-12 57q0 30 11 57t31 46 47 31 57 12q28 0 54-10t46-31l257 150q-5 20-5 36 0 30 11 56t32 47 46 31 57 12q30 0 56-11t47-32 31-46 12-57q0-16-5-36l256-150q20 20 46 30t55 11zM962 787l10 4q5 2 12 4v580q-35 11-61 35l-257-150q5-20 5-36 0-44-23-79l314-358zm438 358q-23 35-23 79 0 20 4 36l-256 150q-26-24-61-35V795q6-2 11-4t11-4l314 358z"
+          />
+        </svg>
+      </span>
+      <br />
+      <code
+        className=
+
+            {
+              background: #f2f2f2;
+              border-radius: 4px;
+              padding-bottom: 4px;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 4px;
+            }
+      >
+        AADLogoIcon
+      </code>
+    </div>
+    <div
+      className=
+
+          {
+            align-items: center;
+            display: flex;
+            flex-direction: column;
+            float: left;
+            height: 50px;
+            margin-bottom: 80px;
+            margin-left: 80px;
+            margin-right: 80px;
+            margin-top: 80px;
+            width: 50px;
+          }
+    >
+      <span
+        aria-label="AcceptIcon"
+        className=
+
+            {
+              font-size: 50px;
+            }
+        role="img"
+        style={Object {}}
+      >
+        <svg
+          viewBox="0 0 2048 2048"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+>>>>>>> 4a0e2d340c (fix(react-examples): Add labels to Icon examples)
             d="M640 1755L19 1133l90-90 531 530L1939 275l90 90L640 1755z"
           />
         </svg>
@@ -341,13 +395,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AcceptMediumIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -392,13 +446,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccessibiltyCheckerIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -443,13 +497,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccessLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -494,13 +548,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccountActivityIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -545,13 +599,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccountBrowserIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -596,13 +650,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccountManagementIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -647,13 +701,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AccountsIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -698,13 +752,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ActionCenterIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -749,13 +803,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ActivateOrdersIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -800,13 +854,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ActivityFeedIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -851,13 +905,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddBookmarkIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -902,13 +956,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddEventIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -953,13 +1007,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddFavoriteFillIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1004,13 +1058,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddFavoriteIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1055,13 +1109,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddFriendIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1106,13 +1160,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddGroupIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1157,13 +1211,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddHomeIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1208,13 +1262,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1259,13 +1313,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddInIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1310,13 +1364,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddLinkIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1361,13 +1415,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddNotesIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1412,13 +1466,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddOnlineMeetingIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1463,13 +1517,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddPhoneIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1514,13 +1568,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddReactionIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1565,13 +1619,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddSpaceAfterIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1616,13 +1670,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddSpaceBeforeIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1667,13 +1721,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddToIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1718,13 +1772,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddToShoppingListIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1769,13 +1823,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AddWorkIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1820,13 +1874,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminALogo32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1871,13 +1925,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminALogoFill32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1922,13 +1976,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminALogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -1973,13 +2027,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminCLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2024,13 +2078,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminDLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2075,13 +2129,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminELogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2126,13 +2180,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2177,13 +2231,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminLLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2228,13 +2282,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminMLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2279,13 +2333,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminOLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2330,13 +2384,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminPLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2381,13 +2435,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminSLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2432,13 +2486,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AdminYLogoInverse32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2483,13 +2537,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AirplaneIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2534,13 +2588,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AirplaneSolidIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2585,13 +2639,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AirTicketsIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2636,13 +2690,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlarmClockIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2687,13 +2741,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlbumIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2738,13 +2792,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlbumRemoveIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2789,13 +2843,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlertSettingsIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2840,13 +2894,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlertSolidIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2891,13 +2945,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignCenterIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2942,13 +2996,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignHorizontalCenterIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -2993,13 +3047,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignHorizontalLeftIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3044,13 +3098,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignHorizontalRightIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3095,13 +3149,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignJustifyIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3146,13 +3200,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignLeftIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3197,13 +3251,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignRightIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3248,13 +3302,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignVerticalBottomIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3299,13 +3353,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignVerticalCenterIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3350,13 +3404,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AlignVerticalTopIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3401,13 +3455,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AllAppsIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3452,13 +3506,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AllAppsMirroredIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3503,13 +3557,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AllCurrencyIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3554,13 +3608,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AltTextIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3605,13 +3659,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AmazonWebServicesLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3656,13 +3710,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnalyticsLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3707,13 +3761,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnalyticsQueryIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3758,13 +3812,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnalyticsReportIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3809,13 +3863,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnalyticsViewIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3860,13 +3914,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnchorLockIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3911,13 +3965,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AndroidLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -3962,13 +4016,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AnnotationIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4013,13 +4067,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ApacheIvyLogo32Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4064,13 +4118,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ApacheMavenLogoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4115,13 +4169,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AppIconDefaultAddIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4166,13 +4220,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AppIconDefaultIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4217,13 +4271,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AppIconDefaultListIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4268,13 +4322,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArchiveIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4319,13 +4373,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArchiveUndoIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4370,13 +4424,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AreaChartIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4421,13 +4475,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrangeBringForwardIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4472,13 +4526,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrangeBringToFrontIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4523,13 +4577,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrangeByFromIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4574,13 +4628,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrangeSendBackwardIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4625,13 +4679,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrangeSendToBackIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4676,13 +4730,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrivalsIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4727,13 +4781,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowDownRight8Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4778,13 +4832,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowDownRightMirrored8Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4829,13 +4883,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowTallDownLeftIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4880,13 +4934,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowTallDownRightIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4931,13 +4985,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowTallUpLeftIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -4982,13 +5036,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowTallUpRightIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5033,13 +5087,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowUpRight8Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5084,13 +5138,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowUpRightIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5135,13 +5189,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArrowUpRightMirrored8Icon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5186,13 +5240,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="ArticlesIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5237,13 +5291,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AscendingIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg
@@ -5288,13 +5342,13 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
           }
     >
       <span
-        aria-hidden={true}
+        aria-label="AspectRatioIcon"
         className=
 
             {
               font-size: 50px;
             }
-        role="presentation"
+        role="img"
         style={Object {}}
       >
         <svg


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [microsoftdesign/fluentui#10276](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10276/)
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Add label and role `img` to all icons in the `Icon` examples.
Fix positioning of the image for the lock icon in the `Icon using image sheet` example