### PR TITLE
Port delayedKeytipQueue fix to onKeytipUpdated [7.0]

### DIFF
--- a/change/office-ui-fabric-react-2021-01-25-14-41-27-keyou-keytip-fix-7.0.json
+++ b/change/office-ui-fabric-react-2021-01-25-14-41-27-keyou-keytip-fix-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Port delayed keytip fix to onKeytipUpdated",
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-25T22:41:27.857Z"
+}

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -509,6 +509,8 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
     this._keytipTree.updateNode(keytipProps, uniqueID);
     this._setKeytips();
     if (this._keytipTree.isCurrentKeytipParent(keytipProps)) {
+      // Ensure existing children are still shown.
+      this._delayedKeytipQueue = this._delayedKeytipQueue.concat(this._keytipTree.currentKeytip?.children || []);
       this._addKeytipToQueue(sequencesToID(keytipProps.keySequences));
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This fix was already made for the 'onKeytipAdded' function and that same change needs to be ported over to 'onKeytipUpdated' for when multiple updates are called

I will also be making the fix for 8.0, PR here: https://github.com/microsoft/fluentui/pull/16614

#### Focus areas to test

Tested a breaking scenario in office-online-ui where the bug was initially found
