### PR TITLE
Update CODEOWNERS for .github and other .folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,9 @@ lerna.json @ecraig12345
 .codesandbox @ecraig12345
 .devops @ecraig12345
 .eslintrc.* @ecraig12345
+.gitattributes @ecraig12345
 .githooks @ecraig12345
+.gitignore @ecraig12345
 .npmrc @ecraig12345
 .npmignore @ecraig12345
 .vscode @ecraig12345

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,13 +27,18 @@ yarn.lock @ecraig12345 @dzearing @xugao
 *.yml @ecraig12345
 tsconfig.json @ecraig12345
 lerna.json @ecraig12345
-LICENSE @ecraig12345
-.git* @ecraig12345
 .codesandbox @ecraig12345
+.devops @ecraig12345
 .eslintrc.* @ecraig12345
+.githooks @ecraig12345
 .npmrc @ecraig12345
 .npmignore @ecraig12345
+.vscode @ecraig12345
 sizeauditor.json @aftab-hassan @ecraig12345
+
+#### Repo stuff
+LICENSE @justSlone
+.github @justSlone
 
 #### Fluent UI N*
 packages/a11y-rules/ @kolaps33 @assuncaocharles @layershifter @miroslavstastny @dzearing @pompomon @jurokapsiar @ling1726
@@ -46,7 +51,7 @@ packages/web-components @chrisdholt @EisenbergEffect @nicholasrice
 #### Apps
 # component-demo/
 public-docsite/ @ecraig12345
-public-docsite-resources/ @ecraig12345
+public-docsite-resources/ @ecraig12345 @justSlone
 perf-test/ @JasonGore @xugao
 # ssr-tests/
 # test-bundle-button/ @dzearing


### PR DESCRIPTION
#### Description of changes

Updates code owners with a few purposes:
- Give @JustSlone codeownership of .github folder (templates, codeowners)
- Give @JustSlone ownership of LICENSE seems reasonable
- Give @JustSlone co-ownership of doc-site-resources for approving documentation changes
- Give @ecraig12345 explicit ownership of a few build folders
- Converge .git* to explict .githooks folder