### PR TITLE
SplitButton: Using menuButtonRef prop correctly when handling state

### DIFF
--- a/change/@fluentui-react-button-2021-02-01-13-19-32-menuRef.json
+++ b/change/@fluentui-react-button-2021-02-01-13-19-32-menuRef.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "SplitButton: Using menuButtonRef prop correctly when handling state.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-01T21:19:32.301Z"
+}

--- a/packages/react-button/src/components/SplitButton/useSplitButton.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButton.ts
@@ -27,6 +27,7 @@ export const useSplitButton = (
     circular,
     block,
     menu,
+    menuButtonRef,
     size,
     transparent,
     ...userProps
@@ -64,6 +65,7 @@ export const useSplitButton = (
 
       menuButton: {
         as: 'span',
+        ref: menuButtonRef,
         primary,
         ghost,
         circular,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`SplitButton` had a `menuButtonRef` prop to point to the `MenuButton` part of the `SplitButton`. However, this was not being used anywhere inside the `SplitButton's` state, which meant that passing it was useless. This PR addresses that issue by correctly handling the `menuButtonRef` prop to point to the `MenuButton` part of `SplitButton` when provided.