### PR TITLE
7.0: UnifiedPicker: Don't show picker after input is cleared

### DIFF
--- a/change/@uifabric-experiments-2021-02-10-14-48-09-pickerpopupfix7.0.json
+++ b/change/@uifabric-experiments-2021-02-10-14-48-09-pickerpopupfix7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker: Don't show picker after input is cleared",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-10T22:48:09.806Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -459,7 +459,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         else if (focusItemIndex === -1 && headerItemIndex === -1 && footerItemIndex === -1) {
           setFocusItemIndex(0);
         }
-        !isSuggestionsShown ? showPicker(true) : null;
+        // suggestions isn't showing and we haven't just cleared the input, show the picker
+        !isSuggestionsShown && value !== '' ? showPicker(true) : null;
         if (!resultItemsList) {
           resultItemsList = [];
         }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 - #16937 

If the picker is already hidden and the query string is empty, don't show the picker
