### PR TITLE
UnifiedPicker: Don't show picker after input is cleared

### DIFF
--- a/change/@fluentui-react-experiments-74f78e6d-e0d1-4f9d-9504-b17e6521c623.json
+++ b/change/@fluentui-react-experiments-74f78e6d-e0d1-4f9d-9504-b17e6521c623.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "UnifiedPicker: Don't show picker after input is cleared",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -453,7 +453,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         else if (focusItemIndex === -1 && headerItemIndex === -1 && footerItemIndex === -1) {
           setFocusItemIndex(0);
         }
-        !isSuggestionsShown ? showPicker(true) : null;
+        // if suggestions aren't showing and we haven't just cleared the input, show the picker
+        !isSuggestionsShown && value !== '' ? showPicker(true) : null;
         if (!resultItemsList) {
           resultItemsList = [];
         }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If the picker is already hidden and the query string is empty, don't show the picker