### PR TITLE
fix(dropdownSelectedItem): long item has tiny icon

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Embed` playback control visuals. @TanelVari ([#16611](https://github.com/microsoft/fluentui/pull/16611))
 - Fixes for `Dropdown`. Fix clear indicator visual styles (focus border, using `CloseIcon`). Fix empty search result text style. Fix left/right padding for multiple selection labels. Using `ChevronDownIcon` for toggle indicator. @TanelVari ([#16522](https://github.com/microsoft/fluentui/pull/16522))
 - Fix docsite header colors for all themes. `ExampleSnippet` now honors theme colors for background and foreground. @TanelVari ([#16643](https://github.com/microsoft/fluentui/pull/16643))
+- Fix `dropdownSelectedItem` has tiny icon when the content is long @yuanboxue-amber ([#16795](https://github.com/microsoft/fluentui/pull/16795))
 
 ## Features
 - Added `disabledFocusable` prop for `Button` component. @jurokapsiar ([#16419](https://github.com/microsoft/fluentui/pull/16419))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownSelectedItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownSelectedItemStyles.ts
@@ -70,6 +70,7 @@ export const dropdownSelectedItemStyles: ComponentSlotStylesPrepared<
     alignItems: 'center',
     justifyContent: 'center',
     width: pxToRem(16),
+    minWidth: pxToRem(16),
     height: pxToRem(16),
     '& > :first-child': {
       width: pxToRem(16),


### PR DESCRIPTION


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
For `DropdownSelectedItem`, when the item content is very very long, the item icon is very very tiny.
Fix by adding `min-width` to icon.

before

<img width="391" alt="Screenshot 2021-02-03 at 18 41 49" src="https://user-images.githubusercontent.com/28751745/106787251-c6e0c180-664f-11eb-8e87-39ba6166e69f.png">

after

<img width="418" alt="Screenshot 2021-02-03 at 18 42 24" src="https://user-images.githubusercontent.com/28751745/106787272-cba57580-664f-11eb-8296-3d26b86d0383.png">

#### Focus areas to test

(optional)
