### PR TITLE
FocusZone: Removing FocusZone type from event callbacks

### DIFF
--- a/change/@fluentui-react-focus-98568b10-bed0-4c76-831e-a3183f8f5281.json
+++ b/change/@fluentui-react-focus-98568b10-bed0-4c76-831e-a3183f8f5281.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FocusZone: Removing FocusZone type from event callbacks.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -27,6 +27,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
 - Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 - Adding aria-hidden to bumper elements so that they are not read by screen readers @khmakoto ([#14376](https://github.com/microsoft/fluentui/pull/14376))
+- Removing `FocusZone` type from event callbacks @khmakoto ([#16952](https://github.com/microsoft/fluentui/pull/16952))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -27,7 +27,6 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
 - Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 - Adding aria-hidden to bumper elements so that they are not read by screen readers @khmakoto ([#14376](https://github.com/microsoft/fluentui/pull/14376))
-- Removing `FocusZone` type from event callbacks @khmakoto ([#16952](https://github.com/microsoft/fluentui/pull/16952))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))
@@ -84,6 +83,7 @@ This is a list of changes made to the Stardust copy of FocusTrapZone in comparis
 ### BREAKING CHANGES
 - Allow using `firstFocusableSelector` for all type of selectors, not only class names @sophieH29 ([#1732](https://github.com/stardust-ui/react/pull/1732))
 - Do not force focus inside focus trap zone on outside focus @sophieH29 ([#1930](https://github.com/stardust-ui/react/pull/1930))
+- Removing `FocusZone` type from event callbacks @khmakoto ([#16952](https://github.com/microsoft/fluentui/pull/16952))
 
 ### Fixes
 - Do not focus trigger on outside click @sophieH29 ([#627](https://github.com/stardust-ui/react/pull/627))

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -1,8 +1,6 @@
 import { FocusZoneDirection, FocusZoneProperties, FocusZoneTabbableElements } from '@fluentui/accessibility';
 import * as React from 'react';
 
-import { FocusZone } from './FocusZone';
-
 /**
  * FocusZone component class interface.
  */
@@ -166,7 +164,7 @@ export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttribute
    * Callback called when "focus" event triggered in FocusZone.
    * @param event - React's original FocusEvent.
    */
-  onFocus?: (event: React.FocusEvent<HTMLElement | FocusZone>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
 
   /**
    * If true, FocusZone prevents the default behavior of Keyboard events when changing focus between elements.

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -55,7 +55,7 @@ export interface IFocusZone {
 }
 
 // @public
-export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | FocusZone> {
+export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement> {
     allowFocusRoot?: boolean;
     // @deprecated
     allowTabKey?: boolean;
@@ -85,7 +85,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
     onActiveElementChanged?: (element?: HTMLElement, ev?: React.FocusEvent<HTMLElement>) => void;
     // @deprecated
     onBeforeFocus?: (childElement?: HTMLElement) => boolean;
-    onFocus?: (event: React.FocusEvent<HTMLElement | FocusZone>) => void;
+    onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
     // @deprecated
     onFocusNotification?: () => void;
     pagingSupportDisabled?: boolean;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FocusZone } from './FocusZone';
 import { IRefObject, Point } from '@fluentui/utilities';
 
 /**
@@ -43,7 +42,7 @@ export interface IFocusZone {
  * FocusZone component props.
  * {@docCategory FocusZone}
  */
-export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | FocusZone> {
+export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IFocusZone interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -243,7 +242,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    * Callback called when "focus" event triggered in FocusZone.
    * @param event - React's original FocusEvent.
    */
-  onFocus?: (event: React.FocusEvent<HTMLElement | FocusZone>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
 
   /**
    * If true, FocusZone prevents the default behavior of Keyboard events when changing focus between elements.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16270
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes the type `FocusZone` from the event handlers since it required a type guard or cast when it was only being used in scenarios where `HTMLElement` would be returned either way.