### PR TITLE
7.0 Memoize callbacks to reduce UPP re-renders

### DIFF
--- a/change/@uifabric-experiments-2021-02-09-14-27-16-memoization7.0.json
+++ b/change/@uifabric-experiments-2021-02-09-14-27-16-memoization7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Memoize callbacks to reduce UPP re-renders",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-09T22:27:16.716Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -4,7 +4,9 @@ import { SelectedPersona } from './Items/SelectedPersona';
 import { ISelectedItemsListProps, ISelectedItemsList, BaseSelectedItem } from '../SelectedItemsList.types';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 
-export type ISelectedPeopleListProps<TPersona> = ISelectedItemsListProps<TPersona>;
+export type ISelectedPeopleListProps<
+  TPersona extends IPersonaProps & BaseSelectedItem = IPersonaProps
+> = ISelectedItemsListProps<TPersona>;
 
 export type ISelectedPeopleList<TPersona extends IPersonaProps & BaseSelectedItem = IPersonaProps> = ISelectedItemsList<
   TPersona

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -520,7 +520,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const _onFloatingSuggestionsDismiss = React.useCallback(
     (ev: React.MouseEvent): void => {
-      onFloatingSuggestionsDismiss?.();
+      onFloatingSuggestionsDismiss?.(ev);
       showPicker(false);
     },
     [onFloatingSuggestionsDismiss, showPicker],

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -180,8 +180,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const _onDropAutoFill = (event?: React.DragEvent<HTMLDivElement>) => {
     event?.preventDefault();
-    if (props.onDropAutoFill) {
-      props.onDropAutoFill(event);
+    if (onDropAutoFill) {
+      onDropAutoFill(event);
     } else {
       insertIndex = selectedItems.length;
       _onDropInner(event?.dataTransfer);
@@ -227,7 +227,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (dataTransfer) {
       const data = dataTransfer.items;
       for (let i = 0; i < data.length; i++) {
-        if (data[i].kind === 'string' && data[i].type === props.customClipboardType) {
+        if (data[i].kind === 'string' && data[i].type === customClipboardType) {
           isDropHandled = true;
           data[i].getAsString((dropText: string) => {
             if (deserializeItemsFromDrop) {
@@ -252,10 +252,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     setDraggedIndex(draggedItemIndex);
     if (event) {
       const dataList = event?.dataTransfer?.items;
-      if (serializeItemsForDrag && props.customClipboardType) {
+      if (serializeItemsForDrag && customClipboardType) {
         const draggedItems = focusedItemIndices.includes(draggedItemIndex) ? [...getSelectedItems()] : [item];
         const dragText = serializeItemsForDrag(draggedItems);
-        dataList?.add(dragText, props.customClipboardType);
+        dataList?.add(dragText, customClipboardType);
       }
     }
   };
@@ -514,7 +514,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onItemsRemoved: _onRemoveSelectedItems,
       replaceItem: _replaceItem,
       dragDropHelper: dragDropHelper,
-      dragDropEvents: props.dragDropEvents ? props.dragDropEvents : defaultDragDropEvents,
+      dragDropEvents: dragDropEvents ? dragDropEvents : defaultDragDropEvents,
     });
   };
 
@@ -555,7 +555,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _renderFloatingPicker = () =>
     onRenderFloatingSuggestions({
       ...floatingSuggestionProps,
-      pickerWidth: props.floatingSuggestionProps.pickerWidth ? props.floatingSuggestionProps.pickerWidth : '300px',
+      pickerWidth: pickerWidth || '300px',
       targetElement: input.current?.inputElement,
       isSuggestionsVisible: isSuggestionsShown,
       suggestions: suggestionItems,

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -36,104 +36,122 @@ export const useSelectedItems = <T extends {}>(
     setSelectedItems(selectedItems ? selectedItems : []);
   }, [selectedItems]);
 
-  const addItems = (itemsToAdd: T[]): void => {
-    const newItems: T[] = items.concat(itemsToAdd);
-    setSelectedItems(newItems);
-    selection.setItems(newItems);
-  };
+  const addItems = React.useCallback(
+    (itemsToAdd: T[]): void => {
+      const newItems: T[] = items.concat(itemsToAdd);
+      setSelectedItems(newItems);
+      selection.setItems(newItems);
+    },
+    [items, selection],
+  );
 
-  const dropItemsAt = (insertIndex: number, itemsToAdd: T[], indicesToRemove: number[]): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = [];
+  const dropItemsAt = React.useCallback(
+    (insertIndex: number, itemsToAdd: T[], indicesToRemove: number[]): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = [];
 
-    for (let i = 0; i < currentItems.length; i++) {
-      const item = currentItems[i];
-      // If this is the insert before index, insert the dragged items, then the current item
-      if (i === insertIndex) {
+      for (let i = 0; i < currentItems.length; i++) {
+        const item = currentItems[i];
+        // If this is the insert before index, insert the dragged items, then the current item
+        if (i === insertIndex) {
+          itemsToAdd.forEach(draggedItem => {
+            updatedItems.push(draggedItem);
+          });
+        }
+        if (!indicesToRemove.includes(i)) {
+          // only insert items into the new list that are not being dragged
+          updatedItems.push(item);
+        }
+      }
+      // if the insert index is at the end, add them now
+      if (insertIndex === currentItems.length) {
         itemsToAdd.forEach(draggedItem => {
           updatedItems.push(draggedItem);
         });
       }
-      if (!indicesToRemove.includes(i)) {
-        // only insert items into the new list that are not being dragged
-        updatedItems.push(item);
-      }
-    }
-    // if the insert index is at the end, add them now
-    if (insertIndex === currentItems.length) {
-      itemsToAdd.forEach(draggedItem => {
-        updatedItems.push(draggedItem);
-      });
-    }
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
-
-  const removeItemAt = (index: number): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = currentItems.slice(0, index).concat(currentItems.slice(index + 1));
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
-
-  const removeItem = (item: T): void => {
-    const currentItems: T[] = [...items];
-    const index: number = currentItems.indexOf(item);
-    removeItemAt(index);
-  };
-
-  const replaceItem = (itemToReplace: T, itemsToReplaceWith: T[]): void => {
-    const currentItems: T[] = [...items];
-    const index: number = items.indexOf(itemToReplace);
-
-    if (index > -1) {
-      const updatedItems = currentItems
-        .slice(0, index)
-        .concat(itemsToReplaceWith)
-        .concat(currentItems.slice(index + 1));
       setSelectedItems(updatedItems);
       selection.setItems(updatedItems);
-    }
-  };
+    },
+    [items, selection],
+  );
 
-  const removeItems = (itemsToRemove: any[]): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = currentItems;
-    // Intentionally not using .filter here as we want to only remove a specific
-    // item in case of duplicates of same item.
-    itemsToRemove.forEach(item => {
-      const index: number = updatedItems.indexOf(item);
-      updatedItems.splice(index, 1);
-    });
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
-  };
+  const removeItemAt = React.useCallback(
+    (index: number): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = currentItems.slice(0, index).concat(currentItems.slice(index + 1));
+      setSelectedItems(updatedItems);
+      selection.setItems(updatedItems);
+    },
+    [items, selection],
+  );
 
-  const removeSelectedItems = (): void => {
-    removeItems(getSelectedItems());
-  };
+  const removeItem = React.useCallback(
+    (item: T): void => {
+      const currentItems: T[] = [...items];
+      const index: number = currentItems.indexOf(item);
+      removeItemAt(index);
+    },
+    [items, removeItemAt],
+  );
 
-  const getSelectedItems = (): T[] => {
-    if (hasSelectedItems()) {
-      return selection.getSelection() as T[];
-    } else {
-      return [];
-    }
-  };
+  const replaceItem = React.useCallback(
+    (itemToReplace: T, itemsToReplaceWith: T[]): void => {
+      const currentItems: T[] = [...items];
+      const index: number = items.indexOf(itemToReplace);
 
-  const hasSelectedItems = (): Boolean => {
+      if (index > -1) {
+        const updatedItems = currentItems
+          .slice(0, index)
+          .concat(itemsToReplaceWith)
+          .concat(currentItems.slice(index + 1));
+        setSelectedItems(updatedItems);
+        selection.setItems(updatedItems);
+      }
+    },
+    [items, selection],
+  );
+
+  const removeItems = React.useCallback(
+    (itemsToRemove: any[]): void => {
+      const currentItems: T[] = [...items];
+      const updatedItems: T[] = currentItems;
+      // Intentionally not using .filter here as we want to only remove a specific
+      // item in case of duplicates of same item.
+      itemsToRemove.forEach(item => {
+        const index: number = updatedItems.indexOf(item);
+        updatedItems.splice(index, 1);
+      });
+      setSelectedItems(updatedItems);
+      selection.setItems(updatedItems);
+    },
+    [items, selection],
+  );
+
+  const hasSelectedItems = React.useCallback((): Boolean => {
     if (items.length && selection.getSelectedCount() > 0) {
       return true;
     } else {
       return false;
     }
-  };
+  }, [items.length, selection]);
 
-  const unselectAll = (): void => {
+  const getSelectedItems = React.useCallback((): T[] => {
+    if (hasSelectedItems()) {
+      return selection.getSelection() as T[];
+    } else {
+      return [];
+    }
+  }, [hasSelectedItems, selection]);
+
+  const removeSelectedItems = React.useCallback((): void => {
+    removeItems(getSelectedItems());
+  }, [removeItems, getSelectedItems]);
+
+  const unselectAll = React.useCallback((): void => {
     if (hasSelectedItems()) {
       selection.setAllSelected(false);
     }
-  };
+  }, [hasSelectedItems, selection]);
 
   return {
     selectedItems: items,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 - #16830 

Many callbacks in UPP and nested components aren't memoised and were causing a ton of needless re-renders on every interaction. Fixed that to greatly reduce renders and improve performance especially with emails with a lot of recipients.
