### PR TITLE
Skip syncpack check for @fluentui/keyboard-key

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
           "@fluentui/dom-utilities",
           "@fluentui/date-time-utilities",
           "@fluentui/eslint-plugin",
+          "@fluentui/keyboard-key",
           "@fluentui/react",
           "@fluentui/react-compose",
           "stylis"

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/microsoft/fluentui/issues",
   "dependencies": {
     "@babel/runtime": "^7.10.4",
-    "@fluentui/keyboard-key": "^0.2.12",
+    "@fluentui/keyboard-key": "^0.2.13-0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -9,7 +9,7 @@
     "@fluentui/accessibility": "^0.52.0",
     "@fluentui/code-sandbox": "^0.52.0",
     "@fluentui/docs-components": "^0.52.0",
-    "@fluentui/keyboard-key": "^0.2.12",
+    "@fluentui/keyboard-key": "^0.2.13-0",
     "@fluentui/react-bindings": "^0.52.0",
     "@fluentui/react-builder": "^0.52.0",
     "@fluentui/react-component-event-listener": "^0.52.0",

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4",
     "@emotion/serialize": "^0.11.16",
     "@fluentui/accessibility": "^0.52.0",
-    "@fluentui/keyboard-key": "^0.2.12",
+    "@fluentui/keyboard-key": "^0.2.13-0",
     "@fluentui/react-component-event-listener": "^0.52.0",
     "@fluentui/react-component-ref": "^0.52.0",
     "@fluentui/react-compose": "^0.19.6",

--- a/packages/fluentui/react-northstar-prototypes/package.json
+++ b/packages/fluentui/react-northstar-prototypes/package.json
@@ -9,7 +9,7 @@
     "@fluentui/accessibility": "^0.52.0",
     "@fluentui/code-sandbox": "^0.52.0",
     "@fluentui/docs-components": "^0.52.0",
-    "@fluentui/keyboard-key": "^0.2.12",
+    "@fluentui/keyboard-key": "^0.2.13-0",
     "@fluentui/react-bindings": "^0.52.0",
     "@fluentui/react-component-event-listener": "^0.52.0",
     "@fluentui/react-component-ref": "^0.52.0",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4",
     "@fluentui/accessibility": "^0.52.0",
     "@fluentui/dom-utilities": "^1.1.1",
-    "@fluentui/keyboard-key": "^0.2.12",
+    "@fluentui/keyboard-key": "^0.2.13-0",
     "@fluentui/react-bindings": "^0.52.0",
     "@fluentui/react-component-event-listener": "^0.52.0",
     "@fluentui/react-component-nesting-registry": "^0.52.0",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Fix [the build break](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=180286&view=results).

`@fluentui/keyboard-key` is shared between V0 and V8 and Beachball is only bumping version for V8 related package, it should not be checked by syncpack within V0 packages. 

I still have to update `@fluentui/keyboard-key` version to latest (match the version in our repo) to avoid the package being pulled by real npm dependency. --- I am going to take this temporary step to unblock build. And follow up with proper way to address which is to fork a copied `@fluentui/keyboard-key` package in `fluentui/*` similar to [what we did for date-time-utils](https://github.com/microsoft/fluentui/pull/16103)

#### Focus areas to test

(optional)
