### PR TITLE
fix(react-examples): Change item names to match icon in OverflowSet example

### DIFF
--- a/packages/react-examples/src/react/OverflowSet/OverflowSet.Vertical.Example.tsx
+++ b/packages/react-examples/src/react/OverflowSet/OverflowSet.Vertical.Example.tsx
@@ -45,20 +45,20 @@ export const OverflowSetVerticalExample: React.FunctionComponent = () => (
       {
         key: 'item1',
         icon: 'Add',
-        name: 'Link 1',
+        name: 'Add',
         ariaLabel: 'New. Use left and right arrow keys to navigate',
         onClick: noOp,
       },
       {
         key: 'item2',
         icon: 'Upload',
-        name: 'Link 2',
+        name: 'Upload',
         onClick: noOp,
       },
       {
         key: 'item3',
         icon: 'Share',
-        name: 'Link 3',
+        name: 'Share',
         onClick: noOp,
       },
     ]}

--- a/packages/react-examples/src/react/OverflowSet/OverflowSet.Vertical.Example.tsx
+++ b/packages/react-examples/src/react/OverflowSet/OverflowSet.Vertical.Example.tsx
@@ -65,13 +65,11 @@ export const OverflowSetVerticalExample: React.FunctionComponent = () => (
     overflowItems={[
       {
         key: 'item4',
-        icon: 'Mail',
         name: 'Overflow Link 1',
         onClick: noOp,
       },
       {
         key: 'item5',
-        icon: 'Calendar',
         name: 'Overflow Link 2',
         onClick: noOp,
       },

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -23,7 +23,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         }
   >
     <button
-      aria-label="Link 1"
+      aria-label="Add"
       className=
           ms-Button
           ms-Button--commandBar
@@ -176,7 +176,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         }
   >
     <button
-      aria-label="Link 2"
+      aria-label="Upload"
       className=
           ms-Button
           ms-Button--commandBar
@@ -329,7 +329,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         }
   >
     <button
-      aria-label="Link 3"
+      aria-label="Share"
       className=
           ms-Button
           ms-Button--commandBar


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes microsoftdesign/fluentui#10282
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Add descriptive names for the icons used in the OverflowSet Vertical example.
Removed unused `icon` props for the `overflowItems`