### PR TITLE
fix(react v7): Add missing HighContrast override to SplitButton

### DIFF
--- a/change/@fluentui-react-examples-2021-01-26-16-12-53-16339.json
+++ b/change/@fluentui-react-examples-2021-01-26-16-12-53-16339.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix chevron colour in high contrast for the Command Bar Split Disabled example",
+  "packageName": "@fluentui/react-examples",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T15:12:52.979Z"
+}

--- a/change/office-ui-fabric-react-2021-01-26-16-12-53-16339.json
+++ b/change/office-ui-fabric-react-2021-01-26-16-12-53-16339.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix high contrast override for SplitButton",
+  "packageName": "office-ui-fabric-react",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T15:12:12.493Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -139,6 +139,11 @@ export const getStyles = memoizeFunction(
         marginTop: 0,
         marginRight: 0,
         marginBottom: 0,
+        [HighContrastSelector]: {
+          '.ms-Button-menuIcon': {
+            color: 'WindowText',
+          },
+        },
       },
       splitButtonDivider: {
         ...splitButtonDividerBaseStyles,

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -281,6 +281,9 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
               vertical-align: top;
               width: 28px;
             }
+            @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+              color: WindowText;
+            }
         data-is-focusable={false}
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
@@ -286,6 +286,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -644,6 +647,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -986,6 +992,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1325,17 +1334,17 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
-              @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
+              @media screen and (-ms-high-contrast: active){& {
                 background-color: Window;
-                border-color: GrayText;
+                border: 1px solid GrayText;
                 color: GrayText;
               }
               @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
                 color: GrayText;
               }
-              @media screen and (-ms-high-contrast: active){& {
+              @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
                 background-color: Window;
-                border: 1px solid GrayText;
+                border-color: GrayText;
                 color: GrayText;
               }
           data-is-focusable={false}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -363,6 +363,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           vertical-align: top;
                           width: 32px;
                         }
+                        @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                          color: WindowText;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -779,6 +782,14 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           vertical-align: top;
                           width: 32px;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: Window;
+                          border: none;
+                          color: GrayText;
+                        }
+                        @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                          color: GrayText;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -799,14 +810,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
                           background-color: Window;
                           border-color: GrayText;
-                          color: GrayText;
-                        }
-                        @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
-                          color: GrayText;
-                        }
-                        @media screen and (-ms-high-contrast: active){& {
-                          background-color: Window;
-                          border: none;
                           color: GrayText;
                         }
                         @media screen and (forced-colors: active){& {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -802,6 +802,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                  color: WindowText;
+                }
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -699,6 +699,9 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           data-ktp-execute-target="ktp-2-b"
           onClick={[Function]}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -802,6 +802,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active){& .ms-Button-menuIcon {
+                  color: WindowText;
+                }
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16339
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added a missing high contrast selector to the SplitButton styles.

#### Focus areas to test

##### CommandBar with split and disabled buttons example
###### Pre
![image](https://user-images.githubusercontent.com/39736248/105845592-4ed52480-5fdb-11eb-9f42-89e1639f00d3.png)
###### Post
![image](https://user-images.githubusercontent.com/39736248/105845668-70cea700-5fdb-11eb-8c66-297a8066849c.png)

