### PR TITLE
chore: fix docsite toolbar props tab

### DIFF
--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentPropsTable/ComponentPropsRow.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentPropsTable/ComponentPropsRow.tsx
@@ -19,23 +19,25 @@ const ComponentPropValue: React.FunctionComponent<ComponentPropType> = props => 
     const componentName = parameters[0].name.replace('Props', '');
 
     const parentInfo = componentInfoContext.byDisplayName[componentName];
-    const linkName = _.kebabCase(parentInfo.parentDisplayName || componentName);
+    if (parentInfo) {
+      const linkName = _.kebabCase(parentInfo.parentDisplayName || componentName);
 
-    const kindParam = parameters[1] && parameters[1].name !== 'never';
-    const kindIsVisible = name === 'ShorthandCollection' && kindParam;
+      const kindParam = parameters[1] && parameters[1].name !== 'never';
+      const kindIsVisible = name === 'ShorthandCollection' && kindParam;
 
-    const showHash = parentInfo.parentDisplayName || _.size(getComponentGroup(componentName)) > 1;
-    const propsSection = showHash ? `#${_.kebabCase(componentName)}` : '';
+      const showHash = parentInfo.parentDisplayName || _.size(getComponentGroup(componentName)) > 1;
+      const propsSection = showHash ? `#${_.kebabCase(componentName)}` : '';
 
-    return (
-      <span>
-        {name}
-        {`<`}
-        <Link to={`/components/${linkName}/props${propsSection}`}>{parameters[0].name}</Link>
-        {kindIsVisible && <span>, {parameters[1].name}</span>}
-        {`>`}
-      </span>
-    );
+      return (
+        <span>
+          {name}
+          {`<`}
+          <Link to={`/components/${linkName}/props${propsSection}`}>{parameters[0].name}</Link>
+          {kindIsVisible && <span>, {parameters[1].name}</span>}
+          {`>`}
+        </span>
+      );
+    }
   }
 
   return <span>{name}</span>;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Doc site to `components/toolbar/props` is broken
This is because toolbar has `overflowItem`, which is a shorthand prop without a real component.
Fix the docsite code to not generate link to component in such case.

#### Focus areas to test

(optional)
