### PR TITLE
Fix test issues discovered while trying to test React 17

### DIFF
--- a/change/@fluentui-react-2d1d37f7-882c-4e93-ab03-c04379e0906a.json
+++ b/change/@fluentui-react-2d1d37f7-882c-4e93-ab03-c04379e0906a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-492353e1-aff4-427f-99e5-4235d7aaf9c6.json
+++ b/change/@fluentui-react-experiments-492353e1-aff4-427f-99e5-4235d7aaf9c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-22a3a5d1-57e5-45ce-97fe-404b58d95486.json
+++ b/change/@fluentui-react-hooks-22a3a5d1-57e5-45ce-97fe-404b58d95486.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-4d75feb2-f40d-4218-94d5-f8d00441de88.json
+++ b/change/@fluentui-react-tabs-4d75feb2-f40d-4218-94d5-f8d00441de88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-2286958d-6e91-45e3-898a-d4cd287d01db.json
+++ b/change/@fluentui-test-utilities-2286958d-6e91-45e3-898a-d4cd287d01db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new safeRender API (wrapping ReactDOM.render) and add attach option to safeMount.",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-48a09f16-6fc1-419f-b032-d212d4913ec0.json
+++ b/change/@fluentui-utilities-48a09f16-6fc1-419f-b032-d212d4913ec0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { create, act } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import { BaseFloatingSuggestions } from './FloatingSuggestions';
 import * as ReactDOM from 'react-dom';
 import { IFloatingSuggestionItem } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
@@ -95,7 +95,7 @@ describe('FloatingSuggestions', () => {
     // since callout mount a new react root with ReactDOM.
     //
     // see https://github.com/facebook/react/pull/12895
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}
@@ -130,7 +130,7 @@ describe('FloatingSuggestions', () => {
   });
 
   it('renders FloatingSuggestions and updates when suggestions are removed', () => {
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}
@@ -165,7 +165,7 @@ describe('FloatingSuggestions', () => {
 
   it('shows no suggestions when no suggestions are provided', () => {
     _suggestions = [];
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}

--- a/packages/react-hooks/src/useUnmount.test.tsx
+++ b/packages/react-hooks/src/useUnmount.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { useUnmount } from './useUnmount';
 
@@ -17,7 +18,9 @@ describe('useUnmount', () => {
     expect(onUnmount).toBeCalledTimes(0);
     const wrapper = mount(<TestComponent />);
     expect(onUnmount).toBeCalledTimes(0);
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
     expect(onUnmount).toBeCalledTimes(1);
   });
 });

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -26,6 +26,7 @@
     "@fluentui/eslint-plugin": "^1.1.0",
     "@fluentui/react-conformance": "^0.2.5",
     "@fluentui/scripts": "^1.0.0",
+    "@fluentui/test-utilities": "^8.0.2",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-tabs/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react-tabs/src/components/Tabs/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { create } from '@fluentui/utilities/lib/test';
-import { mount } from 'enzyme';
 import { resetIds } from '@fluentui/utilities';
+import { safeMount, safeCreate } from '@fluentui/test-utilities';
 import { Tabs, TabItem, TabsImperativeHandle } from './index';
 import { isConformant } from '../../common/isConformant';
 
@@ -10,15 +9,18 @@ describe('Tabs', () => {
     // Resetting ids to create predictability in generated ids.
     resetIds();
   });
+
   it('renders tabs as links correctly', () => {
-    const component = create(
+    safeCreate(
       <Tabs>
         <TabItem headerText="Test Link 1" />
         <TabItem headerText="" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
 
   isConformant({
@@ -29,31 +31,33 @@ describe('Tabs', () => {
   it('can be focused', () => {
     const tabsRef = React.createRef<TabsImperativeHandle>();
 
-    mount(
-      <Tabs componentRef={tabsRef}>
-        <TabItem headerText="Link 1" />
-        <TabItem headerText="Link 2" />
-      </Tabs>,
-    );
-
     // Instruct FocusZone to treat all elements as visible.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (HTMLElement.prototype as any).isVisible = true;
 
-    try {
-      expect(tabsRef.current).toBeTruthy();
+    safeMount(
+      <Tabs componentRef={tabsRef}>
+        <TabItem headerText="Link 1" />
+        <TabItem headerText="Link 2" />
+      </Tabs>,
+      () => {
+        try {
+          expect(tabsRef.current).toBeTruthy();
 
-      tabsRef.current!.focus();
-      expect(document.activeElement).toBeTruthy();
-      expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (HTMLElement.prototype as any).isVisible;
-    }
+          tabsRef.current!.focus();
+          expect(document.activeElement).toBeTruthy();
+          expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
+        } finally {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (HTMLElement.prototype as any).isVisible;
+        }
+      },
+      true /* attached, for focus tests */,
+    );
   });
 
   it('supports JSX expressions', () => {
-    const component = create(
+    safeCreate(
       <Tabs defaultSelectedKey="1">
         <TabItem headerText="Test Link 1">
           <div>This is item 1</div>
@@ -63,79 +67,102 @@ describe('Tabs', () => {
           <div>This is Item 3</div>
         </TabItem>
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large tabs correctly', () => {
-    const component = create(
+    safeCreate(
       <Tabs tabSize="large">
         <TabItem headerText="Test Link 1" />
         <TabItem headerText="" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders tab format correctly', () => {
-    const component = create(
+    safeCreate(
       <Tabs tabFormat="tabs">
         <TabItem headerText="Test Link 1" />
         <TabItem headerText="" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large tab format correctly', () => {
-    const component = create(
+    safeCreate(
       <Tabs tabFormat="tabs" tabSize="large">
         <TabItem headerText="Test Link 1" />
         <TabItem headerText="" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Tabs correctly with custom className', () => {
-    const component = create(
+    safeCreate(
       <Tabs className="specialClassName">
         <TabItem headerText="Test Link 1" className="specialClassName" />
         <TabItem headerText="Test Link 2" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Tabs correctly with icon, text and count', () => {
-    const component = create(
+    safeCreate(
       <Tabs>
         <TabItem itemCount={12} />
         <TabItem headerText="Test Link" itemCount={12} />
         <TabItem headerText="Text with icon" itemIcon="Recent" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Tabs correctly when itemCount is a string', () => {
-    const component = create(
+    safeCreate(
       <Tabs>
         <TabItem headerText="test" />
         <TabItem headerText="Test Link" itemCount="20+" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Tabs with overflow', () => {
-    const component = create(
+    safeCreate(
       <Tabs overflowBehavior="menu">
         <TabItem headerText="Test 1" />
         <TabItem headerText="Test 2" />
       </Tabs>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/react/__mocks__/@fluentui/utilities.ts
+++ b/packages/react/__mocks__/@fluentui/utilities.ts
@@ -36,7 +36,9 @@ class MockAsync extends Async {
   }
 
   public dispose() {
-    clearTimeout(this._timeoutId);
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId);
+    }
     this._timeoutId = null;
 
     super.dispose();

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -14,6 +14,7 @@ import { IContextualMenuRenderItem, IContextualMenuItemStyles } from './Contextu
 import { DefaultButton, IButton } from '../../Button';
 import { resetIds } from '@fluentui/utilities';
 import { isConformant } from '../../common/isConformant';
+import { safeRender } from '@fluentui/test-utilities';
 
 describe('ContextualMenu', () => {
   afterEach(() => {
@@ -1089,40 +1090,42 @@ describe('ContextualMenu', () => {
     });
 
     it('Menu should correctly return focus to previously focused element when dismissed and document has focus', () => {
-      const temp = ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+      safeRender(
         <div>
           <DefaultButton menuProps={{ items: menu }} text="but" id="btn" />
         </div>,
-      ) as HTMLElement;
+        temp => {
+          // Get and make sure that the button is the active element
+          const btn = temp.querySelector('#btn')! as HTMLElement;
+          expect(btn).not.toEqual(null);
+          btn.focus();
+          expect(document.activeElement).toEqual(btn);
 
-      // Get and make sure that the button is the active element
-      const btn = temp.querySelector('#btn')! as HTMLElement;
-      expect(btn).not.toEqual(null);
-      btn.focus();
-      expect(document.activeElement).toEqual(btn);
+          // Click the button and make sure that the menu has opened
+          ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.click(btn);
+          });
+          const cm = document.querySelector('.ms-ContextualMenu-Callout');
+          expect(cm).not.toEqual(null);
 
-      // Click the button and make sure that the menu has opened
-      ReactTestUtils.act(() => {
-        ReactTestUtils.Simulate.click(btn);
-      });
-      const cm = document.querySelector('.ms-ContextualMenu-Callout');
-      expect(cm).not.toEqual(null);
+          // Get an item from the menu and make sure it's focused
+          const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
+          const menuItem = menuList.querySelector('button');
+          menuItem!.focus();
+          expect(document.activeElement).toEqual(menuItem);
+          ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.escape });
+          });
 
-      // Get an item from the menu and make sure it's focused
-      const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-      const menuItem = menuList.querySelector('button');
-      menuItem!.focus();
-      expect(document.activeElement).toEqual(menuItem);
-      ReactTestUtils.act(() => {
-        ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.escape });
-      });
+          // Ensure that the Menu has closed and that focus has returned to the button
+          expect(document.querySelector('.ms-ContextualMenu-Callout')).toBeNull();
 
-      // Ensure that the Menu has closed and that focus has returned to the button
-      expect(document.querySelector('.ms-ContextualMenu-Callout')).toBeNull();
-
-      if (document.hasFocus()) {
-        expect(document.activeElement).toEqual(btn);
-      }
+          if (document.hasFocus()) {
+            expect(document.activeElement).toEqual(btn);
+          }
+        },
+        true /* attach */,
+      );
     });
   });
 

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { KeyCodes } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -107,6 +108,13 @@ describe('FocusTrapZone', () => {
   let componentEventListeners: any = {};
   const ftzClassname = 'ftzTestClassname';
 
+  let host: HTMLElement | undefined;
+  function createHost() {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    return host;
+  }
+
   function _onFocus(ev: any): void {
     lastFocusedElement = ev.target;
   }
@@ -183,6 +191,11 @@ describe('FocusTrapZone', () => {
   afterEach(() => {
     // Make sure registered listeners are cleared between tests.
     componentEventListeners = {};
+
+    if (host) {
+      document.body.removeChild(host);
+      host = undefined;
+    }
   });
 
   afterAll(() => {
@@ -193,7 +206,8 @@ describe('FocusTrapZone', () => {
     it('can tab across FocusZones with different button structures', async () => {
       expect.assertions(3);
 
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div onFocusCapture={_onFocus}>
           <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
             <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
@@ -218,7 +232,8 @@ describe('FocusTrapZone', () => {
             </FocusZone>
           </FocusTrapZone>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
       const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
@@ -270,7 +285,8 @@ describe('FocusTrapZone', () => {
     it('can tab across a FocusZone with different button structures', async () => {
       expect.assertions(3);
 
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div onFocusCapture={_onFocus}>
           <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
             <div data-is-visible={true}>
@@ -290,7 +306,8 @@ describe('FocusTrapZone', () => {
             </FocusZone>
           </FocusTrapZone>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonX = topLevelDiv.querySelector('.x') as HTMLElement;
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
@@ -339,7 +356,8 @@ describe('FocusTrapZone', () => {
       are not the first inner element`, async () => {
       expect.assertions(4);
 
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div onFocusCapture={_onFocus}>
           <button className={'z1'}>z1</button>
           <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
@@ -357,7 +375,8 @@ describe('FocusTrapZone', () => {
           </FocusTrapZone>
           <button className={'z2'}>z2</button>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
@@ -430,7 +449,8 @@ describe('FocusTrapZone', () => {
 
   describe('Tab and shift-tab do nothing (keep focus where it is) when the FTZ contains 0 tabbable items', () => {
     function setupTest(props: IFocusTrapZoneProps) {
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div onFocusCapture={_onFocus}>
           <button className={'z1'}>z1</button>
           <FocusTrapZone className={ftzClassname} forceFocusInsideTrap={true} {...props}>
@@ -446,7 +466,8 @@ describe('FocusTrapZone', () => {
           </FocusTrapZone>
           <button className={'z2'}>z2</button>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
@@ -579,7 +600,10 @@ describe('FocusTrapZone', () => {
     function setupTest(props: IFocusTrapZoneProps) {
       // data-is-visible is embedded in buttons here for testing focus behavior on initial render.
       // Components have to be marked visible before setupElement has a chance to apply the data-is-visible attribute.
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+
+      // As of react 17/jest 25 this has to be attached to the document
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div>
           <div onFocusCapture={_onFocus}>
             <button className={'z1'}>z1</button>
@@ -597,7 +621,8 @@ describe('FocusTrapZone', () => {
             <button className={'z2'}>z2</button>
           </div>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
@@ -801,7 +826,8 @@ describe('FocusTrapZone', () => {
   describe('Focusing the FTZ', () => {
     function setupTest(focusPreviouslyFocusedInnerElement: boolean) {
       const focusTrapZoneRef = React.createRef<HTMLElement>();
-      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+      const topLevelDiv = createHost();
+      ReactDOM.render(
         <div onFocusCapture={_onFocus}>
           <FocusTrapZone
             forceFocusInsideTrap={true}
@@ -817,7 +843,8 @@ describe('FocusTrapZone', () => {
           </FocusTrapZone>
           <button className={'z'}>z</button>
         </div>,
-      ) as unknown) as HTMLElement;
+        topLevelDiv,
+      );
 
       const buttonF = topLevelDiv.querySelector('.f') as HTMLElement;
       const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;

--- a/packages/react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/react/src/components/Pivot/Pivot.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { create } from '@fluentui/utilities/lib/test';
-import { mount } from 'enzyme';
 import { resetIds } from '@fluentui/utilities';
+import { safeMount, safeCreate } from '@fluentui/test-utilities';
 import { Pivot, PivotItem, IPivot } from './index';
 import { isConformant } from '../../common/isConformant';
 
@@ -10,15 +9,18 @@ describe('Pivot', () => {
     // Resetting ids to create predictability in generated ids.
     resetIds();
   });
+
   it('renders link Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
 
   isConformant({
@@ -29,29 +31,31 @@ describe('Pivot', () => {
   it('can be focused', () => {
     const pivotRef = React.createRef<IPivot>();
 
-    mount(
+    // Instruct FocusZone to treat all elements as visible.
+    (HTMLElement.prototype as any).isVisible = true;
+
+    safeMount(
       <Pivot componentRef={pivotRef}>
         <PivotItem headerText="Link 1" />
         <PivotItem headerText="Link 2" />
       </Pivot>,
+      () => {
+        try {
+          expect(pivotRef.current).toBeTruthy();
+
+          pivotRef.current!.focus();
+          expect(document.activeElement).toBeTruthy();
+          expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
+        } finally {
+          delete (HTMLElement.prototype as any).isVisible;
+        }
+      },
+      true /* attached, for focus tests */,
     );
-
-    // Instruct FocusZone to treat all elements as visible.
-    (HTMLElement.prototype as any).isVisible = true;
-
-    try {
-      expect(pivotRef.current).toBeTruthy();
-
-      pivotRef.current!.focus();
-      expect(document.activeElement).toBeTruthy();
-      expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
-    } finally {
-      delete (HTMLElement.prototype as any).isVisible;
-    }
   });
 
   it('supports JSX expressions', () => {
-    const component = create(
+    safeCreate(
       <Pivot defaultSelectedKey="1">
         <PivotItem headerText="Test Link 1">
           <div>This is item 1</div>
@@ -61,79 +65,102 @@ describe('Pivot', () => {
           <div>This is Item 3</div>
         </PivotItem>
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large link Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkSize="large">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders tabbed Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkFormat="tabs">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large tabbed Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkFormat="tabs" linkSize="large">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly with custom className', () => {
-    const component = create(
+    safeCreate(
       <Pivot className="specialClassName">
         <PivotItem headerText="Test Link 1" className="specialClassName" />
         <PivotItem headerText="Test Link 2" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly with icon, text and count', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem itemCount={12} />
         <PivotItem headerText="Test Link" itemCount={12} />
         <PivotItem headerText="Text with icon" itemIcon="Recent" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly when itemCount is a string', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem headerText="test" />
         <PivotItem headerText="Test Link" itemCount="20+" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot with overflow', () => {
-    const component = create(
+    safeCreate(
       <Pivot overflowBehavior="menu">
         <PivotItem headerText="Test 1" />
         <PivotItem headerText="Test 2" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -333,7 +333,8 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
+    // input.focus(); // doesn't work in react 17/jest 25
+    ReactTestUtils.Simulate.focus(input);
 
     expect(getSuggestions(document)).toBeTruthy();
 
@@ -444,7 +445,8 @@ describe('BasePicker', () => {
     expect(getSuggestions(document)).toBeFalsy();
 
     runAllTimers();
-    input.focus();
+    // input.focus(); // doesn't work in react 17/jest 25
+    ReactTestUtils.Simulate.focus(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
@@ -454,16 +456,12 @@ describe('BasePicker', () => {
     jest.useFakeTimers();
     document.body.appendChild(root);
 
-    let count = 0;
-    const resolveCounter = (val: string) => {
-      count++;
-      return onResolveSuggestions(val);
-    };
+    const resolveMock = jest.fn(onResolveSuggestions);
     const picker = React.createRef<IBasePicker<ISimple>>();
 
     ReactDOM.render(
       <BasePickerWithType
-        onResolveSuggestions={resolveCounter}
+        onResolveSuggestions={resolveMock}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
@@ -473,10 +471,11 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
+    // input.focus(); // doesn't work in react 17/jest 25
+    ReactTestUtils.Simulate.focus(input);
     runAllTimers();
 
-    expect(count).toEqual(1);
+    expect(resolveMock).toHaveBeenCalledTimes(1);
 
     expect(getSuggestions(document)).toBeTruthy();
   });

--- a/packages/react/src/utilities/ThemeProvider/ThemeProvider.test.tsx
+++ b/packages/react/src/utilities/ThemeProvider/ThemeProvider.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { ThemeProvider } from './ThemeProvider';
 import * as renderer from 'react-test-renderer';
 import { useTheme } from './useTheme';
@@ -70,7 +71,9 @@ describe('ThemeProvider', () => {
     expect(themeProvider1.getAttribute('dir')).toBe('ltr');
     expect(themeProvider2.getAttribute('dir')).toBe(null);
 
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
   });
 
   it('renders a div with styling', () => {
@@ -137,7 +140,9 @@ describe('ThemeProvider', () => {
 
     expect(document.body).toMatchSnapshot();
 
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
 
     expect(document.body.className).toBe('');
 

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -20,19 +20,22 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.1.0",
+    "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/react": "16.9.42",
+    "@types/react-dom": "16.9.10",
     "@types/react-test-renderer": "^16.0.0",
     "enzyme": "~3.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/scripts": "^1.0.0"
+    "react-dom": "16.8.6",
+    "react-test-renderer": "^16.3.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",
+    "@types/react-dom": ">=16.8.0 <18.0.0",
     "enzyme": "^3.0.0",
     "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0",
     "react-test-renderer": ">=16.3.0 <18.0.0"
   }
 }

--- a/packages/test-utilities/src/index.ts
+++ b/packages/test-utilities/src/index.ts
@@ -1,3 +1,4 @@
 export { getCSSRules } from './getCSSRules';
 export { safeCreate } from './safeCreate';
 export { safeMount } from './safeMount';
+export { safeRender } from './safeRender';

--- a/packages/test-utilities/src/safeMount.ts
+++ b/packages/test-utilities/src/safeMount.ts
@@ -5,21 +5,39 @@ import { mount, ReactWrapper } from 'enzyme';
  * Calls `mount` from enzyme, calls the callback, and unmounts. This prevents mounted components
  * from sitting around doing unfathomable things in the background while other tests execute.
  *
+ * If `attach` is true, the helper will mount the element attached to a child of document.body
+ * (and clean up the element at the end). This is primarily for tests involving event handlers,
+ * which don't work right unless the element is attached.
+ *
  * @param content - JSX content to test.
  * @param callback - Function callback which receives the component to use.
+ * @param attach - Whether to attach the element to the document (sometimes needed for event handlers)
  */
 export function safeMount<
   TComponent extends React.Component,
   TProps = TComponent['props'],
   TState = TComponent['state']
->(content: React.ReactElement<TProps>, callback?: (wrapper: ReactWrapper<TProps, TState, TComponent>) => void): void {
-  const wrapper = mount<TComponent, TProps, TState>(content);
+>(
+  content: React.ReactElement<TProps>,
+  callback?: (wrapper: ReactWrapper<TProps, TState, TComponent>) => void,
+  attach?: boolean,
+): void {
+  let parent: HTMLElement | undefined;
+  if (attach) {
+    parent = document.createElement('div');
+    document.body.appendChild(parent);
+  }
+
+  const wrapper = mount<TComponent, TProps, TState>(content, attach ? { attachTo: parent } : {});
 
   try {
     callback?.(wrapper);
   } finally {
     if (wrapper.exists()) {
       wrapper.unmount();
+    }
+    if (parent) {
+      document.body.removeChild(parent);
     }
   }
 }

--- a/packages/test-utilities/src/safeRender.ts
+++ b/packages/test-utilities/src/safeRender.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+/**
+ * Renders a component with `ReactDOM.render()` and safely cleans it up.
+ *
+ * @param content - JSX content to test.
+ * @param callback - Function callback which receives the host element and a callback for re-rendering.
+ * @param attach - If true, attach the host element to `document.body`. This is primarily for tests
+ * involving event handlers.
+ */
+export function safeRender(
+  content: React.ReactElement,
+  callback: (host: HTMLDivElement, reRender: (content: React.ReactElement) => void) => void,
+  attach?: boolean,
+): void {
+  const host = document.createElement('div');
+  if (attach) {
+    document.body.appendChild(host);
+  }
+
+  const reRender = (newContent: React.ReactElement) => {
+    ReactDOM.render(newContent, host);
+  };
+  reRender(content);
+
+  try {
+    callback(host, reRender);
+  } finally {
+    try {
+      ReactDOM.unmountComponentAtNode(host);
+    } catch {
+      // ignore
+    }
+    if (attach) {
+      document.body.removeChild(host);
+    }
+  }
+}

--- a/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
+++ b/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
@@ -9,10 +9,10 @@ describe('useCustomizatioSettings', () => {
   let wrapper: ReactWrapper | undefined;
 
   afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-    }
-
+    ReactTestUtils.act(() => {
+      wrapper?.unmount();
+      wrapper = undefined;
+    });
     Customizations.reset();
   });
 

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { styled } from './styled';
 import * as renderer from 'react-test-renderer';
 import { Customizer } from './customizations/Customizer';
@@ -79,10 +80,10 @@ describe('styled', () => {
   });
 
   afterEach(() => {
-    if (component) {
-      component.unmount();
+    ReactTestUtils.act(() => {
+      component?.unmount();
       component = undefined;
-    }
+    });
 
     lastStylesInBaseComponent = undefined;
   });

--- a/packages/utilities/src/useFocusRects.test.tsx
+++ b/packages/utilities/src/useFocusRects.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { FocusRects } from './useFocusRects';
 import { IsFocusHiddenClassName, IsFocusVisibleClassName } from './setFocusVisibility';
 import { KeyCodes } from './KeyCodes';
@@ -136,9 +137,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -169,12 +174,16 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
 
     expect(mockWindow2.addEventListenerCallCount).toBe(3);
     expect(mockWindow2.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow2.removeEventListenerCallCount).toBe(3);
   });
 
@@ -191,9 +200,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -214,7 +227,9 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -237,9 +252,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -257,7 +276,9 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(0);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRect.unmount();
+    ReactTestUtils.act(() => {
+      focusRect.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
   });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #15732
- [x] Include a change request file using `$ yarn change`

#### Description of changes

While trying to run tests with React 17 (see #16886), I found a few instances where either:
- Tests were doing things incorrectly in ways that (for whatever reason) worked in master, but doesn't work after upgrading React/Jest
- Tests were doing things in a less than ideal way which outright stops working after upgrading React/Jest

This PR fixes those issues where it makes sense to go ahead and do so. Some common ones:
- React 17-related test utilities have a nice warning when you use the wrong `act` helper, which several tests were.
  - When rendering with `react-dom`, should use `act` from `react-dom/test-utils`
  - When rendering with Enzyme, should use `act` from `enzyme`
- React 17 and/or Jest 25 (and its jsdom version) make focus-related tests trickier. There are a few issues I've yet to resolve, but in a lot of cases the resolution is simple: attach the root element to the document when testing.
- In a few cases, React 17 is pickier about wrapping things such as `unmount()` with `act`. Go ahead and add this since it's harmless.

To help with attaching to the document, I added a new `attach` parameter to `@fluentui/test-utilities` `safeMount`. I also added a new `safeRender` utility which wraps `ReactDOM.render` with cleanup and an `attach` parameter.