### PR TITLE
Adds a Module Federation innerloop experience

### DIFF
--- a/change/@fluentui-react-2021-02-02-11-33-13-feat-mf.json
+++ b/change/@fluentui-react-2021-02-02-11-33-13-feat-mf.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Module federation innerloop experience",
+  "packageName": "@fluentui/react",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T19:33:13.901Z"
+}

--- a/packages/react/just.config.ts
+++ b/packages/react/just.config.ts
@@ -1,3 +1,10 @@
-import { preset } from '@fluentui/scripts';
+import { task, webpackDevServerTask, preset } from '@fluentui/scripts';
 
 preset();
+
+task(
+  'mf',
+  webpackDevServerTask({
+    config: 'webpack.mf.config.js',
+  }),
+);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,8 @@
     "start:legacy": "yarn workspace @fluentui/public-docsite-resources start",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "update-snapshots": "just-scripts jest -u",
+    "mf": "just-scripts mf"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.1",

--- a/packages/react/webpack.mf.config.js
+++ b/packages/react/webpack.mf.config.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const fs = require('fs');
+const webpack = require('webpack');
+const getResolveAlias = require('@fluentui/scripts/webpack/getResolveAlias');
+const { createServeConfig } = require('@fluentui/scripts/webpack/webpack-resources');
+const { webpackMerge } = require('just-scripts');
+
+const shared = {
+  react: { singleton: true },
+  'react-dom': { singleton: true },
+};
+
+const rootComponents = fs
+  .readdirSync(path.join(__dirname, 'src'))
+  .filter(filename => filename[0].toUpperCase() === filename[0])
+  .map(filename => filename.replace(/\.tsx?/, ''));
+const rootComponentsExposes = {};
+for (const component of rootComponents) {
+  rootComponentsExposes[`./lib/${component}`] = `@fluentui/react/src/${component}`;
+}
+
+const myConfig = {
+  output: {},
+  entry: {},
+  mode: 'development',
+  devtool: 'cheap-module-source-map',
+  optimization: {
+    concatenateModules: false,
+  },
+  module: {
+    rules: [],
+  },
+  plugins: [
+    new webpack.container.ModuleFederationPlugin({
+      name: 'fluentuiReact',
+      filename: 'remoteEntry.js',
+      exposes: {
+        ...rootComponentsExposes,
+        './lib/compat/Button': '@fluentui/react/src/compat/Button',
+        '.': '@fluentui/react/src/index',
+        './lib/index': '@fluentui/react/src/index',
+      },
+      shared,
+    }),
+  ],
+  resolve: {
+    alias: getResolveAlias(),
+  },
+  devServer: {
+    port: 2345,
+    contentBase: 'dist',
+  },
+};
+
+const metaConfig = webpackMerge.merge(createServeConfig(), myConfig);
+
+module.exports = metaConfig;


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This adds a `just-scripts` task called "mf" that can be triggered through the command `yarn mf` in the `packages/react` folder. When this is run, a `webpack-dev-server` task is triggered, generating a module federation bundle, served through the WDS. This can then be fed into any MF consumer through the global var of `fluentuiReact`. This global var mechanism can be changed, but needs some investigation. So far, this has proven to be a good innerloop experience in coordination of the @lading/server "manifest service"

#### Focus areas to test

(optional)
