### PR TITLE
Toggle: fix label click target being too wide (7.0)

### DIFF
--- a/change/@fluentui-react-examples-2021-01-15-10-05-48-fix-toggle-label-7.json
+++ b/change/@fluentui-react-examples-2021-01-15-10-05-48-fix-toggle-label-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots for toggle",
+  "packageName": "@fluentui/react-examples",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-15T18:05:48.131Z"
+}

--- a/change/office-ui-fabric-react-2021-01-15-10-05-48-fix-toggle-label-7.json
+++ b/change/office-ui-fabric-react-2021-01-15-10-05-48-fix-toggle-label-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Toggle: fix label click target being too wide.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-15T18:05:03.566Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -48,6 +48,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
 
     label: [
       'ms-Toggle-label',
+      { display: 'inline-block' },
       disabled && {
         color: textDisabledColor,
         selectors: {
@@ -71,7 +72,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
     container: [
       'ms-Toggle-innerContainer',
       {
-        display: 'inline-flex',
+        display: 'flex',
         position: 'relative',
       },
     ],

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -125,7 +125,7 @@ exports[`Toggle renders toggle correctly 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -149,7 +149,7 @@ exports[`Toggle renders toggle correctly 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -257,7 +257,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -285,7 +285,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -393,7 +393,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -419,7 +419,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >
@@ -527,7 +527,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
-          display: block;
+          display: inline-block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 600;
@@ -552,7 +552,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
     className=
         ms-Toggle-innerContainer
         {
-          display: inline-flex;
+          display: flex;
           position: relative;
         }
   >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1266,7 +1266,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -1290,7 +1290,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -442,7 +442,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -466,7 +466,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -578,7 +578,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -602,7 +602,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -81,7 +81,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -231,7 +231,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -255,7 +255,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -37,7 +37,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -61,7 +61,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -157,7 +157,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -183,7 +183,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -292,7 +292,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -318,7 +318,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -30,7 +30,7 @@ Array [
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -54,7 +54,7 @@ Array [
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -46,7 +46,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -70,7 +70,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -92,7 +92,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -250,7 +250,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -274,7 +274,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -250,7 +250,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -274,7 +274,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -92,7 +92,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 box-shadow: none;
                 box-sizing: border-box;
                 color: #323130;
-                display: block;
+                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 600;
@@ -93,7 +93,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           className=
               ms-Toggle-innerContainer
               {
-                display: inline-flex;
+                display: flex;
                 position: relative;
               }
         >
@@ -399,7 +399,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     box-shadow: none;
                     box-sizing: border-box;
                     color: #323130;
-                    display: block;
+                    display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 600;
@@ -423,7 +423,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >
@@ -729,7 +729,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         box-shadow: none;
                         box-sizing: border-box;
                         color: #323130;
-                        display: block;
+                        display: inline-block;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 600;
@@ -753,7 +753,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   className=
                       ms-Toggle-innerContainer
                       {
-                        display: inline-flex;
+                        display: flex;
                         position: relative;
                       }
                 >
@@ -1073,7 +1073,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         box-shadow: none;
                         box-sizing: border-box;
                         color: #323130;
-                        display: block;
+                        display: inline-block;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 600;
@@ -1097,7 +1097,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   className=
                       ms-Toggle-innerContainer
                       {
-                        display: inline-flex;
+                        display: flex;
                         position: relative;
                       }
                 >
@@ -1430,7 +1430,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     box-shadow: none;
                     box-sizing: border-box;
                     color: #323130;
-                    display: block;
+                    display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 600;
@@ -1454,7 +1454,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -213,7 +213,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >
@@ -2199,7 +2199,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >
@@ -4185,7 +4185,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               className=
                                   ms-Toggle-innerContainer
                                   {
-                                    display: inline-flex;
+                                    display: flex;
                                     position: relative;
                                   }
                             >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1029,7 +1029,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               className=
                   ms-Toggle-innerContainer
                   {
-                    display: inline-flex;
+                    display: flex;
                     position: relative;
                   }
             >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1053,7 +1053,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -27,7 +27,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -53,7 +53,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -42,7 +42,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -68,7 +68,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -174,7 +174,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -200,7 +200,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -60,7 +60,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -202,7 +202,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -228,7 +228,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -377,7 +377,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -403,7 +403,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
@@ -27,7 +27,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -53,7 +53,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3616,7 +3616,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3640,7 +3640,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -3744,7 +3744,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3768,7 +3768,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >
@@ -3872,7 +3872,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
@@ -3896,7 +3896,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className=
             ms-Toggle-innerContainer
             {
-              display: inline-flex;
+              display: flex;
               position: relative;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -25,7 +25,7 @@ Array [
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -49,7 +49,7 @@ Array [
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -398,7 +398,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -58,7 +58,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -48,7 +48,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -74,7 +74,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -46,7 +46,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -70,7 +70,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -223,7 +223,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -247,7 +247,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -393,7 +393,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -420,7 +420,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -562,7 +562,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -589,7 +589,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -731,7 +731,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -756,7 +756,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -903,7 +903,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -931,7 +931,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1073,7 +1073,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1099,7 +1099,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1204,7 +1204,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1233,7 +1233,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -1328,7 +1328,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -1352,7 +1352,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -45,7 +45,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -102,7 +102,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >
@@ -249,7 +249,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
-            display: block;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
@@ -307,7 +307,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
       className=
           ms-Toggle-innerContainer
           {
-            display: inline-flex;
+            display: flex;
             position: relative;
           }
     >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13721
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fixing the issue by updating label inside `Toggle` to be as wide as the text width, not as the width of its container.

Cherry-pick #16195

#### Focus areas to test

(optional)
