### PR TITLE
fix(react v7): Add high contrast overrides for the Separator

### DIFF
--- a/change/@fluentui-react-examples-2021-01-25-15-41-00-v7-16193.json
+++ b/change/@fluentui-react-examples-2021-01-25-15-41-00-v7-16193.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add high contrast overrides for Separator",
+  "packageName": "@fluentui/react-examples",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-25T14:41:00.840Z"
+}

--- a/change/office-ui-fabric-react-2021-01-25-15-41-00-v7-16193.json
+++ b/change/office-ui-fabric-react-2021-01-25-15-41-00-v7-16193.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add high contrast overrides for Separator",
+  "packageName": "office-ui-fabric-react",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-25T14:40:53.405Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Separator/Separator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Separator/Separator.styles.ts
@@ -1,4 +1,5 @@
 import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
+import { HighContrastSelector } from '@uifabric/styling';
 
 export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
   const { theme, alignContent, vertical, className } = props;
@@ -47,6 +48,10 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
             left: '50%',
             right: '0',
             zIndex: -1,
+
+            [HighContrastSelector]: {
+              backgroundColor: 'WindowText',
+            },
           },
         },
       },
@@ -63,6 +68,10 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
             bottom: '0',
             left: '0',
             right: '0',
+
+            [HighContrastSelector]: {
+              backgroundColor: 'WindowText',
+            },
           },
         },
       },

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Basic.Example.tsx.shot
@@ -86,6 +86,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             right: 0;
             top: 50%;
           }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: WindowText;
+          }
     >
       <div
         aria-orientation="horizontal"
@@ -170,6 +173,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             position: absolute;
             right: 0;
             top: 50%;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: WindowText;
           }
     >
       <div
@@ -256,6 +262,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             right: 0;
             top: 50%;
           }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: WindowText;
+          }
     >
       <div
         aria-orientation="horizontal"
@@ -340,6 +349,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             position: absolute;
             right: 0;
             top: 50%;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: WindowText;
           }
     >
       <div
@@ -465,6 +477,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
                 width: 1px;
                 z-index: -1;
               }
+              @media screen and (-ms-high-contrast: active){&:after {
+                background-color: WindowText;
+              }
         >
           <div
             aria-orientation="vertical"
@@ -569,6 +584,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
                 top: 0;
                 width: 1px;
                 z-index: -1;
+              }
+              @media screen and (-ms-high-contrast: active){&:after {
+                background-color: WindowText;
               }
         >
           <div
@@ -675,6 +693,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
                 width: 1px;
                 z-index: -1;
               }
+              @media screen and (-ms-high-contrast: active){&:after {
+                background-color: WindowText;
+              }
         >
           <div
             aria-orientation="vertical"
@@ -779,6 +800,9 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
                 top: 0;
                 width: 1px;
                 z-index: -1;
+              }
+              @media screen and (-ms-high-contrast: active){&:after {
+                background-color: WindowText;
               }
         >
           <div

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Icon.Example.tsx.shot
@@ -65,6 +65,9 @@ exports[`Component Examples renders Separator.Icon.Example.tsx correctly 1`] = `
           right: 0;
           top: 50%;
         }
+        @media screen and (-ms-high-contrast: active){&:before {
+          background-color: WindowText;
+        }
   >
     <div
       aria-orientation="horizontal"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Theming.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Separator.Theming.Example.tsx.shot
@@ -65,6 +65,9 @@ exports[`Component Examples renders Separator.Theming.Example.tsx correctly 1`] 
           right: 0;
           top: 50%;
         }
+        @media screen and (-ms-high-contrast: active){&:before {
+          background-color: WindowText;
+        }
   >
     <div
       aria-orientation="horizontal"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16193
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add high contrast overrides for the Separator component

#### Focus areas to test

##### High Contrast Black
###### Before
![image](https://user-images.githubusercontent.com/39736248/105508222-6d31dc00-5ccc-11eb-81eb-69480180c0be.png)
###### After
![image](https://user-images.githubusercontent.com/39736248/105508324-8aff4100-5ccc-11eb-86ad-3d8dc191b568.png)
##### High Contrast White
###### Before
![image](https://user-images.githubusercontent.com/39736248/105508469-abc79680-5ccc-11eb-869c-2e0dac487227.png)
###### After
![image](https://user-images.githubusercontent.com/39736248/105508525-bc780c80-5ccc-11eb-95b2-a95c5c0f7a63.png)
