### PR TITLE
fix(react): DocumentCardPreview add optional limit display count prop

### DIFF
--- a/change/@fluentui-react-2021-01-28-02-57-24-fix-9991-DocumentCardPreview-default-limit.json
+++ b/change/@fluentui-react-2021-01-28-02-57-24-fix-9991-DocumentCardPreview-default-limit.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "DocumentCardPreview: add maxDisplayCount prop",
+  "packageName": "@fluentui/react",
+  "email": "hantatsang@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-27T15:57:24.833Z"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1353,6 +1353,7 @@ export interface IDocumentCardPreviewProps extends IBaseProps<{}> {
     className?: string;
     componentRef?: IRefObject<IDocumentCardPreview>;
     getOverflowDocumentCountText?: (overflowCount: number) => string;
+    maxDisplayCount?: number;
     previewImages: IDocumentCardPreviewImage[];
     styles?: IStyleFunctionOrObject<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>;
     theme?: ITheme;

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -11,7 +11,7 @@ import {
   IDocumentCardPreviewStyles,
 } from './DocumentCardPreview.types';
 
-const LIST_ITEM_COUNT = 3;
+const DEFAULT_DISPLAY_COUNT = 3;
 const getClassNames = classNamesFunction<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>();
 
 /**
@@ -105,10 +105,10 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
   private _renderPreviewList = (
     previewImages: IDocumentCardPreviewImage[],
   ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> => {
-    const { getOverflowDocumentCountText } = this.props;
+    const { getOverflowDocumentCountText, maxDisplayCount = DEFAULT_DISPLAY_COUNT } = this.props;
 
     // Determine how many documents we won't be showing
-    const overflowDocumentCount = previewImages.length - LIST_ITEM_COUNT;
+    const overflowDocumentCount = previewImages.length - maxDisplayCount;
 
     // Determine the overflow text that will be rendered after the preview list.
     const overflowText = overflowDocumentCount
@@ -118,7 +118,7 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
       : null;
 
     // Create list items for the documents to be shown
-    const fileListItems = previewImages.slice(0, LIST_ITEM_COUNT).map((file, fileIndex) => (
+    const fileListItems = previewImages.slice(0, maxDisplayCount).map((file, fileIndex) => (
       <li key={fileIndex}>
         <Image
           className={this._classNames.fileListIcon}

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.types.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.types.ts
@@ -30,6 +30,12 @@ export interface IDocumentCardPreviewProps extends IBaseProps<{}> {
   getOverflowDocumentCountText?: (overflowCount: number) => string;
 
   /**
+   * Maximum number of document previews to display
+   * @default 3
+   */
+  maxDisplayCount?: number;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
   styles?: IStyleFunctionOrObject<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9991 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add optional prop for `DocumentCardPreview` to change the default maximum number of preview documents.

#### Focus areas to test

Open `packages\react-examples\src\react\DocumentCard\DocumentCard.Complete.Example.tsx` file, add `maxDisplayCount` prop with a `number` value for `DocumentCardPreview` and check the changes in Storybook
