### PR TITLE
Use add and removeeventlistener for keydown in the UnifiedPicker

### DIFF
--- a/change/@fluentui-react-experiments-b74d23d9-2fa9-4b03-9e97-4aee2fdb4506.json
+++ b/change/@fluentui-react-experiments-b74d23d9-2fa9-4b03-9e97-4aee2fdb4506.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use add and removeeventlistener for keydown in the UnifiedPicker",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -411,6 +411,15 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     ],
   );
 
+  React.useEffect(() => {
+    const inputElement = input.current?.inputElement;
+    inputElement?.addEventListener('keydown', _onInputKeyDown as () => void);
+
+    return () => {
+      inputElement?.removeEventListener('keydown', _onInputKeyDown as () => void);
+    };
+  });
+
   const _onCopy = React.useCallback(
     (ev: React.ClipboardEvent<HTMLInputElement>) => {
       if (focusedItemIndices.length > 0 && selectedItemsListGetItemCopyText) {
@@ -610,7 +619,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                   }
                   disabled={false}
                   onPaste={_onPaste}
-                  onKeyDown={_onInputKeyDown}
                 />
               </div>
             )}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The old picker was using add and removeeventlistener instead of a react keydown handler. These get called at different points in the handle order. Replacing the ExtendedPicker with the UnifiedPicker therefor had key handling bugs.

Tested that the key down function still gets hit and the different functionalities work.
