### PR TITLE
Updating size auditor config for upcoming PR #16686

### DIFF
--- a/sizeauditor.json
+++ b/sizeauditor.json
@@ -1,4 +1,4 @@
 {
   "devopsDropFolderName": "drop",
-  "devopsWebpackStatsArtifactName": "bundlesizes.json"
+  "devopsAssemblyArtifactName": "drop"
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
We are updating the size auditor to handle React and React Northstar for this PR: https://github.com/microsoft/fluentui/pull/16686

Looking deeper into SizeAuditor code we noticed that:
* `devopsWebpackStatsArtifactName` was never being used
* `devopsAssemblyArtifactName` needs to be set if there is more than 1 drop artifact, currently it works because ADO returns the correct drop even with an empty artifact name, however this will no longer be the case after #16686 
* SizeAuditor always pull config from the master branch of a repo, which makes it impossible to change the config in a PR


#### Focus areas to test

(optional)
