### PR TITLE
[v7.0] BasePicker: combobox role and id are removed when itemLimit is reached 

### DIFF
--- a/change/office-ui-fabric-react-2021-02-11-14-44-36-14170-v7.json
+++ b/change/office-ui-fabric-react-2021-02-11-14-44-36-14170-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "BasePicker: combobox role and id are removed when itemLimit is reached",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T22:44:36.869Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -249,6 +249,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
 
+    const canAddItems = this.canAddItems();
+
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -280,11 +282,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
           componentRef={this.focusZone}
           direction={FocusZoneDirection.bidirectional}
           shouldEnterInnerZone={this._shouldFocusZoneEnterInnerZone}
-          role={'combobox'}
-          id={this._ariaMap.combobox}
-          aria-label={this.props['aria-label']}
-          aria-expanded={!!this.state.suggestionsVisible}
-          aria-owns={suggestionsAvailable || undefined}
+          role={canAddItems ? 'combobox' : undefined}
+          id={canAddItems ? this._ariaMap.combobox : undefined}
+          aria-label={canAddItems ? this.props['aria-label'] : undefined}
+          aria-expanded={canAddItems ? !!this.state.suggestionsVisible : undefined}
+          aria-owns={canAddItems ? suggestionsAvailable || undefined : undefined}
           // Dialog is an acceptable child of a combobox according to the aria specs: https://www.w3.org/TR/wai-aria-practices/#combobox
           // Currently accessibility insights will flag this as not a valid child because the AXE rules are
           // out of date. Tracking issue: https://github.com/dequelabs/axe-core/issues/1009

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -248,7 +248,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       ? this._ariaMap.selectedSuggestionAlert
       : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
-
     const canAddItems = this.canAddItems();
 
     // TODO


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16849
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Adds conditional that sets role and id to undefined if itemLimit has been reached.
- Screenshots below show the changes in the accessibility tree before the itemLimit is reached and after.

    **BEFORE** (role is still combobox)
    ![BasePicker-BeforeLimit (2)](https://user-images.githubusercontent.com/8649804/107076976-0f5bc480-67a1-11eb-894f-5f36e347b495.JPG)
    
    **AFTER** (now a generic)
    ![BasePicker-AfterLimit (2)](https://user-images.githubusercontent.com/8649804/107077057-2f8b8380-67a1-11eb-9f9a-1a17027455cd.JPG)