### PR TITLE
cherry-pick: Update ColorPicker to announce clamping of RGBA values (#15855)

### DIFF
--- a/change/@fluentui-react-internal-2021-02-01-16-23-55-cherry-pick-15855.json
+++ b/change/@fluentui-react-internal-2021-02-01-16-23-55-cherry-pick-15855.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update ColorPicker to announce clamping of RGBA values (#15855)",
+  "packageName": "@fluentui/react-internal",
+  "email": "jakubkonka@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-01T15:23:55.930Z"
+}

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -617,6 +617,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Red"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -789,6 +790,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Green"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -961,6 +963,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Blue"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -1133,6 +1136,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Alpha"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field

--- a/packages/react-internal/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react-internal/src/components/ColorPicker/ColorPicker.base.tsx
@@ -251,6 +251,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                         value={this._getDisplayValue(comp)}
                         spellCheck={false}
                         ariaLabel={textLabels[comp]}
+                        aria-live={comp !== 'hex' ? 'assertive' : undefined}
                         autoComplete="off"
                       />
                     </td>

--- a/packages/react-internal/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react-internal/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -581,6 +581,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -753,6 +754,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -925,6 +927,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1097,6 +1100,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Alpha"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1806,6 +1810,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1978,6 +1983,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -2150,6 +2156,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -2322,6 +2329,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Alpha"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3008,6 +3016,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3180,6 +3189,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3352,6 +3362,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3524,6 +3535,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Transparency"
+                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field


### PR DESCRIPTION
Cherry-pick of #15855.

Update ColorPicker to announce clamping of RGBA values

When a user types an invalid number in an RGBA field in ColorPicker then changes focus from that field ColorPicker will update the field to a valid value. However, this change was not being announced by screen readers, which is an issue as a non-sighted user is unable to know about the new value. This change adds aria-live="assertive" to announce the change to the user even when they are not focused on the field.

Co-authored-by: Justin Slone <justin.slone@microsoft.com>
