### PR TITLE
update filetype cdn version for filetype icons

### DIFF
--- a/change/@uifabric-file-type-icons-2021-01-19-11-35-54-caperez-update_filetype_cdn_version.json
+++ b/change/@uifabric-file-type-icons-2021-01-19-11-35-54-caperez-update_filetype_cdn_version.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating the Fabric CDN url to point to latest version for pulling filetype icon images.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-19T19:35:54.204Z"
+}

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20201125.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20210115.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Now pulls from the latest version of the CDN for filetype icons including Stream, Whiteboard and mobile icon size updates.
- [x] Include a change request file using `$ yarn change`

