### PR TITLE
Charting: Narrator issue fixed in bar charts.

### DIFF
--- a/change/@uifabric-charting-2021-02-10-13-22-38-user-v-jasha-NarratorIssues.json
+++ b/change/@uifabric-charting-2021-02-10-13-22-38-user-v-jasha-NarratorIssues.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Narrator issues fixed in bar charts and updated test cases",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-02-10T07:52:38.780Z"
+}

--- a/change/@uifabric-charting-2021-02-10-13-22-38-user-v-jasha-NarratorIssues.json
+++ b/change/@uifabric-charting-2021-02-10-13-22-38-user-v-jasha-NarratorIssues.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Narrator issues fixed in bar charts and updated test cases",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2021-02-10T07:52:38.780Z"
 }

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -292,7 +292,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             width={widthOfBar}
             x={xScale1(datasetKey)!}
             y={Math.max(containerHeight! - this.margins.bottom! - yBarScale(pointData.data), 0)}
-            data-is-focusable={true}
+            data-is-focusable={!this.props.hideTooltip}
             opacity={this._getOpacity(pointData.legend)}
             ref={(e: SVGRectElement | null) => {
               this._refCallback(e!, pointData.legend, refIndexNumber);
@@ -304,6 +304,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             onFocus={this._onBarFocus.bind(this, pointData, refIndexNumber)}
             onBlur={this._onBarLeave}
             onClick={this._redirectToUrl.bind(this, this.props.href!)}
+            aria-labelledby={`toolTip${this._calloutId}`}
           />,
         );
     });

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -121,6 +122,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -141,6 +143,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -165,6 +168,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -185,6 +189,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -205,6 +210,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout0"
             className=
 
                 {
@@ -662,6 +668,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -682,6 +689,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -702,6 +710,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -726,6 +735,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -746,6 +756,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -766,6 +777,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout14"
             className=
 
                 {
@@ -1203,6 +1215,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1223,6 +1236,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1243,6 +1257,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1267,6 +1282,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1287,6 +1303,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1307,6 +1324,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout5"
             className=
 
                 {
@@ -1434,12 +1452,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#0078d4"
             height={0}
             onBlur={[Function]}
@@ -1454,12 +1473,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#00188f"
             height={0}
             onBlur={[Function]}
@@ -1474,12 +1494,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#00bcf2"
             height={0}
             onBlur={[Function]}
@@ -1498,12 +1519,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#0078d4"
             height={0}
             onBlur={[Function]}
@@ -1518,12 +1540,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#00188f"
             height={0}
             onBlur={[Function]}
@@ -1538,12 +1561,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout9"
             className=
 
                 {
                   cursor: default;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             fill="#00bcf2"
             height={0}
             onBlur={[Function]}
@@ -1995,6 +2019,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2015,6 +2040,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2035,6 +2061,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2059,6 +2086,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2079,6 +2107,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2099,6 +2128,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout19"
             className=
 
                 {
@@ -2556,6 +2586,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -2576,6 +2607,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -2596,6 +2628,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -2620,6 +2653,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -2640,6 +2674,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -2660,6 +2695,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout24"
             className=
 
                 {
@@ -3117,6 +3153,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
           transform="translate(12.222222222222221, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {
@@ -3137,6 +3174,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             y={5.333333333333329}
           />
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {
@@ -3157,6 +3195,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {
@@ -3181,6 +3220,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
           transform="translate(-15.555555555555554, 0)"
         >
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {
@@ -3201,6 +3241,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             y={0}
           />
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {
@@ -3221,6 +3262,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             y={20}
           />
           <rect
+            aria-labelledby="toolTipcallout29"
             className=
 
                 {

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -159,7 +159,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           ref={(e: SVGGElement) => {
             this._refCallback(e, point.legend!);
           }}
-          data-is-focusable={true}
+          data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -245,7 +245,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           ref={(e: SVGGElement) => {
             this._refCallback(e, legend.title);
           }}
-          data-is-focusable={true}
+          data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1450,7 +1450,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
-              data-is-focusable={true}
+              data-is-focusable={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1476,7 +1476,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
-              data-is-focusable={true}
+              data-is-focusable={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1567,7 +1567,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
-              data-is-focusable={true}
+              data-is-focusable={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1593,7 +1593,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
-              data-is-focusable={true}
+              data-is-focusable={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -793,7 +793,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -820,7 +820,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
-            data-is-focusable={true}
+            data-is-focusable={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -466,13 +466,13 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           className={this._classNames.opacityChangeOnHover}
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
-          data-is-focusable={true}
+          data-is-focusable={!this.props.hideTooltip}
           height={Math.max(yBarScale(point.y), 0)}
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!);
           }}
           onMouseOver={this._onBarHover.bind(this, point, colorScale(point.y))}
-          aria-labelledby={this._calloutId}
+          aria-labelledby={`toolTip${this._calloutId}`}
           onMouseLeave={this._onBarLeave}
           onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
           onBlur={this._onBarLeave}
@@ -515,14 +515,14 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
           height={Math.max(yBarScale(point.y), 0)}
-          aria-labelledby={this._calloutId}
+          aria-labelledby={`toolTip${this._calloutId}`}
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!);
           }}
           onMouseOver={this._onBarHover.bind(this, point, colorScale(point.y))}
           onMouseLeave={this._onBarLeave}
           onBlur={this._onBarLeave}
-          data-is-focusable={true}
+          data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
           fill={point.color ? point.color : colorScale(point.y)}
         />

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
       />
       <g>
         <rect
-          aria-labelledby="callout0"
+          aria-labelledby="toolTipcallout0"
           className=
 
               {
@@ -116,7 +116,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
           y={-24}
         />
         <rect
-          aria-labelledby="callout0"
+          aria-labelledby="toolTipcallout0"
           className=
 
               {
@@ -134,7 +134,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
           y={20}
         />
         <rect
-          aria-labelledby="callout0"
+          aria-labelledby="toolTipcallout0"
           className=
 
               {
@@ -585,7 +585,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
       />
       <g>
         <rect
-          aria-labelledby="callout14"
+          aria-labelledby="toolTipcallout14"
           className=
 
               {
@@ -603,7 +603,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           y={-24}
         />
         <rect
-          aria-labelledby="callout14"
+          aria-labelledby="toolTipcallout14"
           className=
 
               {
@@ -621,7 +621,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           y={20}
         />
         <rect
-          aria-labelledby="callout14"
+          aria-labelledby="toolTipcallout14"
           className=
 
               {
@@ -1052,7 +1052,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
       />
       <g>
         <rect
-          aria-labelledby="callout5"
+          aria-labelledby="toolTipcallout5"
           className=
 
               {
@@ -1070,7 +1070,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
           y={-24}
         />
         <rect
-          aria-labelledby="callout5"
+          aria-labelledby="toolTipcallout5"
           className=
 
               {
@@ -1088,7 +1088,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
           y={20}
         />
         <rect
-          aria-labelledby="callout5"
+          aria-labelledby="toolTipcallout5"
           className=
 
               {
@@ -1209,13 +1209,13 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
       />
       <g>
         <rect
-          aria-labelledby="callout9"
+          aria-labelledby="toolTipcallout9"
           className=
 
               {
                 opacity: ;
               }
-          data-is-focusable={true}
+          data-is-focusable={false}
           fill="#0078d4"
           height={0}
           onBlur={[Function]}
@@ -1227,13 +1227,13 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
           y={-24}
         />
         <rect
-          aria-labelledby="callout9"
+          aria-labelledby="toolTipcallout9"
           className=
 
               {
                 opacity: ;
               }
-          data-is-focusable={true}
+          data-is-focusable={false}
           fill="#002050"
           height={0}
           onBlur={[Function]}
@@ -1245,13 +1245,13 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
           y={20}
         />
         <rect
-          aria-labelledby="callout9"
+          aria-labelledby="toolTipcallout9"
           className=
 
               {
                 opacity: ;
               }
-          data-is-focusable={true}
+          data-is-focusable={false}
           fill="#00188f"
           height={0}
           onBlur={[Function]}
@@ -1696,7 +1696,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
       />
       <g>
         <rect
-          aria-labelledby="callout19"
+          aria-labelledby="toolTipcallout19"
           className=
 
               {
@@ -1714,7 +1714,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
           y={-24}
         />
         <rect
-          aria-labelledby="callout19"
+          aria-labelledby="toolTipcallout19"
           className=
 
               {
@@ -1732,7 +1732,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
           y={20}
         />
         <rect
-          aria-labelledby="callout19"
+          aria-labelledby="toolTipcallout19"
           className=
 
               {
@@ -2183,7 +2183,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
       />
       <g>
         <rect
-          aria-labelledby="callout24"
+          aria-labelledby="toolTipcallout24"
           className=
 
               {
@@ -2201,7 +2201,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
           y={-24}
         />
         <rect
-          aria-labelledby="callout24"
+          aria-labelledby="toolTipcallout24"
           className=
 
               {
@@ -2219,7 +2219,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
           y={20}
         />
         <rect
-          aria-labelledby="callout24"
+          aria-labelledby="toolTipcallout24"
           className=
 
               {
@@ -2670,7 +2670,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
       />
       <g>
         <rect
-          aria-labelledby="callout29"
+          aria-labelledby="toolTipcallout29"
           className=
 
               {
@@ -2688,7 +2688,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
           y={-24}
         />
         <rect
-          aria-labelledby="callout29"
+          aria-labelledby="toolTipcallout29"
           className=
 
               {
@@ -2706,7 +2706,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
           y={20}
         />
         <rect
-          aria-labelledby="callout29"
+          aria-labelledby="toolTipcallout29"
           className=
 
               {

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -697,8 +697,8 @@ export class VerticalStackedBarChartBase extends React.Component<
           href: this.props.href,
         });
         const rectFocusProps = !shouldFocusWholeStack && {
-          'data-is-focusable': true,
-          'aria-labelledby': this._calloutId,
+          'data-is-focusable': !this.props.hideTooltip,
+          'aria-labelledby': `toolTip${this._calloutId}`,
           onMouseOver: this._onRectHover.bind(this, singleChartData.xAxisPoint, point, color),
           onMouseMove: this._onRectHover.bind(this, singleChartData.xAxisPoint, point, color),
           onMouseLeave: this._handleMouseOut,
@@ -752,7 +752,8 @@ export class VerticalStackedBarChartBase extends React.Component<
       });
       const groupRef: IRefArrayData = {};
       const stackFocusProps = shouldFocusWholeStack && {
-        'data-is-focusable': true,
+        'data-is-focusable': !this.props.hideTooltip,
+        'aria-labelledby': `toolTip${this._calloutId}`,
         onMouseOver: this._onStackHover.bind(this, singleChartData),
         onMouseMove: this._onStackHover.bind(this, singleChartData),
         onMouseLeave: this._handleMouseOut,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/16140
- [x] Include a change request file using `$ yarn change`

#### Description of changes
(cherry-pick of https://github.com/microsoft/fluentui/pull/16914 to 7.0)
> Updated `aria-labelledby` property in bar charts.
> Updated the focus to the chart when callout disabled.

#### Focus areas to test

Narrator issue fixes in,
> Vertical bar chart
> Vertical stacked bar chart
> Grouped vertical bar chart
> Stacked bar chart