### PR TITLE
Move react-context-selector to react-bindings

### DIFF
--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -21,15 +21,16 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-is": "^16.6.3",
+    "scheduler": "^0.20.1",
     "stylis": "^3.5.4",
     "stylis-plugin-rtl": "^1.0.0"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta",
+    "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
-    "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
     "react-dom": "16.8.6"

--- a/packages/fluentui/react-bindings/src/context-selector/createContext.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/createContext.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import { Context, ContextValue } from './types';
+import { runWithNormalPriority, useIsomorphicLayoutEffect } from './utils';
+
+const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) => {
+  const Provider: React.FC<React.ProviderProps<Value>> = props => {
+    // Holds an actual "props.value"
+    const valueRef = React.useRef(props.value);
+    // Used to sync context updates and avoid stale values, can be considered as render/effect counter of Provider.
+    const versionRef = React.useRef(0);
+
+    // A stable object, is used to avoid context updates via mutation of its values.
+    const contextValue = React.useRef<ContextValue<Value>>();
+
+    if (!contextValue.current) {
+      contextValue.current = {
+        value: valueRef,
+        version: versionRef,
+        listeners: [],
+      };
+    }
+
+    useIsomorphicLayoutEffect(() => {
+      valueRef.current = props.value;
+      versionRef.current += 1;
+
+      runWithNormalPriority(() => {
+        (contextValue.current as ContextValue<Value>).listeners.forEach(listener => {
+          listener([versionRef.current, props.value]);
+        });
+      });
+    }, [props.value]);
+
+    return React.createElement(Original, { value: contextValue.current }, props.children);
+  };
+
+  /* istanbul ignore else */
+  if (process.env.NODE_ENV !== 'production') {
+    Provider.displayName = 'ContextSelector.Provider';
+  }
+
+  return Provider;
+};
+
+export const createContext = <Value>(defaultValue: Value): Context<Value> => {
+  const context = React.createContext<ContextValue<Value>>({
+    value: { current: defaultValue },
+    version: { current: -1 },
+    listeners: [],
+  });
+
+  context.Provider = createProvider<Value>(context.Provider) as any;
+
+  // We don't support Consumer API
+  delete ((context as unknown) as Context<Value>).Consumer;
+
+  return (context as unknown) as Context<Value>;
+};

--- a/packages/fluentui/react-bindings/src/context-selector/types.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/types.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export type Context<Value> = React.Context<Value> & {
+  Provider: React.FC<React.ProviderProps<Value>>;
+  Consumer: never;
+};
+
+export type ContextSelector<Value, SelectedValue> = (value: Value) => SelectedValue;
+
+export type ContextVersion = number;
+
+export type ContextValue<Value> = {
+  /** Holds a set of subscribers from components. */
+  listeners: ((payload: readonly [ContextVersion, Value]) => void)[];
+
+  /** Holds an actual value of React's context that will be propagated down for computations. */
+  value: React.MutableRefObject<Value>;
+
+  /** A version field is used to sync a context value and consumers. */
+  version: React.MutableRefObject<ContextVersion>;
+};
+
+export type ContextValues<Value> = ContextValue<Value> & {
+  /** List of listners to publish changes */
+  listeners: ((payload: readonly [ContextVersion, Record<string, Value>]) => void)[];
+};

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelector.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelector.ts
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import { Context, ContextSelector, ContextValue, ContextVersion } from './types';
+import { useIsomorphicLayoutEffect } from './utils';
+
+/**
+ * This hook returns context selected value by selector.
+ * It will only accept context created by `createContext`.
+ * It will trigger re-render if only the selected value is referencially changed.
+ */
+export const useContextSelector = <Value, SelectedValue>(
+  context: Context<Value>,
+  selector: ContextSelector<Value, SelectedValue>,
+): SelectedValue => {
+  const contextValue = React.useContext((context as unknown) as Context<ContextValue<Value>>);
+
+  const {
+    value: { current: value },
+    version: { current: version },
+    listeners,
+  } = contextValue;
+  const selected = selector(value);
+
+  const [state, dispatch] = React.useReducer(
+    (
+      prevState: readonly [Value /* contextValue */, SelectedValue /* selector(value) */],
+      payload:
+        | undefined // undefined from render below
+        | readonly [ContextVersion, Value], // from provider effect
+    ) => {
+      if (!payload) {
+        // early bail out when is dispatched during render
+        return [value, selected] as const;
+      }
+
+      if (payload[0] <= version) {
+        if (Object.is(prevState[1], selected)) {
+          return prevState; // bail out
+        }
+
+        return [value, selected] as const;
+      }
+
+      try {
+        if (Object.is(prevState[0], payload[1])) {
+          return prevState; // do not update
+        }
+
+        const nextSelected = selector(payload[1]);
+
+        if (Object.is(prevState[1], nextSelected)) {
+          return prevState; // do not update
+        }
+
+        return [payload[1], nextSelected] as const;
+      } catch (e) {
+        // ignored (stale props or some other reason)
+      }
+      return [...prevState] as const; // schedule update
+    },
+    [value, selected] as const,
+  );
+
+  if (!Object.is(state[1], selected)) {
+    // schedule re-render
+    // this is safe because it's self contained
+    dispatch(undefined);
+  }
+
+  useIsomorphicLayoutEffect(() => {
+    listeners.push(dispatch);
+
+    return () => {
+      const index = listeners.indexOf(dispatch);
+      listeners.splice(index, 1);
+    };
+  }, [listeners]);
+
+  return state[1] as SelectedValue;
+};

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { Context, ContextSelector, ContextVersion, ContextValues } from './types';
+import { useIsomorphicLayoutEffect } from './utils';
+
+/**
+ * This hook returns context selected value by selectors.
+ * It will only accept context created by `createContext`.
+ * It will trigger re-render if only the selected value is referencially changed.
+ */
+export const useContextSelectors = <
+  Value,
+  Properties extends string,
+  Selectors extends Record<Properties, ContextSelector<Value, SelectedValue>>,
+  SelectedValue extends any
+>(
+  context: Context<Value>,
+  selectors: Selectors,
+): Record<Properties, SelectedValue> => {
+  const contextValue = React.useContext((context as unknown) as Context<ContextValues<Value>>);
+
+  const {
+    value: { current: value },
+    version: { current: version },
+    listeners,
+  } = contextValue;
+
+  const selected = {} as Record<Properties, SelectedValue>;
+  Object.keys(selectors).forEach((key: Properties) => {
+    selected[key] = selectors[key](value);
+  });
+
+  const [state, dispatch] = React.useReducer(
+    (
+      prevState: readonly [Record<Properties, SelectedValue> /* contextValue */, SelectedValue /* selector(value) */],
+      payload:
+        | undefined // undefined from render below
+        | readonly [ContextVersion, Record<Properties, Value>], // from provider effect
+    ) => {
+      if (!payload) {
+        return [value, selected] as const;
+      }
+
+      if (payload[0] <= version) {
+        const stateHasNotChanged = Object.keys(selectors).every((key: Properties) =>
+          Object.is(prevState[1][key] as SelectedValue, selected[key]),
+        );
+
+        if (stateHasNotChanged) {
+          return prevState; // bail out
+        }
+
+        return [value, selected] as const;
+      }
+
+      try {
+        const statePayloadHasChanged = Object.keys(prevState[0]).some((key: Properties) => {
+          return !Object.is(prevState[0][key] as SelectedValue, payload[1][key]);
+        });
+
+        if (!statePayloadHasChanged) {
+          return prevState;
+        }
+
+        const nextSelected = {} as Record<Properties, SelectedValue>;
+        Object.keys(selectors).forEach((key: Properties) => {
+          nextSelected[key] = selectors[key](payload[1][key]);
+        });
+
+        const selecteddHasNotChanged = Object.keys(selectors).every((key: Properties) => {
+          return Object.is(prevState[1][key] as SelectedValue, nextSelected[key]);
+        });
+
+        if (selecteddHasNotChanged) {
+          return prevState;
+        }
+
+        return [payload[1], nextSelected] as const;
+      } catch (e) {
+        // ignored (stale props or some other reason)
+      }
+      return [...prevState] as const; // schedule update
+    },
+    [value, selected] as const,
+  );
+
+  Object.keys(selectors).forEach((key: Properties) => {
+    if (!Object.is(state[1][key], selected[key])) {
+      // schedule re-render
+      // this is safe because it's self contained
+      dispatch(undefined);
+    }
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    listeners.push(dispatch);
+
+    return () => {
+      const index = listeners.indexOf(dispatch);
+      listeners.splice(index, 1);
+    };
+  }, [listeners]);
+
+  return state[1] as SelectedValue;
+};

--- a/packages/fluentui/react-bindings/src/context-selector/utils.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/utils.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { unstable_NormalPriority as NormalPriority, unstable_runWithPriority as runWithPriority } from 'scheduler';
+
+const isSSR =
+  typeof window === 'undefined' || /ServerSideRendering/.test(window.navigator && window.navigator.userAgent);
+
+export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect;
+
+export function runWithNormalPriority(thunk: () => void) {
+  return runWithPriority(NormalPriority, thunk);
+}

--- a/packages/fluentui/react-bindings/src/index.ts
+++ b/packages/fluentui/react-bindings/src/index.ts
@@ -37,3 +37,8 @@ export { getUnhandledProps } from './utils/getUnhandledProps';
 export { mergeVariablesOverrides } from './utils/mergeVariablesOverrides';
 
 export * from './context';
+
+export { createContext } from './context-selector/createContext';
+export { useContextSelector } from './context-selector/useContextSelector';
+export { useContextSelectors } from './context-selector/useContextSelectors';
+export * from './context-selector/types';

--- a/packages/fluentui/react-bindings/test/context-selector/createContext-test.tsx
+++ b/packages/fluentui/react-bindings/test/context-selector/createContext-test.tsx
@@ -1,0 +1,9 @@
+import { createContext } from '@fluentui/react-bindings';
+import * as ReactIs from 'react-is';
+
+describe('createContext', () => {
+  it('creates a Provider component', () => {
+    const Context = createContext(null);
+    expect(ReactIs.isValidElementType(Context.Provider)).toBeTruthy();
+  });
+});

--- a/packages/fluentui/react-bindings/test/context-selector/useContextSelector-test.tsx
+++ b/packages/fluentui/react-bindings/test/context-selector/useContextSelector-test.tsx
@@ -1,0 +1,100 @@
+import { createContext, useContextSelector } from '@fluentui/react-bindings';
+import * as ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import * as React from 'react';
+
+const TestContext = createContext<{ index: number }>({ index: -1 });
+
+const TestComponent: React.FC<{ index: number; onUpdate?: () => void }> = props => {
+  const active = useContextSelector(TestContext, v => v.index === props.index);
+
+  React.useEffect(() => {
+    props.onUpdate && props.onUpdate();
+  });
+
+  return <div className="test-component" data-active={active} />;
+};
+
+const TestProvider: React.FC = props => {
+  const [index, setIndex] = React.useState<number>(0);
+
+  return (
+    <div className="test-provider" onClick={() => setIndex(prevIndex => prevIndex + 1)}>
+      <TestContext.Provider value={{ index }}>{props.children}</TestContext.Provider>
+    </div>
+  );
+};
+
+describe('useContextSelector', () => {
+  let container: HTMLElement | null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container as HTMLElement);
+    container = null;
+  });
+
+  it('updates only on selector match', () => {
+    const onUpdate = jest.fn();
+    ReactDOM.render(
+      <TestProvider>
+        <TestComponent index={1} onUpdate={onUpdate} />
+      </TestProvider>,
+      container,
+    );
+
+    act(() => {
+      // no-op to wait for effects
+    });
+
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+    expect(onUpdate).toBeCalledTimes(1);
+
+    // Match => update, (v.index: 1, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(onUpdate).toBeCalledTimes(2);
+
+    // No match, but update because "active" changed, (v.index: 2, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+    expect(onUpdate).toBeCalledTimes(3);
+
+    // Match previous => no update, (v.index: 3, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+    expect(onUpdate).toBeCalledTimes(3);
+  });
+
+  it('updates are propogated inside React.memo()', () => {
+    // https://reactjs.org/docs/react-api.html#reactmemo
+    // Will never pass updates
+    const MemoComponent = React.memo(TestComponent, () => true);
+    const onUpdate = jest.fn();
+
+    ReactDOM.render(
+      <TestProvider>
+        <MemoComponent index={1} onUpdate={onUpdate} />
+      </TestProvider>,
+      container,
+    );
+
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(onUpdate).toBeCalledTimes(2);
+  });
+});

--- a/packages/fluentui/react-bindings/test/context-selector/useContextSelectors-test.tsx
+++ b/packages/fluentui/react-bindings/test/context-selector/useContextSelectors-test.tsx
@@ -1,0 +1,145 @@
+import { createContext, useContextSelectors } from '@fluentui/react-bindings';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+const TestContext = createContext<{ index: number; value: string }>({
+  index: -1,
+  value: '',
+});
+
+const TestComponent: React.FC<{ index: number; onUpdate?: () => void }> = props => {
+  const context = useContextSelectors(TestContext, {
+    active: v => v.index === props.index,
+    value: v => v.value,
+  });
+
+  React.useEffect(() => {
+    props.onUpdate && props.onUpdate();
+  });
+
+  return <div className="test-component" data-active={context.active} data-value={context.value} />;
+};
+
+const TestProvider: React.FC<{ value: any; children: any }> = props => {
+  const [index, setIndex] = React.useState<number>(+props.value.index);
+  const [value, setValue] = React.useState<string>(props.value.value);
+
+  return (
+    <div className="test-provider">
+      <button className="set-index" onClick={e => setIndex(+(e.target as HTMLElement)?.dataset.index!)} />
+      <button className="change-value" onClick={e => setValue((e.target as HTMLElement)?.dataset.value!)} />
+      <TestContext.Provider value={{ index, value }}>{props.children}</TestContext.Provider>
+    </div>
+  );
+};
+
+describe('useContextSelectors', () => {
+  let container: HTMLElement | null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container as HTMLElement);
+    container = null;
+  });
+
+  it('propogates values via Context', () => {
+    ReactDOM.render(
+      <TestProvider value={{ index: 1, value: 'foo' }}>
+        <TestComponent index={1} />
+      </TestProvider>,
+      container,
+    );
+
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('foo');
+  });
+
+  it('updates only on selector match', () => {
+    const onUpdate = jest.fn();
+    ReactDOM.render(
+      <TestProvider value={{ index: -1, value: 'foo' }}>
+        <TestComponent index={1} onUpdate={onUpdate} />
+      </TestProvider>,
+      container,
+    );
+
+    act(() => {
+      // no-op to wait for effects
+    });
+
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('foo');
+    expect(onUpdate).toBeCalledTimes(1);
+
+    // No match, (v.index: 2, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.set-index')?.setAttribute('data-index', '2');
+      document.querySelector<HTMLElement>('.change-value')?.setAttribute('data-value', 'foo');
+      document.querySelector<HTMLElement>('.set-index')?.click();
+      document.querySelector<HTMLElement>('.change-value')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('false');
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('foo');
+    expect(onUpdate).toBeCalledTimes(1);
+
+    // // Match => update, (v.index: 1, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.set-index')?.setAttribute('data-index', '1');
+      document.querySelector<HTMLElement>('.change-value')?.setAttribute('data-value', 'foo');
+      document.querySelector<HTMLElement>('.set-index')?.click();
+      document.querySelector<HTMLElement>('.change-value')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('foo');
+    expect(onUpdate).toBeCalledTimes(2);
+
+    // // Match previous => no update, (v.index: 1, p.index: 1)
+    act(() => {
+      document.querySelector<HTMLElement>('.set-index')?.setAttribute('data-index', '1');
+      document.querySelector<HTMLElement>('.change-value')?.setAttribute('data-value', 'foo');
+      document.querySelector<HTMLElement>('.set-index')?.click();
+      document.querySelector<HTMLElement>('.change-value')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('foo');
+    expect(onUpdate).toBeCalledTimes(2);
+
+    // Match => update, (v.value: 'bar')
+    act(() => {
+      document.querySelector<HTMLElement>('.set-index')?.setAttribute('data-index', '1');
+      document.querySelector<HTMLElement>('.change-value')?.setAttribute('data-value', 'bar');
+      document.querySelector<HTMLElement>('.set-index')?.click();
+      document.querySelector<HTMLElement>('.change-value')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.value).toBe('bar');
+    expect(onUpdate).toBeCalledTimes(3);
+  });
+
+  it('updates are propogated inside React.memo()', () => {
+    // https://reactjs.org/docs/react-api.html#reactmemo
+    // Will never pass updates
+    const MemoComponent = React.memo(TestComponent, () => true);
+
+    const onUpdate = jest.fn();
+    ReactDOM.render(
+      <TestProvider value={{ index: 0, value: 'foo' }}>
+        <MemoComponent index={1} onUpdate={onUpdate} />
+      </TestProvider>,
+      container,
+    );
+
+    act(() => {
+      document.querySelector<HTMLElement>('.set-index')?.setAttribute('data-index', '1');
+      document.querySelector<HTMLElement>('.change-value')?.setAttribute('data-value', 'foo');
+      document.querySelector<HTMLElement>('.set-index')?.click();
+      document.querySelector<HTMLElement>('.change-value')?.click();
+    });
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(onUpdate).toBeCalledTimes(2);
+  });
+});

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -12,7 +12,6 @@
     "@fluentui/react-component-event-listener": "^0.52.0",
     "@fluentui/react-component-nesting-registry": "^0.52.0",
     "@fluentui/react-component-ref": "^0.52.0",
-    "@fluentui/react-context-selector": "^0.52.0",
     "@fluentui/react-icons-northstar": "^0.52.0",
     "@fluentui/react-northstar-styles-renderer": "^0.52.0",
     "@fluentui/react-proptypes": "^0.52.0",

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -13,8 +13,8 @@ import {
   useFluentContext,
   useStyles,
   useTelemetry,
+  useContextSelector,
 } from '@fluentui/react-bindings';
-import { useContextSelector } from '@fluentui/react-context-selector';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import cx from 'classnames';

--- a/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@fluentui/react-context-selector';
+import { createContext } from '@fluentui/react-bindings';
 
 export type ChatItemContextValue = {
   attached: boolean | 'top' | 'bottom';

--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -7,8 +7,8 @@ import {
   useFluentContext,
   useStyles,
   useTelemetry,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
-import { useContextSelectors } from '@fluentui/react-context-selector';
 import cx from 'classnames';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';

--- a/packages/fluentui/react-northstar/src/components/List/listContext.ts
+++ b/packages/fluentui/react-northstar/src/components/List/listContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@fluentui/react-context-selector';
+import { createContext } from '@fluentui/react-bindings';
 import { ComponentVariablesInput } from '@fluentui/styles';
 import * as React from 'react';
 

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -9,8 +9,8 @@ import {
   useTelemetry,
   useStyles,
   useUnhandledProps,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
-import { useContextSelectors } from '@fluentui/react-context-selector';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -13,6 +13,7 @@ import {
   useStyles,
   ComponentWithAs,
   ShorthandConfig,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
 
 import { Ref, handleRef } from '@fluentui/react-component-ref';
@@ -40,7 +41,6 @@ import { ComponentEventHandler, ShorthandValue, ShorthandCollection } from '../.
 import { Popper, PopperShorthandProps, partitionPopperPropsFromShorthand } from '../../utils/positioner';
 
 import { MenuContext, MenuItemSubscribedValue } from './menuContext';
-import { useContextSelectors } from '@fluentui/react-context-selector';
 
 export interface MenuItemSlotClassNames {
   submenu: string;

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@fluentui/react-context-selector';
+import { createContext } from '@fluentui/react-bindings';
 import { ComponentVariablesInput } from '@fluentui/styles';
 import * as React from 'react';
 import { Accessibility } from '@fluentui/accessibility';

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -8,11 +8,11 @@ import {
   useAccessibility,
   useStyles,
   useTelemetry,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
 import { handleRef, Ref } from '@fluentui/react-component-ref';
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
-import { useContextSelectors } from '@fluentui/react-context-selector';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -23,10 +23,10 @@ import {
   getElementType,
   useUnhandledProps,
   useAccessibility,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
 
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
-import { useContextSelectors } from '@fluentui/react-context-selector';
 
 import {
   createShorthand,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/toolbarMenuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/toolbarMenuContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@fluentui/react-context-selector';
+import { createContext } from '@fluentui/react-bindings';
 import * as React from 'react';
 
 export type ToolbarMenuContextValue = {

--- a/packages/fluentui/react-northstar/tsconfig.json
+++ b/packages/fluentui/react-northstar/tsconfig.json
@@ -34,9 +34,6 @@
       "path": "../react-component-ref"
     },
     {
-      "path": "../react-context-selector"
-    },
-    {
       "path": "../react-northstar-styles-renderer"
     },
     {


### PR DESCRIPTION
In order to promote the `@fluentui/react-context-selector` for use in converged components, this PR duplicates the package in
`@fluentui/react-bindings` for v0 `react-northstar`.

There should be no more dependency of the `react-context-selector` package anywhere in the repo. Future PR will address the promotion of this v0 package for convergence.