### PR TITLE
Utilize useLayoutEffect for keytips

### DIFF
--- a/change/@fluentui-react-examples-2021-02-17-14-07-54-keyou-keytips-fixes-7.0.json
+++ b/change/@fluentui-react-examples-2021-02-17-14-07-54-keyou-keytips-fixes-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Utilize useLayoutEffect for keytips to mimic didUpdate/didMount - Fixes for dynamic menu overflow keytips",
+  "packageName": "@fluentui/react-examples",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-17T22:07:54.803Z"
+}

--- a/change/office-ui-fabric-react-2021-02-17-14-07-54-keyou-keytips-fixes-7.0.json
+++ b/change/office-ui-fabric-react-2021-02-17-14-07-54-keyou-keytips-fixes-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Utilize useLayoutEffect for keytips to mimic didUpdate/didMount - Fixes for dynamic menu overflow keytips",
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-17T22:07:49.744Z"
+}

--- a/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
@@ -23,8 +23,20 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
     : undefined;
 
   const keytipManager = useConst<KeytipManager>(KeytipManager.getInstance());
+  const prevOptions = usePrevious(options);
 
-  React.useEffect(() => {
+  // useLayoutEffect used to strictly emulate didUpdate/didMount behavior
+  React.useLayoutEffect(() => {
+    if (
+      uniqueId.current &&
+      keytipProps &&
+      (prevOptions?.keytipProps !== options.keytipProps || prevOptions?.disabled !== options.disabled)
+    ) {
+      keytipManager.update(keytipProps, uniqueId.current);
+    }
+  });
+
+  React.useLayoutEffect(() => {
     // Register Keytip in KeytipManager
     if (keytipProps) {
       uniqueId.current = keytipManager.register(keytipProps);
@@ -37,16 +49,6 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
     // this is meant to run only at mount, and updates are handled separately
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const prevOptions = usePrevious(options);
-
-  if (
-    uniqueId.current &&
-    keytipProps &&
-    (prevOptions?.keytipProps !== options.keytipProps || prevOptions?.disabled !== options.disabled)
-  ) {
-    keytipManager.update(keytipProps, uniqueId.current);
-  }
 
   let nativeKeytipProps: IKeytipData = {
     ariaDescribedBy: undefined,

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -513,7 +513,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
    * Helper function to do checks related to persisted/overflow keytips
    * Done on keytip added and keytip updated
    *
-   * @param keytipProps
+   * @param keytipProps - Keytip props
    */
   private _persistedKeytipChecks = (keytipProps: IKeytipProps) => {
     if (this._newCurrentKeytipSequences && arraysEqual(keytipProps.keySequences, this._newCurrentKeytipSequences)) {

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -492,17 +492,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
       }
     }
 
-    if (this._newCurrentKeytipSequences && arraysEqual(keytipProps.keySequences, this._newCurrentKeytipSequences)) {
-      this._triggerKeytipImmediately(keytipProps);
-    }
-
-    if (this._isCurrentKeytipAnAlias(keytipProps)) {
-      let keytipSequence = keytipProps.keySequences;
-      if (keytipProps.overflowSetSequence) {
-        keytipSequence = mergeOverflows(keytipSequence, keytipProps.overflowSetSequence);
-      }
-      this._keytipTree.currentKeytip = this._keytipTree.getNode(sequencesToID(keytipSequence));
-    }
+    this._persistedKeytipChecks(keytipProps);
   };
 
   private _onKeytipUpdated = (eventArgs: any) => {
@@ -516,6 +506,16 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
       this._addKeytipToQueue(sequencesToID(keytipProps.keySequences));
     }
 
+    this._persistedKeytipChecks(keytipProps);
+  };
+
+  /**
+   * Helper function to do checks related to persisted/overflow keytips
+   * Done on keytip added and keytip updated
+   *
+   * @param keytipProps
+   */
+  private _persistedKeytipChecks = (keytipProps: IKeytipProps) => {
     if (this._newCurrentKeytipSequences && arraysEqual(keytipProps.keySequences, this._newCurrentKeytipSequences)) {
       this._triggerKeytipImmediately(keytipProps);
     }

--- a/packages/react-examples/src/office-ui-fabric-react/Keytip/Keytips.Dynamic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Keytip/Keytips.Dynamic.Example.tsx
@@ -16,7 +16,11 @@ const buttonTwoKeytipProps = {
 export const KeytipsDynamicExample: React.FunctionComponent = () => {
   const [currButton, setCurrButton] = React.useState('Button 1');
   const startSequence = currButton === 'Button 1' ? 'gg1' : 'gg2';
-  const onClick = (ev: React.MouseEvent<{}>) => setCurrButton((ev.target as Element).id);
+  const onClick = (buttonId: string) => {
+    return () => {
+      setCurrButton(buttonId);
+    };
+  };
 
   const buttonThreeKeytipProps = React.useMemo(
     () => ({
@@ -39,15 +43,21 @@ export const KeytipsDynamicExample: React.FunctionComponent = () => {
         id="Button 1"
         text="Button 1"
         // eslint-disable-next-line react/jsx-no-bind
-        onClick={onClick}
-        keytipProps={buttonOneKeytipProps}
+        onClick={onClick('Button 1')}
+        keytipProps={{
+          ...buttonOneKeytipProps,
+          onExecute: onClick('Button 1'),
+        }}
       />
       <DefaultButton
         id="Button 2"
         text="Button 2"
         // eslint-disable-next-line react/jsx-no-bind
-        onClick={onClick}
-        keytipProps={buttonTwoKeytipProps}
+        onClick={onClick('Button 2')}
+        keytipProps={{
+          ...buttonTwoKeytipProps,
+          onExecute: onClick('Button 2'),
+        }}
       />
       <div>
         <DefaultButton text={'Button 3, active button is: ' + currButton} keytipProps={buttonThreeKeytipProps} />

--- a/packages/react-examples/src/office-ui-fabric-react/Keytip/Keytips.Overflow.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Keytip/Keytips.Overflow.Example.tsx
@@ -41,6 +41,7 @@ const initialOverflowItems = [
       ...keytipMap.OverflowButton5,
       onExecute: (el: HTMLElement | null) => {
         if (el) {
+          el.focus();
           el.click();
         } else {
           console.log('first overflow item');
@@ -58,6 +59,7 @@ const initialOverflowItems = [
       ...keytipMap.OverflowButton6,
       onExecute: (el: HTMLElement | null) => {
         if (el) {
+          el.focus();
           el.click();
         } else {
           console.log('second overflow item');
@@ -93,11 +95,11 @@ export const KeytipsOverflowExample: React.FunctionComponent = () => {
     </CommandBarButton>
   );
 
-  const onRenderOverflowButton = (): JSX.Element => {
+  const onRenderOverflowButton = (newOverflowItems: any[]): JSX.Element => {
     return (
       <CommandBarButton
         menuIconProps={{ iconName: 'More' }}
-        menuProps={{ items: overflowItems! }}
+        menuProps={{ items: newOverflowItems, shouldFocusOnMount: false }}
         keytipProps={keytipMap.OverflowButton4}
       />
     );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16798
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The keytips were initially written reliant on the "old" class state flow functions, like componentDidMount and componentDidUpdate. A while ago these were converted to "useEffect" hooks which don't exactly follow the old functions. According to the react docs, "useLayoutEffect" is a more closer hook to those old functions, so changed the hooks to that

There are also small fixes regarding overflow keytips, for menus that are only "hidden" and don't get destroyed in the DOM. These are primarily the fixes done in KeytipLayer.base

Some keytip demos were also broken, those have been fixed

Master PR here https://github.com/microsoft/fluentui/pull/17042

#### Focus areas to test

Tested in the Office Online environment
