### PR TITLE
[v7.0] Checkbox: border is now visible when element is in focus in High Contrast White Mode 

### DIFF
--- a/change/@fluentui-react-examples-2021-02-01-18-05-33-16228-v7.json
+++ b/change/@fluentui-react-examples-2021-02-01-18-05-33-16228-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[v7.0]Checkbox: border is now visible when element is in focus in High Contrast White Mode",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T02:05:33.744Z"
+}

--- a/change/office-ui-fabric-react-2021-02-01-18-05-33-16228-v7.json
+++ b/change/office-ui-fabric-react-2021-02-01-18-05-33-16228-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[v7.0]Checkbox: border is now visible when element is in focus in High Contrast White Mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T02:05:09.894Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -158,7 +158,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         outline: '1px solid ' + theme.palette.neutralSecondary,
         outlineOffset: '2px',
         [HighContrastSelector]: {
-          outline: '1px solid ActiveBorder',
+          outline: '1px solid WindowText',
         },
       },
     },

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Checkbox renders checked correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     id="checkbox-1"
     onBlur={[Function]}
@@ -234,7 +234,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     id="checkbox-2"
     onBlur={[Function]}
@@ -416,7 +416,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
           outline: 1px solid #605e5c;
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-          outline: 1px solid ActiveBorder;
+          outline: 1px solid WindowText;
         }
     id="checkbox-0"
     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-0"
         onBlur={[Function]}
@@ -284,7 +284,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-1"
           onBlur={[Function]}
@@ -465,7 +465,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-2"
             onBlur={[Function]}
@@ -649,7 +649,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-3"
         onBlur={[Function]}
@@ -830,7 +830,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-4"
           onBlur={[Function]}
@@ -1011,7 +1011,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-5"
             onBlur={[Function]}
@@ -1200,7 +1200,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-6"
         onBlur={[Function]}
@@ -1381,7 +1381,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-7"
           onBlur={[Function]}
@@ -1562,7 +1562,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-8"
             onBlur={[Function]}
@@ -1746,7 +1746,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-9"
         onBlur={[Function]}
@@ -1927,7 +1927,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-10"
           onBlur={[Function]}
@@ -2108,7 +2108,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-11"
             onBlur={[Function]}
@@ -2297,7 +2297,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-12"
         onBlur={[Function]}
@@ -2478,7 +2478,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-13"
           onBlur={[Function]}
@@ -2659,7 +2659,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-14"
             onBlur={[Function]}
@@ -2843,7 +2843,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-15"
         onBlur={[Function]}
@@ -3024,7 +3024,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 outline: 1px solid #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                outline: 1px solid ActiveBorder;
+                outline: 1px solid WindowText;
               }
           id="checkbox-16"
           onBlur={[Function]}
@@ -3205,7 +3205,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   outline: 1px solid #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-                  outline: 1px solid ActiveBorder;
+                  outline: 1px solid WindowText;
                 }
             id="checkbox-17"
             onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -75,7 +75,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-0"
       onBlur={[Function]}
@@ -243,7 +243,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-1"
       onBlur={[Function]}
@@ -378,7 +378,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       disabled={true}
       id="checkbox-2"
@@ -513,7 +513,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       disabled={true}
       id="checkbox-3"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -81,7 +81,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-0"
       onBlur={[Function]}
@@ -263,7 +263,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-1"
       onBlur={[Function]}
@@ -415,7 +415,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       disabled={true}
       id="checkbox-2"
@@ -601,7 +601,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-0"
       onBlur={[Function]}
@@ -247,7 +247,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-1"
       onBlur={[Function]}
@@ -408,7 +408,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -567,7 +567,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1169,7 +1169,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-9"
         onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -83,7 +83,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               outline: 1px solid #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-              outline: 1px solid ActiveBorder;
+              outline: 1px solid WindowText;
             }
         id="checkbox-1"
         onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -315,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2101,7 +2101,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-37"
       onBlur={[Function]}
@@ -2261,7 +2261,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-38"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -315,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -158,7 +158,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -318,7 +318,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -315,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1515,7 +1515,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-26"
       onBlur={[Function]}
@@ -1675,7 +1675,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-27"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -155,7 +155,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-2"
       onBlur={[Function]}
@@ -315,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-3"
       onBlur={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
+            outline: 1px solid WindowText;
           }
       id="checkbox-0"
       onBlur={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes ##16228
(master PR: #16739)

#### Description of changes

- Changed outline color for focused elements from ActiveBorder to WindowText.
- High Contrast White Mode:
![HighContrastWhiteMode](https://user-images.githubusercontent.com/8649804/106536441-4f732c80-64ad-11eb-9ed1-f7ad73ae4a23.JPG)


