### PR TITLE
Remove use of getEdgeChromiumNoHighContrastAdjustSelector 7.0

### DIFF
--- a/change/@fluentui-react-examples-2021-02-11-11-34-18-sareiff-deprecateselector.json
+++ b/change/@fluentui-react-examples-2021-02-11-11-34-18-sareiff-deprecateselector.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove use of getEdgeChromiumNoHighContrastAdjustSelector",
+  "packageName": "@fluentui/react-examples",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T19:34:18.441Z"
+}

--- a/change/@uifabric-date-time-2021-02-11-11-34-18-sareiff-deprecateselector.json
+++ b/change/@uifabric-date-time-2021-02-11-11-34-18-sareiff-deprecateselector.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove use of getEdgeChromiumNoHighContrastAdjustSelector",
+  "packageName": "@uifabric/date-time",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T19:34:13.355Z"
+}

--- a/change/office-ui-fabric-react-2021-02-11-11-34-18-sareiff-deprecateselector.json
+++ b/change/office-ui-fabric-react-2021-02-11-11-34-18-sareiff-deprecateselector.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove use of getEdgeChromiumNoHighContrastAdjustSelector",
+  "packageName": "office-ui-fabric-react",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T19:34:16.043Z"
+}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -84,9 +84,8 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -4,7 +4,7 @@ import {
   concatStyleSets,
   getFocusStyle,
   HighContrastSelector,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
@@ -128,15 +128,15 @@ export const getStyles = memoizeFunction(
             selectors: {
               [HighContrastSelector]: {
                 color: 'GrayText',
+                ...getHighContrastNoAdjustStyle(),
               },
             },
           },
           [HighContrastSelector]: {
             color: 'GrayText',
             backgroundColor: 'Window',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
 
@@ -199,10 +199,9 @@ export const getStyles = memoizeFunction(
             color: 'GrayText',
             border: 'none',
             backgroundColor: 'Window',
+            ...getHighContrastNoAdjustStyle(),
           },
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
 
       splitButtonMenuButtonChecked: {

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -5,7 +5,6 @@ import {
   concatStyleSets,
   getFocusStyle,
   IStyle,
-  getEdgeChromiumNoHighContrastAdjustSelector,
   getHighContrastNoAdjustStyle,
 } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
@@ -210,9 +209,8 @@ export const getStyles = memoizeFunction(
             color: 'GrayText',
             borderColor: 'GrayText',
             backgroundColor: 'Window',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
     };

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,11 +1,5 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import {
-  HighContrastSelector,
-  getGlobalClassNames,
-  getEdgeChromiumNoHighContrastAdjustSelector,
-  IStyle,
-  getHighContrastNoAdjustStyle,
-} from '../../Styling';
+import { HighContrastSelector, getGlobalClassNames, IStyle, getHighContrastNoAdjustStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -211,9 +205,8 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         ':after': indeterminate ? indeterminateDotStyles : null,
         [HighContrastSelector]: {
           borderColor: 'WindowText',
+          ...getHighContrastNoAdjustStyle(),
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
       indeterminate && {
         borderColor: checkboxBorderIndeterminateColor,
@@ -273,9 +266,8 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         lineHeight: '20px',
         [HighContrastSelector]: {
           color: disabled ? 'GrayText' : 'WindowText',
+          ...getHighContrastNoAdjustStyle(),
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
       !reversed
         ? {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -120,10 +120,9 @@ exports[`Checkbox renders checked correctly 1`] = `
             width: 20px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: Highlight;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >
@@ -163,9 +162,8 @@ exports[`Checkbox renders checked correctly 1`] = `
             margin-left: 4px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: WindowText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >
@@ -310,9 +308,8 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             border-color: WindowText;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             border-color: WindowText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >
@@ -352,9 +349,8 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             margin-left: 4px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: WindowText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >
@@ -473,9 +469,8 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             width: 20px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             border-color: WindowText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >
@@ -515,9 +510,8 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             margin-left: 4px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: WindowText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
     >

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -1,9 +1,4 @@
-import {
-  HighContrastSelector,
-  IStyle,
-  getGlobalClassNames,
-  getEdgeChromiumNoHighContrastAdjustSelector,
-} from '../../../Styling';
+import { HighContrastSelector, IStyle, getGlobalClassNames, getHighContrastNoAdjustStyle } from '../../../Styling';
 import { IsFocusVisibleClassName } from '../../../Utilities';
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
 
@@ -185,9 +180,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         [HighContrastSelector]: {
           borderColor: 'GrayText',
           background: 'Window',
+          ...getHighContrastNoAdjustStyle(),
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
     },
     checked && {
@@ -196,9 +190,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         [HighContrastSelector]: {
           borderColor: 'Highlight',
           background: 'Window',
+          forcedColorAdjust: 'none',
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
     },
     (hasIcon || hasImage) && {
@@ -234,9 +227,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       selectors: {
         [HighContrastSelector]: {
           borderColor: 'Highlight',
+          forcedColorAdjust: 'none',
         },
-        // eslint-disable-next-line deprecation/deprecation
-        ...getEdgeChromiumNoHighContrastAdjustSelector(),
       },
     },
     checked &&
@@ -360,9 +352,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
             selectors: {
               [HighContrastSelector]: {
                 color: 'GrayText',
+                ...getHighContrastNoAdjustStyle(),
               },
-              // eslint-disable-next-line deprecation/deprecation
-              ...getEdgeChromiumNoHighContrastAdjustSelector(),
             },
           },
         },

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -801,8 +801,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
               background: Window;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:before {
               forced-color-adjust: none;
             }
             &:after {
@@ -824,8 +822,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:after {
               forced-color-adjust: none;
             }
       >
@@ -917,10 +913,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              -ms-high-contrast-adjust: none;
               background: Window;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){&:before {
               forced-color-adjust: none;
             }
             &:after {
@@ -940,9 +935,8 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               color: #a19f9d;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               forced-color-adjust: none;
             }
       >
@@ -1037,10 +1031,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              -ms-high-contrast-adjust: none;
               background: Window;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:before {
               forced-color-adjust: none;
             }
             &:after {
@@ -1062,17 +1055,14 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:after {
               forced-color-adjust: none;
             }
             & .ms-ChoiceFieldLabel {
               color: #a19f9d;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               forced-color-adjust: none;
             }
       >
@@ -1642,8 +1632,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
               background: Window;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:before {
               forced-color-adjust: none;
             }
             &:after {
@@ -1665,8 +1653,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:after {
               forced-color-adjust: none;
             }
       >
@@ -1841,10 +1827,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              -ms-high-contrast-adjust: none;
               background: Window;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){&:before {
               forced-color-adjust: none;
             }
             &:after {
@@ -1864,9 +1849,8 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               color: #a19f9d;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               forced-color-adjust: none;
             }
       >

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -400,9 +400,8 @@ exports[`ColorPicker renders correctly 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -572,9 +571,8 @@ exports[`ColorPicker renders correctly 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -745,9 +743,8 @@ exports[`ColorPicker renders correctly 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -918,9 +915,8 @@ exports[`ColorPicker renders correctly 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -1091,9 +1087,8 @@ exports[`ColorPicker renders correctly 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -1629,9 +1624,8 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -1801,9 +1795,8 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -1974,9 +1967,8 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -2147,9 +2139,8 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -2320,9 +2311,8 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -2835,9 +2825,8 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -3007,9 +2996,8 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -3180,9 +3168,8 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -3353,9 +3340,8 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >
@@ -3526,9 +3512,8 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                         border-color: #323130;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                        -ms-high-contrast-adjust: none;
                         border-color: Highlight;
-                      }
-                      @media screen and (forced-colors: active){&:hover {
                         forced-color-adjust: none;
                       }
                 >

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -9,7 +9,6 @@ import {
   getPlaceholderStyles,
   hiddenContentStyle,
   getInputFocusStyle,
-  getEdgeChromiumNoHighContrastAdjustSelector,
   getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
@@ -493,9 +492,8 @@ export const getStyles = memoizeFunction(
           selectors: {
             [HighContrastSelector]: {
               color: 'GrayText',
+              ...getHighContrastNoAdjustStyle(),
             },
-            // eslint-disable-next-line deprecation/deprecation
-            ...getEdgeChromiumNoHighContrastAdjustSelector(),
           },
         },
       ],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -7,7 +7,6 @@ import {
   getScreenSelector,
   ScreenWidthMaxMedium,
   IconFontSizes,
-  getEdgeChromiumNoHighContrastAdjustSelector,
   getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { IMenuItemStyles } from './ContextualMenu.types';
@@ -79,9 +78,8 @@ export const getMenuItemStyles = memoizeFunction(
           [HighContrastSelector]: {
             color: 'GrayText',
             opacity: 1,
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       rootHovered: {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -84,9 +84,8 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -422,6 +422,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -430,8 +431,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -609,6 +608,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -617,8 +617,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -796,6 +794,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -804,8 +803,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -983,6 +980,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -991,8 +989,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -1170,6 +1166,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -1178,8 +1175,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -1357,6 +1352,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -1365,8 +1361,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -1544,6 +1538,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -1552,8 +1547,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -1731,6 +1724,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -1739,8 +1733,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -1918,6 +1910,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -1926,8 +1919,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={
@@ -2105,6 +2096,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                               transform: translateZ(0);
                             }
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
                                                       to right,
@@ -2113,8 +2105,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
-                            }
-                            @media screen and (forced-colors: active){& {
                               forced-color-adjust: none;
                             }
                         style={

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -11,7 +11,6 @@ import {
   HighContrastSelectorWhite,
   getScreenSelector,
   ScreenWidthMinMedium,
-  getEdgeChromiumNoHighContrastAdjustSelector,
   getHighContrastNoAdjustStyle,
 } from '../../Styling';
 
@@ -318,9 +317,8 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
             border: '1px solid GrayText',
             color: 'GrayText',
             backgroundColor: 'Window',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
     ],
@@ -343,9 +341,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       disabled && {
         color: semanticColors.disabledText,
         selectors: {
-          [HighContrastSelector]: { color: 'GrayText' },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+          [HighContrastSelector]: { color: 'GrayText', ...getHighContrastNoAdjustStyle() },
         },
       },
     ],
@@ -400,9 +396,8 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         selectors: {
           [HighContrastSelector]: {
             color: 'GrayText',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
     ],

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -158,9 +158,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -200,9 +199,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 margin-left: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -340,9 +338,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -382,9 +379,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   margin-right: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -522,9 +518,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -564,9 +559,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     margin-left: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -707,9 +701,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -749,9 +742,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 margin-right: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -889,9 +881,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -931,9 +922,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   margin-left: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -1071,9 +1061,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -1113,9 +1102,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     margin-right: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -1261,9 +1249,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -1303,9 +1290,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 margin-left: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -1443,9 +1429,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -1485,9 +1470,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   margin-right: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -1625,9 +1609,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -1667,9 +1650,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     margin-left: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -1810,9 +1792,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -1852,9 +1833,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 margin-right: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -1992,9 +1972,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -2034,9 +2013,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   margin-left: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -2174,9 +2152,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -2216,9 +2193,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     margin-right: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -2364,9 +2340,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -2406,9 +2381,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 margin-left: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -2546,9 +2520,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -2588,9 +2561,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   margin-right: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -2728,9 +2700,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -2770,9 +2741,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     margin-left: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -2913,9 +2883,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -2955,9 +2924,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 margin-right: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -3095,9 +3063,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -3137,9 +3104,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   margin-left: 4px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: WindowText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -3277,9 +3243,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     border-color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >
@@ -3319,9 +3284,8 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     margin-right: 4px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
                     color: WindowText;
-                  }
-                  @media screen and (forced-colors: active){& {
                     forced-color-adjust: none;
                   }
             >

--- a/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
@@ -1,4 +1,4 @@
-import { HighContrastSelector, FontWeights, getEdgeChromiumNoHighContrastAdjustSelector } from '../../Styling';
+import { HighContrastSelector, FontWeights, getHighContrastNoAdjustStyle } from '../../Styling';
 import { ILabelStyleProps, ILabelStyles } from './Label.types';
 
 export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
@@ -31,9 +31,8 @@ export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
         selectors: {
           [HighContrastSelector]: {
             color: 'GrayText',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       required && {

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -1,5 +1,4 @@
 import { getGlobalClassNames, HighContrastSelector } from '../../Styling';
-import { EdgeChromiumHighContrastSelector } from '@uifabric/styling';
 import { ILinkStyleProps, ILinkStyles } from './Link.types';
 
 const GlobalClassNames = {

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -1,4 +1,5 @@
-import { getEdgeChromiumNoHighContrastAdjustSelector, getGlobalClassNames, HighContrastSelector } from '../../Styling';
+import { getGlobalClassNames, HighContrastSelector } from '../../Styling';
+import { EdgeChromiumHighContrastSelector } from '@uifabric/styling';
 import { ILinkStyleProps, ILinkStyles } from './Link.types';
 
 const GlobalClassNames = {
@@ -64,9 +65,8 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         selectors: {
           [HighContrastSelector]: {
             color: 'LinkText',
+            forcedColorAdjust: 'none',
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       !isButton && {

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -103,8 +103,6 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
-      }
-      @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
       }
       &:active {
@@ -243,8 +241,6 @@ exports[`Link renders Link with no href as a button 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
-      }
-      @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
       }
       &:active {
@@ -366,8 +362,6 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
-      }
-      @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
       }
       &:link {
@@ -428,8 +422,6 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
-      }
-      @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
       }
       &:active {

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -4,7 +4,7 @@ import {
   noWrap,
   getGlobalClassNames,
   IRawStyle,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { getRTL, memoizeFunction } from '../../Utilities';
 import { IProgressIndicatorStyleProps, IProgressIndicatorStyles } from './ProgressIndicator.types';
@@ -110,9 +110,8 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
         selectors: {
           [HighContrastSelector]: {
             backgroundColor: 'highlight',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -66,9 +66,8 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"
@@ -162,10 +161,9 @@ exports[`ProgressIndicator renders React content 1`] = `
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"
@@ -259,10 +257,9 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"
@@ -340,10 +337,9 @@ exports[`ProgressIndicator renders with no label or description 1`] = `
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -4,7 +4,7 @@ import {
   getGlobalClassNames,
   hiddenContentStyle,
   HighContrastSelector,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { getRTL, memoizeFunction } from '../../Utilities';
 
@@ -78,9 +78,8 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
                           transparent 100%)
                         0 0 / 90% 100%
                         no-repeat`,
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       isDataLoaded && {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
           transform: translateZ(0);
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
           background: WindowText
                                 linear-gradient(
                                   to right,
@@ -36,8 +37,6 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
                                   transparent 100%)
                                 0 0 / 90% 100%
                                 no-repeat;
-        }
-        @media screen and (forced-colors: active){& {
           forced-color-adjust: none;
         }
     style={
@@ -292,6 +291,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
           transform: translateZ(0);
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
           background: WindowText
                                 linear-gradient(
                                   to right,
@@ -300,8 +300,6 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                                   transparent 100%)
                                 0 0 / 90% 100%
                                 no-repeat;
-        }
-        @media screen and (forced-colors: active){& {
           forced-color-adjust: none;
         }
     style={

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -1,11 +1,5 @@
 import { ISliderStyleProps, ISliderStyles } from './Slider.types';
-import {
-  getGlobalClassNames,
-  HighContrastSelector,
-  AnimationVariables,
-  getFocusStyle,
-  getHighContrastNoAdjustStyle,
-} from '../../Styling';
+import { getGlobalClassNames, HighContrastSelector, AnimationVariables, getFocusStyle } from '../../Styling';
 import { getRTL } from '@uifabric/utilities';
 
 const GlobalClassNames = {

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -4,7 +4,7 @@ import {
   HighContrastSelector,
   AnimationVariables,
   getFocusStyle,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { getRTL } from '@uifabric/utilities';
 
@@ -147,8 +147,9 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
           [`:hover .${classNames.thumb}`]: slideBoxActiveThumbStyles,
           [`:active .${classNames.zeroTick}`]: slideBoxActiveZeroTickStyles,
           [`:hover .${classNames.zeroTick}`]: slideBoxActiveZeroTickStyles,
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+          [HighContrastSelector]: {
+            forcedColorAdjust: 'none',
+          },
         },
       },
       vertical

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`Slider renders correctly 1`] = `
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
             background-color: Highlight;
           }
-          @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             forced-color-adjust: none;
           }
       data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
@@ -4,7 +4,7 @@ import {
   keyframes,
   HighContrastSelector,
   getGlobalClassNames,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { memoizeFunction } from '../../Utilities';
 
@@ -66,9 +66,8 @@ export const getStyles = (props: ISpinnerStyleProps): ISpinnerStyles => {
         selectors: {
           [HighContrastSelector]: {
             borderTopColor: 'Highlight',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       size === SpinnerSize.xSmall && [

--- a/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -28,9 +28,8 @@ exports[`Spinner renders Spinner correctly 1`] = `
           width: 20px;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
           border-top-color: Highlight;
-        }
-        @media screen and (forced-colors: active){& {
           forced-color-adjust: none;
         }
   />

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -83,9 +83,8 @@ exports[`MaskedTextField renders correctly 1`] = `
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -7,7 +7,7 @@ import {
   normalize,
   getPlaceholderStyles,
   IconFontSizes,
-  getEdgeChromiumNoHighContrastAdjustSelector,
+  getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
@@ -158,9 +158,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           selectors: {
             [HighContrastSelector]: {
               borderColor: 'GrayText',
+              ...getHighContrastNoAdjustStyle(),
             },
-            // eslint-disable-next-line deprecation/deprecation
-            ...getEdgeChromiumNoHighContrastAdjustSelector(),
           },
         },
         !disabled && {
@@ -170,9 +169,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
               selectors: {
                 [HighContrastSelector]: {
                   borderBottomColor: 'Highlight',
+                  ...getHighContrastNoAdjustStyle(),
                 },
-                // eslint-disable-next-line deprecation/deprecation
-                ...getEdgeChromiumNoHighContrastAdjustSelector(),
               },
             },
           },
@@ -217,9 +215,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
               selectors: {
                 [HighContrastSelector]: {
                   borderColor: 'Highlight',
+                  ...getHighContrastNoAdjustStyle(),
                 },
-                // eslint-disable-next-line deprecation/deprecation
-                ...getEdgeChromiumNoHighContrastAdjustSelector(),
               },
             },
           },
@@ -236,9 +233,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'GrayText',
+            ...getHighContrastNoAdjustStyle(),
           },
-          // eslint-disable-next-line deprecation/deprecation
-          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
 
         cursor: 'default',

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -84,9 +84,8 @@ exports[`TextField snapshots renders correctly 1`] = `
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -223,9 +222,8 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
           border-bottom-color: #a4262c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          -ms-high-contrast-adjust: none;
           border-bottom-color: Highlight;
-        }
-        @media screen and (forced-colors: active){&:hover {
           forced-color-adjust: none;
         }
   >
@@ -290,9 +288,8 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -499,9 +496,8 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
           border-bottom-color: #a4262c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          -ms-high-contrast-adjust: none;
           border-bottom-color: Highlight;
-        }
-        @media screen and (forced-colors: active){&:hover {
           forced-color-adjust: none;
         }
   >
@@ -566,9 +562,8 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -824,9 +819,8 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -1014,9 +1008,8 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -1206,9 +1199,8 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -1366,9 +1358,8 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >
@@ -1573,9 +1564,8 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
           border-bottom-color: #a4262c;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          -ms-high-contrast-adjust: none;
           border-bottom-color: Highlight;
-        }
-        @media screen and (forced-colors: active){&:hover {
           forced-color-adjust: none;
         }
   >
@@ -1641,9 +1631,8 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
             border-color: #323130;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
             border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
             forced-color-adjust: none;
           }
     >

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -1,9 +1,4 @@
-import {
-  HighContrastSelector,
-  getFocusStyle,
-  FontWeights,
-  getEdgeChromiumNoHighContrastAdjustSelector,
-} from '../../Styling';
+import { HighContrastSelector, getFocusStyle, FontWeights, getHighContrastNoAdjustStyle } from '../../Styling';
 import { IToggleStyleProps, IToggleStyles } from './Toggle.types';
 
 const DEFAULT_PILL_WIDTH = 40;
@@ -135,9 +130,8 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
               ],
               [HighContrastSelector]: {
                 backgroundColor: 'Highlight',
+                ...getHighContrastNoAdjustStyle(),
               },
-              // eslint-disable-next-line deprecation/deprecation
-              ...getEdgeChromiumNoHighContrastAdjustSelector(),
             },
           },
         ],

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -105,8 +105,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -196,8 +194,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -355,8 +351,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -523,8 +517,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -603,8 +595,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -683,8 +673,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -181,8 +181,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -498,8 +496,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -578,8 +574,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -658,8 +652,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -1029,8 +1021,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -1109,8 +1099,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -1541,8 +1529,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {
@@ -1621,8 +1607,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border-bottom: none;
                 color: LinkText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
               &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -219,9 +219,8 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
               width: 0px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         role="progressbar"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -359,8 +359,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -528,8 +526,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -786,8 +782,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -955,8 +949,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1124,8 +1116,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1293,8 +1283,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1462,8 +1450,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1631,8 +1617,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1801,8 +1785,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -2700,8 +2682,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -2869,8 +2849,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -3195,8 +3173,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -3358,8 +3334,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -165,8 +165,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -334,8 +332,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -503,8 +499,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -672,8 +666,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -931,8 +923,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1362,8 +1352,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1621,8 +1609,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -1858,8 +1844,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -2222,8 +2206,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -335,8 +335,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {
@@ -594,8 +592,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                         border-bottom: none;
                         color: LinkText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                       &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
@@ -1108,10 +1108,12 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             position: relative;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: Window;
             border-color: GrayText;
             border: none;
             color: GrayText;
+            forced-color-adjust: none;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -1158,9 +1160,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button--primary + .ms-Button {
             border-left-width: 0;
             border: 1px solid WindowText;
-          }
-          @media screen and (forced-colors: active){& {
-            forced-color-adjust: none;
           }
       data-is-focusable={true}
       onFocusCapture={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -130,9 +130,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -172,9 +171,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -301,10 +299,9 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: Highlight;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -344,9 +341,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -437,9 +433,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -479,9 +474,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -574,10 +568,9 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: Window;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -617,9 +610,8 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -156,9 +156,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               border-color: WindowText;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -198,9 +197,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -339,9 +337,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               border-color: WindowText;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -381,9 +378,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -493,9 +489,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               border-color: WindowText;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -535,9 +530,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -679,9 +673,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               border-color: WindowText;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -721,9 +714,8 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -141,10 +141,9 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: Highlight;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -184,9 +183,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -305,9 +303,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -347,9 +344,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               margin-right: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -465,9 +461,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -507,9 +502,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -625,9 +619,8 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -293,8 +293,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                   background: Window;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -316,8 +314,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:after {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-B"
@@ -415,10 +411,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  -ms-high-contrast-adjust: none;
                   background: Window;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -438,9 +433,8 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                   color: #a19f9d;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+                  -ms-high-contrast-adjust: none;
                   color: GrayText;
-                }
-                @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-C"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -286,8 +286,6 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                   background: Window;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -309,8 +307,6 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:after {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-B"
@@ -407,10 +403,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  -ms-high-contrast-adjust: none;
                   background: Window;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -430,9 +425,8 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                   color: #a19f9d;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+                  -ms-high-contrast-adjust: none;
                   color: GrayText;
-                }
-                @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-C"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -315,11 +315,10 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                         white-space: nowrap;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        -ms-high-contrast-adjust: none;
                         background-color: Window;
                         border: 1px solid GrayText;
                         color: GrayText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                   id="Dropdown2-option"
@@ -355,9 +354,8 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                           speak: none;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
                           color: GrayText;
-                        }
-                        @media screen and (forced-colors: active){& {
                           forced-color-adjust: none;
                         }
                     data-icon-name="ChevronDown"
@@ -473,8 +471,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                   background: Window;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -496,8 +492,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:after {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-B"
@@ -594,10 +588,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  -ms-high-contrast-adjust: none;
                   background: Window;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -617,9 +610,8 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   color: #a19f9d;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+                  -ms-high-contrast-adjust: none;
                   color: GrayText;
-                }
-                @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-C"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -188,8 +188,6 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                   background: Window;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -211,8 +209,6 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:after {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-day"
@@ -599,10 +595,9 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   width: 20px;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  -ms-high-contrast-adjust: none;
                   background: Window;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -622,9 +617,8 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   color: #a19f9d;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+                  -ms-high-contrast-adjust: none;
                   color: GrayText;
-                }
-                @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-month"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -188,8 +188,6 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                   background: Window;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:before {
                   forced-color-adjust: none;
                 }
                 &:after {
@@ -211,8 +209,6 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:after {
                   forced-color-adjust: none;
                 }
             htmlFor="ChoiceGroup0-bar"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -329,8 +329,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                     background: Window;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:before {
                     forced-color-adjust: none;
                   }
                   &:after {
@@ -352,8 +350,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:after {
                     forced-color-adjust: none;
                   }
               htmlFor="ChoiceGroup1-B"
@@ -450,10 +446,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     width: 20px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    -ms-high-contrast-adjust: none;
                     background: Window;
                     border-color: GrayText;
-                  }
-                  @media screen and (forced-colors: active){&:before {
                     forced-color-adjust: none;
                   }
                   &:after {
@@ -473,9 +468,8 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     color: #a19f9d;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-ChoiceFieldLabel {
+                    -ms-high-contrast-adjust: none;
                     color: GrayText;
-                  }
-                  @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
                     forced-color-adjust: none;
                   }
               htmlFor="ChoiceGroup1-C"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -436,9 +436,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
                           border-color: Highlight;
-                        }
-                        @media screen and (forced-colors: active){&:hover {
                           forced-color-adjust: none;
                         }
                   >
@@ -608,9 +607,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
                           border-color: Highlight;
-                        }
-                        @media screen and (forced-colors: active){&:hover {
                           forced-color-adjust: none;
                         }
                   >
@@ -781,9 +779,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
                           border-color: Highlight;
-                        }
-                        @media screen and (forced-colors: active){&:hover {
                           forced-color-adjust: none;
                         }
                   >
@@ -954,9 +951,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
                           border-color: Highlight;
-                        }
-                        @media screen and (forced-colors: active){&:hover {
                           forced-color-adjust: none;
                         }
                   >
@@ -1127,9 +1123,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
                           border-color: Highlight;
-                        }
-                        @media screen and (forced-colors: active){&:hover {
                           forced-color-adjust: none;
                         }
                   >
@@ -1345,9 +1340,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 border-color: Highlight;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 background-color: Highlight;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           data-is-focusable={true}
@@ -1531,8 +1525,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
                       background: Window;
                       border-color: Highlight;
-                    }
-                    @media screen and (forced-colors: active){&:before {
                       forced-color-adjust: none;
                     }
                     &:after {
@@ -1554,8 +1546,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
                       border-color: Highlight;
-                    }
-                    @media screen and (forced-colors: active){&:after {
                       forced-color-adjust: none;
                     }
                 htmlFor="ChoiceGroup17-alpha"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -530,9 +530,8 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -553,12 +553,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       border: 1px solid WindowText;
                     }
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      -ms-high-contrast-adjust: none;
                       background-color: Window;
                       border-color: GrayText;
                       border: none;
                       color: GrayText;
-                    }
-                    @media screen and (forced-colors: active){& {
                       forced-color-adjust: none;
                     }
                 data-is-focusable={true}
@@ -638,9 +637,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           top: 0px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
                           background-color: Window;
                           border: none;
                           color: GrayText;
+                          forced-color-adjust: none;
                         }
                         &:hover {
                           outline: 0px;
@@ -652,9 +653,8 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           color: #c8c6c4;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-icon {
+                          -ms-high-contrast-adjust: none;
                           color: GrayText;
-                        }
-                        @media screen and (forced-colors: active){& {
                           forced-color-adjust: none;
                         }
                     data-is-focusable={false}
@@ -785,9 +785,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           width: 32px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
                           background-color: Window;
                           border: none;
                           color: GrayText;
+                          forced-color-adjust: none;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
                           color: GrayText;
@@ -813,9 +815,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           background-color: Window;
                           border-color: GrayText;
                           color: GrayText;
-                        }
-                        @media screen and (forced-colors: active){& {
-                          forced-color-adjust: none;
                         }
                     data-is-focusable={false}
                     disabled={false}
@@ -990,9 +989,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       top: 0px;
                     }
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      -ms-high-contrast-adjust: none;
                       background-color: Window;
                       border: none;
                       color: GrayText;
+                      forced-color-adjust: none;
                     }
                     &:hover {
                       outline: 0px;
@@ -1004,9 +1005,8 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       color: #c8c6c4;
                     }
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-icon {
+                      -ms-high-contrast-adjust: none;
                       color: GrayText;
-                    }
-                    @media screen and (forced-colors: active){& {
                       forced-color-adjust: none;
                     }
                 data-is-focusable={true}
@@ -1185,9 +1185,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         top: 0px;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        -ms-high-contrast-adjust: none;
                         background-color: Window;
                         border: none;
                         color: GrayText;
+                        forced-color-adjust: none;
                       }
                       &:hover {
                         outline: 0px;
@@ -1199,9 +1201,8 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         color: #c8c6c4;
                       }
                       @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-icon {
+                        -ms-high-contrast-adjust: none;
                         color: GrayText;
-                      }
-                      @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
                       }
                   data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -86,9 +86,8 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -91,9 +91,8 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -85,9 +85,8 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   position: relative;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >
@@ -307,9 +306,8 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   word-wrap: break-word;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   color: GrayText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
             htmlFor="DatePicker5-label"
@@ -343,9 +341,8 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   position: relative;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
                   border-color: GrayText;
-                }
-                @media screen and (forced-colors: active){& {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -118,9 +118,8 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -118,9 +118,8 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -126,9 +126,8 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >
@@ -351,9 +350,8 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
                 &:before {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -86,9 +86,8 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -137,9 +137,8 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -121,9 +121,8 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -793,8 +793,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -870,8 +868,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -461,9 +461,8 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -115,9 +115,8 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 border-color: Highlight;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 background-color: Highlight;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           data-is-focusable={true}
@@ -275,9 +274,8 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -458,9 +456,8 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1095,8 +1095,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -1634,8 +1632,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -2173,8 +2169,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -2712,8 +2706,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -3251,8 +3243,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -3790,8 +3780,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -4329,8 +4317,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -4868,8 +4854,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {
@@ -5407,8 +5391,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                                   border-bottom: none;
                                   color: LinkText;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                                 &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -259,9 +259,8 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: GrayText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       id="Dropdown1-label"
@@ -386,11 +385,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               white-space: nowrap;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Window;
               border: 1px solid GrayText;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         id="Dropdown1-option"
@@ -426,9 +424,8 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
                 speak: none;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           data-icon-name="ChevronDown"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -766,7 +766,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
               }
-              @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           data-is-focusable={true}
@@ -1230,10 +1230,9 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 background: Highlight;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -1273,9 +1272,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 margin-left: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -869,7 +869,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
               }
-              @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -298,9 +298,8 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -480,9 +480,8 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -480,9 +480,8 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -343,9 +343,8 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >
@@ -997,9 +996,8 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -383,9 +383,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -592,9 +591,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1079,9 +1077,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1288,9 +1285,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1775,9 +1771,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1984,9 +1979,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -2471,9 +2465,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -2680,9 +2673,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3167,9 +3159,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3376,9 +3367,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3863,9 +3853,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4072,9 +4061,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4559,9 +4547,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4768,9 +4755,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5255,9 +5241,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5464,9 +5449,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5951,9 +5935,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6160,9 +6143,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6647,9 +6629,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6856,9 +6837,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -343,9 +343,8 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >
@@ -1222,9 +1221,8 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1110,9 +1110,8 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Label.Basic.Example.tsx.shot
@@ -54,9 +54,8 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           word-wrap: break-word;
         }
         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          -ms-high-contrast-adjust: none;
           color: GrayText;
-        }
-        @media screen and (forced-colors: active){& {
           forced-color-adjust: none;
         }
   >
@@ -175,9 +174,8 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -114,9 +114,8 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Link.Basic.Example.tsx.shot
@@ -118,8 +118,6 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -70,8 +70,6 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {
@@ -157,8 +155,6 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {
@@ -244,8 +240,6 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -214,8 +214,6 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {
@@ -301,8 +299,6 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {
@@ -388,8 +384,6 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
             border-bottom: none;
             color: LinkText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
           &:active {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -139,9 +139,8 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -181,9 +180,8 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-left: 4px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: WindowText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -210,9 +210,8 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -252,9 +251,8 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -371,9 +369,8 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -413,9 +410,8 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2161,9 +2161,8 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -2203,9 +2202,8 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -2322,9 +2320,8 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -2364,9 +2361,8 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -210,9 +210,8 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -252,9 +251,8 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -371,9 +369,8 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -413,9 +410,8 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -213,9 +213,8 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -255,9 +254,8 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -374,9 +372,8 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -416,9 +413,8 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -210,9 +210,8 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -252,9 +251,8 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -371,9 +369,8 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -413,9 +410,8 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1573,9 +1573,8 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -1615,9 +1614,8 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -1734,9 +1732,8 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -1776,9 +1773,8 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -210,9 +210,8 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -252,9 +251,8 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -371,9 +369,8 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -413,9 +410,8 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -141,10 +141,9 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: Highlight;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -184,9 +183,8 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: WindowText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
@@ -66,9 +66,8 @@ exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctl
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
@@ -66,10 +66,9 @@ exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx 
             width: 0px;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       role="progressbar"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -548,6 +548,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -556,8 +557,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -861,6 +860,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -869,8 +869,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -1174,6 +1172,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -1182,8 +1181,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -1487,6 +1484,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -1495,8 +1493,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -1800,6 +1796,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -1808,8 +1805,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -2113,6 +2108,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -2121,8 +2117,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -2426,6 +2420,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -2434,8 +2429,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -2739,6 +2732,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -2747,8 +2741,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -3052,6 +3044,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -3060,8 +3053,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={
@@ -3365,6 +3356,7 @@ Array [
                                   transform: translateZ(0);
                                 }
                                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                                  -ms-high-contrast-adjust: none;
                                   background: WindowText
                                                         linear-gradient(
                                                           to right,
@@ -3373,8 +3365,6 @@ Array [
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
-                                }
-                                @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
                                 }
                             style={

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -60,6 +60,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -68,8 +69,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -248,6 +247,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -256,8 +256,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -436,6 +434,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -444,8 +443,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -625,6 +622,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -633,8 +631,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -886,6 +882,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -894,8 +891,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -1525,6 +1520,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -1533,8 +1529,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -2165,6 +2159,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -2173,8 +2168,6 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -60,6 +60,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -68,8 +69,6 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -531,6 +530,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -539,8 +539,6 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -947,6 +945,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -955,8 +954,6 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -184,6 +184,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -192,8 +193,6 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={
@@ -548,6 +547,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             background: WindowText
                                   linear-gradient(
                                     to right,
@@ -556,8 +556,6 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       style={

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -85,6 +85,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -93,8 +94,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -759,6 +758,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -767,8 +767,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -1204,6 +1202,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -1212,8 +1211,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -1641,6 +1638,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -1649,8 +1647,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -1831,6 +1827,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -1839,8 +1836,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -2021,6 +2016,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -2029,8 +2025,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -2211,6 +2205,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -2219,8 +2214,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={
@@ -2401,6 +2394,7 @@ Array [
               transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background: WindowText
                                     linear-gradient(
                                       to right,
@@ -2409,8 +2403,6 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         style={

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -134,7 +134,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -398,7 +398,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -561,9 +561,8 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: GrayText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       htmlFor="Slider2"
@@ -620,7 +619,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               top: 1px;
               z-index: 1;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={false}
@@ -741,9 +740,8 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -891,7 +889,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -1155,7 +1153,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -1419,7 +1417,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Slider.Vertical.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Slider.Vertical.Example.tsx.shot
@@ -170,7 +170,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -344,9 +344,8 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
             color: GrayText;
-          }
-          @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
           }
       htmlFor="Slider1"
@@ -410,7 +409,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               top: 1px;
               z-index: 1;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={false}
@@ -541,9 +540,8 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -699,7 +697,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -981,7 +979,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -1263,7 +1261,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -60,9 +60,8 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         htmlFor="input1"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -83,9 +83,8 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         htmlFor="input1"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Spinner.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Spinner.Basic.Example.tsx.shot
@@ -98,9 +98,8 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
               width: 12px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -182,9 +181,8 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
               width: 16px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -266,9 +264,8 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -350,9 +347,8 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
               width: 28px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Spinner.Labeled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Spinner.Labeled.Example.tsx.shot
@@ -78,9 +78,8 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -160,9 +159,8 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -242,9 +240,8 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />
@@ -324,9 +321,8 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-top-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       />

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -125,9 +125,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -276,9 +275,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           htmlFor="TextField3"
@@ -312,9 +310,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 position: relative;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -496,9 +493,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -685,9 +681,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -840,9 +835,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
               &:before {
@@ -1035,9 +1029,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #a4262c;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -1247,9 +1240,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -1434,9 +1426,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -1640,9 +1631,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -1792,9 +1782,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           htmlFor="TextField27"
@@ -1828,9 +1817,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 position: relative;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -2013,9 +2001,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -78,9 +78,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               border-bottom-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-bottom-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >
@@ -145,9 +144,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -280,9 +278,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               width: 100%;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               border-color: GrayText;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
       >
@@ -313,9 +310,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
           htmlFor="TextField3"
@@ -352,9 +348,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 text-align: left;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
                 border-color: GrayText;
-              }
-              @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
               }
         >
@@ -491,9 +486,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               border-bottom-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-bottom-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >
@@ -563,9 +557,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -771,9 +764,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >
@@ -957,9 +949,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 border-color: #323130;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
                 border-color: Highlight;
-              }
-              @media screen and (forced-colors: active){&:hover {
                 forced-color-adjust: none;
               }
         >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -105,9 +105,8 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >
@@ -288,9 +287,8 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -236,9 +236,8 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >
@@ -479,9 +478,8 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >
@@ -661,9 +659,8 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -108,9 +108,8 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -123,9 +123,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}
@@ -1405,9 +1404,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
               background-color: Highlight;
-            }
-            @media screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable={true}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -343,9 +343,8 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >
@@ -997,9 +996,8 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-            }
-            @media screen and (forced-colors: active){&:hover {
               forced-color-adjust: none;
             }
       >

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -383,9 +383,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -592,9 +591,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1079,9 +1077,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1288,9 +1285,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1775,9 +1771,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -1984,9 +1979,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -2471,9 +2465,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -2680,9 +2673,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3167,9 +3159,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3376,9 +3367,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -3863,9 +3853,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4072,9 +4061,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4559,9 +4547,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -4768,9 +4755,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5255,9 +5241,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5464,9 +5449,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -5951,9 +5935,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6160,9 +6143,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6647,9 +6629,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >
@@ -6856,9 +6837,8 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     border-color: #323130;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    -ms-high-contrast-adjust: none;
                     border-color: Highlight;
-                  }
-                  @media screen and (forced-colors: active){&:hover {
                     forced-color-adjust: none;
                   }
             >

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -343,9 +343,8 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >
@@ -1222,9 +1221,8 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   border-color: #323130;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  -ms-high-contrast-adjust: none;
                   border-color: Highlight;
-                }
-                @media screen and (forced-colors: active){&:hover {
                   forced-color-adjust: none;
                 }
           >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x ] Include a change request file using `$ yarn change`

#### Description of changes
This change removes the use of getEdgeChromiumNoHighContrastAdjustSelector in the repo. We now have getHighContrastNoAdjustStyle to use instead.

There are a few locations where I didn't switch to using getHighContrastNoAdjustStyle and just left forcedColorsAdjust:'none' because the styling would regress the current state of controls in IE. This is because 1) there are some bugs in the styling for HC controls in chromium/edge and 2) not all colors are supported in IE (like LinkText). With this change, the styling for our components remains consistent in IE and in Edge with what we have today. I will follow up about separate HC bugs I found in the current state while testing.

#### Focus areas to test
High Contrast
