### PR TITLE
[v7.0] ChoiceGroup: Focus border is now visible when focus method is called

### DIFF
--- a/change/office-ui-fabric-react-2021-02-09-10-08-53-14191.json
+++ b/change/office-ui-fabric-react-2021-02-09-10-08-53-14191.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[v7.0]ChoiceGroup: Focus border is now visible when focus method is called",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-09T18:08:53.068Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -11,6 +11,7 @@ import {
   isControlled,
   getNativeProps,
   divProperties,
+  setFocusVisibility,
 } from '../../Utilities';
 import {
   IChoiceGroup,
@@ -164,6 +165,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     const elementToFocus = optionToFocus && document.getElementById(this._getOptionId(optionToFocus));
     if (elementToFocus) {
       elementToFocus.focus();
+      setFocusVisibility(true, elementToFocus as Element);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14191 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Sets focus visibility to true when the focus method is invoked
- Example: 
<img width="150" alt="focus-border-shows-after-focus-method-is-invoked" src="https://user-images.githubusercontent.com/8649804/106952912-9bf57c80-66e6-11eb-9470-07df1d92e318.png">

master PR: #16797 



