### PR TITLE
fix(react-button): Allow pointer events in disabledFocusable button

### DIFF
--- a/change/@fluentui-react-button-2021-01-18-08-22-26-master.json
+++ b/change/@fluentui-react-button-2021-01-18-08-22-26-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Enable pointer-events so that tooltip can be attached to disabledFocusable Button.",
+  "packageName": "@fluentui/react-button",
+  "email": "jukapsia@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-18T07:22:26.919Z"
+}

--- a/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -170,7 +170,6 @@ exports[`Button renders a default state 1`] = `
         box-shadow: var(--button-disabled-boxShadow);
         color: var(--button-disabled-contentColor);
         opacity: var(--button-disabled-opacity);
-        pointer-events: none;
       }
       &[aria-disabled=true] .ms-Button-icon {
         color: var(--button-disabled-iconColor);
@@ -367,7 +366,6 @@ exports[`Button renders anchor when href prop is provided 1`] = `
         box-shadow: var(--button-disabled-boxShadow);
         color: var(--button-disabled-contentColor);
         opacity: var(--button-disabled-opacity);
-        pointer-events: none;
       }
       &[aria-disabled=true] .ms-Button-icon {
         color: var(--button-disabled-iconColor);

--- a/packages/react-button/src/components/Button/useButtonClasses.ts
+++ b/packages/react-button/src/components/Button/useButtonClasses.ts
@@ -189,7 +189,6 @@ export const useButtonClasses = makeVariantClasses<ButtonState, ButtonVariants>(
         },
 
         '&[aria-disabled=true]': {
-          pointerEvents: 'none',
           opacity: 'var(--button-disabled-opacity)',
           backgroundColor: 'var(--button-disabled-background)',
           color: 'var(--button-disabled-contentColor)',

--- a/packages/react-examples/src/react-button/Button/Button.stories.tsx
+++ b/packages/react-examples/src/react-button/Button/Button.stories.tsx
@@ -54,10 +54,10 @@ export const Buttons = () => (
 
     <Text>A button can be focusable when disabled</Text>
     <Stack horizontal>
-      <Button disabled icon="X">
+      <Button disabled icon="X" onClick={() => alert('You cannot see me')}>
         Disabled, non-focusable button
       </Button>
-      <Button disabled disabledFocusable icon="X">
+      <Button disabled disabledFocusable icon="X" onClick={() => alert('You cannot see me')}>
         Disabled, focusable button
       </Button>
     </Stack>


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Tooltip can be attached to a disabled focusable button. `pointer-events: none` will prevent all mouse events - including hover/mouseEnter which is usually needed for showing the tooltip.
