### PR TITLE
CI: Fix unhandled promise rejection in prettier

### DIFF
--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -29,9 +29,9 @@ async function main() {
   const queue = new PQueue({ concurrency: numberOfCpus });
 
   if (runOnAllFiles) {
-    runOnAll({ queue, paths });
+    await runOnAll({ queue, paths });
   } else {
-    runOnChanged({ queue, paths });
+    await runOnChanged({ queue, paths });
   }
 
   await queue.onEmpty().catch(error => {
@@ -84,7 +84,7 @@ async function runOnChanged(options) {
   await queue.addAll(
     fileGroups.map(group => () => {
       console.log(`Running for ${group.length} files!`);
-      runPrettier(group, { runAsync: true, check: parsedArgs.check });
+      return runPrettier(group, { runAsync: true, check: parsedArgs.check });
     }),
   );
 }

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -73,7 +73,7 @@ async function runOnChanged(options) {
   const prettierExtRegex = new RegExp(`\\.(${prettierExtensions.join('|')})$`);
   const files = gitDiffOutput
     .toString('utf8')
-    .split(os.EOL)
+    .split('\n')
     .filter(fileName => prettierExtRegex.test(fileName));
 
   const fileGroups = [];


### PR DESCRIPTION
Fixes #14632.

Prettier used to swallow unhandled promise rejections and would always pass CI. Now the promise rejections are caught so CI will fail appropriately for prettier.

Also includes a fix for Windows, since `git diff` will always return unix line endings.

[Failing build for reference](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=187985&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=072a33dd-3583-57e6-ff95-c892c0923c97)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
