### PR TITLE
Add additional prop support to IBreadcrumbItems

### DIFF
--- a/change/office-ui-fabric-react-2021-01-19-16-02-36-10631.json
+++ b/change/office-ui-fabric-react-2021-01-19-16-02-36-10631.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add additional prop support to IBreadcrumbItems",
+  "packageName": "office-ui-fabric-react",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-19T15:02:36.326Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1869,6 +1869,7 @@ export interface IBreadcrumbData {
 
 // @public (undocumented)
 export interface IBreadcrumbItem {
+    [propertyName: string]: any;
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
     href?: string;
     isCurrentItem?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1868,8 +1868,7 @@ export interface IBreadcrumbData {
 }
 
 // @public (undocumented)
-export interface IBreadcrumbItem {
-    [propertyName: string]: any;
+export interface IBreadcrumbItem extends React.AllHTMLAttributes<HTMLElement> {
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
     href?: string;
     isCurrentItem?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -249,28 +249,31 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
   };
 
   private _onRenderItem = (item: IBreadcrumbItem) => {
-    if (item.onClick || item.href) {
+    const { as, href, onClick, isCurrentItem, role, text, ...additionalProps } = item;
+
+    if (onClick || href) {
       return (
         <Link
-          as={item.as}
+          {...additionalProps}
+          as={as}
           className={this._classNames.itemLink}
-          href={item.href}
-          aria-current={item.isCurrentItem ? 'page' : undefined}
+          href={href}
+          aria-current={isCurrentItem ? 'page' : undefined}
           // eslint-disable-next-line react/jsx-no-bind
           onClick={this._onBreadcrumbClicked.bind(this, item)}
-          role={item.role}
+          role={role}
         >
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
-            {item.text}
+          <TooltipHost content={text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
+            {text}
           </TooltipHost>
         </Link>
       );
     } else {
-      const Tag = item.as || 'span';
+      const Tag = as || 'span';
       return (
-        <Tag className={this._classNames.item}>
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
-            {item.text}
+        <Tag {...additionalProps} className={this._classNames.item}>
+          <TooltipHost content={text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
+            {text}
           </TooltipHost>
         </Tag>
       );

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -249,7 +249,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
   };
 
   private _onRenderItem = (item: IBreadcrumbItem) => {
-    const { as, href, onClick, isCurrentItem, role, text, ...additionalProps } = item;
+    const { as, href, onClick, isCurrentItem, text, ...additionalProps } = item;
 
     if (onClick || href) {
       return (
@@ -261,7 +261,6 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
           aria-current={isCurrentItem ? 'page' : undefined}
           // eslint-disable-next-line react/jsx-no-bind
           onClick={this._onBreadcrumbClicked.bind(this, item)}
-          role={role}
         >
           <TooltipHost content={text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {text}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -168,4 +168,37 @@ describe('Breadcrumb', () => {
     expect(overfowItems[0].textContent).toEqual('TestText1');
     expect(overfowItems[1].textContent).toEqual('TestText2');
   });
+
+  describe('additional prop propagation to breadcrumb items', () => {
+    it('for Link', () => {
+      const itemsWithAdditionalProps: IBreadcrumbItem[] = [
+        {
+          key: 'ItemKey1',
+          text: 'Item 1',
+          href: '#',
+          'additional-prop': "I'm an additional prop",
+        },
+      ];
+
+      wrapper = mount(<Breadcrumb items={itemsWithAdditionalProps} />);
+
+      const item = wrapper.find('LinkBase');
+      expect(item.prop('additional-prop')).toEqual("I'm an additional prop");
+    });
+
+    it('for Tag', () => {
+      const itemsWithAdditionalProps: IBreadcrumbItem[] = [
+        {
+          key: 'ItemKey1',
+          text: 'Item 1',
+          'additional-prop': "I'm an additional prop",
+        },
+      ];
+
+      wrapper = mount(<Breadcrumb items={itemsWithAdditionalProps} />);
+
+      const item = wrapper.find('.ms-Breadcrumb-item');
+      expect(item.prop('additional-prop')).toEqual("I'm an additional prop");
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -169,21 +169,21 @@ describe('Breadcrumb', () => {
     expect(overfowItems[1].textContent).toEqual('TestText2');
   });
 
-  describe('additional prop propagation to breadcrumb items', () => {
+  describe('ARIA prop propagation to breadcrumb items', () => {
     it('for Link', () => {
       const itemsWithAdditionalProps: IBreadcrumbItem[] = [
         {
           key: 'ItemKey1',
           text: 'Item 1',
           href: '#',
-          'additional-prop': "I'm an additional prop",
+          'aria-label': "I'm an aria prop",
         },
       ];
 
       wrapper = mount(<Breadcrumb items={itemsWithAdditionalProps} />);
 
       const item = wrapper.find('LinkBase');
-      expect(item.prop('additional-prop')).toEqual("I'm an additional prop");
+      expect(item.prop('aria-label')).toEqual("I'm an aria prop");
     });
 
     it('for Tag', () => {
@@ -191,14 +191,14 @@ describe('Breadcrumb', () => {
         {
           key: 'ItemKey1',
           text: 'Item 1',
-          'additional-prop': "I'm an additional prop",
+          'aria-label': "I'm an aria prop",
         },
       ];
 
       wrapper = mount(<Breadcrumb items={itemsWithAdditionalProps} />);
 
       const item = wrapper.find('.ms-Breadcrumb-item');
-      expect(item.prop('additional-prop')).toEqual("I'm an additional prop");
+      expect(item.prop('aria-label')).toEqual("I'm an aria prop");
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -153,6 +153,11 @@ export interface IBreadcrumbItem {
    * Optional role for the breadcrumb item (which renders as a button by default)
    */
   role?: string;
+
+  /**
+   * Any additional properties to apply to the breadcrumb item.
+   */
+  [propertyName: string]: any;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -113,7 +113,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
 /**
  * {@docCategory Breadcrumb}
  */
-export interface IBreadcrumbItem {
+export interface IBreadcrumbItem extends React.AllHTMLAttributes<HTMLElement> {
   /**
    * Text to display to the user for the breadcrumb item.
    */
@@ -153,11 +153,6 @@ export interface IBreadcrumbItem {
    * Optional role for the breadcrumb item (which renders as a button by default)
    */
   role?: string;
-
-  /**
-   * Any additional properties to apply to the breadcrumb item.
-   */
-  [propertyName: string]: any;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10631
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added [propertyName: string]: any to the IBreadcrumbItem, to allow for additional props to be passed into the items.
Refactored item render implementation to spread the additional properties on the root components without applying the known props
