### PR TITLE
7.0: UnifiedPicker: Modify some picker selection behavior

### DIFF
--- a/change/@uifabric-experiments-2021-02-01-15-30-05-pickerselectontype7.0.json
+++ b/change/@uifabric-experiments-2021-02-01-15-30-05-pickerselectontype7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker should select first suggestion when user begins typing",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-01T23:30:05.292Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -45,6 +45,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const {
     focusItemIndex,
+    setFocusItemIndex,
     suggestionItems,
     footerItemIndex,
     footerItems,
@@ -54,6 +55,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     showPicker,
     selectPreviousSuggestion,
     selectNextSuggestion,
+    clearPickerSelectedIndex,
   } = useFloatingSuggestionItems(
     suggestions,
     pickerSuggestionsProps?.footerItemsProps,
@@ -393,6 +395,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (!composing) {
       // update query string
       setQueryString(value);
+      // If we now have no query string, we want to deselect any selected item in the picker
+      if (value === '') {
+        clearPickerSelectedIndex();
+      }
+      // if nothing is selcted and the user has typed, selected the first picker item
+      else if (focusItemIndex === -1 && headerItemIndex === -1 && footerItemIndex === -1) {
+        setFocusItemIndex(0);
+      }
       !isSuggestionsShown ? showPicker(true) : null;
       if (!resultItemsList) {
         resultItemsList = [];

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -21,6 +21,7 @@ export interface IUseFloatingSuggestionItems<T> {
   getFocusedSuggestion: () => T;
   hasSuggestionSelected: () => void;
   removeSuggestion: (index: number) => void;
+  clearPickerSelectedIndex: () => void;
 }
 
 export const useFloatingSuggestionItems = <T extends {}>(
@@ -94,9 +95,7 @@ export const useFloatingSuggestionItems = <T extends {}>(
   };
 
   const showPicker = (show: boolean) => {
-    setFocusItemIndex(-1);
-    setFooterItemIndex(-1);
-    setHeaderItemIndex(-1);
+    clearPickerSelectedIndex();
     setIsSuggestionsShown(show);
   };
 
@@ -243,6 +242,12 @@ export const useFloatingSuggestionItems = <T extends {}>(
     setSuggestionItems(updatedSuggestions);
   };
 
+  const clearPickerSelectedIndex = (): void => {
+    setFocusItemIndex(-1);
+    setFooterItemIndex(-1);
+    setHeaderItemIndex(-1);
+  };
+
   return {
     focusItemIndex: focusItemIndex,
     setFocusItemIndex: setFocusItemIndex,
@@ -263,5 +268,6 @@ export const useFloatingSuggestionItems = <T extends {}>(
     getFocusedSuggestion: getFocusedSuggestion,
     hasSuggestionSelected: hasSuggestionSelected,
     removeSuggestion: removeSuggestion,
+    clearPickerSelectedIndex: clearPickerSelectedIndex,
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - #16733 
When there is a blank query, nothing in the dropdown should be selected. When the user first starts typing after this, the first item in the dropdown should be selected.
