### PR TITLE
Fix versioning for 0.* packages

### DIFF
--- a/change/@fluentui-cra-template-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-cra-template-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/cra-template",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:39.086Z"
+}

--- a/change/@fluentui-ie11-polyfills-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-ie11-polyfills-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/ie11-polyfills",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:41.084Z"
+}

--- a/change/@fluentui-keyboard-key-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-keyboard-key-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:42.415Z"
+}

--- a/change/@fluentui-make-styles-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-make-styles-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/make-styles",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:43.548Z"
+}

--- a/change/@fluentui-react-avatar-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-react-avatar-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:48.340Z"
+}

--- a/change/@fluentui-react-flex-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-react-flex-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/react-flex",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:50.093Z"
+}

--- a/change/@fluentui-react-image-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-react-image-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/react-image",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:51.563Z"
+}

--- a/change/@fluentui-react-text-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-react-text-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/react-text",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:53.027Z"
+}

--- a/change/@fluentui-react-utilities-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
+++ b/change/@fluentui-react-utilities-2021-01-28-12-51-54-fix-unexpected-prerelease-bumps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add prerelease in disallowed change type for version packages and fix current versioning.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T20:51:54.256Z"
+}

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -18,7 +18,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/ie11-polyfills/package.json
+++ b/packages/ie11-polyfills/package.json
@@ -15,7 +15,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -30,7 +30,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/make-styles/package.json
+++ b/packages/make-styles/package.json
@@ -27,7 +27,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "devDependencies": {

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -63,7 +63,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -48,7 +48,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -62,7 +62,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -60,7 +60,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -52,7 +52,8 @@
   "beachball": {
     "tag": "latest",
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
I saw our packages with version `0.*` are being bumped incorrectly [like this](https://github.com/microsoft/fluentui/commit/cc3588b5f90cf251e90c81e14907bcd701a51d3f#diff-a3a93830e1b9e8580775e67ac6973f7a45603ade05c7abdb0840a915c687f975). I am not sure when/how exactly this issue has started. But looks like we are allowing `prerelease` change type on `0.*` packages is the root cause. This fix is to add prerelease in disallowed change type for version packages and fix current versioning for version `0.*` packages by having all packages to bump with `patch`.

#### Focus areas to test

(optional)
