### PR TITLE
[UPP] Add controlled callbacks to EditableItem

### DIFF
--- a/change/@fluentui-react-experiments-2021-01-19-10-58-04-upp-editable-item-callbacks.json
+++ b/change/@fluentui-react-experiments-2021-01-19-10-58-04-upp-editable-item-callbacks.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "[UPP] Add controlled callbacks to EditableItem",
+  "packageName": "@fluentui/react-experiments",
+  "email": "chrp@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-19T18:58:04.347Z"
+}

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
@@ -36,7 +36,7 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
   /**
    * Build a custom selected item capable of being edited when the item is right clicked
    */
-  const SelectedItem = EditableItem({
+  const SelectedItem = EditableItem<IPersonaProps>({
     itemComponent: TriggerOnContextMenu(SelectedPersona),
     editingItemComponent: DefaultEditingItem({
       getEditingItemText: persona => persona.text || '',

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEdit.Example.tsx
@@ -18,6 +18,7 @@ import {
 
 export const SelectedPeopleListWithEditExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
+  const [editingIndex, setEditingIndex] = React.useState(-1);
 
   const _startsWith = (text: string, filterText: string): boolean => {
     return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
@@ -44,6 +45,9 @@ export const SelectedPeopleListWithEditExample = (): JSX.Element => {
         <FloatingPeopleSuggestions {...props} isSuggestionsVisible={true} />
       ),
     }),
+    getIsEditing: (item, index) => index === editingIndex,
+    onEditingStarted: (item, index) => setEditingIndex(index),
+    onEditingCompleted: () => setEditingIndex(-1),
   });
 
   const _onAddItemButtonClicked = React.useCallback(() => {

--- a/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
+++ b/packages/react-examples/src/react-experiments/SelectedPeopleList/SelectedPeopleList.WithEditInContextMenu.Example.tsx
@@ -18,6 +18,7 @@ import {
 
 export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element => {
   const [currentSelectedItems, setCurrentSelectedItems] = React.useState<IPersonaProps[]>([people[40]]);
+  const [editingIndex, setEditingIndex] = React.useState(-1);
 
   const _startsWith = (text: string, filterText: string): boolean => {
     return text.toLowerCase().indexOf(filterText.toLowerCase()) === 0;
@@ -67,6 +68,9 @@ export const SelectedPeopleListWithEditInContextMenuExample = (): JSX.Element =>
       ],
       itemComponent: TriggerOnContextMenu(SelectedPersona),
     }),
+    getIsEditing: (item, index) => index === editingIndex,
+    onEditingStarted: (item, index) => setEditingIndex(index),
+    onEditingCompleted: () => setEditingIndex(-1),
   });
 
   const _onAddItemButtonClicked = React.useCallback(() => {

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -72,6 +72,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
 
   const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
   const [inputText, setInputText] = React.useState<string>('');
+  const [editingIndex, setEditingIndex] = React.useState(-1);
 
   const ref = React.useRef<any>();
 
@@ -128,13 +129,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
     return suggestionList;
   };
 
-  const _isValid = React.useCallback((item: IPersonaProps): boolean => {
-    if (item.secondaryText) {
-      return true;
-    } else {
-      return false;
-    }
-  }, []);
+  const _isValid = React.useCallback((item: IPersonaProps): boolean => Boolean(item.secondaryText), []);
 
   const SelectedItemInternal = (props: ISelectedItemProps<IPersonaProps>) => (
     <SelectedPersona isValid={_isValid} {...props} />
@@ -169,6 +164,9 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
       ],
       itemComponent: TriggerOnContextMenu(SelectedItemInternal),
     }),
+    getIsEditing: (item, index) => index === editingIndex,
+    onEditingStarted: (item, index) => setEditingIndex(index),
+    onEditingCompleted: () => setEditingIndex(-1),
   });
 
   const _copyToClipboardWrapper = (item: IPersona) => {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
@@ -12,7 +12,7 @@ export type EditingItemComponentProps<T> = {
 /**
  * Parameters to the EditingItem higher-order component
  */
-export type EditableItemProps<T> = Readonly<{
+export type EditableItemProps<T> = {
   /**
    * Component to render when item is in normal state
    */
@@ -49,7 +49,7 @@ export type EditableItemProps<T> = Readonly<{
    * Callback for a click on the normal state item component
    */
   onClick?: (ev: React.MouseEvent<HTMLElement>, item: T, index: number) => void;
-}>;
+};
 
 // `extends unknown` to trick the parser into parsing as a type decl instead of a jsx tag
 export const EditableItem = <T extends unknown>(editableItemProps: EditableItemProps<T>): Item<T> => {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ISelectedItemProps } from '../SelectedItemsList.types';
 import { ItemCanDispatchTrigger, Item } from './ItemTrigger.types';
-import { useBoolean } from '@fluentui/react-hooks';
 
 export type EditingItemComponentProps<T> = {
   item: T;
@@ -13,37 +12,85 @@ export type EditingItemComponentProps<T> = {
 /**
  * Parameters to the EditingItem higher-order component
  */
-export type EditableItemProps<T> = {
+export type EditableItemProps<T> = Readonly<{
+  /**
+   * Component to render when item is in normal state
+   */
   itemComponent: ItemCanDispatchTrigger<T>;
+
+  /**
+   * Component to render when item is in editing state
+   */
   editingItemComponent: React.ComponentType<EditingItemComponentProps<T>>;
-};
 
-// `extends any` to trick the parser into parsing as a type decl instead of a jsx tag
-export const EditableItem = <T extends any>(editableItemProps: EditableItemProps<T>): Item<T> => {
+  /**
+   * Returns editing state (boolean) of the item
+   */
+  getIsEditing: (item: T, index: number) => boolean;
+
+  /**
+   * Callback when editing should be started. The controlling component should ensure
+   * the item is marked as being edited
+   */
+  onEditingStarted: (item: T, index: number) => void;
+
+  /**
+   * Callback when editing is finished. The controlling component should ensure
+   * the item is marked as being not edited
+   */
+  onEditingCompleted: (item: T, index: number) => void;
+
+  /**
+   * Callback when editing is cancelled/dismissed
+   */
+  onEditingDismissed?: (item: T, index: number) => void;
+
+  /**
+   * Callback for a click on the normal state item component
+   */
+  onClick?: (ev: React.MouseEvent<HTMLElement>, item: T, index: number) => void;
+}>;
+
+// `extends unknown` to trick the parser into parsing as a type decl instead of a jsx tag
+export const EditableItem = <T extends unknown>(editableItemProps: EditableItemProps<T>): Item<T> => {
   return React.memo((selectedItemProps: ISelectedItemProps<T>) => {
-    const { onItemChange, index } = selectedItemProps;
-    const [isEditing, { setTrue: setEditingTrue, setFalse: setEditingFalse }] = useBoolean(false);
+    const { getIsEditing, onEditingStarted, onEditingCompleted, onEditingDismissed, onClick } = editableItemProps;
+    const { onItemChange, item, index } = selectedItemProps;
 
-    const onItemEdited = React.useCallback(
-      (_oldItem: T, newItem: T) => {
-        onItemChange && onItemChange(newItem, index);
-        setEditingFalse();
-      },
-      [onItemChange, index, setEditingFalse],
-    );
-
+    const isEditing = getIsEditing(item, index);
     const ItemComponent = editableItemProps.itemComponent;
     const EditingItemComponent = editableItemProps.editingItemComponent;
+
+    const onTrigger = React.useCallback(() => onEditingStarted(item, index), [index, item, onEditingStarted]);
+
+    const onEditingComplete = React.useCallback(
+      (_oldItem: T, newItem: T) => {
+        onItemChange?.(newItem, index);
+        onEditingCompleted(item, index);
+      },
+      [index, item, onEditingCompleted, onItemChange],
+    );
+
+    const onDismiss = React.useCallback(() => {
+      onEditingDismissed?.(item, index);
+    }, [index, item, onEditingDismissed]);
+
+    const onItemClicked = React.useCallback(
+      (ev: React.MouseEvent<HTMLElement>) => {
+        onClick?.(ev, item, index);
+      },
+      [index, item, onClick],
+    );
 
     return isEditing ? (
       <EditingItemComponent
         item={selectedItemProps.item}
-        onEditingComplete={onItemEdited}
-        onDismiss={setEditingFalse}
+        onEditingComplete={onEditingComplete}
+        onDismiss={onDismiss}
         createGenericItem={selectedItemProps.createGenericItem}
       />
     ) : (
-      <ItemComponent {...selectedItemProps} onTrigger={setEditingTrue} />
+      <ItemComponent {...selectedItemProps} onTrigger={onTrigger} onClick={onItemClicked} />
     );
   });
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

EditableItem shouldn't control its own editing state; add callbacks so that the consumer can control it (this allows for ctrl+k resolving).

#### Focus areas to test

(optional)
