### PR TITLE
Fix handling of topOffsetFixed for Modal

### DIFF
--- a/change/office-ui-fabric-react-2021-02-16-17-31-24-hotfix-7.0-top-offset-fixed.json
+++ b/change/office-ui-fabric-react-2021-02-16-17-31-24-hotfix-7.0-top-offset-fixed.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix handling of topOffsetFixed for Modal",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-17T01:31:24.076Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -114,17 +114,6 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
           hasBeenOpened: true,
           isVisible: true,
         });
-
-        if (newProps.topOffsetFixed) {
-          const dialogMain = document.getElementsByClassName('ms-Dialog-main');
-          let modalRectangle;
-          if (dialogMain.length > 0) {
-            modalRectangle = dialogMain[0].getBoundingClientRect();
-            this.setState({
-              modalRectangleTop: modalRectangle.top,
-            });
-          }
-        }
       }
     }
 
@@ -142,7 +131,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
     // isOpen as true. We need to add the keyUp handler in componentDidMount if we are in that case.
     if (this.state.isOpen && this.state.isVisible) {
       this._registerForKeyUp();
-      this._registerInitialModalPosition();
+      requestAnimationFrame(() => setTimeout(this._registerInitialModalPosition, 0));
     }
   }
 
@@ -313,13 +302,18 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
   }
 
   private _registerInitialModalPosition = (): void => {
-    if (this.props.dragOptions?.keepInBounds && !this._minClampedPosition && !this._maxClampedPosition) {
-      const dialogMain = document.querySelector(`[data-id=${this.state.id}]`);
-      if (dialogMain) {
-        const modalRectangle = dialogMain.getBoundingClientRect();
+    const dialogMain = document.querySelector(`[data-id=${this.state.id}]`);
+
+    if (dialogMain) {
+      const modalRectangle = dialogMain.getBoundingClientRect();
+      if (this.props.dragOptions?.keepInBounds && !this._minClampedPosition && !this._maxClampedPosition) {
         this._minClampedPosition = { x: -modalRectangle.x, y: -modalRectangle.y };
         this._maxClampedPosition = { x: modalRectangle.x, y: modalRectangle.y };
       }
+
+      this.setState({
+        modalRectangleTop: modalRectangle.top,
+      });
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
@@ -47,6 +47,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
         transition: `opacity ${animationDuration}`,
       },
       topOffsetFixed &&
+        typeof modalRectangleTop === 'number' &&
         hasBeenOpened && {
           alignItems: 'flex-start',
         },
@@ -75,6 +76,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
         zIndex: isModeless ? ZIndexes.Layer : undefined,
       },
       topOffsetFixed &&
+        typeof modalRectangleTop === 'number' &&
         hasBeenOpened && {
           top: modalRectangleTop,
         },


### PR DESCRIPTION
#### Description of changes

Fixed an issue where `topOffsetFixed` passed to `Modal` would not be honored if the `Modal` was supposed to be open on the *first* render, not initially hidden and then toggled open later.

#### Focus areas to test

There is a demo for `Dialog` which showcases `topOffsetFixed`. That demo was validated as part of this change.

**Note**: This issue has already been fixed in Fluent 8, since the logic was moved to a `useEffect` callback.