### PR TITLE
Adding behavior test to react-button

### DIFF
--- a/change/@fluentui-react-button-2021-01-29-17-08-43-mituron-acc-test-react-button.json
+++ b/change/@fluentui-react-button-2021-01-29-17-08-43-mituron-acc-test-react-button.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "adding accessibility related tests into react-button package",
+  "packageName": "@fluentui/react-button",
+  "email": "milanturon@centrum.cz",
+  "dependentChangeType": "patch",
+  "date": "2021-01-29T16:08:43.464Z"
+}

--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "Fluent UI tests for a11y patterns.",
   "private": true,
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib/src/index.js",
+  "typings": "lib/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/a11y-testing/src/definitions/Button/toggleButtonBehaviorDefinition.ts
+++ b/packages/a11y-testing/src/definitions/Button/toggleButtonBehaviorDefinition.ts
@@ -4,11 +4,11 @@ import { buttonBehaviorDefinition } from './buttonBehaviorDefinition';
 
 export const toggleButtonBehaviorDefinition: Rule[] = [
   BehaviorRule.root()
-    .forProps({ active: 'true' })
+    .forProps({ active: 'true', checked: true })
     .hasAttribute('aria-pressed', 'true')
-    .description(`if element has active prop.`),
+    .description(`if element has active/checked prop.`),
   BehaviorRule.root()
     .hasAttribute('aria-pressed', 'false')
-    .description(`if element has no 'active' prop.`),
+    .description(`if element has no 'active/checked' prop.`),
   ...buttonBehaviorDefinition,
 ];

--- a/packages/a11y-testing/tsconfig.json
+++ b/packages/a11y-testing/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "baseUrl": ".",
     "outDir": "lib",
     "target": "es6",

--- a/packages/a11y-testing/tsconfig.json
+++ b/packages/a11y-testing/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "baseUrl": ".",
     "outDir": "lib",
     "target": "es6",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -43,7 +43,8 @@
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0"
+    "react-test-renderer": "^16.3.0",
+    "@fluentui/a11y-testing": "^0.1.0"
   },
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.13-0",

--- a/packages/react-button/src/components/Button/Button.test.tsx
+++ b/packages/react-button/src/components/Button/Button.test.tsx
@@ -4,6 +4,7 @@ import * as renderer from 'react-test-renderer';
 import { isConformant } from '../../common/isConformant';
 import { Button } from './Button';
 import { GlobalClassNames } from './useButtonClasses';
+import { validateBehavior, ComponentTestFacade, buttonBehaviorDefinition } from '@fluentui/a11y-testing';
 
 describe('Button (isConformant)', () =>
   isConformant({
@@ -83,5 +84,11 @@ describe('Button', () => {
     wrapper.find(`.${GlobalClassNames.root}`).simulate('click');
 
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  describe('AccessibilityButtonBehavior', () => {
+    const testFacade = new ComponentTestFacade(Button, {});
+    const errors = validateBehavior(buttonBehaviorDefinition, testFacade);
+    expect(errors).toEqual([]);
   });
 });

--- a/packages/react-button/src/components/Button/useButtonState.ts
+++ b/packages/react-button/src/components/Button/useButtonState.ts
@@ -14,7 +14,7 @@ export const useButtonState = (draftState: ButtonState) => {
     if (draftState.as !== 'a') {
       const { onClick: onClickCallback, onKeyDown: onKeyDownCallback } = draftState;
 
-      draftState['data-isFocusable'] = true;
+      draftState['data-is-focusable'] = true;
       draftState.tabIndex = 0;
 
       draftState.onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
@@ -49,7 +49,7 @@ export const useButtonState = (draftState: ButtonState) => {
     }
   };
 
-  draftState['aria-disabled'] = draftState.disabled;
+  draftState['aria-disabled'] = draftState.disabled || draftState.disabledFocusable;
   draftState.disabled =
     draftState.as === 'button' ? draftState['aria-disabled'] && !draftState.disabledFocusable : undefined;
 };

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
@@ -1,9 +1,16 @@
 import { ToggleButton } from './ToggleButton';
 import { isConformant } from '../../common/isConformant';
+import { validateBehavior, ComponentTestFacade, toggleButtonBehaviorDefinition } from '@fluentui/a11y-testing';
 
 describe('ToggleButton', () => {
   isConformant({
     Component: ToggleButton,
     displayName: 'ToggleButton',
+  });
+
+  describe('AccesibilityButtonBehavior', () => {
+    const testFacade = new ComponentTestFacade(ToggleButton, {});
+    const errors = validateBehavior(toggleButtonBehaviorDefinition, testFacade);
+    expect(errors).toEqual([]);
   });
 });

--- a/packages/react-button/src/components/ToggleButton/useChecked.ts
+++ b/packages/react-button/src/components/ToggleButton/useChecked.ts
@@ -25,7 +25,7 @@ export const useChecked = <TDraftState extends CheckedState>(draftState: TDraftS
   // Ensure the right aria value is set to represent the checked state.
   const isCheckboxTypeRole = role === 'menuitemcheckbox' || role === 'checkbox';
 
-  draftState[isCheckboxTypeRole ? 'aria-checked' : 'aria-pressed'] = checkedValue;
+  draftState[isCheckboxTypeRole ? 'aria-checked' : 'aria-pressed'] = !!checkedValue;
 
   draftState.onClick = React.useCallback(
     (ev: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Adding behavior tests into react-button. 
Test are accessibility related. 

Definitions of button tests are located in:
packages\a11y-testing\src\definitions\Button

#### Focus areas to test
tests are green :)
