### PR TITLE
Checkbox: border is now visible when element is in focus in High Contrast White Mode

### DIFF
--- a/change/@fluentui-react-internal-2021-02-01-12-16-57-issue-16228.json
+++ b/change/@fluentui-react-internal-2021-02-01-12-16-57-issue-16228.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Checkbox: border is now visible when element is in focus in High Contrast White Mode",
+  "packageName": "@fluentui/react-internal",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-01T20:16:57.832Z"
+}

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -75,7 +75,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-0"
@@ -244,7 +244,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-1"
@@ -380,7 +380,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       disabled={true}
@@ -516,7 +516,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       disabled={true}

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -81,7 +81,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-0"
@@ -264,7 +264,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-1"
@@ -417,7 +417,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       disabled={true}
@@ -604,7 +604,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-0"
@@ -248,7 +248,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-1"
@@ -410,7 +410,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -572,7 +572,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1188,7 +1188,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         data-ktp-execute-target={true}
         id="checkbox-9"

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -75,7 +75,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         data-ktp-execute-target={true}
         id="checkbox-0"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -316,7 +316,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2086,7 +2086,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-37"
@@ -2247,7 +2247,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-38"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -316,7 +316,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -158,7 +158,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -319,7 +319,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -316,7 +316,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1506,7 +1506,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-26"
@@ -1667,7 +1667,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-27"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"
@@ -316,7 +316,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-3"

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-0"

--- a/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
       id="checkbox-2"

--- a/packages/react-internal/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react-internal/src/components/Checkbox/Checkbox.styles.ts
@@ -159,7 +159,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         outline: '1px solid ' + theme.palette.neutralSecondary,
         outlineOffset: '2px',
         [HighContrastSelector]: {
-          outline: '1px solid ActiveBorder',
+          outline: '1px solid WindowText',
         },
       },
     },

--- a/packages/react-internal/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-internal/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Checkbox renders checked correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     data-ktp-execute-target={true}
     id="checkbox-0"
@@ -235,7 +235,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     data-ktp-execute-target={true}
     id="checkbox-0"
@@ -418,7 +418,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     data-ktp-execute-target={true}
     id="checkbox-0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16228 

#### Description of changes
- Changed outline color for focused elements from ActiveBorder to WindowText.
- High Contrast White Mode: 
![HighContrastWhiteMode](https://user-images.githubusercontent.com/8649804/106514769-89cad280-6489-11eb-867d-c084ee544ab7.JPG)
