### PR TITLE
7.0: Fix bug with DefaultEditingItem where mouse selection of suggestions didn't work

### DIFF
--- a/change/@uifabric-experiments-2021-02-10-11-29-46-mousebugfix7.0.json
+++ b/change/@uifabric-experiments-2021-02-10-11-29-46-mousebugfix7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where moue selected suggestions did not work in DefaultEditingItem",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-10T19:29:46.774Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -151,15 +151,21 @@ export const DefaultEditingItemInner = <TItem extends any>(
 
   const _onInputBlur = React.useCallback(
     (ev: React.FocusEvent<HTMLElement>): void => {
-      if (focusItemIndex >= 0) {
-        _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
-      } else if (createGenericItem) {
-        onEditingComplete(item, createGenericItem(inputValue));
+      if (editingFloatingPicker.current) {
+        const target = ev.relatedTarget as HTMLElement;
+        // We don't want to exit out if the user has clicked on a dropdown suggestion
+        if (target === null || target.className.indexOf('ms-FloatingSuggestionsItem-itemButton') === -1) {
+          if (focusItemIndex >= 0) {
+            _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+          } else if (createGenericItem) {
+            onEditingComplete(item, createGenericItem(inputValue));
+          }
+          // else, we come out of editing mode
+        }
       }
-      // else, we come out of editing mode
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- these are the only dependencies which matter
-    [suggestionItems, focusItemIndex, item, createGenericItem, inputValue, onEditingComplete],
+    [suggestionItems, focusItemIndex, item, createGenericItem, inputValue, onEditingComplete, editingFloatingPicker],
   );
 
   const _onInputChange = React.useCallback(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 - #16929 

Previously, when selecting a suggestion item with the mouse, the code would complete with whatever item was keyboard selected instead. This was because onBlur was getting called before onSuggestionSelected and that was the default behavior there.

To fix this, I added an exception in the onBlur function so that it doesn't run that code if the click target was a suggestion item, which allows onSuggestionSelected to run and the right item to be inserted.

Tested:
- mouse selection (right item is inserted)
- keyboard selection (right item is inserted)
- clicking into the regular autocomplete input (onblur is called correctly)
- clicking other places, such as other tabs (onblur is called correctly)
