### PR TITLE
Fix contrast of filter chevron against the background

### DIFF
--- a/change/office-ui-fabric-react-2021-02-08-16-07-16-chevron-contrast.json
+++ b/change/office-ui-fabric-react-2021-02-08-16-07-16-chevron-contrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix contrast of 'filter chevron' against background color",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-09T00:07:16.239Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -46,7 +46,7 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
     iconForegroundColor: semanticColors.bodySubtext,
     headerForegroundColor: semanticColors.bodyText,
     headerBackgroundColor: semanticColors.bodyBackground,
-    dropdownChevronForegroundColor: palette.neutralTertiary,
+    dropdownChevronForegroundColor: palette.neutralSecondary,
     resizerColor: palette.neutralTertiaryAlt,
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -83,7 +83,6 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
     iconForegroundColor: semanticColors.bodySubtext,
     headerForegroundColor: semanticColors.bodyText,
     headerBackgroundColor: semanticColors.bodyBackground,
-    dropdownChevronForegroundColor: palette.neutralTertiary,
     resizerColor: palette.neutralTertiaryAlt,
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -845,7 +845,7 @@ exports[`DetailsHeader can render 1`] = `
                 speak: none;
               }
               {
-                color: #a19f9d;
+                color: #605e5c;
                 font-size: 12px;
                 padding-left: 6px;
                 vertical-align: middle;
@@ -1635,7 +1635,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
                 speak: none;
               }
               {
-                color: #a19f9d;
+                color: #605e5c;
                 font-size: 12px;
                 padding-left: 6px;
                 vertical-align: middle;
@@ -2645,7 +2645,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
                 speak: none;
               }
               {
-                color: #a19f9d;
+                color: #605e5c;
                 font-size: 12px;
                 padding-left: 6px;
                 vertical-align: middle;


### PR DESCRIPTION
#### Description of changes

Fixed the color for the 'filter chevron' to use `neutraySecondary` instead of `neutralTertiary` to align with expected contrast requirements for accessibility. This was recommended by the Fluent Design team.
