### PR TITLE
Make yarn retry wrapper handle non-zero exit codes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,24 +15,25 @@
 # users just like we do for commit author emails.
 # docs/  docs@example.com
 
-#### Core build stuff
+#### Build stuff
 scripts/ @dzearing @ecraig12345 @xugao
 scripts/babel/ @layershifter @miroslavstastny
 scripts/gulp/ @layershifter @miroslavstastny
 scripts/webpack/webpack.config.* @layershifter @miroslavstastny
 package.json @ecraig12345 @dzearing @xugao
-prettier.config.js @ecraig12345
-webpack.config.js @ecraig12345
-webpack.serve.config.js @ecraig12345
-jest.config.js @ecraig12345
+yarn.lock @ecraig12345 @dzearing @xugao
+*.config.js @ecraig12345
+*.sh @ecraig12345
+*.yml @ecraig12345
 tsconfig.json @ecraig12345
 lerna.json @ecraig12345
 LICENSE @ecraig12345
-azure-pipelines* @ecraig12345
+.git* @ecraig12345
+.codesandbox @ecraig12345
 .eslintrc.* @ecraig12345
 .npmrc @ecraig12345
 .npmignore @ecraig12345
-sizeauditor.json @aftab-hassan
+sizeauditor.json @aftab-hassan @ecraig12345
 
 #### Fluent UI N*
 packages/a11y-rules/ @kolaps33 @assuncaocharles @layershifter @miroslavstastny @dzearing @pompomon @jurokapsiar @ling1726

--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -5,13 +5,27 @@
 attempt=1
 MAX_TIME=5
 MAX_RETRIES=3
-# `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
-# https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
-while timeout -k "$((MAX_TIME+1))m" "${MAX_TIME}m" npx midgard-yarn install; [ $? = 124 ]; do
-  if [ $attempt -lt $MAX_RETRIES ]; then
-    printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
-  else
-    printf "\n##vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
-    exit 1
+LOG_ERROR="##vso[task.logissue type=error]"
+LOG_WARNING="##vso[task.logissue type=warning]"
+
+while [ $attempt -le $MAX_RETRIES ]; do
+  printf "\n\nRunning yarn (attempt $attempt)...\n\n"
+
+  # `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
+  # https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
+  timeout -k "$((MAX_TIME+1))m" "${MAX_TIME}m" npx midgard-yarn install
+  result=$?
+
+  if [ $result = 0 ]; then
+    exit 0
+  elif [ $result = 124 ]; then # special timeout exit code
+    printf "\n\n$LOG_WARNING yarn took more than $MAX_TIME minutes"
+  else # other error exit code
+    printf "\n\n$LOG_WARNING yarn exited with code $result"
   fi
+
+  ((attempt++))
 done
+
+printf "\n\n$LOG_ERROR yarn failed to complete successfully in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
+exit 1


### PR DESCRIPTION
The wrapper script which handles timeouts/retries for yarn (meant to work around postinstall hangs) wasn't properly handling the case where yarn exits with an error: it was treating errors as success and not passing through the exit code. This results in builds where [yarn actually failed](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=181545&view=logs&j=a8a82d6e-f5e1-5356-31e4-5989f531914b&t=d7b04a72-48b2-5e6e-9be7-8520e1953d99) but the build step "succeeded," which then causes weird errors in later steps due to missing deps.

Fix is to update the retry logic to detect non-zero yarn exit codes and also retry in that case. (Suggestions for improvements welcome if anyone is more familiar with bash.)
