### PR TITLE
chore: remove inline sourcemap

### DIFF
--- a/scripts/gulp/tasks/bundle.ts
+++ b/scripts/gulp/tasks/bundle.ts
@@ -26,7 +26,7 @@ task('bundle:package:commonjs', () =>
   src(componentsSrc)
     .pipe(sourcemaps.init())
     .pipe(babel())
-    .pipe(sourcemaps.write())
+    .pipe(sourcemaps.write('.'))
     .pipe(dest(paths.packageDist(packageName, 'commonjs'))),
 );
 
@@ -34,7 +34,7 @@ task('bundle:package:es', () =>
   src(componentsSrc)
     .pipe(sourcemaps.init())
     .pipe(babel({ caller: { useESModules: true } } as any))
-    .pipe(sourcemaps.write())
+    .pipe(sourcemaps.write('.'))
     .pipe(dest(paths.packageDist(packageName, 'es'))),
 );
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Revert the inline source map introduced by PR #15331

We still would like to have inline source map, to remove the source map warnings and make it easier to debug in codesandbox. But some how #15331 didn't work.

#### Focus areas to test

(optional)
