### PR TITLE
chore: remove more .npmrc's

### DIFF
--- a/change/@fluentui-react-make-styles-2021-02-03-11-08-54-chore-npmrc.json
+++ b/change/@fluentui-react-make-styles-2021-02-03-11-08-54-chore-npmrc.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "refactor: remove unused .npmrc in packages",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-02-03T10:08:54.140Z"
+}

--- a/packages/react-make-styles/.npmrc
+++ b/packages/react-make-styles/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org/
-

--- a/packages/react-provider/.npmrc
+++ b/packages/react-provider/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org/
-


### PR DESCRIPTION
#### Description of changes

A follow up for #16760. Removes `.npmrc` files for recently added packages.
