### PR TITLE
Making local yarn start work again

### DIFF
--- a/apps/public-docsite/index.html
+++ b/apps/public-docsite/index.html
@@ -156,9 +156,10 @@
 
     <script type="text/javascript">
       // @ts-check
-      var isLocal = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
+      var hostname = location.hostname;
+      var isLocal = ['localhost', '[::]', '127.0.0.1'].indexOf(hostname) !== -1;
       var isDev = isLocal || getParameterByName('dev') === '1' || !!getParameterByName('strict');
-      var isProduction = location.hostname === 'developer.microsoft.com' || getParameterByName('isProduction') === '1';
+      var isProduction = hostname === 'developer.microsoft.com' || getParameterByName('isProduction') === '1';
       var devhost = getParameterByName('devhost');
       var entryPointFilename = 'fabric-sitev5';
       var appPath = '';

--- a/apps/public-docsite/index.html
+++ b/apps/public-docsite/index.html
@@ -39,6 +39,7 @@
       a.m-skip-to-main:focus {
         border: 1px dashed #000;
       }
+
       a.m-skip-to-main:focus,
       a.m-skip-to-main:active {
         background: #e6e6e6;
@@ -155,7 +156,7 @@
 
     <script type="text/javascript">
       // @ts-check
-      var isLocal = location.hostname === 'localhost' || location.hostname.indexOf('ngrok.io') > -1;
+      var isLocal = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
       var isDev = isLocal || getParameterByName('dev') === '1' || !!getParameterByName('strict');
       var isProduction = location.hostname === 'developer.microsoft.com' || getParameterByName('isProduction') === '1';
       var devhost = getParameterByName('devhost');

--- a/apps/public-docsite/src/components/Nav/Nav.tsx
+++ b/apps/public-docsite/src/components/Nav/Nav.tsx
@@ -12,6 +12,7 @@ import {
 import { theme } from '@fluentui/react-docsite-components/lib/styles/theme';
 import { getItem, setItem } from '@fluentui/utilities/lib/sessionStorage';
 import * as styles from './Nav.module.scss';
+import { isLocal } from '../../utilities/index';
 
 export interface INavState {
   searchQuery: string;
@@ -152,7 +153,7 @@ export class Nav extends React.Component<INavProps, INavState> {
         )}
         key={linkIndex + page.url}
       >
-        {!(page.isUhfLink && location.hostname !== 'localhost') && searchRegEx.test(page.title) && (
+        {(!page.isUhfLink || isLocal) && searchRegEx.test(page.title) && (
           <Link
             href={page.url}
             onClick={this._onLinkClick}

--- a/apps/public-docsite/src/utilities/location.ts
+++ b/apps/public-docsite/src/utilities/location.ts
@@ -1,17 +1,13 @@
+const hostname = typeof window === 'undefined' ? undefined : window.location.hostname;
+
 /**
  * Determines whether the site is hosted on the Office Developer portal, which
  * has the Universal Header and Footer (UHF).
  */
 export const hasUHF: boolean =
-  typeof window === 'undefined'
-    ? false
-    : window.location.hostname === 'developer.microsoft.com' ||
-      window.location.hostname === 'developer.microsoft-tst.com';
+  !!hostname && (hostname === 'developer.microsoft.com' || hostname === 'developer.microsoft-tst.com');
 
 /**
  * Determines if the site is running locally.
  */
-export const isLocal: boolean =
-  typeof window === 'undefined'
-    ? false
-    : window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
+export const isLocal: boolean = !!hostname && ['localhost', '[::]', '127.0.0.1'].indexOf(hostname) !== -1;

--- a/change/@fluentui-react-docsite-components-2021-02-01-22-21-03-fix-docsite-start.json
+++ b/change/@fluentui-react-docsite-components-2021-02-01-22-21-03-fix-docsite-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix localhost check in local demo",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-02-02T06:20:56.920Z"
+}

--- a/change/@fluentui-react-monaco-editor-2021-02-01-22-21-03-fix-docsite-start.json
+++ b/change/@fluentui-react-monaco-editor-2021-02-01-22-21-03-fix-docsite-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix localhost check in local demo",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-02-02T06:21:03.837Z"
+}

--- a/packages/react-docsite-components/index.html
+++ b/packages/react-docsite-components/index.html
@@ -10,6 +10,7 @@
   <body>
     <div id="content"></div>
     <script type="text/javascript">
+      // @ts-check
       window.FabricConfig = {
         // Uncommenting this prevents the fontfaces from being registered.
         // Alternatively you can specify a base url which contains the font/icon assets.
@@ -19,8 +20,7 @@
         // }
       };
 
-      var url = document.location.href;
-      var isLocalHost = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
+      var isLocal = ['localhost', '[::]', '127.0.0.1'].indexOf(location.hostname) !== -1;
 
       var isDev = getParameterByName('dev') === '1' || !!getParameterByName('strict');
       var minParam = getParameterByName('min');
@@ -38,7 +38,7 @@
 
       const scripts = [];
 
-      if (isLocalHost) {
+      if (isLocal) {
         scripts.push('./react.development.js');
         scripts.push('./react-dom.development.js');
       } else {

--- a/packages/react-monaco-editor/index.html
+++ b/packages/react-monaco-editor/index.html
@@ -10,6 +10,7 @@
   <body>
     <div id="content"></div>
     <script type="text/javascript">
+      // @ts-check
       window.FabricConfig = {
         // Uncommenting this prevents the fontfaces from being registered.
         // Alternatively you can specify a base url which contains the font/icon assets.
@@ -19,10 +20,9 @@
         // }
       };
 
-      var url = document.location.href;
-      var isLocalHost = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
+      var isLocal = ['localhost', '[::]', '127.0.0.1'].indexOf(location.hostname) !== -1;
 
-      var minMatch = url.match(/\bmin=([01])\b/);
+      var minMatch = location.search.match(/\bmin=([01])\b/);
       var minParam = minMatch && minMatch[1];
       var useMinified = minParam !== '0' && (minParam === '1' || location.pathname === '/fabric-react/master/');
       var jsSuffix = useMinified ? '.min.js' : '.js';
@@ -43,7 +43,7 @@
 
       const scripts = [];
 
-      if (isLocalHost) {
+      if (isLocal) {
         scripts.push('./react.development.js');
         scripts.push('./react-dom.development.js');
       } else {

--- a/scripts/local-codepen.js
+++ b/scripts/local-codepen.js
@@ -28,15 +28,11 @@ if (fs.existsSync(configPath)) {
   }
   const webpackConfig = require(configPath);
   const compiler = webpack(webpackConfig);
-  const devServerOptions = Object.assign({}, webpackConfig.devServer, {
-    stats: {
-      colors: true,
-    },
-  });
-  const server = new WebpackDevServer(compiler, devServerOptions);
+  const server = new WebpackDevServer(compiler, webpackConfig.devServer);
+  const port = webpackConfig.devServer.port || 8080;
 
-  server.listen(8080, '127.0.0.1', async () => {
-    const url = await ngrok.connect({ port: 8080, host_header: 'localhost:8080' });
+  server.listen(port, '127.0.0.1', async () => {
+    const url = await ngrok.connect({ port, host_header: 'localhost:' + port });
     console.log(`Starting server on http://${url}`);
     console.log(
       `Add this to CodePen:

--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -31,10 +31,13 @@ function getResolveAlias(useLib, cwd) {
 
   deps.forEach(({ packageJson: depPackageJson, packagePath: depPackagePath }) => {
     const depName = depPackageJson.name;
-    const entryPoint = depPackageJson.module || depPackageJson.main;
-
     if (excludedPackages.includes(depName)) {
       return;
+    }
+
+    let entryPoint = depPackageJson.module || depPackageJson.main;
+    if (!entryPoint && depName !== '@fluentui/common-styles') {
+      entryPoint = 'lib/index.js'; // guess this entry point
     }
 
     if (!entryPoint) {

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -238,6 +238,7 @@ module.exports = {
     const config = merge(
       {
         devServer: {
+          // As of Webpack 5, this will open the browser at 127.0.0.1 by default
           host: 'localhost',
           port: 4322,
           static: outputPath,

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -4,7 +4,8 @@
  * @typedef {import("webpack").Configuration} WebpackConfig
  * @typedef {WebpackConfig & { devServer?: object }} WebpackServeConfig
  * @typedef {import("webpack").Entry} WebpackEntry
- * @typedef {import("webpack").Module} WebpackModule
+ * @typedef {import("webpack").ModuleOptions} WebpackModule
+ * @typedef {import("webpack").Configuration['output']} WebpackOutput
  */
 /** */
 const webpack = require('webpack');
@@ -310,7 +311,7 @@ module.exports = {
 
         plugins: [
           ...(!process.env.TF_BUILD ? [new ForkTsCheckerWebpackPlugin()] : []),
-          ...(process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME ? [] : [new webpack.ProgressPlugin()]),
+          ...(process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME ? [] : [new webpack.ProgressPlugin({})]),
         ],
       },
       customConfig,

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -238,6 +238,7 @@ module.exports = {
     const config = merge(
       {
         devServer: {
+          host: 'localhost',
           port: 4322,
           static: outputPath,
         },


### PR DESCRIPTION
This change does 2 things:

1. Defaults webpack server starts to use localhost IP address rather than `[::]` for the server name.
2. Adjusts public-docsite bootstrap code to detect this as well for localhost serving.

