### PR TITLE
Charting: Tooltip disappear on escape click issue fixed in line chart

### DIFF
--- a/change/@uifabric-charting-2021-01-15-15-12-29-user-v-jasha-tooltip_hover_issue.json
+++ b/change/@uifabric-charting-2021-01-15-15-12-29-user-v-jasha-tooltip_hover_issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tooltip disappear after click on escape issue fixed",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-01-15T09:42:29.530Z"
+}

--- a/change/@uifabric-charting-2021-01-15-15-12-29-user-v-jasha-tooltip_hover_issue.json
+++ b/change/@uifabric-charting-2021-01-15-15-12-29-user-v-jasha-tooltip_hover_issue.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Tooltip disappear after click on escape issue fixed",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2021-01-15T09:42:29.530Z"
 }

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -129,7 +129,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       isBeakVisible: false,
       gapSpace: 15,
       onDismiss: this._closeCallout,
-      preventDismissOnLostFocus: true,
+      preventDismissOnEvent: () => true,
       hidden: !(!this.props.hideTooltip && this.state.isCalloutVisible),
       ...this.props.calloutProps,
     };

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -128,6 +128,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       target: this.state.refSelected,
       isBeakVisible: false,
       gapSpace: 15,
+      onDismiss: this._closeCallout,
+      preventDismissOnLostFocus: true,
+      hidden: !(!this.props.hideTooltip && this.state.isCalloutVisible),
       ...this.props.calloutProps,
     };
     const tickParams = {
@@ -297,6 +300,12 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     );
     return legends;
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
+  };
 
   private _createLines(xElement: SVGElement): JSX.Element[] {
     const lines = [];

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -95,8 +95,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
 
   public componentDidUpdate(prevProps: ILineChartProps): void {
     /** note that height and width are not used to resize or set as dimesions of the chart,
-     * fitParentContainer is responisble for setting the height and width or resizing of the svg/chart
-     */
+     * fitParentContainer is responisble for setting the height and width or resizing of the svg/chart */
     if (
       prevProps.height !== this.props.height ||
       prevProps.width !== this.props.width ||


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16422
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added 'hidden' and 'onDismiss' props to the callout to enable this feature.

#### Focus areas to test

Line chart