### PR TITLE
DetailsList proportional columns + custom header

### DIFF
--- a/change/@fluentui-react-b24ef479-58cc-4d0e-88b1-98260e973f4b.json
+++ b/change/@fluentui-react-b24ef479-58cc-4d0e-88b1-98260e973f4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added proportional column behavior to the DetailsList component and enabled custom components in cell headers.",
+  "packageName": "@fluentui/react",
+  "email": "jolamusg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-4e255abb-de17-4d66-9f99-2cea4423e441.json
+++ b/change/@fluentui-react-examples-4e255abb-de17-4d66-9f99-2cea4423e441.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added proportional column behavior to the DetailsList component and enabled custom components in cell headers.",
+  "packageName": "@fluentui/react-examples",
+  "email": "jolamusg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.ProportionalColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.ProportionalColumns.Example.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { DetailsList, DetailsListLayoutMode, IColumn, IDetailsColumnProps } from '@fluentui/react/lib/DetailsList';
+import { ActionButton } from '@fluentui/react/lib/Button';
+import { IRenderFunction } from '@fluentui/react/lib/Utilities';
+
+export interface IDetailsListProportionalColumnsExampleItem {
+  key: number;
+  name: string;
+  value: number;
+}
+
+export interface IDetailsListAnimationExampleState {
+  items: IDetailsListProportionalColumnsExampleItem[];
+}
+
+export class DetailsListProportionalColumnsExample extends React.Component<{}, IDetailsListAnimationExampleState> {
+  private _allItems: IDetailsListProportionalColumnsExampleItem[];
+  private _columns: IColumn[];
+  private _updateTimer: any;
+
+  constructor(props: {}) {
+    super(props);
+
+    // Populate with items for demos.
+    this._allItems = [];
+    for (let i = 0; i < 200; i++) {
+      this._allItems.push({
+        key: i,
+        name: 'Item ' + i,
+        value: i,
+      });
+    }
+
+    this._columns = [
+      {
+        key: 'column1',
+        name: 'Number 1',
+        fieldName: 'name',
+        flexGrow: 1,
+        minWidth: 100,
+        isResizable: true,
+        getValueKey: this._getValueKey,
+        onRenderHeader: (
+          colProps?: IDetailsColumnProps,
+          defaultRender?: IRenderFunction<IDetailsColumnProps>,
+        ): JSX.Element | null => (
+          <ActionButton onClick={this._onColumnButtonInvoked}>
+            {(defaultRender && defaultRender(colProps)) || <></>}
+          </ActionButton>
+        ),
+      },
+      {
+        key: 'column2',
+        name: 'Number 2',
+        fieldName: 'value',
+        minWidth: 100,
+        isResizable: true,
+      },
+      {
+        key: 'column3',
+        name: 'Number 3',
+        fieldName: 'value',
+        flexGrow: 2,
+        minWidth: 100,
+        isResizable: true,
+      },
+    ];
+
+    this.state = {
+      items: this._allItems,
+    };
+  }
+
+  public componentWillUnmount(): void {
+    clearInterval(this._updateTimer);
+  }
+
+  public render(): JSX.Element {
+    const { items } = this.state;
+
+    return (
+      <DetailsList
+        items={items}
+        columns={this._columns}
+        setKey="set"
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        selectionPreservedOnEmptyClick={true}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="Row checkbox"
+        onItemInvoked={this._onItemInvoked}
+        enableUpdateAnimations={true}
+        getCellValueKey={this._getCellValueKey}
+      />
+    );
+  }
+
+  private _onColumnButtonInvoked = (): void => {
+    alert('Custom header button invoked');
+  };
+
+  private _onItemInvoked = (item: IDetailsListProportionalColumnsExampleItem): void => {
+    alert(`Item invoked: ${item.name}`);
+  };
+
+  private _getValueKey(item: IDetailsListProportionalColumnsExampleItem, index: number, column: IColumn): string {
+    const key =
+      item && column && column.fieldName
+        ? item[column.fieldName as keyof IDetailsListProportionalColumnsExampleItem]
+        : index;
+    return key.toString();
+  }
+
+  private _getCellValueKey(item: IDetailsListProportionalColumnsExampleItem, index: number, column: IColumn): string {
+    const key =
+      item && column && column.fieldName
+        ? item[column.fieldName as keyof IDetailsListProportionalColumnsExampleItem]
+        : index;
+    return key.toString();
+  }
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
@@ -23,6 +23,9 @@ const DetailsListCustomGroupHeadersExampleCode = require('!raw-loader?esModule=f
 import { DetailsListAdvancedExample } from './DetailsList.Advanced.Example';
 const DetailsListAdvancedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx') as string;
 
+import { DetailsListProportionalColumnsExample } from './DetailsList.ProportionalColumns.Example';
+const DetailsListProportionalColumnsCode = require('!raw-loader!@fluentui/react-examples/src/react/DetailsList/DetailsList.ProportionalColumns.Example.tsx') as string;
+
 import { DetailsListGroupedExample } from './DetailsList.Grouped.Example';
 const DetailsListGroupedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx') as string;
 
@@ -127,6 +130,12 @@ export const DetailsListAdvancedPageProps: IDocPageProps = generateProps({
   title: 'Advanced DetailsList of 5000 items with variable row heights',
   code: DetailsListAdvancedExampleCode,
   view: <DetailsListAdvancedExample />,
+});
+
+export const DetailsListProportionalColumnsProps: IDocPageProps = generateProps({
+  title: 'Rendering proportional and fixed columns',
+  code: DetailsListProportionalColumnsCode,
+  view: <DetailsListProportionalColumnsExample />,
 });
 
 export const DetailsListDragDropPageProps: IDocPageProps = generateProps({

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -1,0 +1,6242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx correctly 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-fixed
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={4}
+      aria-readonly="true"
+      aria-rowcount={201}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone2"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header1-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                aria-describedby="header1-checkTooltip"
+                aria-label="Toggle selection for all items"
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header1-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <label
+            aria-hidden={true}
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-checkTooltip"
+          >
+            Toggle selection for all items
+          </label>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column1"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header1-column1-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column1"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column1-name"
+                >
+                  Number 1
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className=
+                ms-DetailsHeader-cellSizer
+                {
+                  background: transparent;
+                  bottom: 0px;
+                  cursor: ew-resize;
+                  display: inline-block;
+                  height: inherit;
+                  outline: transparent;
+                  overflow: hidden;
+                  position: relative;
+                  top: 0px;
+                  width: 16px;
+                  z-index: 1;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                }
+                &:after {
+                  background: #c8c6c4;
+                  bottom: 0px;
+                  content: "";
+                  left: 50%;
+                  opacity: 0;
+                  position: absolute;
+                  top: 0px;
+                  width: 1px;
+                }
+                &:focus:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &:hover:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &.is-resizing:after {
+                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                {
+                  margin-bottom: 0;
+                  margin-left: -8px;
+                  margin-right: -8px;
+                  margin-top: 0;
+                }
+            data-is-focusable={false}
+            data-sizer-index={0}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+          <div
+            aria-colindex={3}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column2"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header1-column2-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column2"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column2-name"
+                >
+                  Number 2
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className=
+                ms-DetailsHeader-cellSizer
+                {
+                  background: transparent;
+                  bottom: 0px;
+                  cursor: ew-resize;
+                  display: inline-block;
+                  height: inherit;
+                  outline: transparent;
+                  overflow: hidden;
+                  position: relative;
+                  top: 0px;
+                  width: 16px;
+                  z-index: 1;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                }
+                &:after {
+                  background: #c8c6c4;
+                  bottom: 0px;
+                  content: "";
+                  left: 50%;
+                  opacity: 0;
+                  position: absolute;
+                  top: 0px;
+                  width: 1px;
+                }
+                &:focus:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &:hover:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &.is-resizing:after {
+                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                {
+                  margin-bottom: 0;
+                  margin-left: -8px;
+                  margin-right: -8px;
+                  margin-top: 0;
+                }
+            data-is-focusable={false}
+            data-sizer-index={1}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column3"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header1-column3-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column3"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column3-name"
+                >
+                  Number 3
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className=
+                ms-DetailsHeader-cellSizer
+                {
+                  background: transparent;
+                  bottom: 0px;
+                  cursor: ew-resize;
+                  display: inline-block;
+                  height: inherit;
+                  outline: transparent;
+                  overflow: hidden;
+                  position: relative;
+                  top: 0px;
+                  width: 16px;
+                  z-index: 1;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                }
+                &:after {
+                  background: #c8c6c4;
+                  bottom: 0px;
+                  content: "";
+                  left: 50%;
+                  opacity: 0;
+                  position: absolute;
+                  top: 0px;
+                  width: 1px;
+                }
+                &:focus:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &:hover:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &.is-resizing:after {
+                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                {
+                  margin-bottom: 0px;
+                  margin-left: -16px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                }
+            data-is-focusable={false}
+            data-sizer-index={2}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone3"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={2}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone4"
+                      data-is-focusable={true}
+                      data-item-index={0}
+                      data-selection-index={0}
+                      data-selection-touch-invoke={true}
+                      id="row0-0"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-0-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 0
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          0
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          0
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={3}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone5"
+                      data-is-focusable={true}
+                      data-item-index={1}
+                      data-selection-index={1}
+                      data-selection-touch-invoke={true}
+                      id="row0-1"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-1-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 1
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          1
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          1
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={4}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone6"
+                      data-is-focusable={true}
+                      data-item-index={2}
+                      data-selection-index={2}
+                      data-selection-touch-invoke={true}
+                      id="row0-2"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-2-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 2
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          2
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          2
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={5}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone7"
+                      data-is-focusable={true}
+                      data-item-index={3}
+                      data-selection-index={3}
+                      data-selection-touch-invoke={true}
+                      id="row0-3"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-3-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 3
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          3
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          3
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={6}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone8"
+                      data-is-focusable={true}
+                      data-item-index={4}
+                      data-selection-index={4}
+                      data-selection-touch-invoke={true}
+                      id="row0-4"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-4-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 4
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          4
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          4
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={5}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={7}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone9"
+                      data-is-focusable={true}
+                      data-item-index={5}
+                      data-selection-index={5}
+                      data-selection-touch-invoke={true}
+                      id="row0-5"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-5-checkbox row0-5-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-5-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 5
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          5
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          5
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={6}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={8}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone10"
+                      data-is-focusable={true}
+                      data-item-index={6}
+                      data-selection-index={6}
+                      data-selection-touch-invoke={true}
+                      id="row0-6"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-6-checkbox row0-6-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-6-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 6
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          6
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          6
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={7}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={9}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone11"
+                      data-is-focusable={true}
+                      data-item-index={7}
+                      data-selection-index={7}
+                      data-selection-touch-invoke={true}
+                      id="row0-7"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-7-checkbox row0-7-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-7-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 7
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          7
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          7
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={8}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={10}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone12"
+                      data-is-focusable={true}
+                      data-item-index={8}
+                      data-selection-index={8}
+                      data-selection-touch-invoke={true}
+                      id="row0-8"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-8-checkbox row0-8-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-8-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 8
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          8
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          8
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={9}
+                    role="presentation"
+                  >
+                    <div
+                      aria-rowindex={11}
+                      aria-selected={false}
+                      className=
+                          ms-FocusZone
+                          ms-DetailsRow
+                          is-contentUnselectable
+                          &:focus {
+                            outline: none;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            animation-duration: 0.367s;
+                            animation-fill-mode: both;
+                            animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                            animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                            background: #ffffff;
+                            border-bottom: 1px solid #f3f2f1;
+                            box-sizing: border-box;
+                            color: #605e5c;
+                            cursor: default;
+                            display: inline-flex;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 12px;
+                            font-weight: 400;
+                            min-height: 42px;
+                            min-width: 100%;
+                            outline: transparent;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #605e5c;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #ffffff;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          .ms-List-cell:first-child &:before {
+                            display: none;
+                          }
+                          &:hover {
+                            background: #f3f2f1;
+                            color: #323130;
+                          }
+                          &:hover .is-row-header {
+                            color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                            opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
+                      data-automationid="DetailsRow"
+                      data-focuszone-id="FocusZone13"
+                      data-is-focusable={true}
+                      data-item-index={9}
+                      data-selection-index={9}
+                      data-selection-touch-invoke={true}
+                      id="row0-9"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="row"
+                      style={
+                        Object {
+                          "minWidth": 300,
+                        }
+                      }
+                    >
+                      <div
+                        aria-colindex={1}
+                        className=
+                            ms-DetailsRow-cell
+                            ms-DetailsRow-cellCheck
+                            {
+                              box-sizing: border-box;
+                              display: inline-block;
+                              flex-shrink: 0;
+                              margin-top: -1px;
+                              min-height: 42px;
+                              outline: transparent;
+                              overflow: hidden;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 1px;
+                              position: relative;
+                              text-overflow: ellipsis;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 0px;
+                              content: "";
+                              left: 0px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 0px;
+                              top: 0px;
+                              z-index: 1;
+                            }
+                            & > button {
+                              max-width: 100%;
+                            }
+                            & [data-is-focusable='true'] {
+                              outline: transparent;
+                              position: relative;
+                            }
+                            & [data-is-focusable='true']::-moz-focus-inner {
+                              border: 0;
+                            }
+                        data-selection-toggle={true}
+                        role="gridcell"
+                      >
+                        <div
+                          aria-checked={false}
+                          aria-label="Row checkbox"
+                          aria-labelledby="row0-9-checkbox row0-9-header"
+                          className=
+                              ms-DetailsRow-check
+                              ms-Check-checkHost
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                align-items: center;
+                                background-color: transparent;
+                                background: none;
+                                border: none;
+                                box-sizing: border-box;
+                                cursor: default;
+                                display: flex;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 12px;
+                                font-weight: 400;
+                                height: 42px;
+                                justify-content: center;
+                                margin-bottom: 0px;
+                                margin-left: 0px;
+                                margin-right: 0px;
+                                margin-top: 0px;
+                                opacity: 0;
+                                outline: transparent;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: relative;
+                                vertical-align: top;
+                                width: 48px;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                          data-automationid="DetailsRowCheck"
+                          data-selection-toggle={true}
+                          id="row0-9-checkbox"
+                          role="checkbox"
+                          tabIndex={-1}
+                        >
+                          <div
+                            className=
+                                ms-Check
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 18px;
+                                  line-height: 1;
+                                  position: relative;
+                                  user-select: none;
+                                  vertical-align: top;
+                                  width: 18px;
+                                }
+                                &:before {
+                                  background: #ffffff;
+                                  border-radius: 50%;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  opacity: 1;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                }
+                                .ms-Check-checkHost:hover & {
+                                  opacity: 1;
+                                }
+                                .ms-Check-checkHost:focus & {
+                                  opacity: 1;
+                                }
+                                &:hover {
+                                  opacity: 1;
+                                }
+                                &:focus {
+                                  opacity: 1;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-circle
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 18px;
+                                    height: 18px;
+                                    left: 0px;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    color: WindowText;
+                                  }
+                              data-icon-name="CircleRing"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                            <i
+                              aria-hidden={true}
+                              className=
+                                  ms-Icon
+                                  ms-Check-check
+                                  {
+                                    display: inline-block;
+                                  }
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                                  {
+                                    color: #605e5c;
+                                    font-size: 16px;
+                                    height: 18px;
+                                    left: .5px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    text-align: center;
+                                    top: 0px;
+                                    vertical-align: middle;
+                                    width: 18px;
+                                  }
+                                  &:hover {
+                                    opacity: 1;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                    -ms-high-contrast-adjust: none;
+                                    forced-color-adjust: none;
+                                  }
+                              data-icon-name="StatusCircleCheckmark"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
+                            >
+                              
+                            </i>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+                            ms-DetailsRow-fields
+                            {
+                              align-items: stretch;
+                              display: flex;
+                            }
+                        data-automationid="DetailsRowFields"
+                        role="presentation"
+                      >
+                        <div
+                          aria-colindex={2}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column1"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          Item 9
+                        </div>
+                        <div
+                          aria-colindex={3}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column2"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          9
+                        </div>
+                        <div
+                          aria-colindex={4}
+                          aria-readonly={true}
+                          className=
+                              ms-DetailsRow-cell
+                              {
+                                box-sizing: border-box;
+                                display: inline-block;
+                                min-height: 42px;
+                                outline: transparent;
+                                overflow: hidden;
+                                padding-bottom: 11px;
+                                padding-left: 12px;
+                                padding-top: 11px;
+                                position: relative;
+                                text-overflow: ellipsis;
+                                vertical-align: top;
+                                white-space: nowrap;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #605e5c;
+                                bottom: 0px;
+                                content: "";
+                                left: 0px;
+                                outline: 1px solid #ffffff;
+                                position: absolute;
+                                right: 0px;
+                                top: 0px;
+                                z-index: 1;
+                              }
+                              & > button {
+                                max-width: 100%;
+                              }
+                              & [data-is-focusable='true'] {
+                                outline: transparent;
+                                position: relative;
+                              }
+                              & [data-is-focusable='true']::-moz-focus-inner {
+                                border: 0;
+                              }
+                              {
+                                padding-right: 8px;
+                              }
+                          data-automation-key="column3"
+                          data-automationid="DetailsRowCell"
+                          role="gridcell"
+                          style={
+                            Object {
+                              "width": 120,
+                            }
+                          }
+                        >
+                          9
+                        </div>
+                      </div>
+                      <span
+                        aria-checked={false}
+                        className=
+
+                            {
+                              bottom: 0px;
+                              display: none;
+                              left: 0px;
+                              position: absolute;
+                              right: 0px;
+                              top: -1px;
+                            }
+                        data-selection-toggle={true}
+                        role="checkbox"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -414,7 +414,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             role="columnheader"
             style={
               Object {
-                "width": 120,
+                "width": NaN,
               }
             }
           >
@@ -480,7 +480,103 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                   id="header1-column1-name"
                 >
-                  Number 1
+                  <button
+                    className=
+                        ms-Button
+                        ms-Button--action
+                        ms-Button--command
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-radius: 2px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #323130;
+                          cursor: pointer;
+                          display: inline-block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 40px;
+                          outline: transparent;
+                          padding-bottom: 0;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: center;
+                          text-decoration: none;
+                          user-select: none;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid transparent;
+                          bottom: 2px;
+                          content: "";
+                          left: 2px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 2px;
+                          top: 2px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          border-color: Window;
+                        }
+                        &:hover {
+                          color: #0078d4;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          color: Highlight;
+                        }
+                        &:hover .ms-Button-icon {
+                          color: #0078d4;
+                        }
+                        &:active {
+                          color: #000000;
+                        }
+                        &:active .ms-Button-icon {
+                          color: #004578;
+                        }
+                    data-is-focusable={true}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: flex-start;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      Number 1
+                    </span>
+                  </button>
                 </span>
               </span>
             </span>
@@ -794,7 +890,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             role="columnheader"
             style={
               Object {
-                "width": 120,
+                "width": NaN,
               }
             }
           >
@@ -951,7 +1047,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone3"
+            data-focuszone-id="FocusZone6"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -1050,7 +1146,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
@@ -1358,7 +1454,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -1472,7 +1568,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -1576,7 +1672,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
@@ -1884,7 +1980,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -1998,7 +2094,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -2102,7 +2198,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
@@ -2410,7 +2506,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -2524,7 +2620,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -2628,7 +2724,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
@@ -2936,7 +3032,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -3050,7 +3146,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -3154,7 +3250,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
@@ -3462,7 +3558,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -3576,7 +3672,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -3680,7 +3776,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone12"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
@@ -3988,7 +4084,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -4102,7 +4198,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -4206,7 +4302,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone10"
+                      data-focuszone-id="FocusZone13"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
@@ -4514,7 +4610,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -4628,7 +4724,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -4732,7 +4828,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone11"
+                      data-focuszone-id="FocusZone14"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
@@ -5040,7 +5136,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -5154,7 +5250,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -5258,7 +5354,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone12"
+                      data-focuszone-id="FocusZone15"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
@@ -5566,7 +5662,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -5680,7 +5776,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -5784,7 +5880,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                             flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone13"
+                      data-focuszone-id="FocusZone16"
                       data-is-focusable={true}
                       data-item-index={9}
                       data-selection-index={9}
@@ -6092,7 +6188,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >
@@ -6206,7 +6302,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           role="gridcell"
                           style={
                             Object {
-                              "width": 120,
+                              "width": "auto",
                             }
                           }
                         >

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2916,6 +2916,7 @@ export interface IColumn {
     data?: any;
     fieldName?: string;
     filterAriaLabel?: string;
+    flexGrow?: number;
     getValueKey?: (item?: any, index?: number, column?: IColumn) => string;
     groupAriaLabel?: string;
     headerClassName?: string;
@@ -2943,9 +2944,11 @@ export interface IColumn {
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
+    onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;
     styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
+    targetWidthProportion?: number;
 }
 
 // @public (undocumented)
@@ -3795,6 +3798,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     dragDropEvents?: IDragDropEvents;
     enableUpdateAnimations?: boolean;
     enterModalSelectionOnTouch?: boolean;
+    flexMargin?: number;
     getCellValueKey?: (item?: any, index?: number, column?: IColumn) => string;
     getGroupHeight?: IGroupedListProps['getGroupHeight'];
     getKey?: (item: any, index?: number) => string;

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { Icon, FontIcon } from '../../Icon';
 import { IProcessedStyleSet } from '../../Styling';
-import { initializeComponentRef, EventGroup, Async, IDisposable, classNamesFunction } from '../../Utilities';
+import {
+  initializeComponentRef,
+  EventGroup,
+  Async,
+  IDisposable,
+  classNamesFunction,
+  composeRenderFunction,
+} from '../../Utilities';
 import { ColumnActionsMode } from './DetailsList.types';
 import { IDragDropOptions } from '../../DragDrop';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
@@ -18,6 +25,20 @@ const getClassNames = classNamesFunction<IDetailsColumnStyleProps, IDetailsColum
 const TRANSITION_DURATION_DRAG = 200; // ms
 const TRANSITION_DURATION_DROP = 1500; // ms
 const CLASSNAME_ADD_INTERVAL = 20; // ms
+
+const defaultOnRenderHeader = (classNames: IProcessedStyleSet<IDetailsColumnStyles>) => (
+  props?: IDetailsColumnProps,
+): JSX.Element | null => {
+  if (!props) {
+    return null;
+  }
+
+  if (props.column.isIconOnly) {
+    return <span className={classNames.accessibleLabel}>{props.column.name}</span>;
+  }
+
+  return <>{props.column.name}</>;
+};
 
 /**
  * Component for rendering columns in a `DetailsList`.
@@ -67,6 +88,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
+
+    const onRenderHeader = column.onRenderHeader
+      ? composeRenderFunction(column.onRenderHeader, defaultOnRenderHeader(this._classNames))
+      : defaultOnRenderHeader(this._classNames);
 
     return (
       <>
@@ -129,11 +154,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                       <IconComponent className={classNames.iconClassName} iconName={column.iconName} />
                     )}
 
-                    {column.isIconOnly ? (
-                      <span className={classNames.accessibleLabel}>{column.name}</span>
-                    ) : (
-                      column.name
-                    )}
+                    {onRenderHeader(this.props)}
                   </span>
 
                   {column.isFiltered && <IconComponent className={classNames.nearIcon} iconName="Filter" />}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -1110,7 +1110,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     let adjustedColumns: IColumn[];
 
     if (layoutMode === DetailsListLayoutMode.fixedColumns) {
-      adjustedColumns = this._getFixedColumns(newColumns);
+      adjustedColumns = this._getFixedColumns(newColumns, viewportWidth, newProps);
 
       // Preserve adjusted column calculated widths.
       adjustedColumns.forEach(column => {
@@ -1137,12 +1137,64 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
   }
 
   /** Builds a set of columns based on the given columns mixed with the current overrides. */
-  private _getFixedColumns(newColumns: IColumn[]): IColumn[] {
+  private _getFixedColumns(newColumns: IColumn[], viewportWidth: number, props: IDetailsListProps): IColumn[] {
+    const { selectionMode = this._selection.mode, checkboxVisibility, flexMargin, skipViewportMeasures } = this.props;
+    let remainingWidth = viewportWidth - (flexMargin || 0);
+    let sumProportionalWidth = 0;
+
+    newColumns.forEach((col: IColumn) => {
+      if (skipViewportMeasures || !col.flexGrow) {
+        remainingWidth -= col.maxWidth || col.minWidth || MIN_COLUMN_WIDTH;
+      } else {
+        remainingWidth -= col.minWidth || MIN_COLUMN_WIDTH;
+        sumProportionalWidth += col.flexGrow;
+      }
+
+      remainingWidth -= getPaddedWidth(col, props, true);
+    });
+
+    const rowCheckWidth =
+      selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden ? CHECKBOX_WIDTH : 0;
+    const groupExpandWidth = this._getGroupNestingDepth() * GROUP_EXPAND_WIDTH;
+    remainingWidth -= rowCheckWidth + groupExpandWidth;
+
+    let widthFraction = remainingWidth / sumProportionalWidth;
+
+    // Shrinks proportional columns to their max width and adds the remaining width to distribute to other columns.
+    if (!skipViewportMeasures) {
+      newColumns.forEach((column: IColumn) => {
+        const newColumn: IColumn = { ...column, ...this._columnOverrides[column.key] };
+
+        if (newColumn.flexGrow && newColumn.maxWidth) {
+          const fullWidth = newColumn.flexGrow * widthFraction + newColumn.minWidth;
+          const shrinkWidth = fullWidth - newColumn.maxWidth;
+
+          if (shrinkWidth > 0) {
+            remainingWidth += shrinkWidth;
+            sumProportionalWidth -= (shrinkWidth / (fullWidth - newColumn.minWidth)) * newColumn.flexGrow;
+          }
+        }
+      });
+    }
+
+    widthFraction = remainingWidth > 0 ? remainingWidth / sumProportionalWidth : 0;
+
     return newColumns.map(column => {
       const newColumn: IColumn = { ...column, ...this._columnOverrides[column.key] };
 
+      // Delay computation until viewport width is available.
+      if (!skipViewportMeasures && newColumn.flexGrow && remainingWidth <= 0) {
+        return newColumn;
+      }
+
       if (!newColumn.calculatedWidth) {
-        newColumn.calculatedWidth = newColumn.maxWidth || newColumn.minWidth || MIN_COLUMN_WIDTH;
+        if (!skipViewportMeasures && newColumn.flexGrow) {
+          // Assigns the proportion of the remaining extra width after all columns have met minimum widths.
+          newColumn.calculatedWidth = newColumn.minWidth + newColumn.flexGrow * widthFraction;
+          newColumn.calculatedWidth = Math.min(newColumn.calculatedWidth, newColumn.maxWidth || Number.MAX_VALUE);
+        } else {
+          newColumn.calculatedWidth = newColumn.maxWidth || newColumn.minWidth || MIN_COLUMN_WIDTH;
+        }
       }
 
       return newColumn;
@@ -1158,7 +1210,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     const fixedColumns = newColumns.slice(0, resizingColumnIndex);
     fixedColumns.forEach(column => (column.calculatedWidth = this._getColumnOverride(column.key).currentWidth));
 
-    const fixedWidth = fixedColumns.reduce((total, column, i) => total + getPaddedWidth(column, i === 0, props), 0);
+    const fixedWidth = fixedColumns.reduce((total, column, i) => total + getPaddedWidth(column, props), 0);
 
     const remainingColumns = newColumns.slice(resizingColumnIndex);
     const remainingWidth = viewportWidth - fixedWidth;
@@ -1189,8 +1241,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         ...this._columnOverrides[column.key],
       };
 
-      const isFirst = i + firstIndex === 0;
-      totalWidth += getPaddedWidth(newColumn, isFirst, props);
+      totalWidth += getPaddedWidth(newColumn, props);
 
       return newColumn;
     });
@@ -1210,7 +1261,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         column.calculatedWidth = Math.max(column.calculatedWidth! - overflowWidth, minWidth);
         totalWidth -= originalWidth - column.calculatedWidth;
       } else {
-        totalWidth -= getPaddedWidth(column, false, props);
+        totalWidth -= getPaddedWidth(column, props);
         adjustedColumns.splice(lastIndex, 1);
       }
       lastIndex--;
@@ -1389,11 +1440,11 @@ export function buildColumns(
   return columns;
 }
 
-function getPaddedWidth(column: IColumn, isFirst: boolean, props: IDetailsListProps): number {
+function getPaddedWidth(column: IColumn, props: IDetailsListProps, paddingOnly?: true): number {
   const { cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = props;
 
   return (
-    column.calculatedWidth! +
+    (paddingOnly ? 0 : column.calculatedWidth!) +
     cellStyleProps.cellLeftPadding +
     cellStyleProps.cellRightPadding +
     (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0)

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -125,6 +125,113 @@ describe('DetailsList', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders a single proportional column with correct width', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    safeMount(
+      <DetailsList
+        className="list"
+        items={[{ key: 'item1' }, { key: 'item2' }, { key: 'item3' }]}
+        columns={[
+          { fieldName: 'a', key: 'col1', minWidth: 101, name: 'column 1' },
+          { fieldName: 'b', key: 'col2', minWidth: 102, name: 'column 2', flexGrow: 1 },
+          { fieldName: 'c', key: 'col3', minWidth: 103, name: 'column 3' },
+        ]}
+        componentRef={ref => (component = ref)}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        flexMargin={-640}
+        skipViewportMeasures={false}
+        onShouldVirtualize={() => false}
+      />,
+      () => {
+        expect(component).toBeTruthy();
+        component!.focusIndex(2);
+        setTimeout(() => {
+          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[aria-colindex]');
+          elements.forEach((element: Element) => {
+            const itemKey = element.getAttribute('aria-colindex')!;
+            expect(itemKey).toBeDefined();
+
+            if (itemKey === '1') {
+              return;
+            }
+
+            const style = element.getAttribute('style')!;
+            expect(style).toBeDefined();
+
+            const width = style.match(/(?<=width: )\d+/g)!;
+            expect(width).toBeDefined();
+            expect(width[0]).toBeDefined();
+
+            if (itemKey === '2') {
+              expect(width[0]).toBe('121');
+            } else if (itemKey === '3') {
+              expect(width[0]).toBe('348');
+            } else if (itemKey === '4') {
+              expect(width[0]).toBe('123');
+            } else {
+              fail('Unexpected itemKey.');
+            }
+          });
+        }, 0);
+        jest.runOnlyPendingTimers();
+      },
+    );
+  });
+
+  it('renders proportional columns with proper width ratios', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    safeMount(
+      <DetailsList
+        className="list"
+        items={[{ key: 'item1' }, { key: 'item2' }, { key: 'item3' }]}
+        columns={[
+          { fieldName: 'a', key: 'col1', minWidth: 100, name: 'column 1', flexGrow: 0.8 },
+          { fieldName: 'b', key: 'col2', minWidth: 100, name: 'column 2', flexGrow: 0.5 },
+        ]}
+        componentRef={ref => (component = ref)}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        flexMargin={-640}
+        skipViewportMeasures={false}
+        onShouldVirtualize={() => false}
+      />,
+      () => {
+        expect(component).toBeTruthy();
+        component!.focusIndex(2);
+        setTimeout(() => {
+          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[aria-colindex]');
+          elements.forEach((element: Element) => {
+            const itemKey = element.getAttribute('aria-colindex')!;
+            expect(itemKey).toBeDefined();
+
+            if (itemKey === '1') {
+              return;
+            }
+
+            const style = element.getAttribute('style')!;
+            expect(style).toBeDefined();
+
+            const width = style.match(/(?<=width: )\d+/g)!;
+            expect(width).toBeDefined();
+            expect(width[0]).toBeDefined();
+
+            if (itemKey === '2') {
+              expect(width[0]).toBe('336');
+            } else if (itemKey === '3') {
+              expect(width[0]).toBe('255');
+            } else {
+              fail('Unexpected itemKey.');
+            }
+          });
+        }, 0);
+        jest.runOnlyPendingTimers();
+      },
+    );
+  });
+
   it('renders List in compact mode correctly', () => {
     const component = renderer.create(
       <DetailsList

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -251,6 +251,9 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Accessible label for the grid within the list. */
   ariaLabelForGrid?: string;
 
+  /** An optional margin for proportional columns, to e.g. account for scrollbars when laying out width. */
+  flexMargin?: number;
+
   /**
    * Whether the role `application` should be applied to the list.
    * @defaultvalue false
@@ -340,6 +343,14 @@ export interface IColumn {
    */
   fieldName?: string;
 
+  /**
+   * If specified, the width of the column is a portion of the available space equal to this value divided by the sum
+   * of all proportional column widths in the list. For example, if there is a list with two proportional columns that
+   * have widths of 1 and 3, they will respectively occupy (1/4) = 25% and (3/4) = 75% of the remaining space. Note that
+   * this relies on viewport measures and will not work well with skipViewportMeasures.
+   */
+  flexGrow?: number;
+
   /** Class name to apply to the column cell within each row. */
   className?: string;
 
@@ -348,6 +359,14 @@ export interface IColumn {
 
   /** Minimum width for the column. */
   minWidth: number;
+
+  /**
+   * If specified, the width of the column is a portion of the available space equal to this value divided by the sum
+   * of all proportional column widths in the list. For example, if there is a list with two proportional columns that
+   * have widths of 1 and 3, they will respectively occupy (1/4) = 25% and (2/4) = 75% of the remaining space. Note that
+   * this relies on viewport measures and will not work well with skipViewportMeasures.
+   */
+  targetWidthProportion?: number;
 
   /**
    * Accessible label for the column. The column name will still be used as the primary label,
@@ -408,6 +427,9 @@ export interface IColumn {
 
   /** Custom renderer for column header divider. */
   onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
+
+  /** Custom renderer for column header content, instead of the default text rendering. */
+  onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
 
   /** Whether the list is filtered by this column. If true, shows a filter icon next to this column's name. */
   isFiltered?: boolean;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone147"
+            data-focuszone-id="FocusZone163"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -139,7 +139,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection148"
+                        id="GroupedListSection164"
                         role="rowgroup"
                       >
                         <div
@@ -210,7 +210,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection149"
+                        id="GroupedListSection165"
                         role="rowgroup"
                       >
                         <div
@@ -364,7 +364,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone147"
+            data-focuszone-id="FocusZone163"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -405,7 +405,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection148"
+                        id="GroupedListSection164"
                         role="rowgroup"
                       >
                         <div
@@ -484,7 +484,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection149"
+                        id="GroupedListSection165"
                         role="rowgroup"
                       >
                         <div
@@ -646,7 +646,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone136"
+            data-focuszone-id="FocusZone152"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -687,7 +687,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection137"
+                        id="GroupedListSection153"
                         role="rowgroup"
                       >
                         <div
@@ -748,7 +748,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection138"
+                        id="GroupedListSection154"
                         role="rowgroup"
                       >
                         <div
@@ -809,7 +809,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection139"
+                        id="GroupedListSection155"
                         role="rowgroup"
                       >
                         <div
@@ -870,7 +870,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection140"
+                        id="GroupedListSection156"
                         role="rowgroup"
                       >
                         <div
@@ -1014,7 +1014,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone136"
+            data-focuszone-id="FocusZone152"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1055,7 +1055,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection137"
+                        id="GroupedListSection153"
                         role="rowgroup"
                       >
                         <div
@@ -1116,7 +1116,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection138"
+                        id="GroupedListSection154"
                         role="rowgroup"
                       >
                         <div
@@ -1177,7 +1177,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection139"
+                        id="GroupedListSection155"
                         role="rowgroup"
                       >
                         <div
@@ -1238,7 +1238,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection140"
+                        id="GroupedListSection156"
                         role="rowgroup"
                       >
                         <div
@@ -1382,7 +1382,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone136"
+            data-focuszone-id="FocusZone152"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1423,7 +1423,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection143"
+                        id="GroupedListSection159"
                         role="rowgroup"
                       >
                         <div
@@ -1502,7 +1502,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection144"
+                        id="GroupedListSection160"
                         role="rowgroup"
                       >
                         <div
@@ -1664,7 +1664,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone136"
+            data-focuszone-id="FocusZone152"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1705,7 +1705,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection143"
+                        id="GroupedListSection159"
                         role="rowgroup"
                       >
                         <div
@@ -1784,7 +1784,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection144"
+                        id="GroupedListSection160"
                         role="rowgroup"
                       >
                         <div
@@ -3733,7 +3733,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone18"
+          data-focuszone-id="FocusZone34"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -3742,7 +3742,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header17-check"
+            aria-labelledby="header33-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -3848,7 +3848,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header17-check"
+                id="header33-check"
                 role="checkbox"
                 tabIndex={-1}
               >
@@ -4060,7 +4060,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header17-key-name"
+                aria-labelledby="header33-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4092,7 +4092,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header17-key"
+                id="header33-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -4106,7 +4106,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header17-key-name"
+                  id="header33-key-name"
                 >
                   key
                 </span>
@@ -4199,7 +4199,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone19"
+            data-focuszone-id="FocusZone35"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -6539,7 +6539,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone22"
+          data-focuszone-id="FocusZone38"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -6712,7 +6712,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header21-key-name"
+                aria-labelledby="header37-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6744,7 +6744,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header21-key"
+                id="header37-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -6758,7 +6758,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header21-key-name"
+                  id="header37-key-name"
                 >
                   key
                 </span>
@@ -6864,7 +6864,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone23"
+            data-focuszone-id="FocusZone39"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -6901,7 +6901,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader25"
+                        aria-labelledby="GroupHeader41"
                         aria-level={1}
                         className=
                             ms-GroupHeader
@@ -7088,7 +7088,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
-                            id="GroupHeader25"
+                            id="GroupHeader41"
                             role="gridcell"
                           >
                             <span>
@@ -7114,7 +7114,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 0"
                         className="ms-List"
-                        id="GroupedListSection24"
+                        id="GroupedListSection40"
                         role="rowgroup"
                       >
                         <div
@@ -7206,12 +7206,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone28"
+                                data-focuszone-id="FocusZone44"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
                                 data-selection-touch-invoke={true}
-                                id="row20-0"
+                                id="row36-0"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -7397,12 +7397,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone29"
+                                data-focuszone-id="FocusZone45"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
                                 data-selection-touch-invoke={true}
-                                id="row20-1"
+                                id="row36-1"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -7535,7 +7535,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader27"
+                        aria-labelledby="GroupHeader43"
                         aria-level={1}
                         className=
                             ms-GroupHeader
@@ -7722,7 +7722,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
-                            id="GroupHeader27"
+                            id="GroupHeader43"
                             role="gridcell"
                           >
                             <span>
@@ -7748,7 +7748,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 1"
                         className="ms-List"
-                        id="GroupedListSection26"
+                        id="GroupedListSection42"
                         role="rowgroup"
                       >
                         <div
@@ -7840,12 +7840,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone30"
+                                data-focuszone-id="FocusZone46"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
                                 data-selection-touch-invoke={true}
-                                id="row20-2"
+                                id="row36-2"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -8031,12 +8031,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone31"
+                                data-focuszone-id="FocusZone47"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
                                 data-selection-touch-invoke={true}
-                                id="row20-3"
+                                id="row36-3"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -8222,12 +8222,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone32"
+                                data-focuszone-id="FocusZone48"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}
                                 data-selection-touch-invoke={true}
-                                id="row20-4"
+                                id="row36-4"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}


### PR DESCRIPTION
#### Pull request checklist
- [x] Addresses an existing issue: Implements #16872
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adds proportional columns in DetailsList. They skip initial layout, so cannot be used with skipViewportMeasures. Here's how it works:
- viewport width is measured and maxWidth || minWidth is subtracted for each fixed column
- minWidth is subtracted for each proportional column
- column paddings and grouplist indent / select checkbox row column width is subtracted appropriately
- 32 pixels is subtracted to account for rapid layout changes or the presence of a vertical scrollbar
- the remaining extra width is divided by the sum of each column's proportional value (called width fraction)
- each column gets extra width equal to the width fraction * that column's proportional value
- if a column hits maxWidth before using all its allotted extra width, that's redistributed to remaining proportional columns

This also allows rendering custom column header content in place of normal text. This only affects the text, so you can still have a sort icon, the bar that appears between columns when moving them will still show up, etc. There was previously no decent way of changing the header content for a DetailsList column header.

Both of these changes are required by my team's design. Topic opened earlier today at https://github.com/microsoft/fluentui/issues/16872

Example of proportional columns with spacing of 1, 1, 2:
![image](https://user-images.githubusercontent.com/53879690/107256660-9d78ba80-69ee-11eb-87af-a500e565243b.png)

Example with proportional spacing of 1 and 2 with a non-proportional middle column of minWidth 100:
![image](https://user-images.githubusercontent.com/53879690/107256907-f2b4cc00-69ee-11eb-9f77-7b4293cfa213.png)

Example of button rendered in custom header:
![image](https://user-images.githubusercontent.com/53879690/107257858-fac13b80-69ef-11eb-8934-2b951d503e8a.png)

#### Focus areas to test
DetailsList