### PR TITLE
Improve docs for Link props

### DIFF
--- a/change/@fluentui-react-link-2021-01-14-15-43-45-link-props.json
+++ b/change/@fluentui-react-link-2021-01-14-15-43-45-link-props.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Improve handling of built-in Link props",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-14T21:43:45.111Z"
+}

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -15,10 +15,9 @@ export interface ILink {
     focus(): void;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
-    // (undocumented)
-    [index: string]: any;
+    [key: string]: any;
     // (undocumented)
     autoFocus?: boolean;
     // (undocumented)
@@ -55,13 +54,19 @@ export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
     value?: string | string[] | number;
 }
 
-// @public (undocumented)
-export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, React.RefAttributes<HTMLElement> {
+// @public
+export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, Omit<React.ButtonHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, 'type'>, React.RefAttributes<HTMLElement> {
+    [key: string]: any;
     as?: React.ElementType;
     componentRef?: IRefObject<ILink>;
     disabled?: boolean;
+    href?: string;
+    onClick?: (event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLElement>) => void;
+    rel?: string;
     styles?: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles>;
+    target?: string;
     theme?: ITheme;
+    type?: string;
 }
 
 // @public (undocumented)

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -67,7 +67,7 @@ export interface ILinkProps
   href?: string;
 
   /**
-   * Where to display the linked URL. Common values are `_blank` (a new tab or window),
+   * Where to open the linked URL. Common values are `_blank` (a new tab or window),
    * `_self` (the current window/context), `_parent`, and `_top`.
    */
   target?: string;

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -13,7 +13,7 @@ export interface ILink {
 }
 
 /**
- * {@docCategory Link}
+ * @deprecated No longer used.
  */
 export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
   // Shared
@@ -40,22 +40,48 @@ export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
   name?: string;
   value?: string | string[] | number;
 
-  // Any other props for HTMLElements or a React component passed to as=
+  /** Any other props for HTMLElements or a React component passed to `as` */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [index: string]: any;
+  [key: string]: any;
 }
 
 /**
+ * Link component props. All built-in props for `<a>` and `<button>` are supported (including
+ * various event handlers) even if not listed below.
  * {@docCategory Link}
  */
 export interface ILinkProps
-  extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>,
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>,
+    Omit<React.ButtonHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, 'type'>,
     React.RefAttributes<HTMLElement> {
   /**
    * Optional callback to access the ILink interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<ILink>;
+
+  /**
+   * URL the link points to. If not provided, the link renders as a button (unless that behavior is
+   * overridden using `as`).
+   */
+  href?: string;
+
+  /**
+   * Where to display the linked URL. Common values are `_blank` (a new tab or window),
+   * `_self` (the current window/context), `_parent`, and `_top`.
+   */
+  target?: string;
+
+  /**
+   * Relationship to the linked URL (can be a space-separated list).
+   * Most common values are `noreferrer` and/or `noopener`.
+   */
+  rel?: string;
+
+  /**
+   * Click handler for the link.
+   */
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLElement>) => void;
 
   /**
    * Whether the link is disabled
@@ -76,6 +102,17 @@ export interface ILinkProps
    * A component type or primitive that is rendered as the type of the root element.
    */
   as?: React.ElementType;
+
+  /**
+   * Built-in HTML attribute with different behavior depending on how the link is rendered.
+   * If rendered as `<a>`, hints at the MIME type.
+   * If rendered as `<button>`, override the type of button (`button` is the default).
+   */
+  type?: string;
+
+  /** Any other props for elements or a React component passed to `as` */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #12043 but not a complete fix
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add explicit declarations and docs for `href`, `onClick`, and other common Link native props. The lack of explicit docs for these props has caused confusion in the past. 

Also extend the actual native props interfaces instead of our custom `ILinkHTMLAttributes` to more closely match the approach used with other components. (The slight mismatch between the anchor and button types can be resolved with Omit.)