### PR TITLE
 fix aria-label in GroupHeader to match heading

### DIFF
--- a/change/@fluentui-react-2021-01-20-17-02-46-fix-group-list-label.json
+++ b/change/@fluentui-react-2021-01-20-17-02-46-fix-group-list-label.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix aria-label in GroupHeader to match heading",
+  "packageName": "@fluentui/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-20T16:02:46.642Z"
+}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1242,7 +1242,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"red\\""
+                          aria-label="Color: \\"red\\" (2)"
                           aria-level={1}
                           aria-posinset={1}
                           aria-setsize={3}
@@ -2632,7 +2632,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"green\\""
+                          aria-label="Color: \\"green\\" (0)"
                           aria-level={1}
                           aria-posinset={2}
                           aria-setsize={3}
@@ -3052,7 +3052,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-label="Color: \\"blue\\""
+                          aria-label="Color: \\"blue\\" (3)"
                           aria-level={1}
                           aria-posinset={3}
                           aria-setsize={3}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -897,7 +897,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="0"
+                        aria-label="0 (100)"
                         aria-level={1}
                         aria-posinset={1}
                         aria-setsize={10}

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 0"
+                    aria-label="group 0 (3)"
                     aria-level={1}
                     aria-posinset={1}
                     aria-setsize={3}
@@ -2066,7 +2066,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 1"
+                    aria-label="group 1 (3)"
                     aria-level={1}
                     aria-posinset={2}
                     aria-setsize={3}
@@ -4052,7 +4052,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                 >
                   <div
                     aria-expanded={true}
-                    aria-label="group 2"
+                    aria-label="group 2 (3)"
                     aria-level={1}
                     aria-posinset={3}
                     aria-setsize={3}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -6886,7 +6886,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 0"
+                        aria-label="Group 0 (2)"
                         aria-level={1}
                         aria-posinset={1}
                         aria-setsize={2}
@@ -7512,7 +7512,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-label="Group 1"
+                        aria-label="Group 1 (3)"
                         aria-level={1}
                         aria-posinset={2}
                         aria-setsize={2}

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -117,7 +117,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-posinset={ariaPosInSet}
         data-is-focusable={true}
         onKeyUp={this._onKeyUp}
-        aria-label={group.ariaLabel || group.name}
+        aria-label={group.ariaLabel || `${group.name} (${group.count})`}
         aria-expanded={!this.state.isCollapsed}
         aria-level={groupLevel + 1}
       >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16471
- [x] Include a change request file using `$ yarn change`

#### Description of changes

![Titles in GroupedList](https://user-images.githubusercontent.com/14183168/105201812-92461380-5b41-11eb-87fb-60e0bba7ea71.png)

Titles in `GroupedList` contain numbers of items in a group, however default `aria-label`s have different values:

![Aria-label in headers of GroupedList](https://user-images.githubusercontent.com/14183168/105202020-d20cfb00-5b41-11eb-869a-24ddd2f0a717.png)

---

NVDA output:

```
level 2  group 0-0 (9)  expanded
level 3  group 0-0-0 (3)  expanded
```