### PR TITLE
MenuButton: Adding persistMenu prop to allow for constant rendering of the Menu

### DIFF
--- a/change/@fluentui-react-button-2021-02-01-16-38-39-menuButtonPersistMenu.json
+++ b/change/@fluentui-react-button-2021-02-01-16-38-39-menuButtonPersistMenu.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "MenuButton: Adding persistMenu prop to allow for constant rendering of the Menu.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T00:38:39.870Z"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -194,6 +194,7 @@ export type MenuButtonProps = Omit<ButtonProps, 'iconPosition' | 'loader'> & {
     menuIcon?: ShorthandProps;
     defaultExpanded?: boolean;
     expanded?: boolean;
+    persistMenu?: boolean;
     onMenuDismiss?: () => void;
 };
 

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -32,6 +32,15 @@ export type MenuButtonProps = Omit<ButtonProps, 'iconPosition' | 'loader'> & {
   expanded?: boolean;
 
   /**
+   * If true, the menu will not be created or destroyed when opened or closed, being hidden instead. This will improve
+   * the performance of the menu opening but could potentially impact the overall performance by having more elements in
+   * the DOM. As such, it should only be used when the performance of opening the menu is important.
+   *
+   * Note: This may increase the amount of time it takes for the button itself to mount.
+   */
+  persistMenu?: boolean;
+
+  /**
    * Defines a callback that runs after the MenuButton's contextual menu has been dismissed.
    */
   onMenuDismiss?: () => void;

--- a/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
@@ -9,7 +9,7 @@ import { menuButtonShorthandProps } from './useMenuButton';
  */
 export const renderMenuButton = (state: MenuButtonState) => {
   const { slots, slotProps } = getSlots(state, menuButtonShorthandProps);
-  const { iconOnly, children } = state;
+  const { children, expanded, iconOnly, persistMenu } = state;
 
   const contentVisible = !iconOnly && (children || slotProps.content?.children);
 
@@ -18,7 +18,7 @@ export const renderMenuButton = (state: MenuButtonState) => {
       <slots.icon {...slotProps.icon} />
       {contentVisible && <slots.content {...slotProps.content} />}
       {!iconOnly && <slots.menuIcon {...slotProps.menuIcon} />}
-      <slots.menu {...slotProps.menu} />
+      {(persistMenu || expanded) && <slots.menu {...slotProps.menu} />}
     </slots.root>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the `persistMenu` prop to the `MenuButton` component that exists on the v7 version of the `Button`. This prop allows for constant rendering of the `Menu` independent if the `Menu` itself has been `expanded` or not. This is done by `hiding` the `Menu` instead of creating and destroying it, which could potentially improve the performance of the menu opening but impact the overall performance by having more elements in the DOM.