### PR TITLE
fix: correct focus visible outline on accent button and anchor styles

### DIFF
--- a/change/@fluentui-web-components-2021-02-04-15-05-06-users-v-sedono-fix-accent-focus-visible-width.json
+++ b/change/@fluentui-web-components-2021-02-04-15-05-06-users-v-sedono-fix-accent-focus-visible-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "correct focus visible outline on accent button and anchor styles",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-04T23:05:06.344Z"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -195,7 +195,7 @@ export const AccentButtonStyles = css`
     }
 
     :host(.accent) .control:${focusVisible} {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var};
+        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var}, 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var}
     }
 
     :host(.accent.disabled) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The outline on buttons and anchors with `accent` appearance are incorrect, and should have a thicker outline for accessibility contrast purposes.
This adds an additional box-shadow to the focus-visible accent styles to correct it.

before:
<img width="145" alt="Screen Shot 2021-02-04 at 3 28 32 PM" src="https://user-images.githubusercontent.com/31681651/106968437-ad964e80-66fd-11eb-99ec-51cc57cbb620.png">

after:
<img width="95" alt="Screen Shot 2021-02-04 at 2 51 56 PM" src="https://user-images.githubusercontent.com/31681651/106967005-3d86c900-66fb-11eb-9404-403883bc7ff2.png">