### PR TITLE
Fixing the modal Panel outerclick issue

### DIFF
--- a/change/office-ui-fabric-react-2021-02-04-12-39-11-modal-panel-fix.json
+++ b/change/office-ui-fabric-react-2021-02-04-12-39-11-modal-panel-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing the modal Panel outerclick issue",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-04T20:39:11.721Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6330,7 +6330,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     onLightDismissClick?: () => void;
     onOpen?: () => void;
     onOpened?: () => void;
-    onOuterClick?: () => boolean | void | undefined;
+    onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => boolean | void;
     onRenderBody?: IRenderFunction<IPanelProps>;
     onRenderFooter?: IRenderFunction<IPanelProps>;
     onRenderFooterContent?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6330,7 +6330,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     onLightDismissClick?: () => void;
     onOpen?: () => void;
     onOpened?: () => void;
-    onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => boolean | void;
+    onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => void;
     onRenderBody?: IRenderFunction<IPanelProps>;
     onRenderFooter?: IRenderFunction<IPanelProps>;
     onRenderFooterContent?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6330,7 +6330,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     onLightDismissClick?: () => void;
     onOpen?: () => void;
     onOpened?: () => void;
-    onOuterClick?: () => void;
+    onOuterClick?: () => boolean | void | undefined;
     onRenderBody?: IRenderFunction<IPanelProps>;
     onRenderFooter?: IRenderFunction<IPanelProps>;
     onRenderFooterContent?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -413,9 +413,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
     if (this.isActive && panel && !ev.defaultPrevented) {
       if (!elementContains(panel, ev.target as HTMLElement)) {
         if (this.props.onOuterClick) {
-          if (!this.props.onOuterClick()) {
-            ev.preventDefault();
-          }
+          this.props.onOuterClick(ev);
         } else {
           this.dismiss(ev);
         }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -413,8 +413,9 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
     if (this.isActive && panel && !ev.defaultPrevented) {
       if (!elementContains(panel, ev.target as HTMLElement)) {
         if (this.props.onOuterClick) {
-          this.props.onOuterClick();
-          ev.preventDefault();
+          if (!this.props.onOuterClick()) {
+            ev.preventDefault();
+          }
         } else {
           this.dismiss(ev);
         }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -200,7 +200,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   /**
    * Optional custom function to handle clicks outside this component
    */
-  onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => boolean | void;
+  onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => void;
 
   /**
    * Optional custom renderer navigation region. Replaces the region that contains the close button.

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -200,7 +200,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   /**
    * Optional custom function to handle clicks outside this component
    */
-  onOuterClick?: () => boolean | void | undefined;
+  onOuterClick?: (ev?: React.MouseEvent<HTMLDivElement>) => boolean | void;
 
   /**
    * Optional custom renderer navigation region. Replaces the region that contains the close button.

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -200,7 +200,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   /**
    * Optional custom function to handle clicks outside this component
    */
-  onOuterClick?: () => void;
+  onOuterClick?: () => boolean | void | undefined;
 
   /**
    * Optional custom renderer navigation region. Replaces the region that contains the close button.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8470 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR is to address the issue where a modal Panel with the prop `isBlocking` set to true gets dismissed automatically when a user clicks on a foreign element (such as a dialog opened on top, or another panel, anything that is not directly a DOM child of the panel)

The PR updates the private `_dismissOnOuterClick` event handler to pause when the `onOuterClick` prop is set to true in the panel. This way, it will not dismiss the Panel when a user clicks on a foreign element.

master PR: #16835

#### Focus areas to test

(optional)
