### PR TITLE
Fixes custom error rendering in TextField

### DIFF
--- a/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
+++ b/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fixes TextField custom error message rendering",
   "packageName": "@fluentui/react-internal",
   "email": "sorgh@microsoft.com",

--- a/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
+++ b/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "Fix rich error message html DOM",
+  "type": "patch",
+  "comment": "Fixes TextField custom error message rendering",
   "packageName": "@fluentui/react-internal",
   "email": "sorgh@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
+++ b/change/@fluentui-react-internal-2021-01-14-16-34-06-sorgh-iss16049.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix rich error message html DOM",
+  "packageName": "@fluentui/react-internal",
+  "email": "sorgh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-15T00:34:06.681Z"
+}

--- a/packages/react-examples/src/react/TextField/TextField.ErrorMessage.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.ErrorMessage.Example.tsx
@@ -3,6 +3,8 @@ import { TextField } from '@fluentui/react/lib/TextField';
 import { Stack, IStackTokens } from '@fluentui/react/lib/Stack';
 import { Toggle } from '@fluentui/react/lib/Toggle';
 import { useBoolean } from '@fluentui/react-hooks';
+import { Icon } from '@fluentui/react/lib/Icon';
+import { Text } from '@fluentui/react/lib/Text';
 
 const stackTokens: IStackTokens = {
   childrenGap: 20,
@@ -17,6 +19,17 @@ const getErrorMessagePromise = (value: string): Promise<string> => {
   return new Promise(resolve => {
     setTimeout(() => resolve(getErrorMessage(value)), 5000);
   });
+};
+
+const getRichErrorMessage = (value: string) => {
+  return value.length < 3 ? (
+    ''
+  ) : (
+    <Stack styles={{ root: { height: 24 } }} verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
+      <Icon iconName="Error" styles={{ root: { color: 'red' } }} />
+      <Text variant="smallPlus">Input value length must be less than 3. Actual length is {value.length}.</Text>
+    </Stack>
+  );
 };
 
 export const TextFieldErrorMessageExample: React.FunctionComponent = () => {
@@ -81,6 +94,11 @@ export const TextFieldErrorMessageExample: React.FunctionComponent = () => {
             label="Uses the errorMessage property to set an error state"
             placeholder="This field always has an error"
             errorMessage="This is a statically set error message"
+          />
+          <TextField
+            label="Custom rich error message"
+            defaultValue="This value is too long"
+            onGetErrorMessage={getRichErrorMessage}
           />
         </>
       )}

--- a/packages/react-examples/src/react/TextField/TextField.ErrorMessage.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.ErrorMessage.Example.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { TextField } from '@fluentui/react/lib/TextField';
-import { Stack, IStackTokens } from '@fluentui/react/lib/Stack';
+import { Stack, IStackTokens, IStackStyles } from '@fluentui/react/lib/Stack';
 import { Toggle } from '@fluentui/react/lib/Toggle';
 import { useBoolean } from '@fluentui/react-hooks';
-import { Icon } from '@fluentui/react/lib/Icon';
+import { Icon, IIconStyles } from '@fluentui/react/lib/Icon';
 import { Text } from '@fluentui/react/lib/Text';
 
 const stackTokens: IStackTokens = {
   childrenGap: 20,
   maxWidth: 350,
 };
+
+const richErrorIconStyles: Partial<IIconStyles> = { root: { color: 'red' } };
+const richErrorStackStyles: Partial<IStackStyles> = { root: { height: 24 } };
+const richErrorStackTokens: IStackTokens = { childrenGap: 8 };
 
 const getErrorMessage = (value: string): string => {
   return value.length < 3 ? '' : `Input value length must be less than 3. Actual length is ${value.length}.`;
@@ -25,8 +29,8 @@ const getRichErrorMessage = (value: string) => {
   return value.length < 3 ? (
     ''
   ) : (
-    <Stack styles={{ root: { height: 24 } }} verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
-      <Icon iconName="Error" styles={{ root: { color: 'red' } }} />
+    <Stack styles={richErrorStackStyles} verticalAlign="center" horizontal tokens={richErrorStackTokens}>
+      <Icon iconName="Error" styles={richErrorIconStyles} />
       <Text variant="smallPlus">Input value length must be less than 3. Actual length is {value.length}.</Text>
     </Stack>
   );

--- a/packages/react-internal/src/components/TextField/TextField.base.tsx
+++ b/packages/react-internal/src/components/TextField/TextField.base.tsx
@@ -263,11 +263,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {onRenderDescription(this.props, this._onRenderDescription)}
             {errorMessage && (
               <div role="alert">
-                <DelayedRender>
-                  <p className={classNames.errorMessage}>
-                    <span data-automation-id="error-message">{errorMessage}</span>
-                  </p>
-                </DelayedRender>
+                <DelayedRender>{this._renderErrorMessage()}</DelayedRender>
               </div>
             )}
           </span>
@@ -444,6 +440,28 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   private get _errorMessage(): string | JSX.Element {
     const { errorMessage = this.state.errorMessage } = this.props;
     return errorMessage || '';
+  }
+
+  /**
+   * Renders error message based on the type of the message.
+   *
+   * - If error message is string, it will render using the built in styles.
+   * - If error message is an element, user has full control over how it's rendered.
+   */
+  private _renderErrorMessage(): JSX.Element | null {
+    const errorMessage = this._errorMessage;
+
+    return errorMessage ? (
+      typeof errorMessage === 'string' ? (
+        <p className={this._classNames.errorMessage}>
+          <span data-automation-id="error-message">{errorMessage}</span>
+        </p>
+      ) : (
+        <div className={this._classNames.errorMessage} data-automation-id="error-message">
+          {errorMessage}
+        </div>
+      )
+    ) : null;
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16049 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

TextField renders all the error messages under a p tag with custom styles, that's fine as long as the error message is string.
When there is a custom error message (i.e., JSX.Element) rendering it under the p tag violates DOM validation (e.g, div can't be child of p). This PR addresses this issue.