### PR TITLE
fix(react-utils): fix/root slot props passing everything for when `as` is undefined

### DIFF
--- a/change/@fluentui-react-menu-c6bb49b3-0965-41af-bc1a-71b341e4bf0b.json
+++ b/change/@fluentui-react-menu-c6bb49b3-0965-41af-bc1a-71b341e4bf0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix snapshots",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utils-0fdababc-5d60-4bde-8148-548635eed6b5.json
+++ b/change/@fluentui-react-utils-0fdababc-5d60-4bde-8148-548635eed6b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix root slot props passing everything",
+  "packageName": "@fluentui/react-utils",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -3,12 +3,6 @@
 exports[`MenuItem renders a default state 1`] = `
 <div
   className=""
-  icon={
-    Object {
-      "as": "span",
-      "className": "",
-    }
-  }
   role="menuitem"
   tabIndex={0}
 >

--- a/packages/react-utils/src/compose/getSlots.test.tsx
+++ b/packages/react-utils/src/compose/getSlots.test.tsx
@@ -96,4 +96,11 @@ describe('getSlots', () => {
       slotProps: { root: {}, input: { children: null } },
     });
   });
+
+  it('should use `div` as default root element', () => {
+    expect(getSlots({ icon: { children: 'foo' }, customProp: 'bar' }, ['icon'])).toEqual({
+      slots: { root: 'div', icon: 'span' },
+      slotProps: { root: {}, icon: { children: 'foo' } },
+    });
+  });
 });

--- a/packages/react-utils/src/compose/getSlots.ts
+++ b/packages/react-utils/src/compose/getSlots.ts
@@ -23,8 +23,9 @@ export const getSlots = (state: GenericDictionary, slotNames?: string[] | undefi
   const slots: GenericDictionary = {
     root: state.as || 'div',
   };
+
   const slotProps: GenericDictionary = {
-    root: typeof state.as === 'string' ? getNativeElementProps(state.as, state) : omit(state, ['as']),
+    root: typeof slots.root === 'string' ? getNativeElementProps(slots.root, state) : omit(state, ['as']),
   };
 
   if (slotNames) {


### PR DESCRIPTION
#### Description of changes

Previously when `as` was not defined for root then `getSlots` would pass all properties into DOM. Breaking conformance tests.

Check `MenuItem.test.tsx.snap` for an issue example.

#### Focus areas to test

(optional)
