### PR TITLE
chore: fix pipeline warning on `master`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,13 @@ jobs:
       ## manually call this since lage is now used and it calls lint per package, not per repo
       - script: |
           yarn prelint
-          yarn prettier $(targetBranch) --check
+
+          if [ $BUILD_SOURCEBRANCH == "refs/heads/master" ]; then
+            yarn prettier --check
+          else
+            yarn prettier $(targetBranch) --check
+          fi
+
         displayName: do syncpack and lint-files checks
 
       ## Danger.js checks for Fluent UI N*


### PR DESCRIPTION
#### Description of changes

This PR fixes a warning in pipelines when a PR runs for `master` branch:

![Warning in `yarn prettier` check](https://user-images.githubusercontent.com/14183168/108080291-fc35d800-706f-11eb-9b85-cd415bda8c5b.png)

It happens because `targetBranch` variable is defined only for runs on PRs:

https://github.com/microsoft/fluentui/blob/64622c05fd4cd5011bd31d92d8664f128e9d3bf2/.devops/templates/variables.yml#L19-L20
