### PR TITLE
fix(react): Add missing HighContrast override to SplitButton

### DIFF
--- a/change/@fluentui-react-internal-2021-02-03-17-08-02-m-16339.json
+++ b/change/@fluentui-react-internal-2021-02-03-17-08-02-m-16339.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add missing HighContrast override to SplitButton",
+  "packageName": "@fluentui/react-internal",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-03T16:08:02.113Z"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -803,6 +803,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                  color: WindowText;
+                }
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -282,6 +282,9 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
               vertical-align: top;
               width: 28px;
             }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+              color: WindowText;
+            }
         data-is-focusable={false}
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
@@ -287,6 +287,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -648,6 +651,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -991,6 +997,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1331,17 +1340,17 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                 color: Highlight;
               }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button--primary {
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 background-color: Window;
-                border-color: GrayText;
+                border: 1px solid GrayText;
                 color: GrayText;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
                 color: GrayText;
               }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button--primary {
                 background-color: Window;
-                border: 1px solid GrayText;
+                border-color: GrayText;
                 color: GrayText;
               }
           data-is-focusable={false}

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -364,6 +364,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           vertical-align: top;
                           width: 32px;
                         }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                          color: WindowText;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -781,6 +784,14 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           vertical-align: top;
                           width: 32px;
                         }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: Window;
+                          border: none;
+                          color: GrayText;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                          color: GrayText;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -801,14 +812,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button--primary {
                           background-color: Window;
                           border-color: GrayText;
-                          color: GrayText;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
-                          color: GrayText;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background-color: Window;
-                          border: none;
                           color: GrayText;
                         }
                         @media screen and (forced-colors: active){& {

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -700,6 +700,9 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
+                color: WindowText;
+              }
           data-is-focusable={false}
           data-ktp-execute-target="ktp-2-b"
           onClick={[Function]}

--- a/packages/react-internal/src/compat/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react-internal/src/compat/components/Button/SplitButton/SplitButton.styles.ts
@@ -140,6 +140,11 @@ export const getStyles = memoizeFunction(
         marginTop: 0,
         marginRight: 0,
         marginBottom: 0,
+        [HighContrastSelector]: {
+          '.ms-Button-menuIcon': {
+            color: 'WindowText',
+          },
+        },
       },
       splitButtonDivider: {
         ...splitButtonDividerBaseStyles,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16339
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #16635