### PR TITLE
Fixing styling for MDX rendering

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Define value for `largest` font-size in `siteVariables` @assuncaocharles ([#16693](https://github.com/microsoft/fluentui/pull/16693))
 - Fix `Embed` playback control visuals. @TanelVari ([#16611](https://github.com/microsoft/fluentui/pull/16611))
 - Fixes for `Dropdown`. Fix clear indicator visual styles (focus border, using `CloseIcon`). Fix empty search result text style. Fix left/right padding for multiple selection labels. Using `ChevronDownIcon` for toggle indicator. @TanelVari ([#16522](https://github.com/microsoft/fluentui/pull/16522))
+- Fix docsite header colors for all themes. `ExampleSnippet` now honors theme colors for background and foreground. @TanelVari ([#16643](https://github.com/microsoft/fluentui/pull/16643))
 
 ## Features
 - Added `disabledFocusable` prop for `Button` component. @jurokapsiar ([#16419](https://github.com/microsoft/fluentui/pull/16419))

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';
-import { tabListBehavior, Header, Text, Flex, Menu } from '@fluentui/react-northstar';
+import { tabListBehavior, Header, Text, Flex, Menu, teamsTheme } from '@fluentui/react-northstar';
 import { ArrowDownIcon } from '@fluentui/react-icons-northstar';
 
 import { getFormattedHash } from '../../utils';
@@ -152,6 +152,13 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
             activeIndex={currentTabIndex}
             items={tabs}
             style={{ marginTop: '0.5rem', background: 'none', border: 'none' }}
+            variables={{
+              underlinedColorHover: teamsTheme.siteVariables.colors.black,
+              color: teamsTheme.siteVariables.colors.grey[500],
+              colorActive: teamsTheme.siteVariables.colors.black,
+              activeUnderlinedBorderBottomColor: teamsTheme.siteVariables.colors.black,
+              underlinedWrapperColorHover: teamsTheme.siteVariables.colors.black,
+            }}
             onItemClick={this.handleTabClick}
             accessibility={tabListBehavior}
           />

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -158,6 +158,8 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
               colorActive: siteVariables.colors.black,
               activeUnderlinedBorderBottomColor: siteVariables.colors.black,
               underlinedWrapperColorHover: siteVariables.colors.black,
+              backgroundColorActive: siteVariables.colors.black,
+              activeUnderlinedColor: siteVariables.colors.black,
             })}
             onItemClick={this.handleTabClick}
             accessibility={tabListBehavior}

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';
-import { tabListBehavior, Header, Text, Flex, Menu, teamsTheme } from '@fluentui/react-northstar';
+import { tabListBehavior, Header, Text, Flex, Menu } from '@fluentui/react-northstar';
 import { ArrowDownIcon } from '@fluentui/react-icons-northstar';
 
 import { getFormattedHash } from '../../utils';
@@ -152,13 +152,13 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
             activeIndex={currentTabIndex}
             items={tabs}
             style={{ marginTop: '0.5rem', background: 'none', border: 'none' }}
-            variables={{
-              underlinedColorHover: teamsTheme.siteVariables.colors.black,
-              color: teamsTheme.siteVariables.colors.grey[500],
-              colorActive: teamsTheme.siteVariables.colors.black,
-              activeUnderlinedBorderBottomColor: teamsTheme.siteVariables.colors.black,
-              underlinedWrapperColorHover: teamsTheme.siteVariables.colors.black,
-            }}
+            variables={siteVariables => ({
+              underlinedColorHover: siteVariables.colors.black,
+              color: siteVariables.colors.grey[500],
+              colorActive: siteVariables.colors.black,
+              activeUnderlinedBorderBottomColor: siteVariables.colors.black,
+              underlinedWrapperColorHover: siteVariables.colors.black,
+            })}
             onItemClick={this.handleTabClick}
             accessibility={tabListBehavior}
           />

--- a/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
+++ b/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
@@ -1,5 +1,6 @@
-import { CodeSnippet, renderElementToJSX } from '@fluentui/docs-components';
 import * as React from 'react';
+import { CodeSnippet, renderElementToJSX } from '@fluentui/docs-components';
+import { ProviderConsumer } from '@fluentui/react-northstar';
 
 export type ExampleSnippetProps = {
   children?: React.ReactElement;
@@ -7,11 +8,11 @@ export type ExampleSnippetProps = {
   value?: string;
 };
 
-const rootStyle = {
-  background: 'white',
+const rootStyle = siteVariables => ({
+  background: siteVariables.bodyBackground,
   marginBottom: '2rem',
   boxShadow: '0 0 2px rgba(0, 0, 0, 0.2)',
-};
+});
 
 const renderedStyle = {
   padding: '1rem',
@@ -27,10 +28,14 @@ const ExampleSnippet: React.FunctionComponent<ExampleSnippetProps> = props => {
   const string = value || renderElementToJSX(element, !isFunctionWithoutValue);
 
   return (
-    <div style={rootStyle}>
-      <CodeSnippet value={string} fitted />
-      {element && <div style={renderedStyle}>{element}</div>}
-    </div>
+    <ProviderConsumer
+      render={({ siteVariables }) => (
+        <div style={rootStyle(siteVariables)}>
+          <CodeSnippet value={string} fitted />
+          {element && <div style={renderedStyle}>{element}</div>}
+        </div>
+      )}
+    />
   );
 };
 

--- a/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
+++ b/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CodeSnippet, renderElementToJSX } from '@fluentui/docs-components';
-import { ProviderConsumer } from '@fluentui/react-northstar';
+import { Box } from '@fluentui/react-northstar';
 
 export type ExampleSnippetProps = {
   children?: React.ReactElement;
@@ -8,7 +8,7 @@ export type ExampleSnippetProps = {
   value?: string;
 };
 
-const rootStyle = siteVariables => ({
+const rootStyle = ({ theme: { siteVariables } }) => ({
   color: siteVariables.bodyColor,
   background: siteVariables.bodyBackground,
   marginBottom: '2rem',
@@ -29,14 +29,10 @@ const ExampleSnippet: React.FunctionComponent<ExampleSnippetProps> = props => {
   const string = value || renderElementToJSX(element, !isFunctionWithoutValue);
 
   return (
-    <ProviderConsumer
-      render={({ siteVariables }) => (
-        <div style={rootStyle(siteVariables)}>
-          <CodeSnippet value={string} fitted />
-          {element && <div style={renderedStyle}>{element}</div>}
-        </div>
-      )}
-    />
+    <Box styles={rootStyle}>
+      <CodeSnippet value={string} fitted />
+      {element && <div style={renderedStyle}>{element}</div>}
+    </Box>
   );
 };
 

--- a/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
+++ b/packages/fluentui/docs/src/components/ExampleSnippet/ExampleSnippet.tsx
@@ -9,6 +9,7 @@ export type ExampleSnippetProps = {
 };
 
 const rootStyle = siteVariables => ({
+  color: siteVariables.bodyColor,
   background: siteVariables.bodyBackground,
   marginBottom: '2rem',
   boxShadow: '0 0 2px rgba(0, 0, 0, 0.2)',

--- a/packages/fluentui/docs/src/components/MarkdownPage.tsx
+++ b/packages/fluentui/docs/src/components/MarkdownPage.tsx
@@ -28,13 +28,25 @@ const components = teamsTheme => ({
       <code>{children}</code>
     ),
   h1: ({ children }) => (
-    <Header as="h1" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+    <Header
+      as="h1"
+      content={children}
+      styles={({ theme: { siteVariables } }) => ({ color: siteVariables.colors.grey[750] })}
+    />
   ),
   h2: ({ children }) => (
-    <Header as="h2" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+    <Header
+      as="h2"
+      content={children}
+      styles={({ theme: { siteVariables } }) => ({ color: siteVariables.colors.grey[750] })}
+    />
   ),
   h3: ({ children }) => (
-    <Header as="h3" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+    <Header
+      as="h3"
+      content={children}
+      styles={({ theme: { siteVariables } }) => ({ color: siteVariables.colors.grey[750] })}
+    />
   ),
   img: props => <img style={{ maxWidth: '100%' }} {...props} />,
 });

--- a/packages/fluentui/docs/src/components/MarkdownPage.tsx
+++ b/packages/fluentui/docs/src/components/MarkdownPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { CodeSnippet } from '@fluentui/docs-components';
-import { Header, ProviderConsumer } from '@fluentui/react-northstar';
+import { Header, teamsTheme } from '@fluentui/react-northstar';
 import { RouteProps } from 'react-router-dom';
 
 import { link } from '../utils/helpers';
@@ -19,7 +19,7 @@ type MarkdownPageProps = {
   };
 } & RouteProps;
 
-const components = siteVariables => ({
+const components = teamsTheme => ({
   a: ({ children, href }) => link(children, href),
   code: ({ className, children, fitted, label }) =>
     className ? (
@@ -27,9 +27,15 @@ const components = siteVariables => ({
     ) : (
       <code>{children}</code>
     ),
-  h1: ({ children }) => <Header as="h1" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
-  h2: ({ children }) => <Header as="h2" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
-  h3: ({ children }) => <Header as="h3" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
+  h1: ({ children }) => (
+    <Header as="h1" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+  ),
+  h2: ({ children }) => (
+    <Header as="h2" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+  ),
+  h3: ({ children }) => (
+    <Header as="h3" content={children} style={{ color: teamsTheme.siteVariables.colors.grey[750] }} />
+  ),
   img: props => <img style={{ maxWidth: '100%' }} {...props} />,
 });
 
@@ -39,13 +45,9 @@ const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = (props, { siteV
 
   return (
     <DocPage title={meta.title}>
-      <ProviderConsumer
-        render={({ siteVariables }) => (
-          <MDXProvider components={components(siteVariables)}>
-            <Component />
-          </MDXProvider>
-        )}
-      />
+      <MDXProvider components={components(teamsTheme)}>
+        <Component />
+      </MDXProvider>
       <GuidesNavigationFooter previous={meta.previous} next={meta.next} />
     </DocPage>
   );

--- a/packages/fluentui/docs/src/components/MarkdownPage.tsx
+++ b/packages/fluentui/docs/src/components/MarkdownPage.tsx
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { CodeSnippet } from '@fluentui/docs-components';
-import { Header } from '@fluentui/react-northstar';
-import * as React from 'react';
+import { Header, ProviderConsumer } from '@fluentui/react-northstar';
 import { RouteProps } from 'react-router-dom';
 
 import { link } from '../utils/helpers';
@@ -19,7 +19,7 @@ type MarkdownPageProps = {
   };
 } & RouteProps;
 
-const components = {
+const components = siteVariables => ({
   a: ({ children, href }) => link(children, href),
   code: ({ className, children, fitted, label }) =>
     className ? (
@@ -27,21 +27,25 @@ const components = {
     ) : (
       <code>{children}</code>
     ),
-  h1: ({ children }) => <Header as="h1" content={children} />,
-  h2: ({ children }) => <Header as="h2" content={children} />,
-  h3: ({ children }) => <Header as="h3" content={children} />,
+  h1: ({ children }) => <Header as="h1" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
+  h2: ({ children }) => <Header as="h2" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
+  h3: ({ children }) => <Header as="h3" content={children} style={{ color: siteVariables.colors.grey[750] }} />,
   img: props => <img style={{ maxWidth: '100%' }} {...props} />,
-};
+});
 
-const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = props => {
+const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = (props, { siteVariables }) => {
   const { page } = props;
   const { default: Component, meta } = page;
 
   return (
     <DocPage title={meta.title}>
-      <MDXProvider components={components}>
-        <Component />
-      </MDXProvider>
+      <ProviderConsumer
+        render={({ siteVariables }) => (
+          <MDXProvider components={components(siteVariables)}>
+            <Component />
+          </MDXProvider>
+        )}
+      />
       <GuidesNavigationFooter previous={meta.previous} next={meta.next} />
     </DocPage>
   );

--- a/packages/fluentui/docs/src/components/MarkdownPage.tsx
+++ b/packages/fluentui/docs/src/components/MarkdownPage.tsx
@@ -51,7 +51,7 @@ const components = {
   img: props => <img style={{ maxWidth: '100%' }} {...props} />,
 };
 
-const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = (props, { siteVariables }) => {
+const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = props => {
   const { page } = props;
   const { default: Component, meta } = page;
 

--- a/packages/fluentui/docs/src/components/MarkdownPage.tsx
+++ b/packages/fluentui/docs/src/components/MarkdownPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { CodeSnippet } from '@fluentui/docs-components';
-import { Header, teamsTheme } from '@fluentui/react-northstar';
+import { Header } from '@fluentui/react-northstar';
 import { RouteProps } from 'react-router-dom';
 
 import { link } from '../utils/helpers';
@@ -19,7 +19,7 @@ type MarkdownPageProps = {
   };
 } & RouteProps;
 
-const components = teamsTheme => ({
+const components = {
   a: ({ children, href }) => link(children, href),
   code: ({ className, children, fitted, label }) =>
     className ? (
@@ -49,7 +49,7 @@ const components = teamsTheme => ({
     />
   ),
   img: props => <img style={{ maxWidth: '100%' }} {...props} />,
-});
+};
 
 const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = (props, { siteVariables }) => {
   const { page } = props;
@@ -57,7 +57,7 @@ const MarkdownPage: React.FunctionComponent<MarkdownPageProps> = (props, { siteV
 
   return (
     <DocPage title={meta.title}>
-      <MDXProvider components={components(teamsTheme)}>
+      <MDXProvider components={components}>
         <Component />
       </MDXProvider>
       <GuidesNavigationFooter previous={meta.previous} next={meta.next} />

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -590,6 +590,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         vertical: props.vertical,
         primary: props.primary,
         on: props.on,
+        variables: props.variables,
       },
       menu: {
         accessibility: submenuBehavior,


### PR DESCRIPTION
1) Request to make mdx code snippets responsible to theams

**Before:**

![image](https://user-images.githubusercontent.com/14893575/105871360-e483aa80-6001-11eb-9eb5-db2c38be86ae.png)

**After:**

![image](https://user-images.githubusercontent.com/14893575/105871467-03823c80-6002-11eb-8854-60c72b3499fc.png)

2) When navigating away from component examples with dark or high contrast theme active then .mdx content would keep using wrong foreground color.

**Before:**

![image](https://user-images.githubusercontent.com/14893575/105871802-5956e480-6002-11eb-95b5-ac49afc60d12.png)

**After:**

![image](https://user-images.githubusercontent.com/14893575/105871910-77244980-6002-11eb-9ca5-0ab4f283a3d4.png)
