### PR TITLE
Fixes content shifting when anchor has focus due to 2px bottom border

### DIFF
--- a/change/@fluentui-web-components-2021-01-19-12-33-31-users-robarb-anchor-shift.json
+++ b/change/@fluentui-web-components-2021-01-19-12-33-31-users-robarb-anchor-shift.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixes content shifting when anchor has focus due to 2px bottom border",
+  "packageName": "@fluentui/web-components",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-19T20:33:31.709Z"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -292,6 +292,7 @@ export const HypertextStyles = css`
     }
     :host(.hypertext) .control:${focusVisible} {
         border-bottom: calc(var(--focus-outline-width) * 1px) solid ${neutralFocusBehavior.var};
+        margin-bottom: calc(calc(var(--outline-width) - var(--focus-outline-width)) * 1px);
     }
 `.withBehaviors(
   accentForegroundRestBehavior,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Porting a fix from FAST anchor to FluentUI. Anchor focus styles have a 2px bottom border instead of the default 1px bottom border. This adds a bottom-margin based on the calculated difference between the default bottom border and the focus border width.

#### Focus areas to test

Tabbing to the hypertext anchor in the Storybook reveals the shift in content.
