### PR TITLE
add msft fluent-ui team to codeowners for react-menu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,7 +85,7 @@ common/_themeOverrides.scss @phkuo
 common/_common.scss @phkuo
 
 ## Component packages
-packages/react-menu/ @ling1726 @layershifter
+packages/react-menu/ @ling1726 @layershifter @microsoft/fluent-ui
 packages/react-button/ @dzearing @khmakoto
 packages/react-cards/ @khmakoto
 packages/react-checkbox/ @khmakoto @xugao


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
**Only for react-menu as a test**

Try to add an org team to codeowners. This change will be used to test the feasibility of using github teams so that we can create larger pools of reviewers for different areas of the repo and not rely on single/pair reviewers

#### Focus areas to test

(optional)
