### PR TITLE
fix(Form): fix label inline styles

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, Input } from '@fluentui/react-northstar';
+import { Form } from '@fluentui/react-northstar';
 
 const FormExample = () => (
   <Form
@@ -7,29 +7,15 @@ const FormExample = () => (
       alert('Form submitted');
     }}
   >
-    {/* TODO: Remove these Form.Field as soon inline is fixed in Form.Input */}
-    <Form.Field
+    <Form.Input
       label="First name"
       name="firstName"
       id="first-name-inline"
       inline
       required
-      control={{
-        as: Input,
-        showSuccessIndicator: false,
-      }}
+      showSuccessIndicator={false}
     />
-    <Form.Field
-      label="Last name"
-      name="lastName"
-      id="last-name-inline"
-      inline
-      required
-      control={{
-        as: Input,
-        showSuccessIndicator: false,
-      }}
-    />
+    <Form.Input label="Last name" name="lastName" id="last-name-inline" inline required showSuccessIndicator={false} />
     <Form.Checkbox label="I agree to the Terms and Conditions" id="conditions-inline" />
     <Form.Button content="Submit" />
   </Form>

--- a/packages/fluentui/react-northstar/src/components/Form/FormDropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormDropdown.tsx
@@ -25,7 +25,10 @@ export const FormDropdown = compose<'div', DropdownProps, FormDropdownStylesProp
     slots: {
       control: Dropdown,
     },
-    slotProps: ({ errorMessage }) => ({
+    slotProps: ({ errorMessage, inline }) => ({
+      control: {
+        inline,
+      },
       message: {
         error: !!errorMessage,
       },

--- a/packages/fluentui/react-northstar/src/components/Form/FormInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormInput.tsx
@@ -24,13 +24,14 @@ export const FormInput = compose<'input', FormInputProps, FormInputStylesProps, 
     handledProps: ['label', 'labelPosition', 'required'],
     overrideStyles: true,
     slots: {
-      label: () => null,
       control: Input,
     },
-    slotProps: ({ errorMessage, label, labelPosition, required }) => ({
+    slotProps: ({ errorMessage, required, labelPosition }) => ({
+      label: {
+        required,
+      },
       control: {
         error: !!errorMessage,
-        label,
         labelPosition,
         required,
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16468 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We were not applying `inline` styles for `Form.Input` and `Form.Dropdown` previously. This PR fixes it.

Before:

<img width="301" alt="Screen Shot 2021-01-25 at 11 52 01" src="https://user-images.githubusercontent.com/8545105/105721834-c59eee80-5f03-11eb-8da6-5bac502ef883.png">

After:

<img width="301" alt="Screen Shot 2021-01-25 at 11 51 42" src="https://user-images.githubusercontent.com/8545105/105721857-cd5e9300-5f03-11eb-9fac-bf123010a086.png">

#### Focus areas to test

(optional)
