### PR TITLE
fix(Menu): Update focus styling for iconOnly menu in Teams themes

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updated `Datepicker` to allow the entire week selection and removed space between cells. @vejrj ([#16887](https://github.com/microsoft/fluentui/pull/16887))
 
 ## Fixes
+- Fix `Menu` iconOnly focus border to be correct style in Teams themes @codepretty ([#17005](https://github.com/microsoft/fluentui/pull/17005))
 - Fix `Label` color schemes. Fix padding for circular `Label`. @TanelVari ([#16160](https://github.com/microsoft/fluentui/pull/16160))
 - Fix RadioGroup visual issues. Add `RadioButtonIcon`. Fix vertical RadioGroup alignment issue with custom content. Fix focus frame alignment for bare indicator. @TanelVari ([#16478](https://github.com/microsoft/fluentui/pull/16478))
 - Fix event handlers behavior and compatibility with portals in React 17 @layershifter ([#16514](https://github.com/microsoft/fluentui/pull/16514))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -169,8 +169,7 @@ export const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, Me
         color: 'inherit',
 
         ...(iconOnly && {
-          borderRadius: '50%',
-          borderColor: v.iconOnlyColorFocus,
+          ...getBorderFocusStyles({ variables: siteVariables }),
           ...getIconFillOrOutlineStyles({ outline: false }),
         }),
 


### PR DESCRIPTION
#### Description of changes
Update the focus border on iconOnly menu

**Before**
![image](https://user-images.githubusercontent.com/828692/108021030-892a5400-6fd2-11eb-9784-03fc34bf2acd.png)

**After**
![image](https://user-images.githubusercontent.com/828692/108021106-b119b780-6fd2-11eb-86ef-508fc3f55a25.png)
