### PR TITLE
chore(react-image): add Shift as co-codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,7 +98,7 @@ packages/react-button/ @dzearing @khmakoto
 packages/react-cards/ @khmakoto
 packages/react-checkbox/ @khmakoto @xugao
 packages/react-focus/src/components/FocusZone/ @khmakoto
-packages/react-image/ @kubkon
+packages/react-image/ @kubkon @layershifter
 packages/react-link/ @khmakoto
 packages/react-slider/ @joschect
 packages/react-tabs/ @behowell


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds @layershifter as co-codeowner of the converged `react-image` component.
