### PR TITLE
Add getHighContrastNoAdjustStyle (7.0)

### DIFF
--- a/change/@uifabric-styling-2021-02-05-09-57-12-sareiff-addforcedcolormethod.json
+++ b/change/@uifabric-styling-2021-02-05-09-57-12-sareiff-addforcedcolormethod.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Port forced colors method to V7",
+  "packageName": "@uifabric/styling",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-05T17:57:12.718Z"
+}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -116,6 +116,9 @@ export function getFocusStyle(theme: ITheme, inset?: number, position?: 'relativ
 export function getGlobalClassNames<T>(classNames: GlobalClassNames<T>, theme: ITheme, disableGlobalClassNames?: boolean): GlobalClassNames<T>;
 
 // @public
+export function getHighContrastNoAdjustStyle(): IRawStyle;
+
+// @public
 export function getIcon(name?: string): IIconRecord | undefined;
 
 // @public

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -24,6 +24,16 @@ export function getScreenSelector(min: number, max: number): string {
 }
 
 /**
+ * The style which turns off high contrast adjustment in browsers.
+ */
+export function getHighContrastNoAdjustStyle(): IRawStyle {
+  return {
+    forcedColorAdjust: 'none',
+    MsHighContrastAdjust: 'none',
+  };
+}
+
+/**
  * The style which turns off high contrast adjustment in (only) Edge Chromium browser.
  */
 export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IRawStyle } {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This change ports the new method from https://github.com/microsoft/fluentui/pull/16595 for forced-colors support to V7. I am trying to break this change up into smaller pieces so I can unblock some duplicate styling changes for OOUI first.

Next few PRs will be:
1. Deprecating getEdgeChromiumNoHighContrastAdjustSelector in V8
2. Utilizing forced-colors in V7 (similar to very large PR above)
3. Deprecating getEdgeChromiumNoHighContrastAdjustSelector in V7

but I probably will not have time to get those PRs out until next week.

#### Focus areas to test

(optional)
