### PR TITLE
RFC: Add RFC template

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,15 @@
+# Fluent UI RFCs
+
+We're trying a new approach of checking in Fluent UI RFCs to the repo so that they're more persistent, easier to find, and we can use PR comments to discuss the proposals.
+
+## RFC process
+
+### Creation
+
+Start by making a copy of [TEMPLATE.md](./TEMPLATE.md) under an appropriate area sub-folder and name. (While we're still experimenting with the RFC process, feel free to create a new area sub-folder if you don't think an appropriate one exists yet.)
+
+Once you're done writing, make a PR and label it with **Type: RFC**.
+
+### Implementation
+
+TBD: Should the RFC file be updated in some way when implementation starts? Should it be deleted when implementation is done, moved to a different location, other?

--- a/rfcs/TEMPLATE.md
+++ b/rfcs/TEMPLATE.md
@@ -1,0 +1,50 @@
+# RFC: Your proposal name here
+
+<!--
+An RFC can be anything. A question, a suggestion, a plan. The purpose of this template is to give some structure to help folks write successful RFCs. However, don't feel constrained by this template; use your best judgement.
+
+Tips for writing a successful RFC:
+
+- Simple plain words that make your point, fancy words obfuscate
+- Try to stay concise, but don't gloss over important details
+- Try to write a neutral problem statement, not one that motivates your desired solution
+- Remember, "Writing is thinking". It's natural to realize new ideas while writing your proposal
+-->
+
+---
+
+_List contributors to the proposal here_
+
+## Summary
+
+<!-- Explain the proposed change -->
+
+## Background
+
+<!-- If there is relevant background include it here -->
+
+## Problem statement
+
+<!--
+Why are we making this change? What problem are we solving? What do we expect to gain from this?
+
+This section is important as the motivation or problem statement is indepenent from the proposed change. Even if this RFC is not accepted this Motivation can be used for alternative solutions.
+
+In the end, please make sure to present a neutral Problem statement, rather than one that motivates a particular solution
+-->
+
+## Detailed Design or Proposal
+
+<!-- This is the bulk of the RFC. Explain the proposal or design in enough detail for the inteded audience to understand. -->
+
+### Pros and Cons
+
+<!-- Enumerate the pros and cons of the proposal. Make sure to think about and be clear on the cons or drawbacks of this propsoal. If there are multiple proposals include this for each. -->
+
+## Discarded Solutions
+
+<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->
+
+## Open Issues
+
+<!-- Optional section, but useful for first drafts. Use this section to track open issues on unanswered questions regarding the design or proposal.  -->


### PR DESCRIPTION
After some discussion with @JustSlone and @Hotell, we think that it would be helpful to start checking in RFCs as markdown files in our repo so that they're in one easy-to-find place and we can discuss the proposals using PR comments. (GitHub's PR review experience is far from perfect for this purpose, but it's better than the commenting experience on hackmd for discussions of any level of complexity.)

This PR adds two files:
- `rfcs/README.md`: Very tentative outline of the RFC process. Please feel free to make any and all suggestions, even if it's a complete rewrite of the file. :)
- `rfcs/TEMPLATE.md`: RFC file template, copied with minor modifications from https://hackmd.io/xINbpxrXToSWjYGU4sXYGQ -- again very open to suggested changes here!

We may eventually want to move these to a different repo, similar to [React](https://github.com/reactjs/rfcs), [Vue](https://github.com/vuejs/rfcs), [npm](https://github.com/npm/rfcs), and many others, but putting them in our main repo is a good first step to see if this process works for us.

We should probably add CODEOWNERS for RFCs as well. Open to suggestions on who that should be.