### PR TITLE
feat(FlexItem): wrap prop to allow editing in UIBuilder

### DIFF
--- a/packages/fluentui/react-builder/src/config.tsx
+++ b/packages/fluentui/react-builder/src/config.tsx
@@ -196,6 +196,12 @@ export const DRAGGING_ELEMENTS = {
     props: {} as FUI.FlexProps,
   },
 
+  FlexItem: {
+    props: {
+      wrap: true,
+    } as FUI.FlexItemProps,
+  },
+
   // FocusZone: { props: { content: 'FocusZone' } as FUI.FocusZoneProps },
 
   Form: {


### PR DESCRIPTION
#### Description of changes

Adds an optional `wrap` prop that makes FlexItem behave like standard component
Sets `wrap` to `true` by default for UI Buider

This is probably not a good solution as we will need to allow editing non visual components in UI Builder sooner or later and also allows the user to easily break the builder by changing `wrap` to `false` :(

Better would be to allow overrides - UI Builder would render different components in build and design mode - and provide checks and warnings of incorrect usage.