### PR TITLE
Update apple links in 7.0

### DIFF
--- a/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[AvatarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/AvatarView.swift)
+[AvatarView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/People%20Picker/AvatarView.swift)
 
 ### Sample code
 
-[AvatarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift)
+[AvatarView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/AvatarPage/docs/mac/AvatarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/AvatarPage/docs/mac/AvatarImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source Code
 
-[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/AvatarView.swift)
+[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/AvatarView/AvatarView.swift)
 
 ### Sample Code
 
-[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestAvatarViewController.swift)
+[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestAvatarViewController.swift)

--- a/apps/fabric-website/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationImplementation.md
@@ -6,10 +6,10 @@
 
 ### Source code
 
-[TabBarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/TabBarView.swift)
+[TabBarView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Tab%20Bar/TabBarView.swift)
 
-[TabBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/TabBarItem.swift)
+[TabBarItem](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Tab%20Bar/TabBarItem.swift)
 
 ### Sample code
 
-[TabBarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift)
+[TabBarView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Button](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Button.swift)
+[Button](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/Button.swift)
 
 ### Sample code
 
-[Button demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift)
+[Button demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ButtonPage/docs/mac/ButtonImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/docs/mac/ButtonImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Button.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Button.swift)
+[Button.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Button/Button.swift)
 
 ### Sample code
 
-[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestButtonViewController.swift)
+[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestButtonViewController.swift)

--- a/apps/fabric-website/src/pages/Controls/ChipPage/docs/ios/ChipImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ChipPage/docs/ios/ChipImplementation.md
@@ -6,12 +6,12 @@
 
 ### Source code
 
-[BadgeView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/BadgeView.swift)
+[BadgeView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Badge%20Field/BadgeView.swift)
 
-[BadgeField](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/BadgeField.swift)
+[BadgeField](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Badge%20Field/BadgeField.swift)
 
 ### Sample code
 
-[BadgeView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift)
+[BadgeView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift)
 
-[BadgeField demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift)
+[BadgeField demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[DateTimePicker](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Date%20Time%20Pickers/DateTimePicker.swift)
+[DateTimePicker](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Date%20Time%20Pickers/DateTimePicker.swift)
 
 ### Sample code
 
-[DateTimePicker demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift)
+[DateTimePicker demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/mac/DatePickerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/mac/DatePickerImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source Code
 
-[DatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/DatePicker/DatePickerController.swift)
+[DatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/DatePicker/DatePickerController.swift)
 
 ### Sample Code
 
-[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestDatePickerController.swift)
+[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestDatePickerController.swift)

--- a/apps/fabric-website/src/pages/Controls/DrawerPage/docs/ios/DrawerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/DrawerPage/docs/ios/DrawerImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[DrawerController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Drawer/DrawerController.swift)
+[DrawerController](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Drawer/DrawerController.swift)
 
 ### Sample code
 
-[DrawerController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift)
+[DrawerController demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/LinkPage/docs/mac/LinkImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/LinkPage/docs/mac/LinkImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source Code
 
-[Link.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Link.swift)
+[Link.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Link/Link.swift)
 
 ### Sample Code
 
-[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestLinkViewController.swift)
+[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestLinkViewController.swift)

--- a/apps/fabric-website/src/pages/Controls/ListCellsPage/docs/ios/ListCellsImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ListCellsPage/docs/ios/ListCellsImplementation.md
@@ -14,22 +14,22 @@
 
 ### Source code
 
-[TableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewCell.swift)
+[TableViewCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/TableViewCell.swift)
 
-[ActionsCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/ActionsCell.swift)
+[ActionsCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/ActionsCell.swift)
 
-[ActivityIndicatorCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/ActivityIndicatorCell.swift)
+[ActivityIndicatorCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/ActivityIndicatorCell.swift)
 
-[CenteredLabelCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/CenteredLabelCell.swift)
+[CenteredLabelCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/CenteredLabelCell.swift)
 
-[BooleanCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/BooleanCell.swift)
+[BooleanCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/BooleanCell.swift)
 
-[TableViewHeaderFooterView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewHeaderFooterView.swift)
+[TableViewHeaderFooterView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/TableViewHeaderFooterView.swift)
 
 ### Sample code
 
-[TableViewCell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift)
+[TableViewCell demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift)
 
-[Other cells demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift)
+[Other cells demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift)
 
-[TableViewHeaderFooterView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift)
+[TableViewHeaderFooterView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[NotificationView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Notification/NotificationView.swift)
+[NotificationView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Notification/NotificationView.swift)
 
 ### Sample code
 
-[NotificationView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift)
+[NotificationView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/NavBarPage/docs/ios/NavBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/NavBarPage/docs/ios/NavBarImplementation.md
@@ -6,10 +6,10 @@
 
 ### Source code
 
-[NavigationController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Navigation/NavigationController.swift)
+[NavigationController](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Navigation/NavigationController.swift)
 
-[SearchBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/SearchBar.swift)
+[SearchBar](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/SearchBar.swift)
 
 ### Sample code
 
-[NavigationController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift)
+[NavigationController demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaImplementation.md
@@ -6,10 +6,10 @@
 
 ### Source code
 
-[PersonaListView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/PersonaListView.swift)
+[PersonaListView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/People%20Picker/PersonaListView.swift)
 
-[PersonaCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/PersonaCell.swift)
+[PersonaCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/People%20Picker/PersonaCell.swift)
 
 ### Sample code
 
-[PersonaListView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift)
+[PersonaListView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarImplementation.md
@@ -8,12 +8,12 @@
 
 ### Source code
 
-[PillButtonBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
+[PillButtonBar](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
-[PillButtonBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
+[PillButtonBarItem](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
-[PillButtonBarDelegate](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
+[PillButtonBarDelegate](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
 ### Sample code
 
-[PillButtonBar demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift)
+[PillButtonBar demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PivotPage/docs/ios/PivotImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PivotPage/docs/ios/PivotImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[SegmentedControl](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/SegmentedControl.swift)
+[SegmentedControl](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/SegmentedControl.swift)
 
 ### Sample code
 
-[SegmentedControl demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift)
+[SegmentedControl demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
@@ -6,10 +6,10 @@
 
 ### Source code
 
-[PopupMenuController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/PopupMenuController.swift)
+[PopupMenuController](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Popup%20Menu/PopupMenuController.swift)
 
-[PopupMenuItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/PopupMenuItem.swift)
+[PopupMenuItem](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Popup%20Menu/PopupMenuItem.swift)
 
 ### Sample code
 
-[PopupMenuController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift)
+[PopupMenuController demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/ios/SeparatorImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/ios/SeparatorImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Separator](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Separator.swift)
+[Separator](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/Separator.swift)
 
 ### Sample code
 
-[Used in TableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewCell.swift)
+[Used in TableViewCell](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Table%20View/TableViewCell.swift)

--- a/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/mac/SeparatorImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/mac/SeparatorImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Separator.swift)
+[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Separator/Separator.swift)
 
 ### Sample code
 
-[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestSeparatorViewController.swift)
+[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestSeparatorViewController.swift)

--- a/apps/fabric-website/src/pages/Controls/ShimmerPage/docs/ios/ShimmerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ShimmerPage/docs/ios/ShimmerImplementation.md
@@ -6,12 +6,12 @@
 
 ### Source code
 
-[ShimmerView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/ShimmerView.swift)
+[ShimmerView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Shimmer/ShimmerView.swift)
 
-[ShimmerLinesView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/ShimmerLinesView.swift)
+[ShimmerLinesView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Shimmer/ShimmerLinesView.swift)
 
 ### Sample code
 
-[ShimmerView in Table View Cell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift)
+[ShimmerView in Table View Cell demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift)
 
-[ShimmerLinesView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift)
+[ShimmerLinesView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerImplementation.md
@@ -6,12 +6,12 @@
 
 ### Source code
 
-[ActivityIndicatorView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/ActivityIndicatorView.swift)
+[ActivityIndicatorView](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/ActivityIndicatorView.swift)
 
-[HUD](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/HUD/HUD.swift)
+[HUD](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/HUD/HUD.swift)
 
 ### Sample code
 
-[ActivityIndicatorView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorViewDemoController.swift)
+[ActivityIndicatorView demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorViewDemoController.swift)
 
-[HUD demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift)
+[HUD demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Label](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Label.swift)
+[Label](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Controls/Label.swift)
 
 ### Sample code
 
-[Label demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift)
+[Label demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/TooltipPage/docs/ios/TooltipImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/TooltipPage/docs/ios/TooltipImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Tooltip](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tooltip/Tooltip.swift)
+[Tooltip](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Tooltip/Tooltip.swift)
 
 ### Sample code
 
-[Tooltip demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift)
+[Tooltip demo](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift)

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/ios/GetStartedOverview.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/ios/GetStartedOverview.md
@@ -8,4 +8,4 @@ Documentation for the controls is a work in progress. Some controls can be found
 
 ### Start developing
 
-Setup instructions and more information can be found in the [Fluent UI Apple readme](https://github.com/microsoft/fluentui-apple/blob/master/README.md).
+Setup instructions and more information can be found in the [Fluent UI Apple readme](https://github.com/microsoft/fluentui-apple/blob/main/README.md).

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/mac/GetStartedOverview.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/mac/GetStartedOverview.md
@@ -8,4 +8,4 @@ Documentation for the controls is a work in progress. Some controls can be found
 
 ### Start developing
 
-Setup instructions and more information can be found in the [Fluent UI Apple readme](https://github.com/microsoft/fluentui-apple/blob/master/README.md).
+Setup instructions and more information can be found in the [Fluent UI Apple readme](https://github.com/microsoft/fluentui-apple/blob/main/README.md).

--- a/change/@uifabric-fabric-website-2021-02-14-17-34-44-cherry-pick-apple-links.json
+++ b/change/@uifabric-fabric-website-2021-02-14-17-34-44-cherry-pick-apple-links.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update links to fluentui-apple",
+  "packageName": "@uifabric/fabric-website",
+  "email": "mavitale@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-15T01:34:44.800Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The fluentui-apple repository recently updated its default branch to be named 'main'. Since there are some links to the old default branch ('master') in our documentation, update them to be correct. There were a few other minor changes due to some refactoring in the fluentui-apple repository.

Note this was already merged into master with #16978, this is a cherry-pick to the 7.0 branch to update the current website. 

#### Focus areas to test

Ensure the links properly take users to the new default branch of the Microsoft/fluentui-apple GitHub repository. Tested by running the website locally and clicking through the links.