### PR TITLE
SelectedItemsList: Editable item picker should have first item selected on show

### DIFF
--- a/change/@fluentui-react-experiments-2021-02-02-16-22-00-editselectionfix.json
+++ b/change/@fluentui-react-experiments-2021-02-02-16-22-00-editselectionfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "SelectedItemsList EditableItem should have first item selected in picker on show",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-03T00:22:00.102Z"
+}

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -102,6 +102,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
 
   const {
     focusItemIndex,
+    setFocusItemIndex,
     suggestionItems,
     footerItemIndex,
     footerItems,
@@ -124,6 +125,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
       setInputValue(itemText);
       editingInput.current.focus();
     }
+    setFocusItemIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // We only want to run this once
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Want the dropdown to have the first suggestion selected, that's frequently going to be the correct one.