### PR TITLE
chore(Menu): add e2e for dismiss menu on click

### DIFF
--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Menu } from '@fluentui/react-northstar';
+
+const MenuDismissScroll = () => {
+  return (
+    <Menu
+      items={[
+        {
+          key: 'news',
+          content: 'News',
+          id: 'news',
+          menu: {
+            items: [
+              { content: '1', id: 'first', key: '1' },
+              { content: '2', id: 'second', key: '2', menu: [{ content: '3', id: 'third', key: '3' }] },
+            ],
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default MenuDismissScroll;

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Menu } from '@fluentui/react-northstar';
 
-const MenuDismissScroll = () => {
+const MenuDismissOnItemClick = () => {
   return (
     <Menu
       items={[

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Menu } from '@fluentui/react-northstar';
 
+export const firstSubmenuItemID = 'first';
+export const secondSubmenuItemID = 'second';
+
+export const firstSubmenuID = 'firstSubmenu';
+export const secondSubmenuID = 'secondSubmenu';
+
 const MenuDismissOnItemClick = () => {
   return (
     <Menu
@@ -10,15 +16,15 @@ const MenuDismissOnItemClick = () => {
           content: 'News',
           id: 'news',
           menu: {
-            id: 'firstSubmenu',
+            id: firstSubmenuID,
             items: [
-              { content: '1', id: 'first', key: '1' },
+              { content: '1', id: firstSubmenuItemID, key: '1' },
               {
                 content: '2',
-                id: 'second',
+                id: secondSubmenuItemID,
                 key: '2',
                 menu: {
-                  id: 'secondSubmenu',
+                  id: secondSubmenuID,
                   items: [{ content: '3', id: 'third', key: '3' }],
                 },
               },

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
@@ -10,9 +10,18 @@ const MenuDismissScroll = () => {
           content: 'News',
           id: 'news',
           menu: {
+            id: 'firstSubmenu',
             items: [
               { content: '1', id: 'first', key: '1' },
-              { content: '2', id: 'second', key: '2', menu: [{ content: '3', id: 'third', key: '3' }] },
+              {
+                content: '2',
+                id: 'second',
+                key: '2',
+                menu: {
+                  id: 'secondSubmenu',
+                  items: [{ content: '3', id: 'third', key: '3' }],
+                },
+              },
             ],
           },
         },

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-example.tsx
@@ -30,4 +30,4 @@ const MenuDismissOnItemClick = () => {
   );
 };
 
-export default MenuDismissScroll;
+export default MenuDismissOnItemClick;

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -15,7 +15,7 @@ describe('Dismiss Menu on Item Click', () => {
 
   describe('Mouse interactions', () => {
     it('Should close on click', async () => {
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(firstSubmenu);
       await e2e.clickOn(menuItem);
       await e2e.exists(firstSubmenu);
       await e2e.clickOn(firstSubmenuItem);

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -14,7 +14,7 @@ describe('Dismiss Menu on Item Click', () => {
   });
 
   describe('Mouse interactions', () => {
-    it('Should close on click', async () => {
+    it('Should close submenu on click', async () => {
       await e2e.expectHidden(firstSubmenu);
 
       await e2e.clickOn(menuItem);

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -47,9 +47,11 @@ describe('Dismiss Menu on Item Click', () => {
   describe('Keyboard interactions', () => {
     it('Should close on click', async () => {
       await e2e.expectHidden(firstSubmenu);
+
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
       await e2e.exists(firstSubmenu);
+
       await e2e.waitForSelectorAndPressKey(firstSubmenuItem, 'Enter');
       await e2e.expectHidden(firstSubmenu);
     });

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -57,9 +57,11 @@ describe('Dismiss Menu on Item Click', () => {
     it('Should keep open on click of item with submenu', async () => {
       await e2e.expectHidden(secondSubmenu);
       await e2e.expectHidden(firstSubmenu);
+
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
       await e2e.exists(firstSubmenu);
+
       await e2e.focusOn(secondSubmenuItem);
       await e2e.waitForSelectorAndPressKey(secondSubmenuItem, 'Enter');
       await e2e.exists(secondSubmenu);

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -19,6 +19,7 @@ describe('Dismiss Menu on Item Click', () => {
 
       await e2e.clickOn(menuItem);
       await e2e.exists(firstSubmenu);
+
       await e2e.clickOn(firstSubmenuItem);
       await e2e.expectHidden(firstSubmenu);
     });

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -5,6 +5,9 @@ const menuItem = `.${menuItemClassName}`;
 const firstSubmenuItem = '#first';
 const secondSubmenuItem = '#second';
 
+const firstSubmenu = '#firstSubmenu';
+const secondSubmenu = '#secondSubmenu';
+
 describe('Dismiss Menu on Item Click', () => {
   beforeEach(async () => {
     await e2e.gotoTestCase(__filename, menuItem);
@@ -14,17 +17,17 @@ describe('Dismiss Menu on Item Click', () => {
     it('Should close on click', async () => {
       await e2e.expectCount(menuItem, 1);
       await e2e.clickOn(menuItem);
-      await e2e.expectCount(menuItem, 3);
+      await e2e.exists(firstSubmenu);
       await e2e.clickOn(firstSubmenuItem);
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(firstSubmenu);
     });
 
     it('Should keep open on click of item with submenu', async () => {
       await e2e.expectCount(menuItem, 1);
       await e2e.clickOn(menuItem);
-      await e2e.expectCount(menuItem, 3);
+      await e2e.exists(firstSubmenu);
       await e2e.clickOn(secondSubmenuItem);
-      await e2e.expectCount(menuItem, 4);
+      await e2e.exists(secondSubmenu);
     });
   });
 
@@ -33,19 +36,19 @@ describe('Dismiss Menu on Item Click', () => {
       await e2e.expectCount(menuItem, 1);
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
-      await e2e.expectCount(menuItem, 3);
+      await e2e.exists(firstSubmenu);
       await e2e.waitForSelectorAndPressKey(firstSubmenuItem, 'Enter');
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(firstSubmenu);
     });
 
     it('Should keep open on click of item with submenu', async () => {
       await e2e.expectCount(menuItem, 1);
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
-      await e2e.expectCount(menuItem, 3);
+      await e2e.exists(firstSubmenu);
       await e2e.focusOn(secondSubmenuItem);
       await e2e.waitForSelectorAndPressKey(secondSubmenuItem, 'Enter');
-      await e2e.expectCount(menuItem, 4);
+      await e2e.exists(secondSubmenu);
     });
   });
 });

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -1,0 +1,51 @@
+import { menuItemClassName } from '@fluentui/react-northstar';
+
+const menuItem = `.${menuItemClassName}`;
+
+const firstSubmenuItem = '#first';
+const secondSubmenuItem = '#second';
+
+describe('Dismiss Menu on Item Click', () => {
+  beforeEach(async () => {
+    await e2e.gotoTestCase(__filename, menuItem);
+  });
+
+  describe('Mouse interactions', () => {
+    it('Should close on click', async () => {
+      await e2e.expectCount(menuItem, 1);
+      await e2e.clickOn(menuItem);
+      await e2e.expectCount(menuItem, 3);
+      await e2e.clickOn(firstSubmenuItem);
+      await e2e.expectCount(menuItem, 1);
+    });
+
+    it('Should keep open on click of item with submenu', async () => {
+      await e2e.expectCount(menuItem, 1);
+      await e2e.clickOn(menuItem);
+      await e2e.expectCount(menuItem, 3);
+      await e2e.clickOn(secondSubmenuItem);
+      await e2e.expectCount(menuItem, 4);
+    });
+  });
+
+  describe('Keyboard interactions', () => {
+    it('Should close on click', async () => {
+      await e2e.expectCount(menuItem, 1);
+      await e2e.focusOn(menuItem);
+      await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
+      await e2e.expectCount(menuItem, 3);
+      await e2e.waitForSelectorAndPressKey(firstSubmenuItem, 'Enter');
+      await e2e.expectCount(menuItem, 1);
+    });
+
+    it('Should keep open on click of item with submenu', async () => {
+      await e2e.expectCount(menuItem, 1);
+      await e2e.focusOn(menuItem);
+      await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
+      await e2e.expectCount(menuItem, 3);
+      await e2e.focusOn(secondSubmenuItem);
+      await e2e.waitForSelectorAndPressKey(secondSubmenuItem, 'Enter');
+      await e2e.expectCount(menuItem, 4);
+    });
+  });
+});

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -27,11 +27,11 @@ describe('Dismiss Menu on Item Click', () => {
     it('Should keep open on click of item with submenu', async () => {
       await e2e.expectHidden(secondSubmenu);
       await e2e.expectHidden(firstSubmenu);
-      
+
       await e2e.clickOn(menuItem);
       await e2e.exists(firstSubmenu);
       await e2e.expectHidden(secondSubmenu);
-      
+
       await e2e.clickOn(secondSubmenuItem);
       await e2e.exists(firstSubmenu);
       await e2e.exists(secondSubmenu);
@@ -40,7 +40,7 @@ describe('Dismiss Menu on Item Click', () => {
 
   describe('Keyboard interactions', () => {
     it('Should close on click', async () => {
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(firstSubmenu);
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
       await e2e.exists(firstSubmenu);
@@ -49,7 +49,8 @@ describe('Dismiss Menu on Item Click', () => {
     });
 
     it('Should keep open on click of item with submenu', async () => {
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(secondSubmenu);
+      await e2e.expectHidden(firstSubmenu);
       await e2e.focusOn(menuItem);
       await e2e.waitForSelectorAndPressKey(menuItem, 'Enter');
       await e2e.exists(firstSubmenu);

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -1,12 +1,18 @@
 import { menuItemClassName } from '@fluentui/react-northstar';
+import {
+  firstSubmenuID,
+  firstSubmenuItemID,
+  secondSubmenuID,
+  secondSubmenuItemID,
+} from './menuDismissOnItemClick-example';
 
 const menuItem = `.${menuItemClassName}`;
 
-const firstSubmenuItem = '#first';
-const secondSubmenuItem = '#second';
+const firstSubmenuItem = `#${firstSubmenuItemID}`;
+const secondSubmenuItem = `#${secondSubmenuItemID}`;
 
-const firstSubmenu = '#firstSubmenu';
-const secondSubmenu = '#secondSubmenu';
+const firstSubmenu = `#${firstSubmenuID}`;
+const secondSubmenu = `#${secondSubmenuID}`;
 
 describe('Dismiss Menu on Item Click', () => {
   beforeEach(async () => {

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -16,6 +16,7 @@ describe('Dismiss Menu on Item Click', () => {
   describe('Mouse interactions', () => {
     it('Should close on click', async () => {
       await e2e.expectHidden(firstSubmenu);
+
       await e2e.clickOn(menuItem);
       await e2e.exists(firstSubmenu);
       await e2e.clickOn(firstSubmenuItem);

--- a/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
+++ b/packages/fluentui/e2e/tests/menuDismissOnItemClick-test.ts
@@ -25,10 +25,15 @@ describe('Dismiss Menu on Item Click', () => {
     });
 
     it('Should keep open on click of item with submenu', async () => {
-      await e2e.expectCount(menuItem, 1);
+      await e2e.expectHidden(secondSubmenu);
+      await e2e.expectHidden(firstSubmenu);
+      
       await e2e.clickOn(menuItem);
       await e2e.exists(firstSubmenu);
+      await e2e.expectHidden(secondSubmenu);
+      
       await e2e.clickOn(secondSubmenuItem);
+      await e2e.exists(firstSubmenu);
       await e2e.exists(secondSubmenu);
     });
   });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds e2e tests for dismissing menu on item click and keeping it open when item in submenu has other submenu 

#### Focus areas to test

(optional)
