### PR TITLE
Adding svg icon to be consumed by OWA

### DIFF
--- a/change/@fluentui-react-icons-mdl2-5f146c6f-7703-44a4-bbd6-114cd8e41e57.json
+++ b/change/@fluentui-react-icons-mdl2-5f146c6f-7703-44a4-bbd6-114cd8e41e57.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding svg icon to be consumed by OWA",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-icons-mdl2/src/components/TextDocumentSettingsIcon.tsx
+++ b/packages/react-icons-mdl2/src/components/TextDocumentSettingsIcon.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import createSvgIcon from '../utils/createSvgIcon';
+
+const TextDocumentSettingsIcon = createSvgIcon({
+  svg: ({ classes }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" width="2048" height="2048">
+      <path d="M1103 1920q23 37 52 68t62 60H128V0h1115l549 549v494q-63-22-128-29V640h-512V128H256v1792h847zm177-1701v293h293l-293-293zm-128 998q-13 15-25 30t-24 33H512v-128h640v65zm-640 319v-128h512v60q0 14-4 33t-6 35H512zm896-640v128H512V896h896zm512 704q0 31-6 61l124 51-49 119-124-52q-35 51-86 86l52 124-119 49-51-124q-30 6-61 6t-61-6l-51 124-119-49 52-124q-51-35-86-86l-124 52-49-119 124-51q-6-30-6-61t6-61l-124-51 49-119 124 52q18-25 39-47t47-39l-52-124 119-49 51 124q30-6 61-6t61 6l51-124 119 49-52 124q51 35 86 86l124-52 49 119-124 51q6 30 6 61zm-128 0q0-40-15-75t-41-61-61-41-75-15q-40 0-75 15t-61 41-41 61-15 75q0 40 15 75t41 61 61 41 75 15q40 0 75-15t61-41 41-61 15-75z" />
+    </svg>
+  ),
+  displayName: 'TextDocumentSettingsIcon',
+});
+
+export default TextDocumentSettingsIcon;

--- a/packages/react-icons-mdl2/src/index.ts
+++ b/packages/react-icons-mdl2/src/index.ts
@@ -1546,6 +1546,7 @@ export { default as TextBoxIcon } from './components/TextBoxIcon';
 export { default as TextCalloutIcon } from './components/TextCalloutIcon';
 export { default as TextDocumentEditIcon } from './components/TextDocumentEditIcon';
 export { default as TextDocumentIcon } from './components/TextDocumentIcon';
+export { default as TextDocumentSettingsIcon } from './components/TextDocumentSettingsIcon';
 export { default as TextDocumentSharedIcon } from './components/TextDocumentSharedIcon';
 export { default as TextFieldIcon } from './components/TextFieldIcon';
 export { default as TextOverflowIcon } from './components/TextOverflowIcon';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `TextDocumentSettingsIcon.tsx` to `@fluentui/react-icons-mdl2` in order to OWA to be able to use it. There are a total of five icons, as shown in [this](https://github.com/microsoft/fluentui/pull/16877) PR, but 4 icons are branded, and will be added to `@fluentui/react-icons-mdl2-branded` package

#### Focus areas to test

(optional)
