### PR TITLE
7.0: Keyboard focus should be visible on selected footers in pickers in high contrast

### DIFF
--- a/change/office-ui-fabric-react-2021-01-25-16-35-02-floatingpickeracc7.0.json
+++ b/change/office-ui-fabric-react-2021-01-25-16-35-02-floatingpickeracc7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Selected footers in the FloatingPicker should have highlighting in high contrast mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T00:35:02.079Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
@@ -41,6 +41,17 @@
   &:hover {
     background-color: $ms-color-themeLight;
     cursor: pointer;
+
+    @include high-contrast {
+      background-color: Highlight;
+      color: HighlightText;
+    }
+  }
+
+  @include high-contrast {
+    background-color: Highlight;
+    color: HighlightText;
+    -ms-high-contrast-adjust: none;
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - #15985

Currently, keyboard focus is not visible for SuggestionsHeaderFooterItems in high contrast. Regularly they get the same treatment as suggestion items. I added a high contrast state.

In v8, I added an example that has this, but for the backport I'm going as small as possible.
