### PR TITLE
Renamed prop 'quiet' to 'ghost' for react-cards in Card types

### DIFF
--- a/change/@fluentui-react-cards-2021-01-27-17-21-05-TanelVari-ui-polish-card-oneliner.json
+++ b/change/@fluentui-react-cards-2021-01-27-17-21-05-TanelVari-ui-polish-card-oneliner.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Renamed prop 'quiet' to 'ghost' for react-cards Card types",
+  "packageName": "@fluentui/react-cards",
+  "email": "tavari@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-27T15:21:05.491Z"
+}

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,7 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ## BREAKING CHANGES
-- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
 
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -68,6 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` image slot were moved to exact component `AvatarImage` @assuncaocharles ([#16409](https://github.com/microsoft/fluentui/pull/16409))
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
 - Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
+- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
 
 ### Fixes
 - Fix `useTree` by changing `env.NODE` to `env.NODE_ENV` @yuanboxue-amber ([#16630](https://github.com/microsoft/fluentui/pull/16630))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,7 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ## BREAKING CHANGES
-
 - Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
 
 ## Fixes

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## BREAKING CHANGES
 
+- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
+
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))
 - Fix RadioGroup visual issues. Add `RadioButtonIcon`. Fix vertical RadioGroup alignment issue with custom content. Fix focus frame alignment for bare indicator. @TanelVari ([#16478](https://github.com/microsoft/fluentui/pull/16478))
@@ -67,7 +69,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Styles from `Avatar` image slot were moved to exact component `AvatarImage` @assuncaocharles ([#16409](https://github.com/microsoft/fluentui/pull/16409))
 - Styles from `Avatar` image slot were moved to exact component `AvatarLabel` @assuncaocharles ([#16417](https://github.com/microsoft/fluentui/pull/16417))
 - Styles from `Avatar` icon slot were moved to exact component `AvatarIcon` @assuncaocharles ([#16428](https://github.com/microsoft/fluentui/pull/16428))
-- Remove unsupported values for `size` prop in `Button` component @notandrew ([#16416](https://github.com/microsoft/fluentui/pull/16416))
 
 ### Fixes
 - Fix `useTree` by changing `env.NODE` to `env.NODE_ENV` @yuanboxue-amber ([#16630](https://github.com/microsoft/fluentui/pull/16630))

--- a/packages/react-cards/src/next/Card.types.ts
+++ b/packages/react-cards/src/next/Card.types.ts
@@ -38,8 +38,7 @@ export type CardProps = ComponentProps &
     /** A card can have inverted background styles. */
     inverted?: boolean;
 
-    /** A card can have quiet styles. */
-    // TODO: Is this the correct name? Appears as ghost in design spec.
+    /** A card can have ghost styles. */
     ghost?: boolean;
 
     /** A card can show that it is currently selected or not. */

--- a/packages/react-cards/src/next/Card.types.ts
+++ b/packages/react-cards/src/next/Card.types.ts
@@ -40,7 +40,7 @@ export type CardProps = ComponentProps &
 
     /** A card can have quiet styles. */
     // TODO: Is this the correct name? Appears as ghost in design spec.
-    quiet?: boolean;
+    ghost?: boolean;
 
     /** A card can show that it is currently selected or not. */
     // TODO: This should probably have a `defaultSelected` property at the same time.


### PR DESCRIPTION
Renamed prop 'quiet' to 'ghost' for react-cards in Card types
Moved this commit into separate PR as per comment in https://github.com/microsoft/fluentui/pull/16585
