### PR TITLE
Remove doNotLayer from Pivot/Tabs overflow menu

### DIFF
--- a/change/@fluentui-react-tabs-2021-01-22-17-14-16-16342-overflow-donotlayer.json
+++ b/change/@fluentui-react-tabs-2021-01-22-17-14-16-16342-overflow-donotlayer.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove doNotLayer from Pivot/Tabs overflow menu",
+  "packageName": "@fluentui/react-tabs",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-23T00:14:16.401Z"
+}

--- a/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
@@ -224,7 +224,6 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
     const overflowMenuProps: IContextualMenuProps = React.useMemo(
       () => ({
         items: [],
-        doNotLayer: true,
         alignTargetEdge: true,
         directionalHint: DirectionalHint.bottomRightEdge,
       }),

--- a/packages/react-tabs/src/next/components/Tabs/Tabs.base.tsx
+++ b/packages/react-tabs/src/next/components/Tabs/Tabs.base.tsx
@@ -219,7 +219,6 @@ export const TabsBase: React.FunctionComponent<TabsProps> = React.forwardRef<HTM
     const overflowMenuProps: IContextualMenuProps = React.useMemo(
       () => ({
         items: [],
-        doNotLayer: true,
         alignTargetEdge: true,
         directionalHint: DirectionalHint.bottomRightEdge,
       }),


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16342
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove doNotLayer from Pivot/Tabs overflow menu, to fix z-order issue when the Pivot/Tabs control is headersOnly.