### PR TITLE
7.0: Update colors for FloatingSuggestionsComposite items and header footer items

### DIFF
--- a/change/@uifabric-experiments-2021-02-16-16-20-51-fixpickercolors7.0.json
+++ b/change/@uifabric-experiments-2021-02-16-16-20-51-fixpickercolors7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update colors for the FloatingSuggestionsComposite items",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-17T00:20:51.203Z"
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
@@ -7,7 +7,6 @@ import {
 const GlobalClassNames = {
   actionButton: 'ms-FloatingSuggestionsHeaderFooterItem-actionButton',
   buttonSelected: 'ms-FloatingSuggestionsHeaderFooterItem-buttonSelected',
-  suggestionsTitle: 'ms-FloatingSuggestionsHeaderFooterItem-suggestionsTitle',
 };
 
 export const getStyles = (
@@ -19,7 +18,7 @@ export const getStyles = (
     throw new Error('theme is undefined or null in FloatingSuggestionsItem getStyles function.');
   }
 
-  const { semanticColors } = theme;
+  const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
@@ -35,7 +34,7 @@ export const getStyles = (
             color: 'WindowText',
           },
           '&:hover': {
-            color: semanticColors.menuItemTextHovered,
+            background: palette.neutralLighter,
           },
         },
       },
@@ -43,10 +42,15 @@ export const getStyles = (
     buttonSelected: [
       classNames.buttonSelected,
       {
-        background: semanticColors.menuItemBackgroundPressed,
+        background: palette.themeLighter,
         selectors: {
-          ':hover': {
-            background: semanticColors.menuDivider,
+          '&:hover': {
+            background: palette.themeLight,
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'HighlightText',
+              ...getHighContrastNoAdjustStyle(),
+            },
           },
           [HighContrastSelector]: {
             background: 'Highlight',

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -17,8 +17,7 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
   }
 
   const { isSelected } = props;
-  const { palette, semanticColors, fonts } = theme;
-  const { neutralDark, neutralTertiaryAlt, neutralSecondary } = palette;
+  const { palette, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
@@ -33,10 +32,13 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
         overflow: 'hidden',
         selectors: {
           '&:hover': {
-            background: semanticColors.menuItemBackgroundHovered,
+            background: palette.neutralLighter,
           },
           '&:hover .ms-FloatingSuggestionsItem-closeButton': {
             display: 'block',
+          },
+          '&:active, &:focus': {
+            background: palette.themeLight,
           },
         },
       },
@@ -52,18 +54,20 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
           [HighContrastSelector]: {
             color: 'WindowText',
           },
-          '&:hover': {
-            color: semanticColors.menuItemTextHovered,
-          },
         },
       },
       isSelected && [
         classNames.isSelected,
         {
-          background: semanticColors.menuItemBackgroundPressed,
+          background: palette.themeLighter,
           selectors: {
             ':hover': {
-              background: semanticColors.menuDivider,
+              background: palette.themeLight,
+              [HighContrastSelector]: {
+                background: 'Highlight',
+                color: 'HighlightText',
+                ...getHighContrastNoAdjustStyle(),
+              },
             },
             [HighContrastSelector]: {
               background: 'Highlight',
@@ -78,20 +82,35 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
       classNames.closeButton,
       {
         display: 'none',
-        color: neutralSecondary,
         padding: '0 4px',
         height: 'auto',
         width: 32,
         selectors: {
-          ':hover, :active': {
-            background: neutralTertiaryAlt,
-            color: neutralDark,
-          },
-          [HighContrastSelector]: {
-            color: 'WindowText',
+          ':hover': {
+            [HighContrastSelector]: {
+              background: 'Window',
+              color: 'WindowText',
+              ...getHighContrastNoAdjustStyle(),
+            },
           },
         },
       },
+      isSelected && [
+        classNames.isSelected,
+        {
+          background: palette.themeLighter,
+          selectors: {
+            ':hover': {
+              background: palette.themeLight,
+            },
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'HighlightText',
+              ...getHighContrastNoAdjustStyle(),
+            },
+          },
+        },
+      ],
     ],
     displayText: [
       classNames.displayText,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update the colors to be what was used in the old picker, to maintain compatibility with the old one and because some of the colors did not go well together.

I will check this into v8 myself