### PR TITLE
RFC: Prevent CI and code related tasks from triggering on doc/rfc PRs

### DIFF
--- a/rfcs/future/prevent-ci-trigger-on-doc-prs.md
+++ b/rfcs/future/prevent-ci-trigger-on-doc-prs.md
@@ -53,7 +53,7 @@ And this details the new workflow mentioned above:
 
 - Avoiding the GitHub checks in our CI by excluding doc paths
 
-  Due to the branch protection rules, we are unable to avoid the execution of required checks.
+  Due to the branch protection rules, we are unable to avoid the execution of required checks. Another limitation is our current tooling (no ability to implement content aware pipeline).
   CodeSandbox also did not support this at the time of writing this. Upon contacting their support, they added it to their backlog as a possible future feature.
 
 ## Open Issues

--- a/rfcs/prevent-ci-trigger-on-doc-prs.md
+++ b/rfcs/prevent-ci-trigger-on-doc-prs.md
@@ -6,7 +6,7 @@ _Contributors: @andrefcdias_
 
 ## Summary
 
-The purpose of this RFC is to find a solution to prevent unnecessary GitHub checks from running on PRs that only affect documentation.
+The purpose of this RFC is to find a solution to avoid unnecessary GitHub checks from running on PRs that only affect documentation to avoid wasteful resource usage and improve our DX.
 
 ## Problem statement
 
@@ -17,31 +17,20 @@ By avoiding these checks, we can prevent a wasteful CI pipeline and accelerate w
 
 ## Detailed Design or Proposal
 
-### Azure DevOps (Build, Deploy, SizeAuditor, Perf Analysis, BundleSize)
+The agreed solution is to extract our Wiki into its own separate repository and linking it with the fluentui repo wiki.
+This will allow us to avoid the issue altogether and even implement our own checks (like running Prettier as @layershifter suggested) with minimum effort.
 
-To prevent the builds, adding the following will prevent unnecessary triggers:
+Implementation would cover the following:
 
-```yaml
-pr:
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - rfcs
-      - specs
-      - <other relevant doc paths>
-```
+- Creating the fluentui-wiki repository
+- Linking this repository with https://github.com/microsoft/fluentui.wiki.git
+- Add documentation on how to contribute with the new workflow
 
-_There's a PoC repo to test the ADO solution [here](https://github.com/andrefcdias/actions-test) and a draft PR with the implementation [here](https://github.com/microsoft/fluentui/pull/16816)._
+And this details the new workflow mentioned above:
 
-### Screener
-
-_To be defined_
-
-### CodeSanbox
-
-_To be defined_
+- User forks https://github.com/microsoft/fluentui-wiki
+- Applies changes to for and creates a PR
+- Merged docs get reflected in the https://github.com/microsoft/fluentui.wiki.git
 
 ### Pros and Cons
 
@@ -53,13 +42,19 @@ _To be defined_
 
 #### Cons
 
-- None so far
+- New workflow of submitting docs through PRs in a different repo
+- Sending people from the @fluentui/react repo into @fluentui/react-wiki repo to contribute with docs
 
 ## Discarded Solutions
 
-- Moving docs to the Wiki repo;
+- Moving docs directly to the wiki repo;
 
   There is unfortunately no way of creating PRs for changes in the Wiki repo.
+
+- Avoiding the GitHub checks in our CI by excluding doc paths
+
+  Due to the branch protection rules, we are unable to avoid the execution of required checks.
+  CodeSandbox also did not support this at the time of writing this. Upon contacting their support, they added it to their backlog as a possible future feature.
 
 ## Open Issues
 

--- a/rfcs/prevent-ci-trigger-on-doc-prs.md
+++ b/rfcs/prevent-ci-trigger-on-doc-prs.md
@@ -1,0 +1,64 @@
+# RFC: Prevent CI and code related tasks from triggering on doc/rfc PRs
+
+---
+
+_Contributors: @andrefcdias_
+
+## Summary
+
+The purpose of this RFC is to find a solution to prevent unnecessary GitHub checks from running on PRs that only affect documentation.
+
+## Problem statement
+
+Whenever someone creates a PR, independently of the content, the CI is triggered and added as a check for a successfull PR. This, along with Screener and CodeSandbox, is consuming unnecessary resources on our pipeline for, essentially, no reason.
+
+Apart from this, other PRs that actually need CI checks, will be delayed due to the lack of parallelism in our pipeline.
+By avoiding these checks, we can prevent a wasteful CI pipeline and accelerate work in PRs that bring value to our users.
+
+## Detailed Design or Proposal
+
+### Azure DevOps (Build, Deploy, SizeAuditor, Perf Analysis, BundleSize)
+
+To prevent the builds, adding the following will prevent unnecessary triggers:
+
+```yaml
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - rfcs
+      - specs
+      - <other relevant doc paths>
+```
+
+_There's a PoC repo to test the ADO solution [here](https://github.com/andrefcdias/actions-test)._
+
+### Screener
+
+_To be defined_
+
+### CodeSanbox
+
+_To be defined_
+
+### Pros and Cons
+
+#### Pros
+
+- Unblocking of code PRs if a doc/rfc PR is created
+- Reduced usage of our pipeline resources
+- No GitHub checks visual trash on doc/rfc PRs
+
+#### Cons
+
+- None so far
+
+## Discarded Solutions
+
+N/A
+
+## Open Issues
+
+N/A

--- a/rfcs/prevent-ci-trigger-on-doc-prs.md
+++ b/rfcs/prevent-ci-trigger-on-doc-prs.md
@@ -57,7 +57,9 @@ _To be defined_
 
 ## Discarded Solutions
 
-N/A
+- Moving docs to the Wiki repo;
+
+  There is unfortunately no way of creating PRs for changes in the Wiki repo.
 
 ## Open Issues
 

--- a/rfcs/prevent-ci-trigger-on-doc-prs.md
+++ b/rfcs/prevent-ci-trigger-on-doc-prs.md
@@ -33,7 +33,7 @@ pr:
       - <other relevant doc paths>
 ```
 
-_There's a PoC repo to test the ADO solution [here](https://github.com/andrefcdias/actions-test)._
+_There's a PoC repo to test the ADO solution [here](https://github.com/andrefcdias/actions-test) and a draft PR with the implementation [here](https://github.com/microsoft/fluentui/pull/16816)._
 
 ### Screener
 


### PR DESCRIPTION
The purpose of this RFC is to find a solution to prevent unnecessary GitHub checks from running on PRs that only affect documentation.
Azure DevOps is already covered, but I have yet to research how this would apply for CodeSandbox and Screener, hoping you can help on this @ecraig12345.