### PR TITLE
[DatePicker] Support week range selection

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 - Added `CarouselPaddlesContainer` to allow verticaly centering Paddles @assuncaocharles ([#16477](https://github.com/microsoft/fluentui/pull/16477))
 - Removed `@fluentui/keyboard-key` dependency from all packages. @xugao ([#16700](https://github.com/microsoft/fluentui/pull/16700))
-- Updated `Datepicker` to allow the entire week selection. For that reason, a space between cells was removed. @vejrj ([#16887](https://github.com/microsoft/fluentui/pull/16887)) 
+- Updated `Datepicker` to allow the entire week selection and removed space between cells. @vejrj ([#16887](https://github.com/microsoft/fluentui/pull/16887))
 
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 - Added `CarouselPaddlesContainer` to allow verticaly centering Paddles @assuncaocharles ([#16477](https://github.com/microsoft/fluentui/pull/16477))
 - Removed `@fluentui/keyboard-key` dependency from all packages. @xugao ([#16700](https://github.com/microsoft/fluentui/pull/16700))
+- Updated `Datepicker` to allow the entire week selection. For that reason, a space between cells was removed.  
 
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed `Card` property `quiet` to `ghost` as per design spec. @TanelVari ([#16585](https://github.com/microsoft/fluentui/pull/16585))
 - Added `CarouselPaddlesContainer` to allow verticaly centering Paddles @assuncaocharles ([#16477](https://github.com/microsoft/fluentui/pull/16477))
 - Removed `@fluentui/keyboard-key` dependency from all packages. @xugao ([#16700](https://github.com/microsoft/fluentui/pull/16700))
-- Updated `Datepicker` to allow the entire week selection. For that reason, a space between cells was removed.  
+- Updated `Datepicker` to allow the entire week selection. For that reason, a space between cells was removed. @vejrj ([#16887](https://github.com/microsoft/fluentui/pull/16887)) 
 
 ## Fixes
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Types/DatepickerExampleWeek.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Types/DatepickerExampleWeek.shorthand.steps.ts
@@ -1,0 +1,19 @@
+import { ScreenerTestsConfig } from '@fluentui/scripts/screener';
+import { buttonClassName, datepickerCalendarCellClassName } from '@fluentui/react-northstar';
+
+const config: ScreenerTestsConfig = {
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
+  steps: [
+    builder =>
+      builder
+        .click(`.${buttonClassName}`)
+        .snapshot('Shows calendar.')
+        .hover(`.${datepickerCalendarCellClassName}:nth-child(1)`)
+        .snapshot('Calendar is opened with the entire week highlighted on hover.')
+        .click(`.${datepickerCalendarCellClassName}:nth-child(1)`)
+        .click(`.${buttonClassName}`)
+        .snapshot('Calendar is opened with selected week highlighted.'),
+  ],
+};
+
+export default config;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Types/DatepickerExampleWeek.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Types/DatepickerExampleWeek.shorthand.tsx
@@ -1,0 +1,8 @@
+import { Datepicker, DateRangeType } from '@fluentui/react-northstar';
+import * as React from 'react';
+
+const DatepickerExampleWeek = () => (
+  <Datepicker allowManualInput={false} dateRangeType={DateRangeType.Week} today={new Date(2020, 9, 1, 0, 0, 0, 0)} />
+);
+
+export default DatepickerExampleWeek;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Types/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Types/index.tsx
@@ -21,6 +21,11 @@ const Types = () => (
       examplePath="components/Datepicker/Types/DatepickerExampleNoInput"
     />
     <ComponentExample
+      title="Week selection"
+      description="The user can choose the entire week"
+      examplePath="components/Datepicker/Types/DatepickerExampleWeek"
+    />
+    <ComponentExample
       title="Localized Calendar"
       description="The dates can be localized."
       examplePath="components/Datepicker/Types/DatepickerExampleLocalizationStrings"

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -61,7 +61,7 @@ export interface DatepickerCalendarProps extends UIComponentProps, Partial<ICale
   calendarGridRow?: ShorthandValue<DatepickerCalendarGridRowProps>;
 
   /**
-   * The currently selected date range.
+   * The currently selected date range, currently only supports week.
    */
   selectedDateRange?: Date[];
 
@@ -331,7 +331,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
         }),
     });
 
-  const renderCellButton = (day: IDay, week: IDay[]) =>
+  const renderCellButton = (day: IDay, dateRange: IDay[]) =>
     createShorthand(DatepickerCalendarCellButton, calendarCellButton, {
       defaultProps: () =>
         getA11yProps('calendarCell', {
@@ -353,7 +353,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
           _.invoke(props, 'onDateChange', e, {
             ...props,
             value: day,
-            selectedDateRange: dateRangeType === DateRangeType.Week ? week : [day],
+            selectedDateRange: dateRangeType !== DateRangeType.Day ? dateRange : [day],
           });
           _.invoke(predefinedProps, 'onClick', e, predefinedProps);
         },

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -61,6 +61,11 @@ export interface DatepickerCalendarProps extends UIComponentProps, Partial<ICale
   calendarGridRow?: ShorthandValue<DatepickerCalendarGridRowProps>;
 
   /**
+   * The currently selected date range.
+   */
+  selectedDateRange?: Date[];
+
+  /**
    * The currently selected date.
    */
   selectedDate?: Date;
@@ -110,6 +115,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
     calendarCellButton,
     calendarGrid,
     calendarGridRow,
+    dateRangeType,
     header,
     selectedDate,
     navigatedDate,
@@ -325,7 +331,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
         }),
     });
 
-  const renderCellButton = (day: IDay) =>
+  const renderCellButton = (day: IDay, week: IDay[]) =>
     createShorthand(DatepickerCalendarCellButton, calendarCellButton, {
       defaultProps: () =>
         getA11yProps('calendarCell', {
@@ -344,13 +350,17 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
           _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
         },
         onClick: e => {
-          _.invoke(props, 'onDateChange', e, { ...props, value: day });
+          _.invoke(props, 'onDateChange', e, {
+            ...props,
+            value: day,
+            selectedDateRange: dateRangeType === DateRangeType.Week ? week : [day],
+          });
           _.invoke(predefinedProps, 'onClick', e, predefinedProps);
         },
         ref: compareDates(gridNavigatedDate, day.originalDate) ? focusDateRef : null,
       }),
     });
-  const renderWeekRow = (week: IDay[]) => _.map(week, (day: IDay) => renderCell(day, renderCellButton(day)));
+  const renderWeekRow = (week: IDay[]) => _.map(week, (day: IDay) => renderCell(day, renderCellButton(day, week)));
 
   const element = (
     <ElementType
@@ -407,6 +417,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
                       defaultProps: () =>
                         getA11yProps('calendarGridRow', {
                           children: renderWeekRow(week),
+                          'date-range-type': dateRangeType,
                           key: week[0].key,
                         }),
                     }),

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -417,7 +417,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
                       defaultProps: () =>
                         getA11yProps('calendarGridRow', {
                           children: renderWeekRow(week),
-                          'date-range-type': dateRangeType,
+                          isRowSelectionActive: dateRangeType === DateRangeType.Week,
                           key: week[0].key,
                         }),
                     }),

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
@@ -1,14 +1,13 @@
 import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import { BoxProps, Box } from '../Box/Box';
-import { DateRangeType } from '../../utils/date-time-utilities';
 
 export type DatepickerCalendarGridRowProps = {
-  ['date-range-type']?: DateRangeType;
+  isRowSelectionActive?: boolean;
 };
 
 export type DatepickerCalendarGridRowStylesProps = {
-  isWeekSelectionActive: boolean;
+  isRowSelectionActive?: boolean;
 };
 
 export const datepickerCalendarGridRowClassName = 'ui-datepicker__calendargridrow';
@@ -24,9 +23,10 @@ export const DatepickerCalendarGridRow = compose<
 >(Box, {
   className: datepickerCalendarGridRowClassName,
   displayName: 'DatepickerCalendarGridRow',
+  handledProps: ['isRowSelectionActive'],
   overrideStyles: true,
-  mapPropsToStylesProps: p => ({
-    isWeekSelectionActive: p['date-range-type'] === DateRangeType.Week,
+  mapPropsToStylesProps: ({ isRowSelectionActive }) => ({
+    isRowSelectionActive,
   }),
   shorthandConfig: {
     mappedProp: 'content',

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
@@ -1,10 +1,15 @@
 import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import { BoxProps, Box } from '../Box/Box';
+import { DateRangeType } from '../../utils/date-time-utilities';
 
-export type DatepickerCalendarGridRowProps = {};
+export type DatepickerCalendarGridRowProps = {
+  ['date-range-type']?: DateRangeType;
+};
 
-export type DatepickerCalendarGridRowStylesProps = {};
+export type DatepickerCalendarGridRowStylesProps = {
+  isWeekSelectionActive: boolean;
+};
 
 export const datepickerCalendarGridRowClassName = 'ui-datepicker__calendargridrow';
 /**
@@ -20,6 +25,9 @@ export const DatepickerCalendarGridRow = compose<
   className: datepickerCalendarGridRowClassName,
   displayName: 'DatepickerCalendarGridRow',
   overrideStyles: true,
+  mapPropsToStylesProps: p => ({
+    isWeekSelectionActive: p['date-range-type'] === DateRangeType.Week,
+  }),
   shorthandConfig: {
     mappedProp: 'content',
   },

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarCellButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarCellButtonStyles.ts
@@ -22,7 +22,6 @@ export const datepickerCalendarCellButtonStyles: ComponentSlotStylesPrepared<
       height: '100%',
       width: '100%',
 
-      borderRadius: v.calendarCellBorderRadius,
       cursor: 'pointer',
       border: v.calendarCellBorder,
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridRowStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridRowStyles.ts
@@ -1,10 +1,20 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { DatepickerVariables } from './datepickerVariables';
 import { DatepickerCalendarGridRowStylesProps } from '../../../../components/Datepicker/DatepickerCalendarGridRow';
+import { datepickerCalendarCellButtonClassName } from '../../../../components/Datepicker/DatepickerCalendarCellButton';
 
 export const datepickerCalendarGridRowStyles: ComponentSlotStylesPrepared<
   DatepickerCalendarGridRowStylesProps,
   DatepickerVariables
 > = {
-  root: (): ICSSInJSStyle => ({}),
+  root: ({ props: p, variables: v }): ICSSInJSStyle => {
+    return {
+      ...(p.isWeekSelectionActive && {
+        [`:hover .${datepickerCalendarCellButtonClassName}`]: {
+          backgroundColor: v.calendarCellHoverBackgroundColor,
+          color: v.calendarCellHoverColor,
+        },
+      }),
+    };
+  },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridRowStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridRowStyles.ts
@@ -9,7 +9,7 @@ export const datepickerCalendarGridRowStyles: ComponentSlotStylesPrepared<
 > = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
     return {
-      ...(p.isWeekSelectionActive && {
+      ...(p.isRowSelectionActive && {
         [`:hover .${datepickerCalendarCellButtonClassName}`]: {
           backgroundColor: v.calendarCellHoverBackgroundColor,
           color: v.calendarCellHoverColor,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarGridStyles.ts
@@ -7,6 +7,6 @@ export const datepickerCalendarGridStyles: ComponentSlotStylesPrepared<
   DatepickerVariables
 > = {
   root: (): ICSSInJSStyle => {
-    return { tableLayout: 'fixed' };
+    return { 'border-spacing': '0rem', tableLayout: 'fixed' };
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
@@ -64,5 +64,5 @@ export const datepickerVariables = (siteVars): DatepickerVariables => ({
   calendarHeaderLabelPaddingLeft: pxToRem(10),
   calendarHeaderLabelFontWeight: siteVars.fontWeightBold,
 
-  calendarMinHeight: pxToRem(282),
+  calendarMinHeight: pxToRem(268),
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
@@ -5,7 +5,6 @@ export interface DatepickerVariables {
   calendarCellBorder: string;
   calendarCellHeight: string;
   calendarCellWidth: string;
-  calendarCellBorderRadius: string;
   calendarCellPadding: string;
   calendarCellMargin: string;
   calendarCellBackgroundColor: string;
@@ -36,9 +35,8 @@ export interface DatepickerVariables {
 
 export const datepickerVariables = (siteVars): DatepickerVariables => ({
   calendarCellBorder: 'none',
-  calendarCellHeight: pxToRem(32),
-  calendarCellWidth: pxToRem(32),
-  calendarCellBorderRadius: pxToRem(2),
+  calendarCellHeight: pxToRem(34),
+  calendarCellWidth: pxToRem(34),
   calendarCellPadding: pxToRem(0),
   calendarCellMargin: pxToRem(0),
   calendarCellBackgroundColor: siteVars.colorScheme.default.background,
@@ -64,5 +62,5 @@ export const datepickerVariables = (siteVars): DatepickerVariables => ({
   calendarHeaderLabelPaddingLeft: pxToRem(10),
   calendarHeaderLabelFontWeight: siteVars.fontWeightBold,
 
-  calendarMinHeight: pxToRem(268),
+  calendarMinHeight: pxToRem(282),
 });


### PR DESCRIPTION
#### Description of changes

Datepicker can now handle `dateRangeType` containing the value "Week". When this type is active, the Datepicker will hover the entire week and this week will be sent as the prop `selectedDateRange` after submit. For now, the selected date range will be shown only in the calendar and sent to the date picker component.

Spaces between day cells were removed. For that reason, the size of the date picker is a little bit smaller.

Before
![Screenshot 2021-02-10 at 20 58 05](https://user-images.githubusercontent.com/77059398/107564491-c82b6480-6be2-11eb-847d-4a3ad25847f3.png)
After
![Screenshot 2021-02-10 at 20 57 23](https://user-images.githubusercontent.com/77059398/107564502-ccf01880-6be2-11eb-9158-5355197fa928.png)
Week selection
![Screenshot 2021-02-10 at 20 57 13](https://user-images.githubusercontent.com/77059398/107564511-cf527280-6be2-11eb-90ad-d7f2d03bca97.png)

#### Focus areas to test
Datepicker
