### PR TITLE
(7.0) Make yarn retry wrapper handle non-zero exit codes

### DIFF
--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -5,13 +5,27 @@
 attempt=1
 MAX_TIME=5
 MAX_RETRIES=3
-# `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
-# https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
-while timeout -k "$((MAX_TIME+1))m" "${MAX_TIME}m" npx midgard-yarn install; [ $? = 124 ]; do
-  if [ $attempt -lt $MAX_RETRIES ]; then
-    printf "\nyarn took more than $MAX_TIME minutes. Retrying (attempt $((++attempt)))...\n"
-  else
-    printf "\n##vso[task.logissue type=error]yarn failed to complete in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
-    exit 1
+LOG_ERROR="##vso[task.logissue type=error]"
+LOG_WARNING="##vso[task.logissue type=warning]"
+
+while [ $attempt -le $MAX_RETRIES ]; do
+  printf "\n\nRunning yarn (attempt $attempt)...\n\n"
+
+  # `timeout` is in GNU coreutils. These are installed by default on Linux but not on Mac.
+  # https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html#index-timeout
+  timeout -k "$((MAX_TIME+1))m" "${MAX_TIME}m" npx midgard-yarn install
+  result=$?
+
+  if [ $result = 0 ]; then
+    exit 0
+  elif [ $result = 124 ]; then # special timeout exit code
+    printf "\n\n$LOG_WARNING yarn took more than $MAX_TIME minutes"
+  else # other error exit code
+    printf "\n\n$LOG_WARNING yarn exited with code $result"
   fi
+
+  ((attempt++))
 done
+
+printf "\n\n$LOG_ERROR yarn failed to complete successfully in $MAX_TIME minutes after $MAX_RETRIES attempts\n"
+exit 1


### PR DESCRIPTION
Cherry-pick of #16753

The wrapper script which handles timeouts/retries for yarn (meant to work around postinstall hangs) wasn't properly handling the case where yarn exits with an error: it was treating errors as success and not passing through the exit code. This results in builds where yarn actually failed but the build step "succeeded," which then causes weird errors in later steps due to missing deps.

Fix is to update the retry logic to detect non-zero yarn exit codes and also retry in that case. (Suggestions for improvements welcome if anyone is more familiar with bash.)