### PR TITLE
7.0: Use add and removeeventlistener for keydown in the UnifiedPicker

### DIFF
--- a/change/@uifabric-experiments-2021-02-11-14-08-54-uselisteners7.0.json
+++ b/change/@uifabric-experiments-2021-02-11-14-08-54-uselisteners7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use add and remove eventlistener for keydown in the UnifiedPicker",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T22:08:54.226Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -417,6 +417,15 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     ],
   );
 
+  React.useEffect(() => {
+    const inputElement = input.current?.inputElement;
+    inputElement?.addEventListener('keydown', _onInputKeyDown as () => void);
+
+    return () => {
+      inputElement?.removeEventListener('keydown', _onInputKeyDown as () => void);
+    };
+  });
+
   const _onCopy = React.useCallback(
     (ev: React.ClipboardEvent<HTMLInputElement>) => {
       if (focusedItemIndices.length > 0 && selectedItemsListGetItemCopyText) {
@@ -612,7 +621,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                   }
                   disabled={false}
                   onPaste={_onPaste}
-                  onKeyDown={_onInputKeyDown}
                 />
               </div>
             )}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
 v8- #16954 

The old picker was using add and removeeventlistener instead of a react keydown handler. These get called at different points in the handle order. Replacing the ExtendedPicker with the UnifiedPicker therefor had key handling bugs.

Tested that the key down function still gets hit and the different functionalities work.