### PR TITLE
test(react-button): fix conformance

### DIFF
--- a/change/@fluentui-react-button-2021-01-15-09-38-52-fix-conformance-test.json
+++ b/change/@fluentui-react-button-2021-01-15-09-38-52-fix-conformance-test.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update react-button conformance test",
+  "packageName": "@fluentui/react-button",
+  "email": "me@levithomason.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-15T17:38:52.001Z"
+}

--- a/packages/react-button/src/common/isConformant.ts
+++ b/packages/react-button/src/common/isConformant.ts
@@ -1,9 +1,14 @@
+import * as path from 'path';
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+  const componentPath = module!.parent!.filename.replace(/.test.tsx$/, '.tsx');
+  const packagePath = path.resolve(path.parse(componentPath).dir, '../../..');
+
+  const defaultOptions: Partial<IsConformantOptions> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
-    componentPath: module!.parent!.filename.replace('.test', ''),
+    componentPath,
+    packagePath,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -373,11 +373,14 @@ export const defaultErrorMessages = {
     failedTests.push('exported-top-level');
   },
 
-  'has-top-level-file': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
-    const { displayName, componentPath } = testInfo;
+  'has-top-level-file': (
+    pathToCheck: string,
+    componentInfo: ComponentDoc,
+    testInfo: IsConformantOptions,
+    error: string,
+  ) => {
+    const { displayName } = testInfo;
     const { testErrorPath, resolveInfo } = errorMessageColors;
-    const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-    const topLevelFile = path.join(rootPath, 'src', displayName);
 
     // Message Description: Handles scenario where the displayName doesn't match the component's filename.
     //
@@ -389,7 +392,7 @@ export const defaultErrorMessages = {
       defaultErrorMessage(
         `has-top-level-file`,
         displayName,
-        'top level file in:' + paragraph() + testErrorPath(topLevelFile),
+        'top level file in:' + paragraph() + testErrorPath(pathToCheck),
       ) +
         resolveErrorMessages([
           `Make sure that your component's folder and name match it's displayName: ${resolveInfo(displayName)}`,

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -166,9 +166,8 @@ export const defaultTests: TestObject = {
     if (!testInfo.isInternal) {
       it(`is exported at top-level`, () => {
         try {
-          const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
-          const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-          const indexFile = require(path.join(rootPath, 'src', exportSubdir, 'index'));
+          const { displayName, packagePath, exportSubdir = '', Component } = testInfo;
+          const indexFile = require(path.join(packagePath, 'src', exportSubdir, 'index'));
 
           expect(indexFile[displayName]).toBe(Component);
         } catch (e) {
@@ -183,14 +182,15 @@ export const defaultTests: TestObject = {
   'has-top-level-file': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     if (!testInfo.isInternal) {
       it(`has corresponding top-level file 'package/src/Component'`, () => {
-        try {
-          const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
-          const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-          const topLevelFile = require(path.join(rootPath, 'src', exportSubdir, displayName));
+        const { displayName, packagePath, exportSubdir = '', Component } = testInfo;
+        const pathToCheck = path.join(packagePath, 'src', exportSubdir, displayName);
 
+        try {
+          // TODO: require parses and executes top level code, use fs module to verify file instead
+          const topLevelFile = require(pathToCheck);
           expect(topLevelFile[displayName]).toBe(Component);
         } catch (e) {
-          defaultErrorMessages['has-top-level-file'](componentInfo, testInfo, e);
+          defaultErrorMessages['has-top-level-file'](pathToCheck, componentInfo, testInfo, e);
           throw new Error('has-top-level-file');
         }
       });

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -20,6 +20,10 @@ export interface IsConformantOptions<TProps = {}> {
    */
   componentPath: string;
   /**
+   * Path to root of package.
+   */
+  packagePath: string;
+  /**
    * Component object to test.
    */
   Component: React.ComponentType<TProps>;


### PR DESCRIPTION
#### Pull request checklist

Currently, react-conformance is sensitive to what directory you run tests from and what words exist in your machine's path to the components. It only works from a specific cwd and it will fail if you have `src` in your path.  Both of which I was hitting on my machine and workflow.

#### Description of changes

This PR address the the use of `src` in your path and allows running tests from any directory.

#### Focus areas to test

Run `yarn start-test` in `react-button` or any of it's subdirectories.
