### PR TITLE
chore: disable a requirement of prebuilt styles for production builds

### DIFF
--- a/change/@fluentui-make-styles-2021-01-26-12-02-24-fix-mk-disable-force-build-req.json
+++ b/change/@fluentui-make-styles-2021-01-26-12-02-24-fix-mk-disable-force-build-req.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "chore: disable a requirement of prebuilt styles for production builds",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T11:02:24.740Z"
+}

--- a/packages/make-styles/src/makeStyles.ts
+++ b/packages/make-styles/src/makeStyles.ts
@@ -22,6 +22,7 @@ export function makeStyles<Selectors, Tokens>(
     // let tokens: Tokens | null;
     // let resolvedDefinitions: MakeStylesResolvedDefinition<Selectors, Tokens>[];
     //
+    // This requires a build step which is currently WIP
     // if (process.env.NODE_ENV === 'production') {
     //   tokens = CAN_USE_CSS_VARIABLES ? null : options.tokens;
     //   resolvedDefinitions = CAN_USE_CSS_VARIABLES

--- a/packages/make-styles/src/makeStyles.ts
+++ b/packages/make-styles/src/makeStyles.ts
@@ -19,27 +19,26 @@ export function makeStyles<Selectors, Tokens>(
     ...classNames: (string | undefined)[]
   ): string;
   function computeClasses(selectors: Selectors, options: MakeStylesOptions<Tokens>): string {
-    let tokens: Tokens | null;
-    let resolvedDefinitions: MakeStylesResolvedDefinition<Selectors, Tokens>[];
-
-    // TODO: describe me
-    if (process.env.NODE_ENV === 'production') {
-      tokens = CAN_USE_CSS_VARIABLES ? null : options.tokens;
-      resolvedDefinitions = CAN_USE_CSS_VARIABLES
-        ? ((definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[])
-        : resolveDefinitions(
-            (definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[],
-            tokens,
-            unstable_cssPriority,
-          );
-    } else {
-      tokens = CAN_USE_CSS_VARIABLES ? createCSSVariablesProxy(options.tokens) : options.tokens;
-      resolvedDefinitions = resolveDefinitions(
-        (definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[],
-        tokens,
-        unstable_cssPriority,
-      );
-    }
+    // let tokens: Tokens | null;
+    // let resolvedDefinitions: MakeStylesResolvedDefinition<Selectors, Tokens>[];
+    //
+    // if (process.env.NODE_ENV === 'production') {
+    //   tokens = CAN_USE_CSS_VARIABLES ? null : options.tokens;
+    //   resolvedDefinitions = CAN_USE_CSS_VARIABLES
+    //     ? ((definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[])
+    //     : resolveDefinitions(
+    //         (definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[],
+    //         tokens,
+    //         unstable_cssPriority,
+    //       );
+    // } else {
+    const tokens = CAN_USE_CSS_VARIABLES ? createCSSVariablesProxy(options.tokens) : options.tokens;
+    const resolvedDefinitions = resolveDefinitions(
+      (definitions as unknown) as MakeStylesResolvedDefinition<Selectors, Tokens>[],
+      tokens,
+      unstable_cssPriority,
+    );
+    // }
 
     let nonMakeClasses: string = '';
     const overrides: MakeStylesMatchedDefinitions = {};


### PR DESCRIPTION
Currently `makeStyles()` relies that in production we will have prebuilt styles, but as we don't have a built time transform yet it leads to confusion as styles will not be rendered.
