### PR TITLE
Delete update-api script which is no longer needed

### DIFF
--- a/change/@fluentui-date-time-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-date-time-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:09.378Z"
+}

--- a/change/@fluentui-dom-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-dom-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:11.379Z"
+}

--- a/change/@fluentui-example-data-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-example-data-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/example-data",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:15.251Z"
+}

--- a/change/@fluentui-font-icons-mdl2-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-font-icons-mdl2-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:16.590Z"
+}

--- a/change/@fluentui-foundation-legacy-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-foundation-legacy-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:17.684Z"
+}

--- a/change/@fluentui-keyboard-key-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-keyboard-key-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:14.720Z"
+}

--- a/change/@fluentui-make-styles-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-make-styles-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:19.323Z"
+}

--- a/change/@fluentui-merge-styles-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-merge-styles-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:20.572Z"
+}

--- a/change/@fluentui-react-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:40.148Z"
+}

--- a/change/@fluentui-react-avatar-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-avatar-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:18.131Z"
+}

--- a/change/@fluentui-react-button-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-button-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:19.039Z"
+}

--- a/change/@fluentui-react-cards-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-cards-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:21.836Z"
+}

--- a/change/@fluentui-react-checkbox-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-checkbox-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:20.673Z"
+}

--- a/change/@fluentui-react-compose-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-compose-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:21.674Z"
+}

--- a/change/@fluentui-react-date-time-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-date-time-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:22.784Z"
+}

--- a/change/@fluentui-react-flex-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-flex-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-flex",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:22.804Z"
+}

--- a/change/@fluentui-react-focus-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-focus-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:23.706Z"
+}

--- a/change/@fluentui-react-hooks-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-hooks-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:23.725Z"
+}

--- a/change/@fluentui-react-icons-mdl2-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-icons-mdl2-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:24.724Z"
+}

--- a/change/@fluentui-react-image-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-image-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:27.323Z"
+}

--- a/change/@fluentui-react-internal-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-internal-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:29.670Z"
+}

--- a/change/@fluentui-react-link-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-link-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:30.796Z"
+}

--- a/change/@fluentui-react-shared-contexts-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-shared-contexts-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:25.962Z"
+}

--- a/change/@fluentui-react-slider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-slider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-slider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:33.489Z"
+}

--- a/change/@fluentui-react-stylesheets-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-stylesheets-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-stylesheets",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:34.566Z"
+}

--- a/change/@fluentui-react-tabs-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-tabs-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:36.060Z"
+}

--- a/change/@fluentui-react-text-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-react-text-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:29.147Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-theme-provider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:36.949Z"
+}

--- a/change/@fluentui-react-toggle-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-toggle-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-toggle",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:37.703Z"
+}

--- a/change/@fluentui-react-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:38.599Z"
+}

--- a/change/@fluentui-react-window-provider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-window-provider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:39.373Z"
+}

--- a/change/@fluentui-style-utilities-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-style-utilities-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/style-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:30.655Z"
+}

--- a/change/@fluentui-test-utilities-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-test-utilities-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:32.135Z"
+}

--- a/change/@fluentui-theme-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-theme-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:43.486Z"
+}

--- a/change/@fluentui-utilities-2021-01-27-15-05-33-update-api.json
+++ b/change/@fluentui-utilities-2021-01-27-15-05-33-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-01-27T23:05:33.234Z"
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test:fluentui:circulars": "gulp test:circulars:run",
     "test:fluentui:e2e": "yarn workspace @fluentui/e2e test",
     "test:fluentui:projects": "yarn workspace @fluentui/projects-test test",
-    "update-api": "cd packages/react && yarn update-api",
+    "update-api": "echo API files are now updated when running yarn build",
     "update-snapshots": "lage update-snapshots --verbose",
     "update-a11y": "cd apps/a11y-tests && yarn update-snapshots",
     "vrtest": "cd apps && cd vr-tests && yarn screener"

--- a/packages/date-time-utilities/package.json
+++ b/packages/date-time-utilities/package.json
@@ -20,8 +20,7 @@
     "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
     "start-test": "just-scripts jest-watch",
-    "lint": "just-scripts lint",
-    "update-api": "just-scripts update-api"
+    "lint": "just-scripts lint"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/dom-utilities/package.json
+++ b/packages/dom-utilities/package.json
@@ -22,8 +22,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -17,7 +17,6 @@
     "test": "just-scripts test",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/fluentui/CONTRIBUTING.md
+++ b/packages/fluentui/CONTRIBUTING.md
@@ -150,7 +150,6 @@ I (@rymeskar) have been part of the FluentUI framework team for the past two mon
 - Changelog has a special format.
 - Always try to find the most relevant and similar component to get inspired by.
 - Try to extract [pure functions](https://en.wikipedia.org/wiki/Pure_function) outside of component's body; possibly into special files.
-- When developing date-time-utilities, one must run `yarn change` in the root and then `yarn update-api` in the date-time-utilities folder.
 - Don't name boolean flags with 'is' prefix.
 - `Yarn build` is not necessary when working with FluentUI. You should just call `yarn` (resolve packages) and then `yarn start` (start application).
 - For benchmarking JavaScript, one can use the https://jsperf.com .

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -20,8 +20,7 @@
     "test": "just-scripts test",
     "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "update-api": "just-scripts update-api"
+    "code-style": "just-scripts code-style"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -23,7 +23,6 @@
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -17,8 +17,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
-    "test": "just-scripts test",
-    "update-api": "just-scripts update-api"
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/make-styles/package.json
+++ b/packages/make-styles/package.json
@@ -22,8 +22,7 @@
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
     "test": "just-scripts test",
-    "test:watch": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api"
+    "test:watch": "just-scripts jest-watch"
   },
   "beachball": {
     "tag": "latest",

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -21,8 +21,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api"
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -24,7 +24,6 @@
     "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -23,7 +23,6 @@
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -21,7 +21,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/react-date-time/package.json
+++ b/packages/react-date-time/package.json
@@ -24,8 +24,7 @@
     "start": "just-scripts dev:storybook",
     "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
-    "update-snapshots": "just-scripts jest -u",
-    "update-api": "just-scripts update-api"
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -20,8 +20,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@types/react": "16.9.42",

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -21,7 +21,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-internal/package.json
+++ b/packages/react-internal/package.json
@@ -21,7 +21,6 @@
     "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-shared-contexts/package.json
+++ b/packages/react-shared-contexts/package.json
@@ -21,7 +21,6 @@
     "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-stylesheets/package.json
+++ b/packages/react-stylesheets/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-theme-provider/package.json
+++ b/packages/react-theme-provider/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-toggle/package.json
+++ b/packages/react-toggle/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,6 @@
     "start:legacy": "yarn workspace @fluentui/public-docsite-resources start",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/style-utilities/package.json
+++ b/packages/style-utilities/package.json
@@ -23,7 +23,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -21,8 +21,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev",
-    "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api"
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -22,7 +22,6 @@
     "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -22,7 +22,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -11,7 +11,7 @@ import { sass } from './tasks/sass';
 import { ts } from './tasks/ts';
 import { eslint } from './tasks/eslint';
 import { webpack, webpackDevServer } from './tasks/webpack';
-import { verifyApiExtractor, updateApiExtractor } from './tasks/api-extractor';
+import { apiExtractor } from './tasks/api-extractor';
 import { lintImports } from './tasks/lint-imports';
 import { prettier } from './tasks/prettier';
 import { checkForModifiedFiles } from './tasks/check-for-modified-files';
@@ -91,8 +91,7 @@ export function preset() {
   task('ts:commonjs-only', ts.commonjsOnly);
   task('webpack', webpack);
   task('webpack-dev-server', webpackDevServer(getJustArgv()));
-  task('api-extractor:verify', verifyApiExtractor());
-  task('api-extractor:update', updateApiExtractor());
+  task('api-extractor', apiExtractor());
   task('lint-imports', lintImports);
   task('prettier', prettier);
   task('check-for-modified-files', checkForModifiedFiles);
@@ -125,7 +124,6 @@ export function preset() {
   task('lint', parallel('lint-imports', 'eslint'));
 
   task('code-style', series('prettier', 'lint'));
-  task('update-api', series('clean', 'copy', 'sass', 'ts', 'api-extractor:update'));
 
   task('dev:storybook', series('storybook:start'));
   task('dev', series('copy', 'sass', 'webpack-dev-server'));
@@ -139,7 +137,7 @@ export function preset() {
       'copy',
       'sass',
       'ts',
-      condition('api-extractor:verify', () => !getJustArgv().min),
+      condition('api-extractor', () => !getJustArgv().min),
     ),
   ).cached();
 

--- a/scripts/tasks/api-extractor.ts
+++ b/scripts/tasks/api-extractor.ts
@@ -1,6 +1,6 @@
 import * as glob from 'glob';
 import * as path from 'path';
-import { apiExtractorVerifyTask, apiExtractorUpdateTask, task, series } from 'just-scripts';
+import { apiExtractorVerifyTask, task, series } from 'just-scripts';
 
 const apiExtractorConfigs = glob
   .sync(path.join(process.cwd(), 'config/api-extractor*.json'))
@@ -9,24 +9,12 @@ const apiExtractorConfigs = glob
 // Whether to update automatically on build
 const localBuild = !process.env.TF_BUILD;
 
-export function verifyApiExtractor() {
+export function apiExtractor() {
   return apiExtractorConfigs.length
     ? series(
         ...apiExtractorConfigs.map(([configPath, configName]) => {
-          const taskName = `api-extractor:${configName}:verify`;
+          const taskName = `api-extractor:${configName}`;
           task(taskName, apiExtractorVerifyTask({ configJsonFilePath: configPath, localBuild }));
-          return taskName;
-        }),
-      )
-    : 'no-op';
-}
-
-export function updateApiExtractor() {
-  return apiExtractorConfigs.length
-    ? series(
-        ...apiExtractorConfigs.map(([configPath, configName]) => {
-          const taskName = `api-extractor:${configName}:update`;
-          task(taskName, apiExtractorUpdateTask({ configJsonFilePath: configPath, localBuild }));
           return taskName;
         }),
       )


### PR DESCRIPTION
Now that API Extractor updates are run automatically, we don't need the update-api command.