### PR TITLE
Use custom YarnInstaller task

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -6,8 +6,8 @@ steps:
     displayName: 'Install Node.js'
 
   - task: YarnInstaller@0
-    displayName: 'Use Yarn 1.19.x'
+    displayName: 'Use Yarn 1.22.x'
     inputs:
-      versionSpec: 1.19.x
-      checkLatest: true
+      versionSpec: 1.22.x
+      checkLatest: false
       includePrerelease: false

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -5,7 +5,7 @@ steps:
       versionSpec: '12.x'
     displayName: 'Install Node.js'
 
-  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
+  - task: YarnInstaller@0
     displayName: 'Use Yarn 1.19.x'
     inputs:
       versionSpec: 1.19.x

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -10,10 +10,7 @@ jobs:
     pool:
       vmImage: 'windows-2019'
     steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.x'
-        displayName: 'Install Node.js'
+      - template: .devops/templates/tools.yml
 
       - script: npx midgard-yarn install
         displayName: yarn


### PR DESCRIPTION
Due to intermittent issues with the yarn installer task we were using (see https://github.com/geeklearningio/gl-vsts-tasks-yarn/issues/91), switch to using a private forked version where I added better error handling.