### PR TITLE
Fix: Layer's div element is not removed from body

### DIFF
--- a/change/@fluentui-react-charting-ff3a82e7-f623-43ad-a740-20c5198ec596.json
+++ b/change/@fluentui-react-charting-ff3a82e7-f623-43ad-a740-20c5198ec596.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix: VerticalBarChart: Cannot read property 'x' of undefined error if empty data provided",
+  "packageName": "@fluentui/react-charting",
+  "email": "feodor@appveyor.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -85,7 +85,10 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     this._calloutId = getId('callout');
     this._tooltipId = getId('VCTooltipID_');
     this._refArray = [];
-    this._xAxisType = getTypeOfAxis(this.props.data![0].x, true) as XAxisTypes;
+    this._xAxisType =
+      this.props.data! && this.props.data!.length > 0
+        ? (getTypeOfAxis(this.props.data![0].x, true) as XAxisTypes)
+        : XAxisTypes.StringAxis;
   }
 
   public render(): JSX.Element {

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -12,6 +12,9 @@ const getClassNames = classNamesFunction<ILayerStyleProps, ILayerStyles>();
 export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<HTMLDivElement, ILayerProps>(
   (props, ref) => {
     const [layerElement, setLayerElement] = React.useState<HTMLDivElement | undefined>();
+    const refLayerElement = React.useRef(layerElement);
+    refLayerElement.current = layerElement;
+
     const rootRef = React.useRef<HTMLSpanElement>(null);
     const mergedRef = useMergedRefs(rootRef, ref);
 
@@ -56,10 +59,11 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
     const removeLayerElement = (): void => {
       onLayerWillUnmount?.();
 
-      if (layerElement && layerElement.parentNode) {
-        const parentNode = layerElement.parentNode;
+      const elem = refLayerElement.current;
+      if (elem && elem.parentNode) {
+        const parentNode = elem.parentNode;
         if (parentNode) {
-          parentNode.removeChild(layerElement);
+          parentNode.removeChild(elem);
         }
       }
     };


### PR DESCRIPTION
All components depending on Layer component (e.g. Tooltip, ContextMenus, Dialog, Panel, even Chart callouts) are affected by this bug.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16808
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

A reference to a state were added to access it from `useLayoutEffect` callback.

#### Focus areas to test

(optional)
