### PR TITLE
Renamed Card property 'quiet' to 'ghost' as per design spec

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -68,9 +68,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` image slot were moved to exact component `AvatarImage` @assuncaocharles ([#16409](https://github.com/microsoft/fluentui/pull/16409))
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
 - Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
+- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
+- Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 
 ### Fixes
-- Fix `useTree` by changing `env.NODE` to `env.NODE_ENV` @yuanboxue-amber ([#16630](https://github.com/microsoft/fluentui/pull/16630))
 - optimize largest icons used by calling @yuanboxue-amber ([#16590](https://github.com/microsoft/fluentui/pull/16590))
 - Fix selectable `Tree` where node with unselectable children displaying wrong selection state @yuanboxue-amber ([#16158](https://github.com/microsoft/fluentui/pull/16158))
 - Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## BREAKING CHANGES
 - Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
+- Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))
@@ -69,7 +70,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
 - Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
 - Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
-- Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 
 ### Fixes
 - optimize largest icons used by calling @yuanboxue-amber ([#16590](https://github.com/microsoft/fluentui/pull/16590))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -69,9 +69,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` image slot were moved to exact component `AvatarImage` @assuncaocharles ([#16409](https://github.com/microsoft/fluentui/pull/16409))
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
 - Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
-- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
 
 ### Fixes
+- Fix `useTree` by changing `env.NODE` to `env.NODE_ENV` @yuanboxue-amber ([#16630](https://github.com/microsoft/fluentui/pull/16630))
 - optimize largest icons used by calling @yuanboxue-amber ([#16590](https://github.com/microsoft/fluentui/pull/16590))
 - Fix selectable `Tree` where node with unselectable children displaying wrong selection state @yuanboxue-amber ([#16158](https://github.com/microsoft/fluentui/pull/16158))
 - Fix screen reader narrates incorrect items count for `toolbar` menu with radio group @yuanboxue-amber ([#15951](https://github.com/microsoft/fluentui/pull/15951))

--- a/packages/fluentui/docs/src/examples/components/Card/States/CardExampleDisabled.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/States/CardExampleDisabled.tsx
@@ -5,13 +5,13 @@ import { useBooleanKnob } from '@fluentui/docs-components';
 const CardExampleDisabled = () => {
   const [clickCount, setClickCount] = React.useState(0);
   const [inverted] = useBooleanKnob({ name: 'inverted', initialValue: false });
-  const [quiet] = useBooleanKnob({ name: 'quiet', initialValue: false });
+  const [ghost] = useBooleanKnob({ name: 'ghost', initialValue: false });
   const updateClickCount = () => {
     setClickCount(count => count + 1);
   };
 
   return (
-    <Card onClick={updateClickCount} disabled aria-roledescription="disabled card" inverted={inverted} quiet={quiet}>
+    <Card onClick={updateClickCount} disabled aria-roledescription="disabled card" inverted={inverted} ghost={ghost}>
       <Card.Header>
         <Text content={`Card was clicked ${clickCount} times.`} weight="bold" />
       </Card.Header>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleQuiet.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleQuiet.tsx
@@ -2,7 +2,7 @@ import { Avatar, Card, Flex, Image, Text } from '@fluentui/react-northstar';
 import * as React from 'react';
 
 const CardExampleQuiet = () => (
-  <Card aria-roledescription="card with avatar, image and text" quiet>
+  <Card aria-roledescription="card with avatar, image and text" ghost>
     <Card.Header>
       <Flex gap="gap.small">
         <Avatar
@@ -12,7 +12,7 @@ const CardExampleQuiet = () => (
           status="unknown"
         />
         <Flex column>
-          <Text content="Quiet card" weight="bold" />
+          <Text content="Ghost card" weight="bold" />
           <Text content="Secondary line" size="small" />
         </Flex>
       </Flex>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/index.tsx
@@ -16,8 +16,8 @@ const Variations = () => (
       examplePath="components/Card/Variations/CardExampleInverted"
     />
     <ComponentExample
-      title="Quiet"
-      description="Card with quiet styles"
+      title="Ghost"
+      description="Card with ghost styles"
       examplePath="components/Card/Variations/CardExampleQuiet"
     />
     <ComponentExample

--- a/packages/fluentui/react-northstar/src/components/Card/Card.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/Card.tsx
@@ -67,8 +67,8 @@ export interface CardProps extends UIComponentProps {
   /** A card can have inverted background styles. */
   inverted?: boolean;
 
-  /** A card can have quiet styles. */
-  quiet?: boolean;
+  /** A card can have ghost styles. */
+  ghost?: boolean;
 
   /** A card can show that it is currently selected or not. */
   selected?: boolean;
@@ -85,7 +85,7 @@ export type CardStylesProps = Pick<
   | 'expandable'
   | 'elevated'
   | 'inverted'
-  | 'quiet'
+  | 'ghost'
   | 'selected'
 > & {
   actionable: boolean;
@@ -132,7 +132,7 @@ export const Card: ComponentWithAs<'div', CardProps> &
     expandable,
     elevated,
     inverted,
-    quiet,
+    ghost,
     selected,
   } = props;
   const ElementType = getElementType(props);
@@ -168,7 +168,7 @@ export const Card: ComponentWithAs<'div', CardProps> &
       expandable,
       elevated,
       inverted,
-      quiet,
+      ghost,
       selected,
     }),
     mapPropsToInlineStyles: () => ({
@@ -221,7 +221,7 @@ Card.propTypes = {
   expandable: PropTypes.bool,
   disabled: PropTypes.bool,
   elevated: PropTypes.bool,
-  quiet: PropTypes.bool,
+  ghost: PropTypes.bool,
   inverted: PropTypes.bool,
   selected: PropTypes.bool,
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
@@ -26,8 +26,8 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
       borderColor: v.borderColor,
       borderRadius: v.borderRadius,
       backgroundColor: v.backgroundColor,
-      ...(p.quiet && {
-        backgroundColor: v.quietBackgroundColor,
+      ...(p.ghost && {
+        backgroundColor: v.ghostBackgroundColor,
       }),
 
       ...(p.inverted && {
@@ -46,8 +46,8 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
 
       ':hover': {
         backgroundColor: v.backgroundColorHover,
-        ...(p.quiet && {
-          backgroundColor: v.quietBackgroundColorHover,
+        ...(p.ghost && {
+          backgroundColor: v.ghostBackgroundColorHover,
         }),
         ...(p.inverted && {
           backgroundColor: v.invertedBackgroundColorHover,
@@ -68,8 +68,8 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
         cursor: 'pointer',
         ':focus-visible': {
           backgroundColor: v.backgroundColorFocus,
-          ...(p.quiet && {
-            backgroundColor: v.quietBackgroundColorFocus,
+          ...(p.ghost && {
+            backgroundColor: v.ghostBackgroundColorFocus,
           }),
           ...(p.inverted && {
             backgroundColor: v.invertedBackgroundColorFocus,
@@ -87,8 +87,8 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
         },
         ':active': {
           backgroundColor: v.backgroundColorPressed,
-          ...(p.quiet && {
-            backgroundColor: v.quietBackgroundColorPressed,
+          ...(p.ghost && {
+            backgroundColor: v.ghostBackgroundColorPressed,
           }),
           ...(p.inverted && {
             backgroundColor: v.invertedBackgroundColorPressed,
@@ -121,8 +121,8 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
         ...(p.inverted && {
           backgroundColor: v.invertedBackgroundColorDisabled,
         }),
-        ...(p.quiet && {
-          backgroundColor: v.quietBackgroundColorDisabled,
+        ...(p.ghost && {
+          backgroundColor: v.ghostBackgroundColorDisabled,
         }),
         ...(p.selected && {
           backgroundColor: v.selectedBackgroundColorDisabled,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardVariables.ts
@@ -6,11 +6,11 @@ export interface CardVariables {
   backgroundColorFocus: string;
   backgroundColorHover: string;
   backgroundColorPressed: string;
-  quietBackgroundColor: string;
-  quietBackgroundColorDisabled: string;
-  quietBackgroundColorFocus: string;
-  quietBackgroundColorHover: string;
-  quietBackgroundColorPressed: string;
+  ghostBackgroundColor: string;
+  ghostBackgroundColorDisabled: string;
+  ghostBackgroundColorFocus: string;
+  ghostBackgroundColorHover: string;
+  ghostBackgroundColorPressed: string;
   invertedBackgroundColor: string;
   invertedBackgroundColorDisabled: string;
   invertedBackgroundColorFocus: string;
@@ -78,11 +78,11 @@ export const cardVariables = (siteVars): CardVariables => {
     backgroundColorFocus: siteVars.colorScheme.default.backgroundFocus1,
     backgroundColorHover: siteVars.colorScheme.default.backgroundHover1,
     backgroundColorPressed: siteVars.colorScheme.default.backgroundPressed,
-    quietBackgroundColor: 'none',
-    quietBackgroundColorDisabled: siteVars.colorScheme.default.backgroundDisabled,
-    quietBackgroundColorFocus: 'none',
-    quietBackgroundColorHover: siteVars.colorScheme.default.backgroundHover,
-    quietBackgroundColorPressed: siteVars.colorScheme.default.backgroundPressed,
+    ghostBackgroundColor: 'none',
+    ghostBackgroundColorDisabled: siteVars.colorScheme.default.backgroundDisabled,
+    ghostBackgroundColorFocus: 'none',
+    ghostBackgroundColorHover: siteVars.colorScheme.default.backgroundHover,
+    ghostBackgroundColorPressed: siteVars.colorScheme.default.backgroundPressed,
     invertedBackgroundColor: siteVars.colorScheme.default.background2,
     invertedBackgroundColorDisabled: siteVars.colorScheme.default.backgroundDisabled2,
     invertedBackgroundColorFocus: siteVars.colorScheme.default.background2,

--- a/packages/react-cards/src/next/Card.types.ts
+++ b/packages/react-cards/src/next/Card.types.ts
@@ -38,9 +38,8 @@ export type CardProps = ComponentProps &
     /** A card can have inverted background styles. */
     inverted?: boolean;
 
-    /** A card can have quiet styles. */
-    // TODO: Is this the correct name? Appears as ghost in design spec.
-    quiet?: boolean;
+    /** A card can have ghost styles. */
+    ghost?: boolean;
 
     /** A card can show that it is currently selected or not. */
     // TODO: This should probably have a `defaultSelected` property at the same time.

--- a/packages/react-cards/src/next/Card.types.ts
+++ b/packages/react-cards/src/next/Card.types.ts
@@ -39,7 +39,7 @@ export type CardProps = ComponentProps &
     inverted?: boolean;
 
     /** A card can have ghost styles. */
-    ghost?: boolean;
+    quiet?: boolean;
 
     /** A card can show that it is currently selected or not. */
     // TODO: This should probably have a `defaultSelected` property at the same time.

--- a/packages/react-cards/src/next/Card.types.ts
+++ b/packages/react-cards/src/next/Card.types.ts
@@ -38,7 +38,8 @@ export type CardProps = ComponentProps &
     /** A card can have inverted background styles. */
     inverted?: boolean;
 
-    /** A card can have ghost styles. */
+    /** A card can have quiet styles. */
+    // TODO: Is this the correct name? Appears as ghost in design spec.
     quiet?: boolean;
 
     /** A card can show that it is currently selected or not. */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

BREAKING: Renamed Card property 'quiet' to 'ghost' as per design spec
