### PR TITLE
Add documentation path exclusion to ADO CI triggers

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -1,5 +1,11 @@
 pr:
-  - master
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - rfcs
+      - specs
 
 trigger:
   - master

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -1,6 +1,12 @@
 pr:
-  - master
-  - website-content
+  branches:
+    include:
+      - master
+      - website-content
+  paths:
+    exclude:
+      - rfcs
+      - specs
 
 trigger: none
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,11 @@
 pr:
-  - master
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - rfcs
+      - specs
 
 trigger:
   - master


### PR DESCRIPTION
#### Description of changes

Add Azure DevOps config to exclude CI tasks when updating `rfcs` or `specs` folders.
