### PR TITLE
chore(scripts): add support for standard jestTask arguments when execu…

### DIFF
--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -1,10 +1,24 @@
-import { jestTask, argv } from 'just-scripts';
+import { jestTask, argv, JestTaskOptions } from 'just-scripts';
 import * as path from 'path';
 
-const commonArgs = () => {
+/**
+ * Partial support of native jest CLI arguments https://jestjs.io/docs/en/cli
+ * > Why partial support only? just jestTask limits support to only those specified as return value of this function
+ */
+const commonArgs = (): JestTaskOptions => {
   return {
-    ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME) && { runInBand: true }),
-    ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined),
+    ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME || argv().runInBand) && { runInBand: true }),
+    ...((argv().u || argv().updateSnapshot) && { updateSnapshot: true }),
+    clearCache: argv().clearCache,
+    config: argv().config,
+    watch: argv().watch,
+    coverage: argv().coverage,
+    passWithNoTests: argv().coverage,
+    testNamePattern: argv().testNamePattern,
+    testPathPattern: argv().testPathPattern,
+
+    // Just specific config
+    nodeArgs: argv().nodeArgs,
   };
 };
 
@@ -28,7 +42,7 @@ export const jestWatch = () => {
   return jestTask({
     ...commonArgs(),
     watch: true,
-    _: ['-i', ...(argv()._ || []).filter(arg => arg !== 'jest-watch')],
+    _: [...(argv()._ || []).filter(arg => arg !== 'jest-watch')],
     env: {
       ...process.env,
       PACKAGE_NAME: argv().package,

--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -15,12 +15,14 @@ const commonArgs = (): JestTaskOptions => {
     config: args.config,
     watch: args.watch,
     coverage: args.coverage,
-    passWithNoTests: args.coverage,
+    passWithNoTests: args.passWithNoTests,
     testNamePattern: args.testNamePattern,
     testPathPattern: args.testPathPattern,
 
     // Just specific config
     nodeArgs: args.nodeArgs,
+    // pass forward positional args (to narrow down tests to be run)
+    _: args._,
   };
 };
 

--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -6,31 +6,39 @@ import * as path from 'path';
  * > Why partial support only? just jestTask limits support to only those specified as return value of this function
  */
 const commonArgs = (): JestTaskOptions => {
+  const args: JestTaskOptions = argv();
+
   return {
-    ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME || argv().runInBand) && { runInBand: true }),
-    ...((argv().u || argv().updateSnapshot) && { updateSnapshot: true }),
-    clearCache: argv().clearCache,
-    config: argv().config,
-    watch: argv().watch,
-    coverage: argv().coverage,
-    passWithNoTests: argv().coverage,
-    testNamePattern: argv().testNamePattern,
-    testPathPattern: argv().testPathPattern,
+    ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME || args.runInBand) && { runInBand: true }),
+    ...((args.u || args.updateSnapshot) && { updateSnapshot: true }),
+    clearCache: args.clearCache,
+    config: args.config,
+    watch: args.watch,
+    coverage: args.coverage,
+    passWithNoTests: args.coverage,
+    testNamePattern: args.testNamePattern,
+    testPathPattern: args.testPathPattern,
 
     // Just specific config
-    nodeArgs: argv().nodeArgs,
+    nodeArgs: args.nodeArgs,
   };
 };
 
-export const jest = () =>
-  jestTask({
+const commonJestTask = (options: JestTaskOptions = {}) => {
+  return jestTask({
     ...commonArgs(),
     env: {
       ...process.env,
       NODE_ENV: 'test',
       PACKAGE_NAME: argv().package,
     },
+    ...options,
   });
+};
+
+export const jest = () => {
+  return commonJestTask();
+};
 
 export const jestDom = () =>
   jestTask({
@@ -39,13 +47,5 @@ export const jestDom = () =>
   });
 
 export const jestWatch = () => {
-  return jestTask({
-    ...commonArgs(),
-    watch: true,
-    _: [...(argv()._ || []).filter(arg => arg !== 'jest-watch')],
-    env: {
-      ...process.env,
-      PACKAGE_NAME: argv().package,
-    },
-  });
+  return commonJestTask({ watch: true });
 };


### PR DESCRIPTION
…ting our custom jest scripts

#### Pull request checklist

~- [ ] Addresses an existing issue:~
~- [ ] Include a change request file using `$ yarn change` NO CHANGE NEEDED~

#### Description of changes

Adds support to all supported jest flags within just scripts. With this we can for instance clear jest cache if we run into issues.

**Before:**
```
# to run tests
yarn just jest

# to run tests in watch mode
yarn just jest-watch

# to run update snaphosts
yarn just jest -u

# clear jest cache
❌

# run in band
❌

# specify custom config
❌

# run coverage
❌
```

**After:**

```
# to run tests
yarn just jest

# to run tests in watch mode
yarn just jest --watch
yarn just jest-watch # old way

# to run update snaphosts
yarn just jest -u

# clear jest cache
yarn just --clearCache

# run in band
yarn just jest --runInBand

# specify custom config
yarn just jest --config ./path/to/custom/jest.config.js

# run coverage
yarn just jest --coverage
```

#### Focus areas to test

(optional)
