### PR TITLE
feat(UIBuilder): Edit shorthands

### DIFF
--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -80,6 +80,9 @@ export const Designer: React.FunctionComponent = () => {
     ? componentInfoContext.byDisplayName[selectedJSONTreeElement.displayName]
     : null;
 
+  const getShorthandComponentInfo = shorthandType =>
+    componentInfoContext.byDisplayName[shorthandType.replaceAll('Props', '')];
+
   const handleReset = React.useCallback(() => {
     /* eslint-disable-next-line no-alert */
     if (confirm('Lose your changes?')) {
@@ -168,6 +171,17 @@ export const Designer: React.FunctionComponent = () => {
         type: 'PROP_DELETE',
         component: jsonTreeElement,
         propName: name,
+      });
+    },
+    [dispatch],
+  );
+
+  const handlePropNavigate = React.useCallback(
+    ({ jsonTreeElement, path }) => {
+      dispatch({
+        type: 'PROP_NAVIGATE',
+        component: jsonTreeElement,
+        propPath: path,
       });
     },
     [dispatch],
@@ -569,8 +583,11 @@ export const Designer: React.FunctionComponent = () => {
               <Knobs
                 onPropChange={handlePropChange}
                 onPropDelete={handlePropDelete}
+                onPropNavigate={handlePropNavigate}
                 info={selectedComponentInfo}
                 jsonTreeElement={selectedJSONTreeElement}
+                propPath={state.propPath}
+                getShorthandComponentInfo={getShorthandComponentInfo}
               />
             )}
           </div>

--- a/packages/fluentui/react-builder/src/components/MultiTypeKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/MultiTypeKnob.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-// import { isElement } from 'react-is';
-// import * as _ from 'lodash';
-// import * as FUI from '@fluentui/react-northstar';
-// import * as FUIIcons from '@fluentui/react-icons-northstar';
+import { knobs } from './knobs/index';
 
 /**
  * Displays a knob with the ability to switch between data `types`.
@@ -11,11 +8,13 @@ export const MultiTypeKnob: React.FunctionComponent<{
   label: string;
   types: ('boolean' | 'number' | 'string' | 'literal')[];
   value: any;
+  shorthandType?: string;
   onChange: (value: any) => void;
   onRemoveProp: () => void;
+  onNavigateProp: (propName: string) => void;
   options: string[];
   required: boolean;
-}> = ({ label, types, value, onChange, onRemoveProp, options, required }) => {
+}> = ({ label, types, value, onChange, onRemoveProp, options, required, onNavigateProp }) => {
   const defaultType = types[0];
   const [type, setType] = React.useState(defaultType);
 
@@ -41,7 +40,7 @@ export const MultiTypeKnob: React.FunctionComponent<{
           ))
         )}
       </div>
-      {knob && knob({ options, value, onChange, id: propId })}
+      {knob && knob({ options, value, onChange, onNavigateProp, id: propId })}
       {type === 'boolean' && <label htmlFor={propId}> {label}</label>}
       {!required && type === 'literal' && value && (
         <button
@@ -61,39 +60,4 @@ export const MultiTypeKnob: React.FunctionComponent<{
       )}
     </div>
   );
-};
-
-export const knobs = {
-  boolean: ({ value, onChange, id }) => (
-    <input id={id} type="checkbox" checked={!!value} onChange={e => onChange(!!e.target.checked)} />
-  ),
-
-  number: ({ value, onChange, id }) => (
-    <input
-      id={id}
-      style={{ width: '100%' }}
-      type="number"
-      value={Number(value)}
-      onChange={e => onChange(Number(e.target.value))}
-    />
-  ),
-
-  string: ({ value, onChange, id }) => (
-    <input id={id} style={{ width: '100%' }} value={String(value)} onChange={e => onChange(e.target.value)} />
-  ),
-
-  literal: ({ options, value, onChange, id }) => (
-    <select id={id} onChange={e => onChange(e.target.value)} value={value}>
-      {options?.map((
-        opt, // FIXME the optional is workaround for showing `Dialog` props when selected from component tree
-      ) => (
-        <option key={opt} value={opt}>
-          {opt}
-        </option>
-      ))}
-    </select>
-  ),
-
-  ReactText: ({ value, onChange, id }) => knobs.string({ value, onChange, id }),
-  'React.ElementType': ({ value, onChange, id }) => knobs.string({ value, onChange, id }),
 };

--- a/packages/fluentui/react-builder/src/components/PropPathBreadcrumb.tsx
+++ b/packages/fluentui/react-builder/src/components/PropPathBreadcrumb.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Breadcrumb } from '@fluentui/react-northstar';
+import { JSONTreeElement } from './types';
+
+interface PropPathBreadcrumbProps {
+  onPropNavigate: ({ jsonTreeElement, path }: { jsonTreeElement: JSONTreeElement; path: string[] }) => void;
+  jsonTreeElement: JSONTreeElement;
+  propPath: string[];
+  displayName: string;
+}
+
+export const PropPathBreadcrumb: React.FC<PropPathBreadcrumbProps> = props => {
+  const { onPropNavigate, jsonTreeElement, displayName, propPath } = props;
+
+  return (
+    <Breadcrumb aria-label="Nested properties">
+      <Breadcrumb.Item key="root">
+        <Breadcrumb.Link
+          href="#"
+          onClick={e => {
+            onPropNavigate({ jsonTreeElement, path: [] });
+            e.preventDefault();
+          }}
+        >
+          {displayName}
+        </Breadcrumb.Link>
+      </Breadcrumb.Item>
+      {propPath.map((prop, i) => (
+        <React.Fragment key={prop}>
+          <Breadcrumb.Divider />
+          <Breadcrumb.Item>
+            <Breadcrumb.Link
+              href=""
+              onClick={e => {
+                onPropNavigate({ jsonTreeElement, path: propPath.slice(0, i + 1) });
+                e.preventDefault();
+              }}
+            >
+              {prop}
+            </Breadcrumb.Link>
+          </Breadcrumb.Item>
+        </React.Fragment>
+      ))}
+    </Breadcrumb>
+  );
+};

--- a/packages/fluentui/react-builder/src/components/knobs/BooleanKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/knobs/BooleanKnob.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { KnobProps } from './Knob.interface';
+
+export const BooleanKnob: React.FC<KnobProps> = ({ value, onChange, id }) => (
+  <input id={id} type="checkbox" checked={!!value} onChange={e => onChange(!!e.target.checked)} />
+);

--- a/packages/fluentui/react-builder/src/components/knobs/Knob.interface.ts
+++ b/packages/fluentui/react-builder/src/components/knobs/Knob.interface.ts
@@ -1,0 +1,7 @@
+export interface KnobProps {
+  id: string;
+  value: any;
+  options: string[];
+  onChange: (value: any) => void;
+  onNavigateProp: (propName: string) => void;
+}

--- a/packages/fluentui/react-builder/src/components/knobs/LiteralKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/knobs/LiteralKnob.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { KnobProps } from './Knob.interface';
+
+export const LiteralKnob: React.FC<KnobProps> = ({ value, onChange, id, options }) => (
+  <select id={id} onChange={e => onChange(e.target.value)} value={value}>
+    {options?.map((
+      opt, // FIXME the optional is workaround for showing `Dialog` props when selected from component tree
+    ) => (
+      <option key={opt} value={opt}>
+        {opt}
+      </option>
+    ))}
+  </select>
+);

--- a/packages/fluentui/react-builder/src/components/knobs/NumberKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/knobs/NumberKnob.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { KnobProps } from './Knob.interface';
+
+export const NumberKnob: React.FC<KnobProps> = ({ value, onChange, id }) => (
+  <input
+    id={id}
+    style={{ width: '100%' }}
+    type="number"
+    value={Number(value)}
+    onChange={e => onChange(Number(e.target.value))}
+  />
+);

--- a/packages/fluentui/react-builder/src/components/knobs/ShorthandKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/knobs/ShorthandKnob.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { KnobProps } from './Knob.interface';
+
+const EMPTY_VALUES = {
+  undefined,
+  string: '',
+  shorthand: { $$typeof: 'shorthand', props: {} },
+  element: { $$typeof: 'Symbol(react.element)', props: {} },
+};
+
+const newValue = type => EMPTY_VALUES[type];
+
+const getFlags = value => ({
+  undefined: value === undefined,
+  string: value !== undefined && typeof value === 'string',
+  element: value && value['$$typeof'] === 'Symbol(react.element)',
+  shorthand: value && value['$$typeof'] === 'shorthand',
+});
+
+const getFlagValue = flags => {
+  for (const flag of Object.keys(flags)) {
+    if (flags[flag]) {
+      return flag;
+    }
+  }
+  return 'unknown';
+};
+
+export const ShorthandKnob: React.FC<KnobProps> = ({ value, onChange, id, options, onNavigateProp }) => {
+  const flags = getFlags(value);
+  const contentEditor = flags.string ? (
+    <input
+      title={options ? options[0] : ''}
+      id={id}
+      style={{ width: '50%' }}
+      value={String(value)}
+      onChange={e => onChange(e.target.value)}
+    />
+  ) : flags.shorthand ? (
+    <button title="Modify" style={{ width: '50%' }} onClick={() => onNavigateProp(id)}>
+      ...
+    </button>
+  ) : (
+    undefined
+  );
+
+  return (
+    <div style={{ display: 'inline' }}>
+      {contentEditor}
+      <select onChange={e => onChange(newValue(e.target.value))} value={getFlagValue(flags)}>
+        {Object.keys(flags).map(flag => {
+          if (flag === 'element' && !flags.element) {
+            return undefined;
+          }
+          return (
+            <option key={flag} value={flag}>
+              {flag}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};

--- a/packages/fluentui/react-builder/src/components/knobs/StringKnob.tsx
+++ b/packages/fluentui/react-builder/src/components/knobs/StringKnob.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { KnobProps } from './Knob.interface';
+
+export const StringKnob: React.FC<KnobProps> = ({ value, onChange, id }) => (
+  <input id={id} style={{ width: '100%' }} value={String(value)} onChange={e => onChange(e.target.value)} />
+);

--- a/packages/fluentui/react-builder/src/components/knobs/index.ts
+++ b/packages/fluentui/react-builder/src/components/knobs/index.ts
@@ -1,0 +1,15 @@
+import { BooleanKnob } from './BooleanKnob';
+import { LiteralKnob } from './LiteralKnob';
+import { NumberKnob } from './NumberKnob';
+import { ShorthandKnob } from './ShorthandKnob';
+import { StringKnob } from './StringKnob';
+
+export const knobs = {
+  boolean: BooleanKnob,
+  number: NumberKnob,
+  string: StringKnob,
+  ShorthandValue: ShorthandKnob,
+  literal: LiteralKnob,
+  ReactText: StringKnob,
+  'React.ElementType': StringKnob,
+};

--- a/packages/fluentui/react-builder/src/config.tsx
+++ b/packages/fluentui/react-builder/src/config.tsx
@@ -521,6 +521,8 @@ const resolveProps = (input, cb) => {
     if (_.isPlainObject(value)) {
       if ((value as any).$$typeof === 'Symbol(react.element)') {
         acc[key] = renderJSONTreeToJSXElement(value as any, cb);
+      } else if ((value as any).$$typeof === 'shorthand') {
+        acc[key] = renderJSONTreeShorthand(value as any, cb);
       } else {
         acc[key] = resolveProps(value, cb);
       }
@@ -551,6 +553,19 @@ export const renderJSONTreeToJSXElement = (
     key: modifiedTree.uuid,
     'data-builder-id': modifiedTree.uuid,
   });
+};
+
+export const renderJSONTreeShorthand = (
+  tree: JSONTreeElement,
+  iterator: (jsonTreeElement: JSONTreeElement) => JSONTreeElement = x => x,
+) => {
+  if (tree === null) {
+    return null;
+  }
+
+  const { props = null } = tree;
+
+  return resolveProps(props, iterator);
 };
 
 const packageImportList: Record<string, CodeSandboxImport> = {


### PR DESCRIPTION
#### Description of changes

Allows editing shorthands - as text, shorthand object or set it to undefined:
![image](https://user-images.githubusercontent.com/13742664/106434964-8a0ba380-6472-11eb-89e7-2f6230a66c0d.png)
![image](https://user-images.githubusercontent.com/13742664/106435010-97c12900-6472-11eb-98e1-4bd7ba27dbc3.png)

Displays JSX in slot as `element` but does not allow to edit it for now:
![image](https://user-images.githubusercontent.com/13742664/106435100-b9221500-6472-11eb-9280-24b18d76b2b6.png)

Editing shorthands works by drilling down in the prop editor:
![image](https://user-images.githubusercontent.com/13742664/106435198-dbb42e00-6472-11eb-89f7-00eb42f4067d.png)

Things that don't work:
Editing after making a code change in code editor - probably need to fix codeToTree magic
Editing second level shorthands (Button.content.content) as shorthand object breaks the canvas
Editing JSX elements in slots
