### PR TITLE
chore: fix dependencies for perf test

### DIFF
--- a/scripts/webpack/webpack.config.perf.ts
+++ b/scripts/webpack/webpack.config.perf.ts
@@ -67,6 +67,10 @@ const webpackConfig: webpack.Configuration = {
       // https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977
       'react-dom$': 'react-dom/profiling',
       'scheduler/tracing': 'scheduler/tracing-profiling',
+
+      // Can be removed once Prettier will be upgraded to v2
+      // https://github.com/prettier/prettier/issues/6903
+      '@microsoft/typescript-etw': false,
     },
   },
   performance: {


### PR DESCRIPTION
## Description of changes

After we moved prototypes (#16183) we also added a perf test for prototypes (#16412), one of prototypes uses `prettier` as a dependency. Once it will be included into a bundle it produce an error (see below), fix PR fixes it. 

#### Before

![An error about missing module](https://user-images.githubusercontent.com/14183168/106731065-5ade6900-660f-11eb-958e-a87a0d17fd79.png)
