### PR TITLE
ToggleButton: Replacing use of pressed semanticColors with checked semanticColors for checked states

### DIFF
--- a/change/@fluentui-react-button-2021-01-22-18-36-35-toggleButtonSemanticColors.json
+++ b/change/@fluentui-react-button-2021-01-22-18-36-35-toggleButtonSemanticColors.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "ToggleButton: Replacing use of pressed semanticColors with checked semanticColors for checked states.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-23T02:36:35.851Z"
+}

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonClasses.tsx
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonClasses.tsx
@@ -94,12 +94,12 @@ const useToggleButtonBaseClasses = makeVariantClasses<ToggleButtonState, ToggleB
     return {
       root: {
         checked: {
-          background: semanticColors?.buttonBackgroundPressed,
+          background: semanticColors?.buttonBackgroundChecked,
           contentColor: semanticColors?.buttonTextChecked,
         },
 
         checkedHovered: {
-          background: semanticColors?.buttonBackgroundPressed,
+          background: semanticColors?.buttonBackgroundCheckedHovered,
           contentColor: semanticColors?.buttonTextCheckedHovered,
         },
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16563
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR replaces the use of  `buttonBackgroundPressed` with `buttonBackgroundChecked` and `buttonBackgroundCheckedHovered` in the correct scenarios in `ToggleButton` where it is checked.

#### Focus areas to test

(optional)
