### PR TITLE
Revert "Fix React as external config" 

### DIFF
--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -205,16 +205,8 @@ module.exports = {
               : output,
 
           externals: {
-            react: {
-              commonjs: 'react',
-              amd: 'react',
-              root: 'React',
-            },
-            'react-dom': {
-              commonjs: 'react-dom',
-              amd: 'react-dom',
-              root: 'ReactDOM',
-            },
+            react: 'React',
+            'react-dom': 'ReactDOM',
           },
 
           resolve: {


### PR DESCRIPTION
Reverts #15773 (sorry @filoxo 😢) because it broke our UMD bundle for the case where React is a global, which is what we use in codepens. (demo: https://codepen.io/ecraig12345/pen/ExgJGeq)

Bottom of [UMD bundle before the change](https://unpkg.com/@fluentui/react@8.0.0-beta.37/dist/fluentui-react.js):
```js
/***/ "react":
/***/ (function(module, exports) {

module.exports = React;

/***/ }),

/***/ "react-dom":
/***/ (function(module, exports) {

module.exports = ReactDOM;

/***/ })
```

Bottom of [UMD bundle after the change](https://unpkg.com/@fluentui/react@8.0.0-beta.39/dist/fluentui-react.js):
```js
/***/ "react":
/***/ (function(module, exports) {

module.exports = undefined;

/***/ }),

/***/ "react-dom":
/***/ (function(module, exports) {

module.exports = undefined;

/***/ })
```

Alternatively, if someone can suggest a fix, I'll do that instead. I'm pretty confused because based on https://webpack.js.org/configuration/externals/#object it looks like the new config is correct.