### PR TITLE
Additional Pragma - @jsxRuntime

### DIFF
--- a/packages/react-internal/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/react-internal/src/components/Stack/StackItem/StackItem.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx withSlots */
 import * as React from 'react';
 import { withSlots, createComponent, getSlots } from '@fluentui/foundation-legacy';


### PR DESCRIPTION
Adding additional pragma - `/** @jsxRuntime classic */` as per : https://babeljs.io/docs/en/babel-plugin-transform-react-jsx/#customizing-the-automatic-runtime-import

Thanks!

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16678
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Babel complains about pragma when runtime is automatic.  This change will request Babel to execute with classic runtime.

