### PR TITLE
feat(Tree): add keyboard navigation based on first letter of the text content in `useTree` hook

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `FormTextArea` component @assuncaocharles ([#16660](https://github.com/microsoft/fluentui/pull/16660))
 - Added `checked="mixed"` support for `Checkbox` @assuncaocharles ([#16081](https://github.com/microsoft/fluentui/pull/16081))
 - Added `ImageAltTextIcon` @notandrew ([#16884](https://github.com/microsoft/fluentui/pull/16884))
+- For `Tree`, add keyboard navigation based on the first letter of the text content of tree items @yuanboxue-amber ([#16994](https://github.com/microsoft/fluentui/pull/16994))
 
 ## Performance
 

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
@@ -1,4 +1,4 @@
-import { keyboardKey, SpacebarKey, EnterKey } from '../../keyboard-key';
+import { keyboardKey, SpacebarKey, EnterKey, LetterKeys } from '../../keyboard-key';
 import { Accessibility, AriaRole } from '../../types';
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
@@ -74,6 +74,9 @@ export const treeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => {
             }),
         expandSiblings: {
           keyCombinations: [{ keyCode: keyboardKey['*'] }],
+        },
+        setFocusByFirstCharacter: {
+          keyCombinations: LetterKeys.map(key => ({ keyCode: key })),
         },
         ...(props.selectable && {
           performClick: {

--- a/packages/fluentui/accessibility/src/keyboard-key/index.ts
+++ b/packages/fluentui/accessibility/src/keyboard-key/index.ts
@@ -291,3 +291,32 @@ export const HomeKey = keyboardKey.Home;
 export const PageDownKey = keyboardKey.PageDown;
 export const PageUpKey = keyboardKey.PageUp;
 export const TabKey = keyboardKey.Tab;
+
+export const LetterKeys = [
+  keyboardKey.a,
+  keyboardKey.b,
+  keyboardKey.c,
+  keyboardKey.d,
+  keyboardKey.e,
+  keyboardKey.f,
+  keyboardKey.g,
+  keyboardKey.h,
+  keyboardKey.i,
+  keyboardKey.j,
+  keyboardKey.k,
+  keyboardKey.l,
+  keyboardKey.m,
+  keyboardKey.n,
+  keyboardKey.o,
+  keyboardKey.p,
+  keyboardKey.q,
+  keyboardKey.r,
+  keyboardKey.s,
+  keyboardKey.t,
+  keyboardKey.u,
+  keyboardKey.v,
+  keyboardKey.w,
+  keyboardKey.x,
+  keyboardKey.y,
+  keyboardKey.z,
+];

--- a/packages/fluentui/e2e/e2eApi.ts
+++ b/packages/fluentui/e2e/e2eApi.ts
@@ -29,7 +29,9 @@ type E2EKeys =
   | 'Tab'
   | 'F'
   | 'O'
-  | '*';
+  | '*'
+  | 'T'
+  | 'H';
 
 const PUPPETEER_ACTION_TIMEOUT = 10 * 1000;
 

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-example.tsx
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-example.tsx
@@ -14,6 +14,14 @@ const items = [
             id: 'jaime',
             title: 'Jaime',
           },
+          {
+            id: 'cersei',
+            title: 'cersei',
+          },
+          {
+            id: 'tyrion',
+            title: 'tyrion',
+          },
         ],
       },
       {

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
@@ -16,7 +16,7 @@ const navigateToLastLevel = async () => {
   await e2e.isFocused(selectors.treeItemAt(2));
 
   await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowRight'); // Expand second level item
-  await e2e.expectCount(selectors.treeItem, 4);
+  await e2e.expectCount(selectors.treeItem, 6);
 
   await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowRight'); // Focus first child 3rd level
   await e2e.isFocused(selectors.treeTitleAt(3)); // last level has always tree title focused
@@ -36,7 +36,7 @@ describe('Tree keyboard navigation', () => {
 
     await e2e.waitForSelectorAndPressKey(selectors.treeTitleAt(3), 'ArrowLeft'); // Focus parent 2nd level
     await e2e.isFocused(selectors.treeItemAt(2));
-    await e2e.expectCount(selectors.treeItem, 4);
+    await e2e.expectCount(selectors.treeItem, 6);
 
     await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // closes 3rd level
     await e2e.expectCount(selectors.treeItem, 3);
@@ -44,6 +44,23 @@ describe('Tree keyboard navigation', () => {
 
     await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // Focus parent 1nd level
     await e2e.expectCount(selectors.treeItem, 3);
+    await e2e.isFocused(selectors.treeItemAt(1));
+  });
+
+  it('Should set focus based on first letter', async () => {
+    await navigateToLastLevel();
+
+    await e2e.focusOn(selectors.treeItemAt(1)); // focus on 'House Lannister'
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(1), 'T'); // expect focus to be on 'Tywin'
+    await e2e.isFocused(selectors.treeItemAt(2));
+
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'T'); // expect focus to be on 'tyrion'
+    await e2e.isFocused(selectors.treeItemAt(5));
+
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'F'); // expect focus to stay because no node is start with 'F'
+    await e2e.isFocused(selectors.treeItemAt(5));
+
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'H'); // expect focus to be on 'House Lannister'
     await e2e.isFocused(selectors.treeItemAt(1));
   });
 });

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
@@ -55,10 +55,10 @@ describe('Tree keyboard navigation', () => {
     await e2e.isFocused(selectors.treeItemAt(2));
 
     await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'T'); // expect focus to be on 'tyrion'
-    await e2e.isFocused(selectors.treeItemAt(5));
+    await e2e.isFocused(selectors.treeTitleAt(5));
 
     await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'F'); // expect focus to stay because no node is start with 'F'
-    await e2e.isFocused(selectors.treeItemAt(5));
+    await e2e.isFocused(selectors.treeTitleAt(5));
 
     await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'H'); // expect focus to be on 'House Lannister'
     await e2e.isFocused(selectors.treeItemAt(1));

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedStickyTree/VirtualStickyTree.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedStickyTree/VirtualStickyTree.tsx
@@ -86,6 +86,7 @@ export const VirtualStickyTree: ComponentWithAs<'div', VirtualStickyTreeProps> =
     expandSiblings,
     listRef,
     getItemRef,
+    setToFocusIDByFirstCharacter,
   } = useVirtualTree({ ...props, defaultActiveItemIds: stickyItemIds });
 
   const getItemSize = React.useCallback(
@@ -170,8 +171,9 @@ export const VirtualStickyTree: ComponentWithAs<'div', VirtualStickyTreeProps> =
       focusItemById,
       expandSiblings,
       toggleItemSelect: _.noop,
+      setToFocusIDByFirstCharacter,
     }),
-    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings],
+    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, setToFocusIDByFirstCharacter],
   );
 
   // When using keyboard, and navigate to non-sticky items, they could be hidden behind sticky headers.

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedStickyTree/VirtualStickyTree.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedStickyTree/VirtualStickyTree.tsx
@@ -86,7 +86,7 @@ export const VirtualStickyTree: ComponentWithAs<'div', VirtualStickyTreeProps> =
     expandSiblings,
     listRef,
     getItemRef,
-    setToFocusIDByFirstCharacter,
+    getToFocusIDByFirstCharacter,
   } = useVirtualTree({ ...props, defaultActiveItemIds: stickyItemIds });
 
   const getItemSize = React.useCallback(
@@ -171,9 +171,9 @@ export const VirtualStickyTree: ComponentWithAs<'div', VirtualStickyTreeProps> =
       focusItemById,
       expandSiblings,
       toggleItemSelect: _.noop,
-      setToFocusIDByFirstCharacter,
+      getToFocusIDByFirstCharacter,
     }),
-    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, setToFocusIDByFirstCharacter],
+    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, getToFocusIDByFirstCharacter],
   );
 
   // When using keyboard, and navigate to non-sticky items, they could be hidden behind sticky headers.

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedTree/VirtualTree.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedTree/VirtualTree.tsx
@@ -70,6 +70,7 @@ export const VirtualTree: ComponentWithAs<'div', VirtualTreeProps> = props => {
     focusItemById,
     expandSiblings,
     listRef,
+    setToFocusIDByFirstCharacter,
   } = useVirtualTree(props);
 
   const contextValue: TreeRenderContextValue = React.useMemo(
@@ -80,8 +81,9 @@ export const VirtualTree: ComponentWithAs<'div', VirtualTreeProps> = props => {
       focusItemById,
       expandSiblings,
       toggleItemSelect: _.noop,
+      setToFocusIDByFirstCharacter,
     }),
-    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings],
+    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, setToFocusIDByFirstCharacter],
   );
 
   // always use item id as key instead of index (react-window's default)

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedTree/VirtualTree.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/VirtualizedTree/VirtualTree.tsx
@@ -70,7 +70,7 @@ export const VirtualTree: ComponentWithAs<'div', VirtualTreeProps> = props => {
     focusItemById,
     expandSiblings,
     listRef,
-    setToFocusIDByFirstCharacter,
+    getToFocusIDByFirstCharacter,
   } = useVirtualTree(props);
 
   const contextValue: TreeRenderContextValue = React.useMemo(
@@ -81,9 +81,9 @@ export const VirtualTree: ComponentWithAs<'div', VirtualTreeProps> = props => {
       focusItemById,
       expandSiblings,
       toggleItemSelect: _.noop,
-      setToFocusIDByFirstCharacter,
+      getToFocusIDByFirstCharacter,
     }),
-    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, setToFocusIDByFirstCharacter],
+    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, getToFocusIDByFirstCharacter],
   );
 
   // always use item id as key instead of index (react-window's default)

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -145,6 +145,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
     focusItemById,
     expandSiblings,
     toggleItemSelect,
+    setToFocusIDByFirstCharacter,
   } = useTree(props);
 
   const contextValue: TreeRenderContextValue = React.useMemo(
@@ -155,8 +156,17 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
       expandSiblings,
       focusItemById,
       toggleItemSelect,
+      setToFocusIDByFirstCharacter,
     }),
-    [getItemById, registerItemRef, toggleItemActive, focusItemById, expandSiblings, toggleItemSelect],
+    [
+      getItemById,
+      registerItemRef,
+      toggleItemActive,
+      focusItemById,
+      expandSiblings,
+      toggleItemSelect,
+      setToFocusIDByFirstCharacter,
+    ],
   );
 
   const renderContent = (): React.ReactElement[] => {

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -145,7 +145,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
     focusItemById,
     expandSiblings,
     toggleItemSelect,
-    setToFocusIDByFirstCharacter,
+    getToFocusIDByFirstCharacter,
   } = useTree(props);
 
   const contextValue: TreeRenderContextValue = React.useMemo(
@@ -156,7 +156,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
       expandSiblings,
       focusItemById,
       toggleItemSelect,
-      setToFocusIDByFirstCharacter,
+      getToFocusIDByFirstCharacter,
     }),
     [
       getItemById,
@@ -165,7 +165,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
       focusItemById,
       expandSiblings,
       toggleItemSelect,
-      setToFocusIDByFirstCharacter,
+      getToFocusIDByFirstCharacter,
     ],
   );
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -145,6 +145,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     focusItemById,
     expandSiblings,
     toggleItemSelect,
+    setToFocusIDByFirstCharacter,
   } = React.useContext(TreeContext);
 
   const { selected, hasSubtree, childrenIds } = getItemById(id);
@@ -185,6 +186,14 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
         e.stopPropagation();
 
         handleSiblingsExpand(e);
+      },
+      setFocusByFirstCharacter: e => {
+        e.preventDefault();
+        e.stopPropagation();
+        const toFocusID = setToFocusIDByFirstCharacter(e, props.id);
+        if (toFocusID !== props.id) {
+          focusItemById(toFocusID);
+        }
       },
       performSelection: e => {
         e.preventDefault();

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -145,7 +145,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     focusItemById,
     expandSiblings,
     toggleItemSelect,
-    setToFocusIDByFirstCharacter,
+    getToFocusIDByFirstCharacter,
   } = React.useContext(TreeContext);
 
   const { selected, hasSubtree, childrenIds } = getItemById(id);
@@ -190,7 +190,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
       setFocusByFirstCharacter: e => {
         e.preventDefault();
         e.stopPropagation();
-        const toFocusID = setToFocusIDByFirstCharacter(e, props.id);
+        const toFocusID = getToFocusIDByFirstCharacter(e, props.id);
         if (toFocusID !== props.id) {
           focusItemById(toFocusID);
         }

--- a/packages/fluentui/react-northstar/src/components/Tree/context.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/context.ts
@@ -9,6 +9,7 @@ export interface TreeRenderContextValue {
   focusItemById: (id: string) => void;
   expandSiblings: (e: React.SyntheticEvent, id: string) => void;
   toggleItemSelect: (e: React.SyntheticEvent, idToToggle: string) => void;
+  setToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToStartSearch: string) => string;
 }
 
 export const TreeContext = React.createContext<TreeRenderContextValue>({
@@ -18,4 +19,5 @@ export const TreeContext = React.createContext<TreeRenderContextValue>({
   focusItemById: _.noop,
   expandSiblings: _.noop,
   toggleItemSelect: _.noop,
+  setToFocusIDByFirstCharacter: (e, id) => id,
 });

--- a/packages/fluentui/react-northstar/src/components/Tree/context.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/context.ts
@@ -9,7 +9,7 @@ export interface TreeRenderContextValue {
   focusItemById: (id: string) => void;
   expandSiblings: (e: React.SyntheticEvent, id: string) => void;
   toggleItemSelect: (e: React.SyntheticEvent, idToToggle: string) => void;
-  setToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToStartSearch: string) => string;
+  getToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToStartSearch: string) => string;
 }
 
 export const TreeContext = React.createContext<TreeRenderContextValue>({
@@ -19,5 +19,5 @@ export const TreeContext = React.createContext<TreeRenderContextValue>({
   focusItemById: _.noop,
   expandSiblings: _.noop,
   toggleItemSelect: _.noop,
-  setToFocusIDByFirstCharacter: (e, id) => id,
+  getToFocusIDByFirstCharacter: (e, id) => id,
 });

--- a/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
@@ -249,7 +249,7 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
         // get first charater of tree node using the same way aria does (https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/js/treeitemLinks.js)
         const itemFirstChar = getItemRef(visibleItemIds[i])
           ?.textContent?.trim()
-          ?.substring(0, 1)
+          ?.charAt(0)
           ?.toLowerCase();
         if (itemFirstChar === char) {
           return i;

--- a/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
@@ -251,7 +251,7 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
           ?.textContent?.trim()
           ?.charAt(0)
           ?.toLowerCase();
-        if (itemFirstChar === char) {
+        if (itemFirstChar === char.toLowerCase()) {
           return i;
         }
       }

--- a/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
@@ -90,7 +90,7 @@ export interface UseTreeResult {
    * Search wraps to first matching node if a matching is not found among the nodes that follow the focused node.
    * Focus stays when no matching is found among all visible nodes.
    */
-  setToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToToggle: string) => string;
+  getToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToToggle: string) => string;
 }
 
 export function useTree(options: UseTreeOptions): UseTreeResult {
@@ -260,7 +260,7 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
     [getItemRef, visibleItemIds],
   );
 
-  const setToFocusIDByFirstCharacter = React.useCallback(
+  const getToFocusIDByFirstCharacter = React.useCallback(
     (e: React.KeyboardEvent, idToStartSearch: string) => {
       // Get start index for search
       let starIndex = visibleItemIds.indexOf(idToStartSearch) + 1;
@@ -291,7 +291,7 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
     focusItemById,
     expandSiblings,
     toggleItemSelect,
-    setToFocusIDByFirstCharacter,
+    getToFocusIDByFirstCharacter,
   };
 }
 

--- a/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/hooks/useTree.ts
@@ -84,6 +84,13 @@ export interface UseTreeResult {
 
   /** update the state of tree when a tree item is selected/unselected */
   toggleItemSelect: (e: React.SyntheticEvent, idToToggle: string) => void;
+
+  /**
+   * When a-z/A-Z key is pressed on a tree item, move focus to the next visible tree node with content that starts with the typed char.
+   * Search wraps to first matching node if a matching is not found among the nodes that follow the focused node.
+   * Focus stays when no matching is found among all visible nodes.
+   */
+  setToFocusIDByFirstCharacter: (e: React.KeyboardEvent, idToToggle: string) => string;
 }
 
 export function useTree(options: UseTreeOptions): UseTreeResult {
@@ -236,6 +243,43 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
     [getItemById, getItemRef],
   );
 
+  const searchByFirstChar = React.useCallback(
+    (startIndex: number, endIndex: number, char: string) => {
+      for (let i = startIndex; i < endIndex; ++i) {
+        // get first charater of tree node using the same way aria does (https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/js/treeitemLinks.js)
+        const itemFirstChar = getItemRef(visibleItemIds[i])
+          ?.textContent?.trim()
+          ?.substring(0, 1)
+          ?.toLowerCase();
+        if (itemFirstChar === char) {
+          return i;
+        }
+      }
+      return -1;
+    },
+    [getItemRef, visibleItemIds],
+  );
+
+  const setToFocusIDByFirstCharacter = React.useCallback(
+    (e: React.KeyboardEvent, idToStartSearch: string) => {
+      // Get start index for search
+      let starIndex = visibleItemIds.indexOf(idToStartSearch) + 1;
+      if (starIndex === visibleItemIds.length) {
+        starIndex = 0;
+      }
+
+      // Check following nodes in tree
+      let toFocusIndex = searchByFirstChar(starIndex, visibleItemIds.length, e.key);
+      // If not found in following nodes, check from beginning
+      if (toFocusIndex === -1) {
+        toFocusIndex = searchByFirstChar(0, starIndex - 1, e.key);
+      }
+
+      return visibleItemIds[toFocusIndex];
+    },
+    [searchByFirstChar, visibleItemIds],
+  );
+
   return {
     flatTree,
     getItemById,
@@ -247,6 +291,7 @@ export function useTree(options: UseTreeOptions): UseTreeResult {
     focusItemById,
     expandSiblings,
     toggleItemSelect,
+    setToFocusIDByFirstCharacter,
   };
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds keyboard navigation based on first letter of the tree item's text content:
![image](https://user-images.githubusercontent.com/28751745/107951947-6465ba80-6f99-11eb-9be2-aecfdf0878b1.png)

Following aria example here: https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html

This PR focus on non-virtualized tree. There will be a separate follow up PR to support the same for virtualized tree.

#### Focus areas to test

(optional)
