### PR TITLE
7.0: Editable item picker should have first item selected on show

### DIFF
--- a/change/@uifabric-experiments-2021-02-02-16-26-09-editselectionfix7.0.json
+++ b/change/@uifabric-experiments-2021-02-02-16-26-09-editselectionfix7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SelectedItemsList EditableItem should have first item selected in picker on show",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-03T00:26:09.914Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -102,6 +102,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
 
   const {
     focusItemIndex,
+    setFocusItemIndex,
     suggestionItems,
     footerItemIndex,
     footerItems,
@@ -123,6 +124,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
       setInputValue(itemText);
       editingInput.current.focus();
     }
+    setFocusItemIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // We only want to run this once
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
v8 - #16777 

Want the dropdown to have the first suggestion selected, that's frequently going to be the correct one.
