### PR TITLE
Add issue template for component convergence epic

### DIFF
--- a/.github/ISSUE_TEMPLATE/convergence_epic.md
+++ b/.github/ISSUE_TEMPLATE/convergence_epic.md
@@ -1,0 +1,42 @@
+---
+name: Component Convergence Epic
+about: Epic issue tracking convergence of a particular component
+---
+
+<!--
+These issues are used by core contributors to track the list of items that should be
+completed as part of converging a component. More info can be found here: https://github.com/microsoft/fluentui/wiki/Component-Convergence-Guide
+-->
+
+# Preparation:
+
+- [ ] Open UI Research complete
+  - [link to https://open-ui.org/]
+- [ ] Comparison on v8 and v0 complete
+- [ ] Gather open GitHub issues related to component
+- [ ] react-\* package scaffolded
+  - [link to package]
+- [ ] Component Spec authored and reviewed
+  - [link to spec in component package]
+- [ ] **Deliverable:** Reviewed component spec
+
+# Implementation
+
+[link to react-* package folder]
+
+- [ ] Implement component
+- [ ] Add storybook stories
+- [ ] Add tests - Conformance, Unit, and VR
+- [ ] Write README.md covering basic usage
+- [ ] Write initial MIGRATION.md guide (include v8 and v0)
+- [ ] **Deliverable:** Experimental component ready for partner use
+
+# Validation
+
+- [ ] Add and validate in UI Builder
+- [ ] Add and validate in docs site
+- [ ] Validate with token pipeline
+- [ ] Validate in product
+- [ ] Finalize migration guide
+  - [ ] Author codemods
+- [ ] **Deliverable:** Preview component ready for broader/3rd party use

--- a/.github/ISSUE_TEMPLATE/convergence_epic.md
+++ b/.github/ISSUE_TEMPLATE/convergence_epic.md
@@ -32,6 +32,10 @@ completed as part of converging a component. More info can be found here: https:
 - [ ] Respects API principles, shorthands and slots handling
 - [ ] No dependency on v0/v7
 - [ ] Add tests - Conformance, Unit, and VR
+  - [ ] Conformance tests
+  - [ ] Unit tests
+  - [ ] VR tests
+  - [ ] Accessibility behavior tests 
 - [ ] Write README.md covering basic usage
 - [ ] Write initial MIGRATION.md guide (include v8 and v0)
 - [ ] **Deliverable:** Experimental component ready for partner use

--- a/.github/ISSUE_TEMPLATE/convergence_epic.md
+++ b/.github/ISSUE_TEMPLATE/convergence_epic.md
@@ -26,6 +26,11 @@ completed as part of converging a component. More info can be found here: https:
 
 - [ ] Implement component
 - [ ] Add storybook stories
+- [ ] Using hooks
+- [ ] Using makeStyles
+- [ ] Respects Figma tokens (and using provider)
+- [ ] Respects API principles, shorthands and slots handling
+- [ ] No dependency on v0/v7
 - [ ] Add tests - Conformance, Unit, and VR
 - [ ] Write README.md covering basic usage
 - [ ] Write initial MIGRATION.md guide (include v8 and v0)


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes N/A
- [ ] Include a change request file using `$ yarn change` N/A

#### Description of changes

Adds a new issue template for the Convergence Epic template which is currently stored in a URL and very hard to edit. 
https://github.com/microsoft/fluentui/wiki/Component-Convergence-Guide

@jurokapsiar and @ling1726 have wanted to update the Converged Epic issue template which is located in the convergence guide. However, since it's currently stored in a URL it's really a pain (have to decode it edit it, and re-encode it, if you make any mistake it will break). 

I originally avoided adding the template to the github issue templates since it may confuse contributors. Since we're actually using the template and updating it as we go, I think the convenience for the team outweighs potential confusion.  

