### PR TITLE
[v7.0] ScrollablePane: removes aria-hidden attribute so Sticky content are no longer hidden from screen readers

### DIFF
--- a/change/office-ui-fabric-react-2021-02-17-14-32-54-13974-v7.json
+++ b/change/office-ui-fabric-react-2021-02-17-14-32-54-13974-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ScrollablePane: removes aria-hidden attribute so Sticky content are no longer hidden from screen readers",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-17T22:32:54.413Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -197,7 +197,6 @@ export class ScrollablePaneBase extends React.Component<IScrollablePaneProps, IS
     return (
       <div {...getNativeProps(this.props, divProperties)} ref={this._root} className={classNames.root}>
         <div
-          aria-hidden="true"
           ref={this._stickyAboveRef}
           className={classNames.stickyAbove}
           style={this._getStickyContainerStyle(stickyTopHeight, true)}
@@ -207,11 +206,7 @@ export class ScrollablePaneBase extends React.Component<IScrollablePaneProps, IS
             {this.props.children}
           </ScrollablePaneContext.Provider>
         </div>
-        <div
-          aria-hidden="true"
-          className={classNames.stickyBelow}
-          style={this._getStickyContainerStyle(stickyBottomHeight, false)}
-        >
+        <div className={classNames.stickyBelow} style={this._getStickyContainerStyle(stickyBottomHeight, false)}>
           <div ref={this._stickyBelowRef} className={classNames.stickyBelowItems} />
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`ScrollablePane renders correctly 1`] = `
       }
 >
   <div
-    aria-hidden="true"
     className=
 
         {
@@ -55,7 +54,6 @@ exports[`ScrollablePane renders correctly 1`] = `
     data-is-scrollable={true}
   />
   <div
-    aria-hidden="true"
     className=
 
         {

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -160,27 +160,18 @@ export class Sticky extends React.Component<IStickyProps, IStickyState> {
     return (
       <div ref={this._root}>
         {this.canStickyTop && (
-          <div
-            ref={this._stickyContentTop}
-            aria-hidden={!isStickyTop}
-            style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentTop} style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div
-            ref={this._stickyContentBottom}
-            aria-hidden={!isStickyBottom}
-            style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentBottom} style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
         <div style={this._getNonStickyPlaceholderHeightAndWidth()} ref={this._placeHolder}>
           {(isStickyTop || isStickyBottom) && <span style={hiddenContentStyle as any}>{children}</span>}
           <div
-            aria-hidden={isStickyTop || isStickyBottom}
             ref={this._nonStickyContent}
             className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
             style={this._getContentStyles(isStickyTop || isStickyBottom)}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13974 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Removed hardcoded aria-hidden true attribute from ScrollablePane.
- Removed aria-hidden attribute from Sticky.
- Updated ScrollablePane snapshots to reflect changes.