### PR TITLE
fix(Tree): change selectionIndicator from visibility:hidden to display:none

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updating various icons, `ArrowSortIcon`, `BreakoutRoomIcon`, `CalendarAgendaIcon`, `CallControlCloseTrayIcon`, `PlayIcon`, `TenantPersonalIcon` @notandrew ([#16723](https://github.com/microsoft/fluentui/pull/16723))
 - Export treeContext from `Tree` @yuanboxue-amber ([#16891](https://github.com/microsoft/fluentui/pull/16891))
 - Add missing prop type for `Dropdown` @pompomon ([#16920](https://github.com/microsoft/fluentui/pull/16920))
+- Change `TreeTitle`'s `selectionIndicator` from visibility:hidden to display:none @yuanboxue-amber ([#16922](https://github.com/microsoft/fluentui/pull/16922))
 
 ## Features
 - Added `disabledFocusable` prop for `Button` component. @jurokapsiar ([#16419](https://github.com/microsoft/fluentui/pull/16419))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeItemStyles.ts
@@ -12,7 +12,7 @@ export const treeItemStyles: ComponentSlotStylesPrepared<TreeItemStylesProps> = 
       ':focus': {
         ...(p.selectable && {
           [`& .${treeTitleSlotClassNames.indicator}`]: {
-            visibility: 'visible',
+            display: 'inline-block',
           },
         }),
         ...borderFocusStyles[':focus'],
@@ -21,7 +21,7 @@ export const treeItemStyles: ComponentSlotStylesPrepared<TreeItemStylesProps> = 
         outline: 0,
         ...(p.selectable && {
           [`& .${treeTitleSlotClassNames.indicator}`]: {
-            visibility: 'visible',
+            display: 'inline-block',
           },
         }),
         [`> .${treeTitleClassName}`]: {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeTitleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeTitleStyles.ts
@@ -27,7 +27,7 @@ export const treeTitleStyles: ComponentSlotStylesPrepared<TreeTitleStylesProps, 
       ':focus': {
         ...(p.selectable && {
           [`> .${treeTitleSlotClassNames.indicator}`]: {
-            visibility: 'visible',
+            display: 'inline-block',
           },
         }),
         ...borderFocusStyles[':focus'],
@@ -37,21 +37,20 @@ export const treeTitleStyles: ComponentSlotStylesPrepared<TreeTitleStylesProps, 
         ...(p.selectable && {
           background: v.hoverBackground,
           [`> .${treeTitleSlotClassNames.indicator}`]: {
-            visibility: 'visible',
+            display: 'inline-block',
           },
         }),
       },
       ...(p.showIndicator && {
         [`> .${treeTitleSlotClassNames.indicator}`]: {
-          visibility: 'visible',
+          display: 'inline-block',
         },
       }),
     };
   },
 
   selectionIndicator: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    display: 'inline-block',
-    visibility: 'hidden',
+    display: 'none',
     float: 'right',
     verticalAlign: 'middle',
     boxShadow: 'unset',


### PR DESCRIPTION
…y:none

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

As described in title.
`visibility: hidden` cause problem because the selectionIndicator still takes width

#### Focus areas to test

(optional)
