### PR TITLE
[v7.0] PersonaCoin: now accepts initialsTextColor prop which sets the text color of the Persona Coin

### DIFF
--- a/change/office-ui-fabric-react-2021-02-09-16-05-28-13323-v7.json
+++ b/change/office-ui-fabric-react-2021-02-09-16-05-28-13323-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "PersonaCoin: now accepts initialsTextColor prop which sets the text color of the Persona Coin",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-10T00:05:28.805Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6532,6 +6532,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
     imageShouldStartVisible?: boolean;
     imageUrl?: string;
     initialsColor?: PersonaInitialsColor | string;
+    initialsTextColor?: string;
     isOutOfOffice?: boolean;
     onPhotoLoadingStateChange?: (newImageLoadState: ImageLoadState) => void;
     // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -63,6 +63,7 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
       imageShouldStartVisible,
       imageUrl,
       initialsColor,
+      initialsTextColor,
       isOutOfOffice,
       onPhotoLoadingStateChange,
       // eslint-disable-next-line deprecation/deprecation
@@ -86,6 +87,7 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
       imageShouldStartVisible,
       imageUrl,
       initialsColor,
+      initialsTextColor,
       onPhotoLoadingStateChange,
       onRenderCoin,
       onRenderInitials,

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -88,6 +88,11 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
    */
   initialsColor?: PersonaInitialsColor | string;
 
+  /**
+   * The text color when the user's initials are displayed
+   */
+  initialsTextColor?: string;
+
   /** The colors to be used for the presence-icon and it's background */
   presenceColors?: {
     available: string;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -74,6 +74,7 @@ export class PersonaCoinBase extends React.Component<IPersonaCoinProps, IPersona
       coinSize,
       styles,
       imageUrl,
+      initialsTextColor,
       isOutOfOffice,
       /* eslint-disable deprecation/deprecation */
       onRenderCoin = this._onRenderCoin,
@@ -127,7 +128,10 @@ export class PersonaCoinBase extends React.Component<IPersonaCoinProps, IPersona
               <div
                 className={mergeStyles(
                   classNames.initials,
-                  !showUnknownPersonaCoin && { backgroundColor: getPersonaInitialsColor(this.props) },
+                  !showUnknownPersonaCoin && {
+                    backgroundColor: getPersonaInitialsColor(this.props),
+                    color: initialsTextColor,
+                  },
                 )}
                 style={coinSizeStyle}
                 aria-hidden="true"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13323 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
cherry-picking master PR: #16873 

- PersonaCoin component now takes prop initialsTextColor which sets the text color.
- Persona component now passes initialsTextColor prop to PersonaCoin.
