### PR TITLE
fix: add margin to space separator and content

### DIFF
--- a/change/@fluentui-web-components-2021-01-21-11-16-12-users-khamu-breadcrumb-separator.json
+++ b/change/@fluentui-web-components-2021-01-21-11-16-12-users-khamu-breadcrumb-separator.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "set margin on separator slot",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-21T19:16:11.984Z"
+}

--- a/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -99,6 +99,7 @@ export const BreadcrumbItemStyles = css`
     .separator {
       display: flex;
       fill: ${neutralForegroundRestBehavior.var};
+      margin: 0 6px;
     }
 `.withBehaviors(
   accentForegroundActiveBehavior,

--- a/packages/web-components/src/breadcrumb-item/fixtures/breadcrumb-item.html
+++ b/packages/web-components/src/breadcrumb-item/fixtures/breadcrumb-item.html
@@ -4,6 +4,11 @@
   <h4>Default</h4>
   <fluent-breadcrumb-item href="#">
     Breadcrumb item
+  </fluent-breadcrumb-item>
+
+  <h4>Default with custom separator</h4>
+  <fluent-breadcrumb-item href="#">
+    Breadcrumb item
     <svg slot="separator" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg%22%3E">
       <path
         d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 01-.7-.7L12.8 10 7.65 4.85a.5.5 0 010-.7z"

--- a/packages/web-components/src/breadcrumb/fixtures/breadcrumb.html
+++ b/packages/web-components/src/breadcrumb/fixtures/breadcrumb.html
@@ -4,6 +4,17 @@
   <fluent-breadcrumb>
     <fluent-breadcrumb-item href="#">
       Breadcrumb item 1
+    </fluent-breadcrumb-item>
+    <fluent-breadcrumb-item href="#">
+      Breadcrumb item 2
+    </fluent-breadcrumb-item>
+    <fluent-breadcrumb-item>Breadcrumb item 3</fluent-breadcrumb-item>
+  </fluent-breadcrumb>
+
+  <h4>Default with custom separator</h4>
+  <fluent-breadcrumb>
+    <fluent-breadcrumb-item href="#">
+      Breadcrumb item 1
       <svg slot="separator" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg%22%3E">
         <path
           d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 01-.7-.7L12.8 10 7.65 4.85a.5.5 0 010-.7z"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added margin on the separator slot and updated fixtures to add examples of Default(with the default separator) and Default with custom  separator

before
![image](https://user-images.githubusercontent.com/37851220/105399115-0e8b3600-5bd8-11eb-9d6e-5fe1d05f5452.png)

after
![image](https://user-images.githubusercontent.com/37851220/105399129-121ebd00-5bd8-11eb-8fd2-e4c5cdb30d8d.png)


#### Focus areas to test

(optional)
