### PR TITLE
fix(react-examples): Fix high contrast visibility issues in DetailsList example

### DIFF
--- a/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
@@ -46,7 +46,6 @@ const classNames = mergeStyleSets({
     headerDividerClass,
   ],
   linkField: {
-    display: 'block',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     maxWidth: '100%',
@@ -722,7 +721,11 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
         column.isMultiline = true;
         column.minWidth = 200;
       } else if (column.key === 'name') {
-        column.onRender = (item: IExampleItem) => <Link data-selection-invoke={true}>{item.name}</Link>;
+        column.onRender = (item: IExampleItem) => (
+          <Link href="#" data-selection-invoke={true}>
+            {item.name}
+          </Link>
+        );
       } else if (column.key === 'key') {
         column.columnActionsMode = ColumnActionsMode.disabled;
         column.onRender = (item: IExampleItem) => (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes microsoftdesign/fluentui#10836
- [x] Include a change request file using `$ yarn change`: No change files are needed

#### Description of changes

Remove `display: block` from the `key` column links and add an `href=#` to properly mark the `name` column links as hyperlinks.