### PR TITLE
Charting: Horizontal bar chart custom text on right side

### DIFF
--- a/change/@fluentui-react-examples-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
+++ b/change/@fluentui-react-examples-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
@@ -1,8 +1,8 @@
 {
   "type": "none",
-  "comment": "braChartCustomData prop eexposed to Horizontal bar chart",
+  "comment": "barChartCustomData prop exposed to Horizontal bar chart - used to customize the right side data of tha chart",
   "packageName": "@fluentui/react-examples",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "none",
   "date": "2021-02-02T11:13:06.215Z"
 }

--- a/change/@fluentui-react-examples-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
+++ b/change/@fluentui-react-examples-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "braChartCustomData prop eexposed to Horizontal bar chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "email not defined",
+  "dependentChangeType": "none",
+  "date": "2021-02-02T11:13:06.215Z"
+}

--- a/change/@uifabric-charting-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
+++ b/change/@uifabric-charting-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
@@ -1,8 +1,8 @@
 {
   "type": "minor",
-  "comment": "braChartCustomData prop eexposed to Horizontal bar chart",
+  "comment": "barChartCustomData prop exposed to Horizontal bar chart - used to customize the right side data of tha chart",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2021-02-02T11:12:58.166Z"
 }

--- a/change/@uifabric-charting-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
+++ b/change/@uifabric-charting-2021-02-02-16-43-06-user-v-jasha-HorizontalCustomText.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "braChartCustomData prop eexposed to Horizontal bar chart",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T11:12:58.166Z"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -196,7 +196,11 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     });
   };
 
-  private _getChartDataText(data: IChartProps): JSX.Element {
+  private _getChartDataText = (data: IChartProps) => {
+    return this.props.barChartCustomData ? this.props.barChartCustomData(data) : this._getDefaultTextData(data);
+  };
+
+  private _getDefaultTextData = (data: IChartProps): JSX.Element => {
     const chartDataMode = this.props.chartDataMode || 'default';
     const x = data!.chartData![0].horizontalBarChartdata!.x;
     const y = data!.chartData![0].horizontalBarChartdata!.y;
@@ -217,7 +221,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
         const dataRatio = Math.round((x / y) * 100);
         return <div className={this._classNames.chartDataText}>{dataRatio + '%'}</div>;
     }
-  }
+  };
 
   private _createBenchmark(data: IChartProps): JSX.Element {
     const totalData = data.chartData![0].horizontalBarChartdata!.y;

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -44,6 +44,7 @@ export interface IHorizontalBarChartProps {
 
   /**
    * This property tells how to show data text on top right of bar chart.
+   * If barChartCustomData props added, then this props will be overrided.
    * @default 'default'
    */
   chartDataMode?: ChartDataMode;
@@ -62,6 +63,14 @@ export interface IHorizontalBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * Custom text to the chart (right side of the chart)
+   * IChartProps will be available as props to the method prop.
+   * If this method not given, default values (IHorizontalDataPoint {x,y})
+   * will be used to disaply the data/text based on given chartModeData prop.
+   */
+  barChartCustomData?: IRenderFunction<IChartProps>;
 }
 
 export interface IHorizontalBarChartStyleProps {

--- a/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
@@ -112,6 +112,7 @@ export const HorizontalBarChartCustomCalloutExample: React.FunctionComponent<{}>
       calloutProps={{
         directionalHint: DirectionalHint.topCenter,
       }}
+      // eslint-disable-next-line react/jsx-no-bind
       barChartCustomData={(props: IChartProps) => {
         return (
           <div>

--- a/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
@@ -112,6 +112,14 @@ export const HorizontalBarChartCustomCalloutExample: React.FunctionComponent<{}>
       calloutProps={{
         directionalHint: DirectionalHint.topCenter,
       }}
+      barChartCustomData={(props: IChartProps) => {
+        return (
+          <div>
+            <span style={{ fontWeight: 'bold' }}>19K</span>
+            <span>{'/ 45.9 T'}</span>
+          </div>
+        );
+      }}
       // eslint-disable-next-line react/jsx-no-bind
       onRenderCalloutPerHorizonalBar={(props: IChartDataPoint) =>
         props ? (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/15191
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Exposed prop `barChartCustomData` - method to the horizontal bar chart. Which returns `IChartProps`. 
By adding this prop, we can customize the the right side text of the bar chart.

#### Focus areas to test

Horizontal bar chart.

#### Examples
` barChartCustomData={(props: IChartProps) => {
        return (
          <div>
            {.....}
          </div>
        );
      }}`


