### PR TITLE
Add retries when launching chromium in e2e tests

### DIFF
--- a/packages/fluentui/e2e/setup.test.ts
+++ b/packages/fluentui/e2e/setup.test.ts
@@ -16,7 +16,20 @@ const launchOptions: puppeteer.LaunchOptions = safeLaunchOptions({
 });
 
 beforeAll(async () => {
-  browser = await puppeteer.launch(launchOptions);
+  let attempt = 1;
+  while (!browser) {
+    try {
+      browser = await puppeteer.launch(launchOptions);
+    } catch (err) {
+      if (attempt === 5) {
+        console.error(`Puppeteer failed to launch after 5 attempts`);
+        throw err;
+      }
+      console.warn('Puppeteer failed to launch (will retry):');
+      console.warn(err);
+      attempt++;
+    }
+  }
 });
 
 beforeEach(async () => {

--- a/packages/fluentui/projects-test/src/performBrowserTest.ts
+++ b/packages/fluentui/projects-test/src/performBrowserTest.ts
@@ -20,7 +20,23 @@ function startServer(publicDirectory: string, listenPort: number) {
 export async function performBrowserTest(publicDirectory: string, listenPort: number) {
   const server = await startServer(publicDirectory, listenPort);
 
-  const browser = await puppeteer.launch(safeLaunchOptions());
+  const options = safeLaunchOptions();
+  let browser: puppeteer.Browser;
+  let attempt = 1;
+  while (!browser) {
+    try {
+      browser = await puppeteer.launch(options);
+    } catch (err) {
+      if (attempt === 5) {
+        console.error(`Puppeteer failed to launch after 5 attempts`);
+        throw err;
+      }
+      console.warn('Puppeteer failed to launch (will retry):');
+      console.warn(err);
+      attempt++;
+    }
+  }
+
   const page = await browser.newPage();
   let error: Error | undefined;
 

--- a/scripts/gulp/tasks/browserAdapters.ts
+++ b/scripts/gulp/tasks/browserAdapters.ts
@@ -20,7 +20,23 @@ export type Browser = {
 };
 
 export async function createChrome(): Promise<Browser> {
-  const browser = await puppeteer.launch(safeLaunchOptions());
+  const options = safeLaunchOptions();
+  let browser: puppeteer.Browser;
+  let attempt = 1;
+  while (!browser) {
+    try {
+      browser = await puppeteer.launch(options);
+    } catch (err) {
+      if (attempt === 5) {
+        console.error(`Puppeteer failed to launch after 5 attempts`);
+        throw err;
+      }
+      console.warn('Puppeteer failed to launch (will retry):');
+      console.warn(err);
+      attempt++;
+    }
+  }
+
   console.log(`Chromium version: ${await browser.version()}`);
 
   return {


### PR DESCRIPTION
Northstar e2e tests are intermittently failing (pretty often) due to chromium failing to launch. Per https://github.com/puppeteer/puppeteer/issues/2207#issuecomment-717108459 adding retries is currently the best workaround.

[example build](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=181731&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=3dbc0aa8-94d2-5f1a-6c00-c4086d74d6b7) with this failure (also had some unrelated failures)
