### PR TITLE
Button: Re-exporting MenuContext from react-button to avoid fragility in package versions usage.

### DIFF
--- a/change/@fluentui-react-button-2021-01-21-15-43-49-exportSharedContextFromReactButton.json
+++ b/change/@fluentui-react-button-2021-01-21-15-43-49-exportSharedContextFromReactButton.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Re-exporting MenuContext from react-button to avoid fragility in package versions usage.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-21T23:43:49.064Z"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -7,11 +7,13 @@
 import { ColorTokens } from '@fluentui/theme';
 import { ComponentProps } from '@fluentui/react-compose/lib/next/index';
 import { FontTokens } from '@fluentui/theme';
+import { MenuContext } from '@fluentui/react-shared-contexts';
 import { MinimalMenuProps } from '@fluentui/react-shared-contexts';
 import * as React from 'react';
 import { RecursivePartial } from '@fluentui/theme';
 import { ShorthandProps } from '@fluentui/react-compose/lib/next/index';
 import { SizeValue } from '@fluentui/theme';
+import { useMenuContext } from '@fluentui/react-shared-contexts';
 
 // @public
 export const Button: React.ForwardRefExoticComponent<Pick<ButtonProps, string | number> & React.RefAttributes<HTMLElement>>;
@@ -213,6 +215,10 @@ export type MenuButtonTokens = ButtonTokens & {
 // @public (undocumented)
 export type MenuButtonVariants = ButtonVariants<MenuButtonTokens>;
 
+export { MenuContext }
+
+export { MinimalMenuProps }
+
 // @public
 const renderButton: (state: ButtonState) => JSX.Element;
 
@@ -305,6 +311,8 @@ export const useMenuButtonClasses: (state: MenuButtonState) => void;
 
 // @public (undocumented)
 export const useMenuButtonState: (state: MenuButtonState) => void;
+
+export { useMenuContext }
 
 // @public
 export const useSplitButton: (props: SplitButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: SplitButtonProps | undefined) => SplitButtonState;

--- a/packages/react-button/src/MenuContext.ts
+++ b/packages/react-button/src/MenuContext.ts
@@ -1,0 +1,1 @@
+export { useMenuContext, MenuContext, MinimalMenuProps } from '@fluentui/react-shared-contexts';

--- a/packages/react-button/src/index.ts
+++ b/packages/react-button/src/index.ts
@@ -3,5 +3,6 @@ import './version';
 export * from './Button';
 export * from './CompoundButton';
 export * from './MenuButton';
+export * from './MenuContext';
 export * from './SplitButton';
 export * from './ToggleButton';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR re-exports from `@fluentui/react-button` the `MenuContext` that was already exported from `@fluentui/react-shared-contexts`. This is done because, depending on the versions used, their separate usage could lead to different versions of the context being called, which in turn defeats the functionality of this approach. By importing everything from `@fluentui/react-button` you eliminate this fragile step of having to look up the correct versions.
