### PR TITLE
Link: Adding underline prop

### DIFF
--- a/apps/public-docsite/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/apps/public-docsite/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -57,7 +57,7 @@ export class NotFoundPage extends React.Component<INotFoundPageProps, {}> {
           <p>The URL may be misspelled or the page you are looking for is no longer available.</p>
           <ul>
             <li>
-              <Link href="#/" onClick={ev => this._onInternalLinkClick(ev, '#/')}>
+              <Link href="#/" onClick={ev => this._onInternalLinkClick(ev, '#/')} underline>
                 Fluent UI Home
               </Link>
             </li>
@@ -78,7 +78,7 @@ export class NotFoundPage extends React.Component<INotFoundPageProps, {}> {
 
       return (
         <li>
-          <Link href={url} onClick={ev => this._onInternalLinkClick(ev, url)}>
+          <Link href={url} onClick={ev => this._onInternalLinkClick(ev, url)} underline>
             {title}
           </Link>
         </li>

--- a/apps/public-docsite/src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx
+++ b/apps/public-docsite/src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx
@@ -50,10 +50,17 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                       Microsoft Office files.
                       <br />
                       <br />
-                      If you are looking for icons for command bars, navigation, status indicators, or similar, check
-                      out the <Link href="#/styles/web/icons">Fluent UI icons page</Link>. Alternatively, if you're
-                      looking for brand logos, or the icons of apps themselves, check out the{' '}
-                      <Link href="#/styles/web/office-brand-icons">Fluent UI brand icons page</Link>.
+                      If you're looking for icons for command bars, navigation, status indicators, or similar, check out
+                      the{' '}
+                      <Link href="#/styles/web/icons" underline>
+                        Fluent UI icons page
+                      </Link>
+                      . {/* comment to prevent eslint/prettier conflict */}Alternatively, if you're looking for brand
+                      logos, or the icons of apps themselves, check out the{' '}
+                      <Link href="#/styles/web/office-brand-icons" underline>
+                        Fluent UI brand icons page
+                      </Link>
+                      .
                     </p>
                   </div>
                   <div className="ms-Grid-col ms-sm12 ms-lg6">

--- a/apps/public-docsite/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
+++ b/apps/public-docsite/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
@@ -51,11 +51,17 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                       icon for the menu option that allows users create a new Word document.
                     </p>
                     <p>
-                      If you are looking for icons for command bars, navigation, status indicators, or similar, check
-                      out the <Link href="#/styles/web/icons">Fluent UI icons page</Link>. Alternatively, if you're
-                      looking for file type icons to represent digital content or to indicate to users that they are
-                      creating a new file of that type, check out the{' '}
-                      <Link href="#/styles/web/file-type-icons">Fluent UI file type icons page</Link>.
+                      If you're looking for icons for command bars, navigation, status indicators, or similar, check out
+                      the{' '}
+                      <Link href="#/styles/web/icons" underline>
+                        Fluent UI icons page
+                      </Link>
+                      . Alternatively, if you're looking for file type icons to represent digital content or to indicate
+                      to users that they are creating a new file of that type, check out the{' '}
+                      <Link href="#/styles/web/file-type-icons" underline>
+                        Fluent UI file type icons page
+                      </Link>
+                      .
                     </p>
                   </div>
                   <div className="ms-Grid-col ms-sm12 ms-lg6">

--- a/apps/vr-tests/src/stories/Link.stories.tsx
+++ b/apps/vr-tests/src/stories/Link.stories.tsx
@@ -51,4 +51,14 @@ storiesOf('Link', module)
     <Link disabled styles={{ root: { fontSize: '14px' } }}>
       I'm rendered as a button because I have no href and am disabled
     </Link>
+  ))
+  .addStory('Underlined', () => (
+    <Link underline styles={{ root: { fontSize: '14px' } }}>
+      I'm rendered as a button because I have no href
+    </Link>
+  ))
+  .addStory('Underlined Disabled', () => (
+    <Link disabled underline styles={{ root: { fontSize: '14px' } }}>
+      I'm rendered as a button because I have no href and am disabled
+    </Link>
   ));

--- a/change/@fluentui-react-docsite-components-2021-01-25-20-00-44-linkUnderline.json
+++ b/change/@fluentui-react-docsite-components-2021-01-25-20-00-44-linkUnderline.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "MarkdownLink: Adding underline prop and setting it to true by default.",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T04:00:41.623Z"
+}

--- a/change/@fluentui-react-link-2021-01-25-20-00-44-linkUnderline.json
+++ b/change/@fluentui-react-link-2021-01-25-20-00-44-linkUnderline.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Link: Adding underline prop.",
+  "packageName": "@fluentui/react-link",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T04:00:44.756Z"
+}

--- a/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -352,7 +352,7 @@ function _renderLinkTokens(
 
       if (token.linkedPage && token.linkedPageGroup) {
         return (
-          <Link key={key} {...tokenResolver(token as Required<ILinkToken>)}>
+          <Link key={key} {...tokenResolver(token as Required<ILinkToken>)} underline>
             <code>{token.text}</code>
           </Link>
         );

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
@@ -80,7 +80,7 @@ function getMarkdownProps(subComponentStyles: IMarkdownSubComponentStyles, props
         },
         a: {
           component: MarkdownLink,
-          props: { className: 'ms-mdLink', styles: subComponentStyles.link },
+          props: { className: 'ms-mdLink', styles: subComponentStyles.link, underline: false },
         },
         img: {
           component: Image,

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
@@ -80,7 +80,7 @@ function getMarkdownProps(subComponentStyles: IMarkdownSubComponentStyles, props
         },
         a: {
           component: MarkdownLink,
-          props: { className: 'ms-mdLink', styles: subComponentStyles.link, underline: false },
+          props: { className: 'ms-mdLink', styles: subComponentStyles.link },
         },
         img: {
           component: Image,

--- a/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, ILinkProps } from 'office-ui-fabric-react/lib/Link';
+import { Link, ILinkProps } from '@fluentui/react/lib/Link';
 import { removeAnchorLink } from '../../utilities/index2';
 
 export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {

--- a/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
@@ -4,10 +4,11 @@ import { removeAnchorLink } from '../../utilities/index2';
 
 export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {
   let href = props.href;
+  const { underline = true } = props;
   if (href && href[0] === '#' && href.indexOf('/') === -1) {
     // This is an anchor link within this page. We need to prepend the current route.
     href = removeAnchorLink(location.hash) + href;
   }
 
-  return <Link {...props} href={href} />;
+  return <Link {...props} href={href} underline={underline} />;
 };

--- a/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { Link, ILinkProps } from '@fluentui/react/lib/Link';
 import { removeAnchorLink } from '../../utilities/index2';
+import { styled } from '@fluentui/react/lib/Utilities';
 
-export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {
+const MarkdownLinkBase: React.FunctionComponent<ILinkProps> = props => {
   let href = props.href;
   const { underline = true } = props;
   if (href && href[0] === '#' && href.indexOf('/') === -1) {
@@ -12,3 +13,12 @@ export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {
 
   return <Link {...props} href={href} underline={underline} />;
 };
+MarkdownLinkBase.displayName = 'MarkdownLink';
+
+// Allow MarkdownLink to be targeted with Customizer
+export const MarkdownLink: React.FunctionComponent<ILinkProps> = styled<ILinkProps, {}, {}>(
+  MarkdownLinkBase,
+  {},
+  undefined,
+  { scope: 'MarkdownLink' },
+);

--- a/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/MarkdownLink.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Link, ILinkProps } from '@fluentui/react/lib/Link';
+import { Link, ILinkProps } from 'office-ui-fabric-react/lib/Link';
 import { removeAnchorLink } from '../../utilities/index2';
-import { styled } from '@fluentui/react/lib/Utilities';
 
-const MarkdownLinkBase: React.FunctionComponent<ILinkProps> = props => {
+export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {
   let href = props.href;
   const { underline = true } = props;
   if (href && href[0] === '#' && href.indexOf('/') === -1) {
@@ -13,12 +12,3 @@ const MarkdownLinkBase: React.FunctionComponent<ILinkProps> = props => {
 
   return <Link {...props} href={href} underline={underline} />;
 };
-MarkdownLinkBase.displayName = 'MarkdownLink';
-
-// Allow MarkdownLink to be targeted with Customizer
-export const MarkdownLink: React.FunctionComponent<ILinkProps> = styled<ILinkProps, {}, {}>(
-  MarkdownLinkBase,
-  {},
-  undefined,
-  { scope: 'MarkdownLink' },
-);

--- a/packages/react-docsite-components/src/components/Page/Page.module.scss
+++ b/packages/react-docsite-components/src/components/Page/Page.module.scss
@@ -162,16 +162,6 @@ $usageListPadding: 24px;
   }
 }
 
-.hiddenContent {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: 'hidden';
-}
-
 .subHeading,
 .smallSubHeading {
   @include ms-fontColor-gray160;

--- a/packages/react-docsite-components/src/components/Page/Page.tsx
+++ b/packages/react-docsite-components/src/components/Page/Page.tsx
@@ -42,6 +42,11 @@ const scopedSettings: ICustomizations['scopedSettings'] = {
   Link: linkCustomizations,
 };
 
+const relatedLinkCustomizations: Partial<ILinkProps> = { underline: false };
+const relatedScopedSettings: ICustomizations['scopedSettings'] = {
+  MarkdownLink: relatedLinkCustomizations,
+};
+
 // TODO: I think this component should be templated to forward the TPlatform type to props.
 //        It can then be used in JSX like this:
 //        <Page<Platform> {...props} />
@@ -266,7 +271,14 @@ export class Page extends React.Component<IPageProps, IPageState> {
       let processedRelated: JSX.Element | ISideRailLink[] | undefined;
       if (typeof related === 'string') {
         // don't show section if the content is empty
-        processedRelated = related.trim() ? <Markdown>{related}</Markdown> : undefined;
+        processedRelated = related.trim() ? (
+          // Customizer ensures that the links in this section are not underlined
+          <Customizer scopedSettings={relatedScopedSettings}>
+            <Markdown>{related}</Markdown>
+          </Customizer>
+        ) : (
+          undefined
+        );
       } else {
         processedRelated = related;
       }

--- a/packages/react-docsite-components/src/components/Page/Page.tsx
+++ b/packages/react-docsite-components/src/components/Page/Page.tsx
@@ -42,11 +42,6 @@ const scopedSettings: ICustomizations['scopedSettings'] = {
   Link: linkCustomizations,
 };
 
-const relatedLinkCustomizations: Partial<ILinkProps> = { underline: false };
-const relatedScopedSettings: ICustomizations['scopedSettings'] = {
-  MarkdownLink: relatedLinkCustomizations,
-};
-
 // TODO: I think this component should be templated to forward the TPlatform type to props.
 //        It can then be used in JSX like this:
 //        <Page<Platform> {...props} />
@@ -271,14 +266,7 @@ export class Page extends React.Component<IPageProps, IPageState> {
       let processedRelated: JSX.Element | ISideRailLink[] | undefined;
       if (typeof related === 'string') {
         // don't show section if the content is empty
-        processedRelated = related.trim() ? (
-          // Customizer ensures that the links in this section are not underlined
-          <Customizer scopedSettings={relatedScopedSettings}>
-            <Markdown>{related}</Markdown>
-          </Customizer>
-        ) : (
-          undefined
-        );
+        processedRelated = related.trim() ? <Markdown>{related}</Markdown> : undefined;
       } else {
         processedRelated = related;
       }

--- a/packages/react-docsite-components/src/components/Page/sections/OverviewSection.tsx
+++ b/packages/react-docsite-components/src/components/Page/sections/OverviewSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Markdown } from '../../Markdown/index';
 import { IPageSectionPropsWithSectionName } from '../Page.types';
 import * as styles from '../Page.module.scss';
+import { hiddenContentStyle } from '@fluentui/react/lib/Styling';
 
 export const OverviewSection: React.FunctionComponent<IPageSectionPropsWithSectionName> = props => {
   const { className, content: overview, sectionName, readableSectionName = sectionName, style, id } = props;
@@ -9,8 +10,10 @@ export const OverviewSection: React.FunctionComponent<IPageSectionPropsWithSecti
   return (
     <div className={className} style={style}>
       <div id={id} tabIndex={-1}>
-        {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
-        <h2 className={styles.subHeading + ' ' + styles.hiddenContent}>{readableSectionName}</h2>
+        {/* This heading isn't shown but must be programmatically focusable for simulating jumping to an anchor */}
+        <h2 className={styles.subHeading} style={hiddenContentStyle as React.CSSProperties}>
+          {readableSectionName}
+        </h2>
       </div>
       <div className={styles.content}>
         <Markdown>{overview}</Markdown>

--- a/packages/react-docsite-components/src/components/SideRail/SideRail.styles.ts
+++ b/packages/react-docsite-components/src/components/SideRail/SideRail.styles.ts
@@ -49,16 +49,15 @@ export const getStyles: IStyleFunction<ISideRailStyleProps, ISideRailStyles> = p
     },
     markdownList: {
       selectors: {
-        'ul li': [
+        li: [
           {
             fontSize: theme.fonts.medium.fontSize,
             padding: '4px 8px',
-            selectors: {
-              '&:hover': { background: theme.palette.neutralLight },
-            },
           },
           getFocusOutlineStyle(theme, 1),
         ],
+        // doing :hover styles together with li above applied them to root markdownList
+        'li:hover': { background: theme.palette.neutralLight },
       },
     },
     jumpLinkWrapper: {

--- a/packages/react-docsite-components/src/components/SiteMessageBar/SiteMessageBar.tsx
+++ b/packages/react-docsite-components/src/components/SiteMessageBar/SiteMessageBar.tsx
@@ -35,7 +35,7 @@ export class SiteMessageBar extends React.Component<ISiteMessageBarProps, ISiteM
       <MessageBar onDismiss={this._onClose} isMultiline dismissButtonAriaLabel="Close" styles={styles} {...rest}>
         {text}{' '}
         {!!(linkUrl && linkText) && (
-          <Link href={linkUrl} target={linkUrl.indexOf('http') === 0 ? '_blank' : ''}>
+          <Link href={linkUrl} target={linkUrl.indexOf('http') === 0 ? '_blank' : ''} underline>
             {linkText}
           </Link>
         )}

--- a/packages/react-docsite-components/src/components/TopNav/TopNav.module.scss
+++ b/packages/react-docsite-components/src/components/TopNav/TopNav.module.scss
@@ -48,6 +48,7 @@ $linkPadding: 16px;
     white-space: nowrap;
     position: relative;
     padding: 0 $linkPadding;
+    text-decoration: none;
 
     @include focus-border(2px);
   }

--- a/packages/react-examples/src/react-checkbox/Checkbox/Checkbox.Other.Example.tsx
+++ b/packages/react-examples/src/react-checkbox/Checkbox/Checkbox.Other.Example.tsx
@@ -37,9 +37,9 @@ export const CheckboxOtherExample: React.FunctionComponent = () => {
 function _renderLabelWithLink() {
   return (
     <span>
-      Custom-rendered label with a link{' '}
-      <Link href="https://www.microsoft.com" target="_blank">
-        go to Microsoft home page
+      Custom-rendered label with a link to{' '}
+      <Link href="https://www.microsoft.com" target="_blank" underline>
+        Microsoft home page
       </Link>
     </span>
   );

--- a/packages/react-examples/src/react-checkbox/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react-checkbox/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -655,7 +655,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span>
-        Custom-rendered label with a link
+        Custom-rendered label with a link to
          
         <a
           className=
@@ -668,7 +668,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
                 font-size: inherit;
                 font-weight: inherit;
                 outline: none;
-                text-decoration: none;
+                text-decoration: underline;
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
@@ -712,7 +712,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           onClick={[Function]}
           target="_blank"
         >
-          go to Microsoft home page
+          Microsoft home page
         </a>
       </span>
     </label>

--- a/packages/react-examples/src/react-experiments/Pagination/PaginationPage.tsx
+++ b/packages/react-examples/src/react-experiments/Pagination/PaginationPage.tsx
@@ -61,7 +61,7 @@ export class PaginationPage extends React.Component<IComponentDemoPageProps, {}>
               For cases when your application supports theming, Pagination component is equipped with everything you
               need to just load the custom theme to the application, and as long as the color palette you provide has an
               override for the{' '}
-              <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/colors">
+              <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/colors" underline>
                 <code>Fabric colors</code>
               </Link>{' '}
               used in Pagination, everything should be ok. If no theming is supported, then follow the example showing

--- a/packages/react-examples/src/react-experiments/TilesList/TilesListPage.tsx
+++ b/packages/react-examples/src/react-experiments/TilesList/TilesListPage.tsx
@@ -67,7 +67,7 @@ export class TilesListPage extends React.Component<IComponentDemoPageProps, ITil
           <div>
             <p>
               <code>TilesList</code> is a specialization of the{' '}
-              <Link href="#/examples/List">
+              <Link href="#/examples/List" underline>
                 <code>List</code>
               </Link>{' '}
               component. It is intended to represent items visually using one or more content-focused flowing grids.

--- a/packages/react-examples/src/react-link/Link/Link.Basic.Example.tsx
+++ b/packages/react-examples/src/react-link/Link/Link.Basic.Example.tsx
@@ -7,12 +7,15 @@ export const LinkBasicExample: React.FunctionComponent = () => {
     <div>
       <Text>
         When a link has an href,{' '}
-        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link">
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link" underline>
           it renders as an anchor tag.
         </Link>{' '}
-        Without an href, <Link onClick={handleClickOnLink}>the link is rendered as a button</Link>. You can also use the
-        disabled attribute to create a{' '}
-        <Link disabled={true} href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link">
+        Without an href,{' '}
+        <Link onClick={handleClickOnLink} underline>
+          the link is rendered as a button
+        </Link>
+        . You can also use the disabled attribute to create a{' '}
+        <Link disabled={true} href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link" underline>
           disabled link.
         </Link>
       </Text>

--- a/packages/react-examples/src/react-link/Link/Link.Basic.Example.tsx
+++ b/packages/react-examples/src/react-link/Link/Link.Basic.Example.tsx
@@ -15,7 +15,7 @@ export const LinkBasicExample: React.FunctionComponent = () => {
           the link is rendered as a button
         </Link>
         . You can also use the disabled attribute to create a{' '}
-        <Link disabled={true} href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link" underline>
+        <Link disabled href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link" underline>
           disabled link.
         </Link>
       </Text>

--- a/packages/react-examples/src/react-link/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react-link/__snapshots__/Link.Basic.Example.tsx.shot
@@ -29,7 +29,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             font-size: inherit;
             font-weight: inherit;
             outline: none;
-            text-decoration: none;
+            text-decoration: underline;
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
@@ -75,7 +75,8 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
       it renders as an anchor tag.
     </a>
      
-    Without an href, 
+    Without an href,
+     
     <button
       className=
           ms-Link
@@ -103,7 +104,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             text-align: left;
-            text-decoration: none;
+            text-decoration: underline;
             text-overflow: inherit;
             user-select: text;
           }
@@ -169,7 +170,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             font-size: inherit;
             font-weight: inherit;
             outline: none;
-            text-decoration: none;
+            text-decoration: underline;
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;

--- a/packages/react-examples/src/react/ActivityItem/ActivityItem.Basic.Example.tsx
+++ b/packages/react-examples/src/react/ActivityItem/ActivityItem.Basic.Example.tsx
@@ -10,97 +10,97 @@ const classNames = mergeStyleSets({
   },
 });
 
-export const ActivityItemBasicExample: React.FunctionComponent = () => {
-  /* eslint-disable react/jsx-no-bind */
-  const activityItemExamples = [
-    {
-      key: 1,
-      activityDescription: [
-        <Link
-          key={1}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('A name was clicked.');
-          }}
-        >
-          Philippe Lampros
-        </Link>,
-        <span key={2}> commented</span>,
-      ],
-      activityIcon: <Icon iconName={'Message'} />,
-      comments: [
-        <span key={1}>Hello! I am making a comment and mentioning </span>,
-        <Link
-          key={2}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('An @mentioned name was clicked.');
-          }}
-        >
-          @Anđela Debeljak
-        </Link>,
-        <span key={3}> in the text of the comment.</span>,
-      ],
-      timeStamp: 'Just now',
-    },
-    {
-      key: 2,
-      activityDescription: [
-        <Link
-          key={1}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('A name was clicked.');
-          }}
-        >
-          Lisha Refai
-        </Link>,
-        <span key={2}> deleted </span>,
-        <span key={3} className={classNames.nameText}>
-          DocumentTitle.docx
-        </span>,
-      ],
-      activityIcon: <Icon iconName={'Trash'} />,
-      timeStamp: '2 hours ago',
-    },
-    {
-      key: 3,
-      activityDescription: [
-        <Link
-          key={1}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('A name was clicked.');
-          }}
-        >
-          Julian Arvidsson
-        </Link>,
-        <span key={2}> moved </span>,
-        <Link
-          key={3}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('A document was clicked.');
-          }}
-        >
-          PresentationTitle.pptx
-        </Link>,
-        <span key={4}> to </span>,
-        <Link
-          key={5}
-          className={classNames.nameText}
-          onClick={() => {
-            alert('A folder was clicked.');
-          }}
-        >
-          Destination Folder
-        </Link>,
-      ],
-      activityIcon: <Icon iconName={'FabricMovetoFolder'} />,
-      timeStamp: 'Yesterday',
-    },
-  ];
+/* eslint-disable react/jsx-no-bind */
+const activityItemExamples = [
+  {
+    key: 1,
+    activityDescription: [
+      <Link
+        key={1}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('A name was clicked.');
+        }}
+      >
+        Philippe Lampros
+      </Link>,
+      <span key={2}> commented</span>,
+    ],
+    activityIcon: <Icon iconName={'Message'} />,
+    comments: [
+      <span key={1}>Hello! I am making a comment and mentioning </span>,
+      <Link
+        key={2}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('An @mentioned name was clicked.');
+        }}
+      >
+        @Anđela Debeljak
+      </Link>,
+      <span key={3}> in the text of the comment.</span>,
+    ],
+    timeStamp: 'Just now',
+  },
+  {
+    key: 2,
+    activityDescription: [
+      <Link
+        key={1}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('A name was clicked.');
+        }}
+      >
+        Lisha Refai
+      </Link>,
+      <span key={2}> deleted </span>,
+      <span key={3} className={classNames.nameText}>
+        DocumentTitle.docx
+      </span>,
+    ],
+    activityIcon: <Icon iconName={'Trash'} />,
+    timeStamp: '2 hours ago',
+  },
+  {
+    key: 3,
+    activityDescription: [
+      <Link
+        key={1}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('A name was clicked.');
+        }}
+      >
+        Julian Arvidsson
+      </Link>,
+      <span key={2}> moved </span>,
+      <Link
+        key={3}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('A document was clicked.');
+        }}
+      >
+        PresentationTitle.pptx
+      </Link>,
+      <span key={4}> to </span>,
+      <Link
+        key={5}
+        className={classNames.nameText}
+        onClick={() => {
+          alert('A folder was clicked.');
+        }}
+      >
+        Destination Folder
+      </Link>,
+    ],
+    activityIcon: <Icon iconName={'FabricMovetoFolder'} />,
+    timeStamp: 'Yesterday',
+  },
+];
 
+export const ActivityItemBasicExample: React.FunctionComponent = () => {
   return (
     <div>
       {activityItemExamples.map((item: { key: string | number }) => (

--- a/packages/react-examples/src/react/ActivityItem/ActivityItem.Compact.Example.tsx
+++ b/packages/react-examples/src/react/ActivityItem/ActivityItem.Compact.Example.tsx
@@ -11,62 +11,62 @@ const classNames = mergeStyleSets({
   },
 });
 
-export const ActivityItemCompactExample: React.FunctionComponent = () => {
-  const activityItemExamples: Partial<IActivityItemProps & React.ClassAttributes<{}>>[] = [
-    {
-      key: 1,
-      activityDescription: [
-        <span key={1} className={classNames.nameText}>
-          Tahlia Whittle
-        </span>,
-        <span key={2}> edited this file</span>,
-      ],
-      activityPersonas: [{ imageUrl: TestImages.personaFemale }],
-      isCompact: true,
-    },
-    {
-      key: 2,
-      activityDescription: [
-        <span key={1} className={classNames.nameText}>
-          Patrick Loton
-        </span>,
-        <span key={2}> and </span>,
-        <span key={3} className={classNames.nameText}>
-          {' '}
-          6 others
-        </span>,
-      ],
-      activityPersonas: [
-        { imageInitials: 'PT', text: 'Robert Larsson' },
-        { imageUrl: TestImages.personaMale },
-        { imageInitials: 'EC', text: 'Eduarda Costa' },
-      ],
-      isCompact: true,
-    },
-    {
-      key: 3,
-      activityDescription: [
-        <span key={1} className={classNames.nameText}>
-          Sabrina De Luca
-        </span>,
-        <span key={2}> added this file</span>,
-      ],
-      activityIcon: <Icon iconName={'Add'} />,
-      isCompact: true,
-    },
-    {
-      key: 4,
-      activityDescription: [
-        <span key={1} className={classNames.nameText}>
-          Chuan Rojumanong
-        </span>,
-        <span key={2}> shared this file</span>,
-      ],
-      activityIcon: <Icon iconName={'Share'} />,
-      isCompact: true,
-    },
-  ];
+const activityItemExamples: Partial<IActivityItemProps & React.ClassAttributes<{}>>[] = [
+  {
+    key: 1,
+    activityDescription: [
+      <span key={1} className={classNames.nameText}>
+        Tahlia Whittle
+      </span>,
+      <span key={2}> edited this file</span>,
+    ],
+    activityPersonas: [{ imageUrl: TestImages.personaFemale }],
+    isCompact: true,
+  },
+  {
+    key: 2,
+    activityDescription: [
+      <span key={1} className={classNames.nameText}>
+        Patrick Loton
+      </span>,
+      <span key={2}> and </span>,
+      <span key={3} className={classNames.nameText}>
+        {' '}
+        6 others
+      </span>,
+    ],
+    activityPersonas: [
+      { imageInitials: 'PT', text: 'Robert Larsson' },
+      { imageUrl: TestImages.personaMale },
+      { imageInitials: 'EC', text: 'Eduarda Costa' },
+    ],
+    isCompact: true,
+  },
+  {
+    key: 3,
+    activityDescription: [
+      <span key={1} className={classNames.nameText}>
+        Sabrina De Luca
+      </span>,
+      <span key={2}> added this file</span>,
+    ],
+    activityIcon: <Icon iconName={'Add'} />,
+    isCompact: true,
+  },
+  {
+    key: 4,
+    activityDescription: [
+      <span key={1} className={classNames.nameText}>
+        Chuan Rojumanong
+      </span>,
+      <span key={2}> shared this file</span>,
+    ],
+    activityIcon: <Icon iconName={'Share'} />,
+    isCompact: true,
+  },
+];
 
+export const ActivityItemCompactExample: React.FunctionComponent = () => {
   return (
     <div>
       {activityItemExamples.map((item: { key: string | number }) => (

--- a/packages/react-examples/src/react/Button/Button.Icon.Example.tsx
+++ b/packages/react-examples/src/react/Button/Button.Icon.Example.tsx
@@ -44,7 +44,10 @@ export const ButtonIconExample: React.FunctionComponent<IButtonExampleProps> = p
       </Stack>
       <p>
         For a list of Icons, visit our{' '}
-        <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/icons">Icon documentation</Link>.
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/icons" underline>
+          Icon documentation
+        </Link>
+        .
       </p>
     </div>
   );

--- a/packages/react-examples/src/react/Keytip/Keytips.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Keytip/Keytips.Basic.Example.tsx
@@ -41,7 +41,7 @@ export const KeytipsBasicExample: React.FunctionComponent = () => {
             <Toggle ref={toggleRef} onText="Yes" offText="No" />
             <span>
               Go to{' '}
-              <Link ref={linkRef} href="http://www.bing.com" target="_blank">
+              <Link ref={linkRef} href="http://www.bing.com" target="_blank" underline>
                 Bing
               </Link>
             </span>

--- a/packages/react-examples/src/react/MessageBar/MessageBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/MessageBar/MessageBar.Basic.Example.tsx
@@ -24,7 +24,7 @@ const choiceGroupStyles = {
 const DefaultExample = () => (
   <MessageBar>
     Info/Default MessageBar.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>
@@ -38,7 +38,7 @@ const ErrorExample = (p: IExampleProps) => (
     dismissButtonAriaLabel="Close"
   >
     Error MessageBar with single line, with dismiss button.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>
@@ -75,7 +75,7 @@ const SevereExample = (p: IExampleProps) => (
     }
   >
     SevereWarning MessageBar with action buttons which defaults to multiline.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>
@@ -93,7 +93,7 @@ const SuccessExample = () => (
     isMultiline={false}
   >
     Success MessageBar with single line and action buttons.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>
@@ -112,7 +112,7 @@ const WarningExample = (p: IExampleProps) => (
     }
   >
     Warning MessageBar content.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>
@@ -136,7 +136,7 @@ const WarningExample2 = (p: IExampleProps) => (
     faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse
     platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu
     mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris.
-    <Link href="www.bing.com" target="_blank">
+    <Link href="www.bing.com" target="_blank" underline>
       Visit our website.
     </Link>
   </MessageBar>

--- a/packages/react-examples/src/react/Panel/Panel.Sizes.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.Sizes.Example.tsx
@@ -58,7 +58,7 @@ export const PanelSizesExample: React.FunctionComponent = () => {
     <div>
       <p style={firstPStyle}>
         See the{' '}
-        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#PanelType">
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#PanelType" underline>
           PanelType documentation
         </Link>{' '}
         for details on how each option affects panel sizing at different screen widths.

--- a/packages/react-examples/src/react/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Icon.Example.tsx.shot
@@ -337,7 +337,7 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             font-size: inherit;
             font-weight: inherit;
             outline: none;
-            text-decoration: none;
+            text-decoration: underline;
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1177,7 +1177,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                     font-size: inherit;
                     font-weight: inherit;
                     outline: none;
-                    text-decoration: none;
+                    text-decoration: underline;
                   }
                   .ms-Fabric--isFocusVisible &:focus {
                     box-shadow: 0 0 0 1px #605e5c inset;

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -67,6 +67,7 @@ export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement
     target?: string;
     theme?: ITheme;
     type?: string;
+    underline?: boolean;
 }
 
 // @public (undocumented)
@@ -77,6 +78,8 @@ export interface ILinkStyleProps {
     isButton?: boolean;
     // (undocumented)
     isDisabled?: boolean;
+    // (undocumented)
+    isUnderlined?: boolean;
     // (undocumented)
     theme: ITheme;
 }

--- a/packages/react-link/src/components/Link/Link.styles.ts
+++ b/packages/react-link/src/components/Link/Link.styles.ts
@@ -10,7 +10,7 @@ const GlobalClassNames = {
 };
 
 export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
-  const { className, isButton, isDisabled, theme } = props;
+  const { className, isButton, isDisabled, isUnderlined, theme } = props;
   const { semanticColors } = theme;
 
   // Tokens
@@ -30,7 +30,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         outline: 'none',
         fontSize: 'inherit',
         fontWeight: 'inherit',
-        textDecoration: 'none',
+        textDecoration: isUnderlined ? 'underline' : 'none',
 
         selectors: {
           '.ms-Fabric--isFocusVisible &:focus': {

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -110,6 +110,12 @@ export interface ILinkProps
    */
   type?: string;
 
+  /**
+   * Whether the link is styled with an underline or not.
+   * Should be used when the link is placed alongside other text content.
+   */
+  underline?: boolean;
+
   /** Any other props for elements or a React component passed to `as` */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -122,6 +128,7 @@ export interface ILinkStyleProps {
   className?: string;
   isButton?: boolean;
   isDisabled?: boolean;
+  isUnderlined?: boolean;
   theme: ITheme;
 }
 

--- a/packages/react-link/src/components/Link/useLink.ts
+++ b/packages/react-link/src/components/Link/useLink.ts
@@ -73,7 +73,7 @@ const adjustPropsForRootType = (
   // Deconstruct the props so we remove props like `as`, `theme` and `styles`
   // as those will always be removed. We also take some props that are optional
   // based on the RootType.
-  const { as, disabled, target, href, theme, getStyles, styles, componentRef, ...restProps } = props;
+  const { as, disabled, target, href, theme, getStyles, styles, componentRef, underline, ...restProps } = props;
 
   // RootType will be a string if we're dealing with an html component
   if (typeof RootType === 'string') {

--- a/packages/react-link/src/components/Link/useLink.ts
+++ b/packages/react-link/src/components/Link/useLink.ts
@@ -11,7 +11,7 @@ const getClassNames = classNamesFunction<ILinkStyleProps, ILinkStyles>();
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useLink = (props: ILinkProps, forwardedRef: React.Ref<HTMLElement>): any => {
-  const { as, className, disabled, href, onClick, styles, theme } = props;
+  const { as, className, disabled, href, onClick, styles, theme, underline } = props;
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const mergedRootRefs: React.Ref<HTMLElement> = useMergedRefs(rootRef, forwardedRef);
 
@@ -22,6 +22,7 @@ export const useLink = (props: ILinkProps, forwardedRef: React.Ref<HTMLElement>)
     className,
     isButton: !href,
     isDisabled: disabled,
+    isUnderlined: underline,
     theme: theme!,
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16302
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds an `underline` prop that provider underline styling to the `Link` component. This is done to add a styling difference in places where color is not enough contrast to differentiate the `Link` (i.e. cases where the `Link` is alongside other text).