### PR TITLE
AzureTheme: Primary Button for Dark Theme alignment

### DIFF
--- a/change/@uifabric-azure-themes-2021-01-28-15-36-28-gtcarroll-primary-button-dark-theme.json
+++ b/change/@uifabric-azure-themes-2021-01-28-15-36-28-gtcarroll-primary-button-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updated primary button styles to match fluentui",
+  "packageName": "@uifabric/azure-themes",
+  "email": "gtcarroll96@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-28T23:36:28.275Z"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -188,17 +188,17 @@ export const DarkSemanticColors: IAzureSemanticColors = {
   },
   primaryButton: {
     rest: {
-      background: BaseColors.BLUE_2899F5,
-      text: BaseColors.GRAY_1B1A19,
-      border: BaseColors.BLUE_2899F5,
+      background: BaseColors.BLUE_0078D4,
+      text: BaseColors.WHITE,
+      border: BaseColors.BLUE_0078D4,
     },
     hover: {
-      background: BaseColors.BLUE_3AA0F3,
-      text: BaseColors.GRAY_1B1A19,
+      background: BaseColors.BLUE_106EBE,
+      text: BaseColors.WHITE,
     },
     pressed: {
-      background: BaseColors.BLUE_6CB8F6,
-      text: BaseColors.GRAY_1B1A19,
+      background: BaseColors.BLUE_005A9E,
+      text: BaseColors.WHITE,
     },
     disabled: {
       background: BaseColors.GRAY_F3F2F1,

--- a/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
@@ -21,6 +21,11 @@ export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
     rootFocused: {
+      selectors: {
+        '::after': {
+          outlineColor: `${semanticColors.primaryButtonText} !important`,
+        },
+      },
       backgroundColor: semanticColors.primaryButtonBackground,
       color: semanticColors.primaryButtonText,
       borderColor: extendedSemanticColors.primaryCompoundButtonBorder,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

1. Updated primary button 'rest' styles in dark theme

Before:
<img src="https://user-images.githubusercontent.com/11547803/106205527-7b23a900-6173-11eb-8a55-0df601e3559c.png" alt="screenshot" width="200"/>

After:
<img src="https://user-images.githubusercontent.com/11547803/106205332-34ce4a00-6173-11eb-84fe-5013d8d349aa.png" alt="screenshot" width="200"/>

2. Updated primary button 'hover' styles in dark theme

Before: 
<img src="https://user-images.githubusercontent.com/11547803/106205137-dc974800-6172-11eb-8095-49668f0d0ccc.png" alt="screenshot" width="200"/>

After:
<img src="https://user-images.githubusercontent.com/11547803/106205365-40217580-6173-11eb-814b-a108756ebaf9.png" alt="screenshot" width="200"/>

3. Updated primary button 'focus' styles in dark theme

Before:
<img src="https://user-images.githubusercontent.com/11547803/106205707-c50c8f00-6173-11eb-8654-2b4bcb8cc9ba.png" alt="screenshot" width="200"/>

After:
<img src="https://user-images.githubusercontent.com/11547803/106205385-49124700-6173-11eb-9aef-acd574050a01.png" alt="screenshot" width="200"/>

...primary button 'press' state is a WIP.