### PR TITLE
fix(react v7): Add missing styles for disabled buttons

### DIFF
--- a/change/@fluentui-react-examples-2021-01-26-19-05-37-16156.json
+++ b/change/@fluentui-react-examples-2021-01-26-19-05-37-16156.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix(react v7): Add missing styles for disabled buttons",
+  "packageName": "@fluentui/react-examples",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T18:05:36.989Z"
+}

--- a/change/office-ui-fabric-react-2021-01-26-19-05-37-16156.json
+++ b/change/office-ui-fabric-react-2021-01-26-19-05-37-16156.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing styles for disabled buttons",
+  "packageName": "office-ui-fabric-react",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-26T18:05:27.386Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -18,9 +18,11 @@ export function standardStyles(theme: ITheme): IButtonStyles {
   const buttonBackground = s.buttonBackground;
   const buttonBackgroundPressed = s.buttonBackgroundPressed;
   const buttonBackgroundHovered = s.buttonBackgroundHovered;
+  const buttonBackgroundDisabled = s.buttonBackgroundDisabled;
 
   const buttonText = s.buttonText;
   const buttonTextHovered = s.buttonTextHovered;
+  const buttonTextDisabled = s.buttonTextDisabled;
   const buttonTextChecked = s.buttonTextChecked;
   const buttonTextCheckedHovered = s.buttonTextCheckedHovered;
 
@@ -62,6 +64,8 @@ export function standardStyles(theme: ITheme): IButtonStyles {
     },
 
     rootDisabled: {
+      color: buttonTextDisabled,
+      backgroundColor: buttonBackgroundDisabled,
       selectors: {
         [HighContrastSelector]: {
           color: 'GrayText',
@@ -215,6 +219,8 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     },
 
     rootDisabled: {
+      color: s.primaryButtonTextDisabled,
+      backgroundColor: s.primaryButtonBackgroundDisabled,
       selectors: {
         [HighContrastSelector]: {
           color: 'GrayText',

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
@@ -17,7 +17,7 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
             border-radius: 2px;
             border: 1px solid #0078d4;
             box-sizing: border-box;
-            color: #a19f9d;
+            color: #d2d0ce;
             cursor: default;
             display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16156
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added missing `buttonTextDisabled`, `buttonBackgroundDisabled`, `primaryButtonTextDisabled` and `primaryButtonBackgroundDisabled` semantic color styles to `Button.styles`.

#### Focus areas to test
##### Button/disabled button with colors
###### Before
_See Elizabeth's codepen [here](https://codepen.io/ecraig12345/pen/gOwKxOp)_
###### After
![image](https://user-images.githubusercontent.com/39736248/105878689-95d61080-6001-11eb-97f8-8464ca260c40.png)
_Colours changed for accessibility purposes.
Forcing `black` for primary and split button text and `white` for the others._
