### PR TITLE
Memoize callbacks to reduce UPP re-renders

### DIFF
--- a/change/@fluentui-react-experiments-2021-02-02-09-54-29-perffixes.json
+++ b/change/@fluentui-react-experiments-2021-02-02-09-54-29-perffixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Memoize callbacks to reduce UPP re-renders",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-02T17:54:29.739Z"
+}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -4,7 +4,9 @@ import { SelectedPersona } from './Items/SelectedPersona';
 import { ISelectedItemsListProps, ISelectedItemsList, BaseSelectedItem } from '../SelectedItemsList.types';
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
 
-export type ISelectedPeopleListProps<TPersona> = ISelectedItemsListProps<TPersona>;
+export type ISelectedPeopleListProps<
+  TPersona extends IPersonaProps & BaseSelectedItem = IPersonaProps
+> = ISelectedItemsListProps<TPersona>;
 
 export type ISelectedPeopleList<TPersona extends IPersonaProps & BaseSelectedItem = IPersonaProps> = ISelectedItemsList<
   TPersona

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -66,13 +66,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const [focusedItemIndices, setFocusedItemIndices] = React.useState(selection.getSelectedIndices() || []);
 
   const [draggedIndex, setDraggedIndex] = React.useState<number>(-1);
-  const dragDropHelper = React.useMemo(
-    () =>
-      new DragDropHelper({
-        selection: selection,
-      }),
-    [selection],
-  );
+  const dragDropHelper = new DragDropHelper({
+    selection: selection,
+  });
 
   const {
     focusItemIndex,
@@ -273,7 +269,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     setDraggedIndex(-1);
   };
 
-  const defaultDragDropEvents = React.useRef<IDragDropEvents>({
+  const defaultDragDropEvents: IDragDropEvents = {
     canDrop: _canDrop,
     canDrag: () => defaultDragDropEnabled,
     onDragEnter: _onDragEnter,
@@ -281,7 +277,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDrop: _onDropList,
     onDragStart: _onDragStart,
     onDragEnd: _onDragEnd,
-  });
+  };
 
   const _onSuggestionSelected = React.useCallback(
     (ev: any, item: IFloatingSuggestionItemProps<T>) => {
@@ -512,7 +508,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onItemsRemoved: _onRemoveSelectedItems,
       replaceItem: _replaceItem,
       dragDropHelper: dragDropHelper,
-      dragDropEvents: dragDropEvents || defaultDragDropEvents.current,
+      dragDropEvents: dragDropEvents || defaultDragDropEvents,
     });
   };
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -17,23 +17,62 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();
   const classNames = getClassNames(getStyles);
 
-  const rootRef = React.createRef<HTMLDivElement>();
-  const input = React.useRef<Autofill>(null);
-  const { setQueryString, clearQueryString } = useQueryString('');
-  const [selection, setSelection] = React.useState(new Selection({ onSelectionChanged: () => _onSelectionChanged() }));
-  const [focusedItemIndices, setFocusedItemIndices] = React.useState(selection.getSelectedIndices() || []);
   const {
+    dragDropEvents,
+    onKeyDown,
+    onDropAutoFill,
+    onPaste,
+    className,
+    focusZoneProps,
+    inputProps,
+    onRenderSelectedItems,
+    selectedItemsListProps,
+    onRenderFloatingSuggestions,
+    floatingSuggestionProps,
+    headerComponent,
+    onInputChange,
+    customClipboardType,
+  } = props;
+
+  const {
+    pickerWidth,
     suggestions,
     selectedSuggestionIndex,
     selectedFooterIndex,
     selectedHeaderIndex,
     pickerSuggestionsProps,
     isSuggestionsVisible,
+    onSuggestionSelected,
+    onFloatingSuggestionsDismiss,
+    onRemoveSuggestion,
   } = props.floatingSuggestionProps;
+
+  const {
+    onItemsRemoved: selectedItemsListOnItemsRemoved,
+    dropItemsAt: selectedItemsListDropItemsAt,
+    getItemCopyText: selectedItemsListGetItemCopyText,
+    replaceItem: selectedItemsListReplaceItem,
+    itemsAreEqual,
+    deserializeItemsFromDrop,
+    serializeItemsForDrag,
+  } = props.selectedItemsListProps;
+
+  const { onClick: inputPropsOnClick, onFocus: inputPropsOnFocus } = props.inputProps || {};
+
+  const rootRef = React.createRef<HTMLDivElement>();
+  const input = React.useRef<Autofill>(null);
+  const { setQueryString, clearQueryString } = useQueryString('');
+  const [selection, setSelection] = React.useState(new Selection({ onSelectionChanged: () => _onSelectionChanged() }));
+  const [focusedItemIndices, setFocusedItemIndices] = React.useState(selection.getSelectedIndices() || []);
+
   const [draggedIndex, setDraggedIndex] = React.useState<number>(-1);
-  const dragDropHelper = new DragDropHelper({
-    selection: selection,
-  });
+  const dragDropHelper = React.useMemo(
+    () =>
+      new DragDropHelper({
+        selection: selection,
+      }),
+    [selection],
+  );
 
   const {
     focusItemIndex,
@@ -74,27 +113,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     setFocusedItemIndices(selection.getSelectedIndices());
   };
 
-  const {
-    className,
-    focusZoneProps,
-    inputProps,
-    onRenderSelectedItems,
-    selectedItemsListProps,
-    onRenderFloatingSuggestions,
-    floatingSuggestionProps,
-    headerComponent,
-    onInputChange,
-  } = props;
+  const defaultDragDropEnabled = props.defaultDragDropEnabled !== undefined ? props.defaultDragDropEnabled : true;
 
-  const defaultDragDropEnabled = React.useMemo(
-    () => (props.defaultDragDropEnabled !== undefined ? props.defaultDragDropEnabled : true),
-    [props.defaultDragDropEnabled],
-  );
-
-  const autofillDragDropEnabled = React.useMemo(
-    () => (props.autofillDragDropEnabled !== undefined ? props.autofillDragDropEnabled : defaultDragDropEnabled),
-    [props.autofillDragDropEnabled, defaultDragDropEnabled],
-  );
+  const autofillDragDropEnabled =
+    props.autofillDragDropEnabled !== undefined ? props.autofillDragDropEnabled : defaultDragDropEnabled;
 
   React.useImperativeHandle(props.componentRef, () => ({
     clearInput: () => {
@@ -138,8 +160,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (draggedIndex > -1) {
       indicesToRemove = focusedItemIndices.includes(draggedIndex) ? [...focusedItemIndices] : [draggedIndex];
     }
-    if (props.selectedItemsListProps.dropItemsAt) {
-      props.selectedItemsListProps.dropItemsAt(insertIndex, newItems, indicesToRemove);
+    if (selectedItemsListProps.dropItemsAt) {
+      selectedItemsListProps.dropItemsAt(insertIndex, newItems, indicesToRemove);
     }
     dropItemsAt(insertIndex, newItems, indicesToRemove);
     unselectAll();
@@ -154,8 +176,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const _onDropAutoFill = (event?: React.DragEvent<HTMLDivElement>) => {
     event?.preventDefault();
-    if (props.onDropAutoFill) {
-      props.onDropAutoFill(event);
+    if (onDropAutoFill) {
+      onDropAutoFill(event);
     } else {
       insertIndex = selectedItems.length;
       _onDropInner(event?.dataTransfer);
@@ -171,12 +193,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
        if the item is something where properties can change frequently, then the
        itemsAreEqual prop should be overloaded
        Otherwise it's possible for the indexOf check to fail and return -1 */
-    if (props.selectedItemsListProps.itemsAreEqual) {
-      insertIndex = selectedItems.findIndex(currentItem =>
-        props.selectedItemsListProps.itemsAreEqual
-          ? props.selectedItemsListProps.itemsAreEqual(currentItem, item)
-          : false,
-      );
+    if (itemsAreEqual) {
+      insertIndex = selectedItems.findIndex(currentItem => (itemsAreEqual ? itemsAreEqual(currentItem, item) : false));
     } else {
       insertIndex = selectedItems.indexOf(item);
     }
@@ -205,11 +223,11 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (dataTransfer) {
       const data = dataTransfer.items;
       for (let i = 0; i < data.length; i++) {
-        if (data[i].kind === 'string' && data[i].type === props.customClipboardType) {
+        if (data[i].kind === 'string' && data[i].type === customClipboardType) {
           isDropHandled = true;
           data[i].getAsString((dropText: string) => {
-            if (props.selectedItemsListProps.deserializeItemsFromDrop) {
-              const newItems = props.selectedItemsListProps.deserializeItemsFromDrop(dropText);
+            if (deserializeItemsFromDrop) {
+              const newItems = deserializeItemsFromDrop(dropText);
               _dropItemsAt(newItems);
             }
           });
@@ -230,10 +248,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     setDraggedIndex(draggedItemIndex);
     if (event) {
       const dataList = event?.dataTransfer?.items;
-      if (props.selectedItemsListProps.serializeItemsForDrag && props.customClipboardType) {
+      if (serializeItemsForDrag && customClipboardType) {
         const draggedItems = focusedItemIndices.includes(draggedItemIndex) ? [...getSelectedItems()] : [item];
-        const dragText = props.selectedItemsListProps.serializeItemsForDrag(draggedItems);
-        dataList?.add(dragText, props.customClipboardType);
+        const dragText = serializeItemsForDrag(draggedItems);
+        dataList?.add(dragText, customClipboardType);
       }
     }
   };
@@ -255,7 +273,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     setDraggedIndex(-1);
   };
 
-  const defaultDragDropEvents: IDragDropEvents = {
+  const defaultDragDropEvents = React.useRef<IDragDropEvents>({
     canDrop: _canDrop,
     canDrag: () => defaultDragDropEnabled,
     onDragEnter: _onDragEnter,
@@ -263,158 +281,208 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDrop: _onDropList,
     onDragStart: _onDragStart,
     onDragEnd: _onDragEnd,
-  };
+  });
 
-  const _onKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
-    // Allow the caller to handle the key down
-    if (props.onKeyDown) {
-      props.onKeyDown(ev);
-    }
-
-    // Handle copy if focus is in the selected items list
-    // This is a temporary work around, it has localization issues
-    // we plan on rewriting how this works in the future
-    // eslint-disable-next-line deprecation/deprecation
-    if (ev.ctrlKey && ev.which === KeyCodes.c) {
-      if (focusedItemIndices.length > 0 && props.selectedItemsListProps?.getItemCopyText) {
-        ev.preventDefault();
-        const copyItems = selection.getSelection() as T[];
-        const copyString = props.selectedItemsListProps.getItemCopyText(copyItems);
-        navigator.clipboard.writeText(copyString).then(
-          () => {
-            /* clipboard successfully set */
-          },
-          () => {
-            /* clipboard write failed */
-            // Swallow the error
-          },
-        );
+  const _onSuggestionSelected = React.useCallback(
+    (ev: any, item: IFloatingSuggestionItemProps<T>) => {
+      addItems([item.item]);
+      onSuggestionSelected?.(ev, item);
+      if (input.current) {
+        input.current.clear();
       }
-    }
-    // Handle delete of items via backspace
-    // eslint-disable-next-line deprecation/deprecation
-    else if (ev.which === KeyCodes.backspace && selectedItems.length) {
-      if (
-        focusedItemIndices.length === 0 &&
-        input &&
-        input.current &&
-        !input.current.isValueSelected &&
-        input.current.inputElement === document.activeElement &&
-        (input.current as Autofill).cursorLocation === 0
-      ) {
-        showPicker(false);
-        ev.preventDefault();
-        if (props.selectedItemsListProps.onItemsRemoved) {
-          props.selectedItemsListProps.onItemsRemoved([selectedItems[selectedItems.length - 1]]);
-        }
-        removeItemAt(selectedItems.length - 1);
-      } else if (focusedItemIndices.length > 0) {
-        showPicker(false);
-        ev.preventDefault();
-        if (props.selectedItemsListProps.onItemsRemoved) {
-          props.selectedItemsListProps.onItemsRemoved(getSelectedItems());
-        }
-        removeSelectedItems();
-        input.current?.focus();
-      }
-    }
-  };
+      showPicker(false);
+    },
+    [addItems, onSuggestionSelected, showPicker],
+  );
 
-  const _onInputKeyDown = (ev: React.KeyboardEvent<Autofill | HTMLElement>) => {
-    if (isSuggestionsShown) {
+  const _onKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLDivElement>) => {
+      // Allow the caller to handle the key down
+      onKeyDown?.(ev);
+
+      // Handle copy if focus is in the selected items list
+      // This is a temporary work around, it has localization issues
+      // we plan on rewriting how this works in the future
       // eslint-disable-next-line deprecation/deprecation
-      const keyCode = ev.which;
-      switch (keyCode) {
-        case KeyCodes.escape:
+      if (ev.ctrlKey && ev.which === KeyCodes.c) {
+        if (focusedItemIndices.length > 0 && selectedItemsListGetItemCopyText) {
+          ev.preventDefault();
+          const copyItems = selection.getSelection() as T[];
+          const copyString = selectedItemsListGetItemCopyText(copyItems);
+          navigator.clipboard.writeText(copyString).then(
+            () => {
+              /* clipboard successfully set */
+            },
+            () => {
+              /* clipboard write failed */
+              // Swallow the error
+            },
+          );
+        }
+      }
+      // Handle delete of items via backspace
+      // eslint-disable-next-line deprecation/deprecation
+      else if (ev.which === KeyCodes.backspace && selectedItems.length) {
+        if (
+          focusedItemIndices.length === 0 &&
+          input &&
+          input.current &&
+          !input.current.isValueSelected &&
+          input.current.inputElement === document.activeElement &&
+          (input.current as Autofill).cursorLocation === 0
+        ) {
           showPicker(false);
           ev.preventDefault();
-          ev.stopPropagation();
-          break;
-        case KeyCodes.enter:
-        case KeyCodes.tab:
-          if (!ev.shiftKey && !ev.ctrlKey && (focusItemIndex >= 0 || footerItemIndex >= 0 || headerItemIndex >= 0)) {
+          selectedItemsListOnItemsRemoved?.([selectedItems[selectedItems.length - 1]]);
+          removeItemAt(selectedItems.length - 1);
+        } else if (focusedItemIndices.length > 0) {
+          showPicker(false);
+          ev.preventDefault();
+          selectedItemsListOnItemsRemoved?.(getSelectedItems());
+          removeSelectedItems();
+          input.current?.focus();
+        }
+      }
+    },
+    [
+      focusedItemIndices.length,
+      getSelectedItems,
+      onKeyDown,
+      removeItemAt,
+      removeSelectedItems,
+      selectedItems,
+      selectedItemsListGetItemCopyText,
+      selectedItemsListOnItemsRemoved,
+      selection,
+      showPicker,
+    ],
+  );
+
+  const _onInputKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<Autofill | HTMLElement>) => {
+      if (isSuggestionsShown) {
+        // eslint-disable-next-line deprecation/deprecation
+        const keyCode = ev.which;
+        switch (keyCode) {
+          case KeyCodes.escape:
+            showPicker(false);
             ev.preventDefault();
             ev.stopPropagation();
-            if (focusItemIndex >= 0) {
-              // Get the focused element and add it to selectedItemsList
-              showPicker(false);
-              _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
-            } else if (footerItemIndex >= 0) {
-              // execute the footer action
-              footerItems![footerItemIndex].onExecute!();
-            } else if (headerItemIndex >= 0) {
-              // execute the header action
-              headerItems![headerItemIndex].onExecute!();
+            break;
+          case KeyCodes.enter:
+          case KeyCodes.tab:
+            if (!ev.shiftKey && !ev.ctrlKey && (focusItemIndex >= 0 || footerItemIndex >= 0 || headerItemIndex >= 0)) {
+              ev.preventDefault();
+              ev.stopPropagation();
+              if (focusItemIndex >= 0) {
+                // Get the focused element and add it to selectedItemsList
+                showPicker(false);
+                _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+              } else if (footerItemIndex >= 0) {
+                // execute the footer action
+                footerItems![footerItemIndex].onExecute!();
+              } else if (headerItemIndex >= 0) {
+                // execute the header action
+                headerItems![headerItemIndex].onExecute!();
+              }
             }
-          }
-          break;
-        case KeyCodes.up:
-          ev.preventDefault();
-          ev.stopPropagation();
-          selectPreviousSuggestion();
-          break;
-        case KeyCodes.down:
-          ev.preventDefault();
-          ev.stopPropagation();
-          selectNextSuggestion();
-          break;
+            break;
+          case KeyCodes.up:
+            ev.preventDefault();
+            ev.stopPropagation();
+            selectPreviousSuggestion();
+            break;
+          case KeyCodes.down:
+            ev.preventDefault();
+            ev.stopPropagation();
+            selectNextSuggestion();
+            break;
+        }
       }
-    }
-  };
+    },
+    [
+      _onSuggestionSelected,
+      focusItemIndex,
+      footerItemIndex,
+      footerItems,
+      headerItemIndex,
+      headerItems,
+      isSuggestionsShown,
+      selectNextSuggestion,
+      selectPreviousSuggestion,
+      showPicker,
+      suggestionItems,
+    ],
+  );
 
-  const _onCopy = (ev: React.ClipboardEvent<HTMLInputElement>) => {
-    if (focusedItemIndices.length > 0 && props.selectedItemsListProps?.getItemCopyText) {
-      const copyItems = selection.getSelection() as T[];
-      const copyString = props.selectedItemsListProps.getItemCopyText(copyItems);
-      ev.clipboardData.setData('text/plain', copyString);
-      ev.preventDefault();
-    }
-  };
-  const _onInputFocus = (ev: React.FocusEvent<HTMLInputElement | Autofill>): void => {
-    unselectAll();
-    if (props.inputProps && props.inputProps.onFocus) {
-      props.inputProps.onFocus(ev as React.FocusEvent<HTMLInputElement>);
-    }
-  };
-  const _onInputClick = (ev: React.MouseEvent<HTMLInputElement | Autofill>) => {
-    unselectAll();
-    showPicker(true);
-    if (props.inputProps && props.inputProps.onClick) {
-      props.inputProps.onClick(ev as React.MouseEvent<HTMLInputElement>);
-    }
-  };
-  const _onInputChange = (value: string, composing?: boolean, resultItemsList?: T[]) => {
-    if (!composing) {
-      // update query string
-      setQueryString(value);
-      !isSuggestionsShown ? showPicker(true) : null;
-      if (!resultItemsList) {
-        resultItemsList = [];
+  const _onCopy = React.useCallback(
+    (ev: React.ClipboardEvent<HTMLInputElement>) => {
+      if (focusedItemIndices.length > 0 && selectedItemsListGetItemCopyText) {
+        const copyItems = selection.getSelection() as T[];
+        const copyString = selectedItemsListGetItemCopyText(copyItems);
+        ev.clipboardData.setData('text/plain', copyString);
+        ev.preventDefault();
       }
-      if (onInputChange) {
-        onInputChange(value, composing, resultItemsList);
-        clearQueryString();
-        if (resultItemsList && resultItemsList.length > 0) {
-          addItems(resultItemsList);
-          showPicker(false);
-          // Clear the input
-          if (input.current) {
-            input.current.clear();
+    },
+    [focusedItemIndices.length, selectedItemsListGetItemCopyText, selection],
+  );
+
+  const _onInputFocus = React.useCallback(
+    (ev: React.FocusEvent<HTMLInputElement | Autofill>): void => {
+      unselectAll();
+      inputPropsOnFocus?.(ev as React.FocusEvent<HTMLInputElement>);
+    },
+    [inputPropsOnFocus, unselectAll],
+  );
+
+  const _onInputClick = React.useCallback(
+    (ev: React.MouseEvent<HTMLInputElement | Autofill>) => {
+      unselectAll();
+      showPicker(true);
+      inputPropsOnClick?.(ev as React.MouseEvent<HTMLInputElement>);
+    },
+    [inputPropsOnClick, showPicker, unselectAll],
+  );
+
+  const _onInputChange = React.useCallback(
+    (value: string, composing?: boolean, resultItemsList?: T[]) => {
+      if (!composing) {
+        // update query string
+        setQueryString(value);
+        !isSuggestionsShown ? showPicker(true) : null;
+        if (!resultItemsList) {
+          resultItemsList = [];
+        }
+        if (onInputChange) {
+          onInputChange(value, composing, resultItemsList);
+          clearQueryString();
+          if (resultItemsList && resultItemsList.length > 0) {
+            addItems(resultItemsList);
+            showPicker(false);
+            // Clear the input
+            if (input.current) {
+              input.current.clear();
+            }
           }
         }
       }
-    }
-  };
-  const _onPaste = (ev: React.ClipboardEvent<Autofill | HTMLInputElement>) => {
-    if (props.onPaste) {
-      const inputText = ev.clipboardData.getData('Text');
-      ev.preventDefault();
-      // Pass current selected items
-      props.onPaste(inputText, selectedItems);
-      setSelectedItems(selectedItems);
-      selection.setItems(selectedItems);
-    }
-  };
+    },
+    [addItems, clearQueryString, isSuggestionsShown, onInputChange, setQueryString, showPicker],
+  );
+
+  const _onPaste = React.useCallback(
+    (ev: React.ClipboardEvent<Autofill | HTMLInputElement>) => {
+      if (onPaste) {
+        const inputText = ev.clipboardData.getData('Text');
+        ev.preventDefault();
+        // Pass current selected items
+        onPaste(inputText, selectedItems);
+        setSelectedItems(selectedItems);
+        selection.setItems(selectedItems);
+      }
+    },
+    [onPaste, selectedItems, selection, setSelectedItems],
+  );
 
   const _renderSelectedItemsList = (): JSX.Element => {
     return onRenderSelectedItems({
@@ -424,50 +492,48 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onItemsRemoved: _onRemoveSelectedItems,
       replaceItem: _replaceItem,
       dragDropHelper: dragDropHelper,
-      dragDropEvents: props.dragDropEvents ? props.dragDropEvents : defaultDragDropEvents,
+      dragDropEvents: dragDropEvents || defaultDragDropEvents.current,
     });
   };
-  const _canAddItems = () => true;
-  const _onFloatingSuggestionsDismiss = (ev: React.MouseEvent): void => {
-    if (props.floatingSuggestionProps.onFloatingSuggestionsDismiss) {
-      props.floatingSuggestionProps.onFloatingSuggestionsDismiss();
-    }
-    showPicker(false);
-  };
-  const _onFloatingSuggestionRemoved = (ev: any, item: IFloatingSuggestionItemProps<T>) => {
-    if (props.floatingSuggestionProps.onRemoveSuggestion) {
-      props.floatingSuggestionProps.onRemoveSuggestion(ev, item);
-    }
-    // We want to keep showing the picker to show the user that the entry has been removed from the list.
-    showPicker(true);
-  };
-  const _onSuggestionSelected = (ev: any, item: IFloatingSuggestionItemProps<T>) => {
-    addItems([item.item]);
-    if (props.floatingSuggestionProps.onSuggestionSelected) {
-      props.floatingSuggestionProps.onSuggestionSelected(ev, item);
-    }
-    if (input.current) {
-      input.current.clear();
-    }
-    showPicker(false);
-  };
-  const _onRemoveSelectedItems = (itemsToRemove: T[]) => {
-    removeItems(itemsToRemove);
-    if (props.selectedItemsListProps.onItemsRemoved) {
-      props.selectedItemsListProps.onItemsRemoved(itemsToRemove);
-    }
-  };
-  const _replaceItem = (newItem: T | T[], index: number) => {
-    const newItems = Array.isArray(newItem) ? newItem : [newItem];
-    dropItemsAt(index, newItems, [index]);
-    if (props.selectedItemsListProps.replaceItem) {
-      props.selectedItemsListProps.replaceItem(newItem, index);
-    }
-  };
+
+  const _onFloatingSuggestionsDismiss = React.useCallback(
+    (ev: React.MouseEvent): void => {
+      onFloatingSuggestionsDismiss?.();
+      showPicker(false);
+    },
+    [onFloatingSuggestionsDismiss, showPicker],
+  );
+
+  const _onFloatingSuggestionRemoved = React.useCallback(
+    (ev: any, item: IFloatingSuggestionItemProps<T>) => {
+      onRemoveSuggestion?.(ev, item);
+      // We want to keep showing the picker to show the user that the entry has been removed from the list.
+      showPicker(true);
+    },
+    [onRemoveSuggestion, showPicker],
+  );
+
+  const _onRemoveSelectedItems = React.useCallback(
+    (itemsToRemove: T[]) => {
+      removeItems(itemsToRemove);
+      selectedItemsListOnItemsRemoved?.(itemsToRemove);
+    },
+    [selectedItemsListOnItemsRemoved, removeItems],
+  );
+
+  const _replaceItem = React.useCallback(
+    (newItem: T | T[], index: number) => {
+      const newItems = Array.isArray(newItem) ? newItem : [newItem];
+      dropItemsAt(index, newItems, [index]);
+      selectedItemsListReplaceItem?.(newItem, index);
+    },
+    [dropItemsAt, selectedItemsListReplaceItem],
+  );
+
   const _renderFloatingPicker = () =>
     onRenderFloatingSuggestions({
       ...floatingSuggestionProps,
-      pickerWidth: props.floatingSuggestionProps.pickerWidth ? props.floatingSuggestionProps.pickerWidth : '300px',
+      pickerWidth: pickerWidth || '300px',
       targetElement: input.current?.inputElement,
       isSuggestionsVisible: isSuggestionsShown,
       suggestions: suggestionItems,
@@ -480,6 +546,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onKeyDown: _onInputKeyDown,
       onRemoveSuggestion: _onFloatingSuggestionRemoved,
     });
+
+  const _canAddItems = () => true;
 
   return (
     <div
@@ -515,11 +583,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                   {...(inputProps as IInputProps)}
                   className={css('ms-BasePicker-input', classNames.pickerInput)}
                   ref={input}
-                  /* eslint-disable react/jsx-no-bind */
                   onFocus={_onInputFocus}
                   onClick={_onInputClick}
                   onInputValueChange={_onInputChange}
-                  /* eslint-enable react/jsx-no-bind */
                   aria-autocomplete="list"
                   aria-activedescendant={
                     isSuggestionsShown && focusItemIndex >= 0
@@ -527,10 +593,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                       : undefined
                   }
                   disabled={false}
-                  /* eslint-disable react/jsx-no-bind */
                   onPaste={_onPaste}
                   onKeyDown={_onInputKeyDown}
-                  /* eslint-enable react/jsx-no-bind */
                 />
               </div>
             )}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -162,9 +162,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (draggedIndex > -1) {
       indicesToRemove = focusedItemIndices.includes(draggedIndex) ? [...focusedItemIndices] : [draggedIndex];
     }
-    if (selectedItemsListProps.dropItemsAt) {
-      selectedItemsListProps.dropItemsAt(insertIndex, newItems, indicesToRemove);
-    }
+    selectedItemsListDropItemsAt?.(insertIndex, newItems, indicesToRemove);
     dropItemsAt(insertIndex, newItems, indicesToRemove);
     unselectAll();
     insertIndex = -1;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -477,7 +477,19 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         }
       }
     },
-    [addItems, clearQueryString, isSuggestionsShown, onInputChange, setQueryString, showPicker],
+    [
+      addItems,
+      clearQueryString,
+      isSuggestionsShown,
+      onInputChange,
+      setQueryString,
+      showPicker,
+      clearPickerSelectedIndex,
+      setFocusItemIndex,
+      focusItemIndex,
+      footerItemIndex,
+      headerItemIndex,
+    ],
   );
 
   const _onPaste = React.useCallback(

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -36,104 +36,122 @@ export const useSelectedItems = <T extends {}>(
     setSelectedItems(selectedItems ? selectedItems : []);
   }, [selectedItems]);
 
-  const addItems = (itemsToAdd: T[]): void => {
-    const newItems: T[] = items.concat(itemsToAdd);
-    setSelectedItems(newItems);
-    selection.setItems(newItems);
-  };
+  const addItems = React.useCallback(
+    (itemsToAdd: T[]): void => {
+      const newItems: T[] = items.concat(itemsToAdd);
+      setSelectedItems(newItems);
+      selection.setItems(newItems);
+    },
+    [items, selection],
+  );
 
-  const dropItemsAt = (insertIndex: number, itemsToAdd: T[], indicesToRemove: number[]): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = [];
+  const dropItemsAt = React.useCallback(
+    (insertIndex: number, itemsToAdd: T[], indicesToRemove: number[]): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = [];
 
-    for (let i = 0; i < currentItems.length; i++) {
-      const item = currentItems[i];
-      // If this is the insert before index, insert the dragged items, then the current item
-      if (i === insertIndex) {
+      for (let i = 0; i < currentItems.length; i++) {
+        const item = currentItems[i];
+        // If this is the insert before index, insert the dragged items, then the current item
+        if (i === insertIndex) {
+          itemsToAdd.forEach(draggedItem => {
+            updatedItems.push(draggedItem);
+          });
+        }
+        if (!indicesToRemove.includes(i)) {
+          // only insert items into the new list that are not being dragged
+          updatedItems.push(item);
+        }
+      }
+      // if the insert index is at the end, add them now
+      if (insertIndex === currentItems.length) {
         itemsToAdd.forEach(draggedItem => {
           updatedItems.push(draggedItem);
         });
       }
-      if (!indicesToRemove.includes(i)) {
-        // only insert items into the new list that are not being dragged
-        updatedItems.push(item);
-      }
-    }
-    // if the insert index is at the end, add them now
-    if (insertIndex === currentItems.length) {
-      itemsToAdd.forEach(draggedItem => {
-        updatedItems.push(draggedItem);
-      });
-    }
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
-
-  const removeItemAt = (index: number): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = currentItems.slice(0, index).concat(currentItems.slice(index + 1));
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
-
-  const removeItem = (item: T): void => {
-    const currentItems: T[] = [...items];
-    const index: number = currentItems.indexOf(item);
-    removeItemAt(index);
-  };
-
-  const replaceItem = (itemToReplace: T, itemsToReplaceWith: T[]): void => {
-    const currentItems: T[] = [...items];
-    const index: number = items.indexOf(itemToReplace);
-
-    if (index > -1) {
-      const updatedItems = currentItems
-        .slice(0, index)
-        .concat(itemsToReplaceWith)
-        .concat(currentItems.slice(index + 1));
       setSelectedItems(updatedItems);
       selection.setItems(updatedItems);
-    }
-  };
+    },
+    [items, selection],
+  );
 
-  const removeItems = (itemsToRemove: any[]): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = currentItems;
-    // Intentionally not using .filter here as we want to only remove a specific
-    // item in case of duplicates of same item.
-    itemsToRemove.forEach(item => {
-      const index: number = updatedItems.indexOf(item);
-      updatedItems.splice(index, 1);
-    });
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
+  const removeItemAt = React.useCallback(
+    (index: number): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = currentItems.slice(0, index).concat(currentItems.slice(index + 1));
+      setSelectedItems(updatedItems);
+      selection.setItems(updatedItems);
+    },
+    [items, selection],
+  );
 
-  const removeSelectedItems = (): void => {
-    removeItems(getSelectedItems());
-  };
+  const removeItem = React.useCallback(
+    (item: T): void => {
+      const currentItems: T[] = [...items];
+      const index: number = currentItems.indexOf(item);
+      removeItemAt(index);
+    },
+    [items, removeItemAt],
+  );
 
-  const getSelectedItems = (): T[] => {
-    if (hasSelectedItems()) {
-      return selection.getSelection() as T[];
-    } else {
-      return [];
-    }
-  };
+  const replaceItem = React.useCallback(
+    (itemToReplace: T, itemsToReplaceWith: T[]): void => {
+      const currentItems: T[] = [...items];
+      const index: number = items.indexOf(itemToReplace);
 
-  const hasSelectedItems = (): Boolean => {
+      if (index > -1) {
+        const updatedItems = currentItems
+          .slice(0, index)
+          .concat(itemsToReplaceWith)
+          .concat(currentItems.slice(index + 1));
+        setSelectedItems(updatedItems);
+        selection.setItems(updatedItems);
+      }
+    },
+    [items, selection],
+  );
+
+  const removeItems = React.useCallback(
+    (itemsToRemove: any[]): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = currentItems;
+      // Intentionally not using .filter here as we want to only remove a specific
+      // item in case of duplicates of same item.
+      itemsToRemove.forEach(item => {
+        const index: number = updatedItems.indexOf(item);
+        updatedItems.splice(index, 1);
+      });
+      setSelectedItems(updatedItems);
+      selection.setItems(updatedItems);
+    },
+    [items, selection],
+  );
+
+  const hasSelectedItems = React.useCallback((): Boolean => {
     if (items.length && selection.getSelectedCount() > 0) {
       return true;
     } else {
       return false;
     }
-  };
+  }, [items.length, selection]);
 
-  const unselectAll = (): void => {
+  const getSelectedItems = React.useCallback((): T[] => {
+    if (hasSelectedItems()) {
+      return selection.getSelection() as T[];
+    } else {
+      return [];
+    }
+  }, [hasSelectedItems, selection]);
+
+  const removeSelectedItems = React.useCallback((): void => {
+    removeItems(getSelectedItems());
+  }, [getSelectedItems, removeItems]);
+
+  const unselectAll = React.useCallback((): void => {
     if (hasSelectedItems()) {
       selection.setAllSelected(false);
     }
-  };
+  }, [hasSelectedItems, selection]);
 
   return {
     selectedItems: items,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

(This is an updated version of #16237)

Many callbacks in UPP and nested components aren't memoised and were causing a ton of needless re-renders on every interaction. Fixed that to greatly reduce renders and improve performance especially with emails with a lot of recipients.
