### PR TITLE
fix(react-examples): Add allowed data title to TextField mask example

### DIFF
--- a/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
@@ -22,7 +22,7 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With error message" errorMessage="Error message" />
       </Stack>
       <Stack {...columnProps}>
-        <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" />
+        <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" title="A 10 digit number" />
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -1345,6 +1345,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             onMouseDown={[Function]}
             onMouseUp={[Function]}
             onPaste={[Function]}
+            title="A 10 digit number"
             type="text"
             value="mask: (___) ___ - ____"
           />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes microsoftdesign/fluentui#10301
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Add `title` to input describing the allowed characters in the `Text Field Basic` example