### PR TITLE
FocusZone: Removing contextual RTL awareness to get rid of react-theme-provider dependency from react-focus package

### DIFF
--- a/change/@fluentui-react-focus-2021-02-01-12-08-28-removeFocusContextualRTL.json
+++ b/change/@fluentui-react-focus-2021-02-01-12-08-28-removeFocusContextualRTL.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "FocusZone: Removing contextual RTL checks to get rid of react-theme-provider dependency from react-focus package.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-01T20:08:28.166Z"
+}

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.13",
     "@fluentui/merge-styles": "^8.0.0-beta.4",
-    "@fluentui/react-theme-provider": "^1.0.0-beta.18",
     "@fluentui/set-version": "^8.0.0-beta.1",
     "@fluentui/style-utilities": "^8.0.0-beta.13",
     "@fluentui/utilities": "^8.0.0-beta.10",

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -28,8 +28,7 @@ import {
   createMergedRef,
 } from '@fluentui/utilities';
 import { mergeStyles } from '@fluentui/merge-styles';
-import { ThemeContext, Theme } from '@fluentui/react-theme-provider';
-import { getTheme } from '@fluentui/style-utilities';
+import { getTheme, ITheme } from '@fluentui/style-utilities';
 
 const IS_FOCUSABLE_ATTRIBUTE = 'data-is-focusable';
 const IS_ENTER_DISABLED_ATTRIBUTE = 'data-disable-click-on-enter';
@@ -253,36 +252,35 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // the case the element was removed.
     this._evaluateFocusBeforeRender();
 
+    // Only support RTL defined in global theme, not contextual theme/RTL.
+    const theme: ITheme = getTheme();
+
     return (
-      <ThemeContext.Consumer>
-        {theme => (
-          <Tag
-            aria-labelledby={ariaLabelledBy}
-            aria-describedby={ariaDescribedBy}
-            {...divProps}
-            {
-              // root props has been deprecated and should get removed.
-              // it needs to be marked as "any" since root props expects a div element, but really Tag can
-              // be any native element so typescript rightly flags this as a problem.
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ...(rootProps as any)
-            }
-            // Once the getClassName correctly memoizes inputs this should
-            // be replaced so that className is passed to getRootClass and is included there so
-            // the class names will always be in the same order.
-            className={css(getRootClass(), className)}
-            // eslint-disable-next-line deprecation/deprecation
-            ref={this._mergedRef(this.props.elementRef, this._root)}
-            data-focuszone-id={this._id}
-            // eslint-disable-next-line react/jsx-no-bind
-            onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme || getTheme())}
-            onFocus={this._onFocus}
-            onMouseDownCapture={this._onMouseDown}
-          >
-            {this.props.children}
-          </Tag>
-        )}
-      </ThemeContext.Consumer>
+      <Tag
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        {...divProps}
+        {
+          // root props has been deprecated and should get removed.
+          // it needs to be marked as "any" since root props expects a div element, but really Tag can
+          // be any native element so typescript rightly flags this as a problem.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(rootProps as any)
+        }
+        // Once the getClassName correctly memoizes inputs this should
+        // be replaced so that className is passed to getRootClass and is included there so
+        // the class names will always be in the same order.
+        className={css(getRootClass(), className)}
+        // eslint-disable-next-line deprecation/deprecation
+        ref={this._mergedRef(this.props.elementRef, this._root)}
+        data-focuszone-id={this._id}
+        // eslint-disable-next-line react/jsx-no-bind
+        onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => this._onKeyDown(ev, theme)}
+        onFocus={this._onFocus}
+        onMouseDownCapture={this._onMouseDown}
+      >
+        {this.props.children}
+      </Tag>
     );
   }
 
@@ -574,7 +572,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   /**
    * Handle the keystrokes.
    */
-  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme: Theme): boolean | undefined => {
+  private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>, theme: ITheme): boolean | undefined => {
     if (this._portalContainsElement(ev.target as HTMLElement)) {
       // If the event target is inside a portal do not process the event.
       return;
@@ -992,7 +990,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusLeft(theme: Theme): boolean {
+  private _moveFocusLeft(theme: ITheme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(
@@ -1034,7 +1032,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _moveFocusRight(theme: Theme): boolean {
+  private _moveFocusRight(theme: ITheme): boolean {
     const shouldWrap = this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP);
     if (
       this._moveFocus(


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes the contextual RTL awareness from `FocusZone` and uses the regular global RTL awareness so that we can get rid of the dependency on `@fluentui/react-theme-provider` in `@fluentui/react-focus` package to unblock #16729.
