### PR TITLE
Fix update-snapshots

### DIFF
--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
  */
 const commonArgs = (): JestTaskOptions => {
   const args: JestTaskOptions = argv();
-
   return {
     ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME || args.runInBand) && { runInBand: true }),
     ...((args.u || args.updateSnapshot) && { updateSnapshot: true }),
@@ -22,7 +21,7 @@ const commonArgs = (): JestTaskOptions => {
     // Just specific config
     nodeArgs: args.nodeArgs,
     // pass forward positional args (to narrow down tests to be run)
-    // _: args._, // TODO: investigate and fix. this broke `update-snapshots`.
+    _: (args._ || []).filter(arg => arg !== 'jest' && arg !== 'jest-watch'),
   };
 };
 

--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -22,7 +22,7 @@ const commonArgs = (): JestTaskOptions => {
     // Just specific config
     nodeArgs: args.nodeArgs,
     // pass forward positional args (to narrow down tests to be run)
-    _: args._,
+    // _: args._, // TODO: investigate and fix. this broke `update-snapshots`.
   };
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
**Repro of the issue:**
1. go to any package with jest test (e.g. `react-internal`)
2. run `yarn update-snapshots`
3. error thrown due to unable to find tests

**Cause:**
`yarn update-snapshot` is broken because `_` is set to `[ 'jest' ]` and as a result, arg `jest` is passed as positional arg.
(related change: #16526)

**Fix:**
filter out `jest` or `jest-watch` from `_`

#### Focus areas to test

(optional)
