### PR TITLE
fix(siteVariables): add largest fontsize

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Accordion` title and content margins. @TanelVari ([#16533](https://github.com/microsoft/fluentui/pull/16533))
 - Fix `TextArea` disabled styles to match `Input` disabled styles @assuncaocharles ([#16661](https://github.com/microsoft/fluentui/pull/16661))
 - Remove unused `paddleNextSize` and `paddlePreviousSize` variables @assuncaocharles ([#16665](https://github.com/microsoft/fluentui/pull/16665))
+- Define value for `largest` font-size in `siteVariables` @assuncaocharles ([#16693](https://github.com/microsoft/fluentui/pull/16693))
 
 ## Features
 - Added `disabledFocusable` prop for `Button` component. @jurokapsiar ([#16419](https://github.com/microsoft/fluentui/pull/16419))

--- a/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
@@ -54,6 +54,7 @@ export const lineHeightSmall = 1.3333;
 export const lineHeightMedium = 1.4286;
 export const lineHeightLarge = 1.3333;
 export const lineHeightLarger = 1.3333;
+export const lineHeightLargest = 1.3333;
 
 //
 // Z-INDEX

--- a/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
@@ -33,7 +33,7 @@ export const fontSizes = {
   medium: pxToRem(14),
   large: pxToRem(18),
   larger: pxToRem(24),
-  largest: pxToRem(30),
+  largest: pxToRem(28),
 };
 
 //

--- a/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
@@ -33,6 +33,7 @@ export const fontSizes = {
   medium: pxToRem(14),
   large: pxToRem(18),
   larger: pxToRem(24),
+  largest: pxToRem(30),
 };
 
 //


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Set `largest` value for `fontSizes` in `siteVariables`. 

Before:

<img width="154" alt="Screen Shot 2021-01-28 at 16 25 40" src="https://user-images.githubusercontent.com/8545105/106188249-7bc53b00-6185-11eb-9d5c-94b2aaba5a2c.png">

After: 

<img width="286" alt="Screen Shot 2021-01-28 at 16 25 55" src="https://user-images.githubusercontent.com/8545105/106188280-897ac080-6185-11eb-8b26-04cc2bf3ff4a.png">


#### Focus areas to test

(optional)
