### PR TITLE
BREAKING CHANGE(Avatar): remove components that are static properties

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ## BREAKING CHANGES
+- `Avatar`: removed static properties: `Avatar.Status`, `Avatar.StatusIcon`, `Avatar.Image`, `Avatar.Label`, `Avatar.Icon`  @yuanboxue-amber ([#16565](https://github.com/microsoft/fluentui/pull/16565))
 - `Tree`: removed management of `contentRef` for tree items. `TreeItem`: removed `selected`, `selectableParent` and `indeterminate` props @yuanboxue-amber ([#15831](https://github.com/microsoft/fluentui/pull/15831))
 - Delete `HierarchicalTree`, `HierarchicalTreeItem` and `HierarchicalTreeTitle` component @assuncaocharles ([#14515](https://github.com/microsoft/fluentui/pull/14515))
 - Styles from `listItemStyles` were moved to dedicated components @layershifter ([#14487](https://github.com/microsoft/fluentui/pull/14487))

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -17,7 +17,6 @@ import { ShorthandValue, FluentComponentStaticProps } from '../../types';
 import { createShorthandFactory, UIComponentProps, commonPropTypes, SizeValue, createShorthand } from '../../utils';
 import { AvatarStatusProps, AvatarStatus } from './AvatarStatus';
 import { AvatarImage, AvatarImageProps } from './AvatarImage';
-import { AvatarStatusIcon } from './AvatarStatusIcon';
 import { AvatarIcon, AvatarIconProps } from './AvatarIcon';
 import { AvatarLabel, AvatarLabelProps } from './AvatarLabel';
 
@@ -58,14 +57,7 @@ export const avatarClassName = 'ui-avatar';
 /**
  * An Avatar is a graphical representation of a user.
  */
-export const Avatar: ComponentWithAs<'div', AvatarProps> &
-  FluentComponentStaticProps<AvatarProps> & {
-    Status: typeof AvatarStatus;
-    StatusIcon: typeof AvatarStatusIcon;
-    Image: typeof AvatarImage;
-    Label: typeof AvatarLabel;
-    Icon: typeof AvatarIcon;
-  } = props => {
+export const Avatar: ComponentWithAs<'div', AvatarProps> & FluentComponentStaticProps<AvatarProps> = props => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(Avatar.displayName, context.telemetry);
   setStart();
@@ -204,12 +196,6 @@ Avatar.propTypes = {
   status: customPropTypes.itemShorthand,
   getInitials: PropTypes.func,
 };
-
-Avatar.Status = AvatarStatus;
-Avatar.StatusIcon = AvatarStatusIcon;
-Avatar.Image = AvatarImage;
-Avatar.Label = AvatarLabel;
-Avatar.Icon = AvatarIcon;
 
 Avatar.handledProps = Object.keys(Avatar.propTypes) as any;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The followings are removed
```js
Avatar.Status 
Avatar.StatusIcon 
Avatar.Image  
Avatar.Label 
Avatar.Icon 
```

Use below instead:
```js
AvatarStatus
AvatarStatusIcon
AvatarImage
AvatarLabel
AvatarIcon
```

Changes are made due to issue #16564

#### Focus areas to test

(optional)
