### PR TITLE
Clean up dependencies and build of utility packages

### DIFF
--- a/change/@fluentui-jest-serializer-merge-styles-33a75029-20f1-49c8-a33f-cff622424d5d.json
+++ b/change/@fluentui-jest-serializer-merge-styles-33a75029-20f1-49c8-a33f-cff622424d5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Built files use commonjs only.",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-7ef10246-8db0-4670-b4e8-3b77a80019df.json
+++ b/change/@fluentui-react-utilities-7ef10246-8db0-4670-b4e8-3b77a80019df.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "align typings for shorthands",
-  "packageName": "@fluentui/react-utils",
+  "packageName": "@fluentui/react-utilities",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-test-utilities-2286958d-6e91-45e3-898a-d4cd287d01da.json
+++ b/change/@fluentui-test-utilities-2286958d-6e91-45e3-898a-d4cd287d01da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Built files use commonjs only.",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-a5424386-8ddc-4cc6-b2c3-fc0ef5bdf922.json
+++ b/change/@fluentui-utilities-a5424386-8ddc-4cc6-b2c3-fc0ef5bdf922.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unused prop-types dependencies",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-serializer-merge-styles/just.config.ts
+++ b/packages/jest-serializer-merge-styles/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts';
+import { preset, task } from '@fluentui/scripts';
 
 preset();
+
+task('build', 'build:node-lib').cached();

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -2,11 +2,7 @@
   "name": "@fluentui/jest-serializer-merge-styles",
   "version": "8.0.0-beta.6",
   "description": "Jest serializer for merge-styles.",
-  "main": "lib-commonjs/index.js",
-  "module": "lib/index.js",
-  "sideEffects": [
-    "lib/version.js"
-  ],
+  "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "repository": {
     "type": "git",
@@ -15,7 +11,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",
@@ -25,17 +20,15 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.2",
+    "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-test-renderer": "^16.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/scripts": "^1.0.0"
+    "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/set-version": "^8.0.0-beta.2",
     "@fluentui/merge-styles": "^8.0.0-beta.5"
   }
 }

--- a/packages/jest-serializer-merge-styles/src/index.ts
+++ b/packages/jest-serializer-merge-styles/src/index.ts
@@ -1,5 +1,4 @@
 import { Stylesheet } from '@fluentui/merge-styles';
-import './version';
 
 /**
  * Jest serialize function which takes in a given (className) value, a serialize function, and

--- a/packages/jest-serializer-merge-styles/src/version.ts
+++ b/packages/jest-serializer-merge-styles/src/version.ts
@@ -1,4 +1,0 @@
-// Do not modify this file; it is generated as part of publish.
-// The checked in version is a placeholder only and will not be updated.
-import { setVersion } from '@fluentui/set-version';
-setVersion('@fluentui/jest-serializer-merge-styles', '0.0.0');

--- a/packages/test-utilities/just.config.ts
+++ b/packages/test-utilities/just.config.ts
@@ -1,5 +1,5 @@
-import { preset, task, series } from '@fluentui/scripts';
+import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', series('clean', 'ts')).cached();
+task('build', 'build:node-lib').cached();

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -2,12 +2,8 @@
   "name": "@fluentui/test-utilities",
   "version": "8.0.0-beta.7",
   "description": "Utilities used when testing components.",
-  "main": "lib-commonjs/index.js",
-  "module": "lib/index.js",
+  "main": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "sideEffects": [
-    "lib/version.js"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"
@@ -15,7 +11,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",
@@ -27,20 +22,13 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.0-beta.2",
     "@types/enzyme": "3.10.3",
-    "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",
     "@types/react-test-renderer": "^16.0.0",
-    "@types/webpack-env": "1.16.0",
-    "@fluentui/jest-serializer-merge-styles": "^8.0.0-beta.6",
     "enzyme": "~3.10.0",
-    "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
     "react-test-renderer": "^16.3.0",
     "@fluentui/scripts": "^1.0.0"
-  },
-  "dependencies": {
-    "@fluentui/set-version": "^8.0.0-beta.2"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/test-utilities/src/index.ts
+++ b/packages/test-utilities/src/index.ts
@@ -1,6 +1,3 @@
-import './version';
-
+export { getCSSRules } from './getCSSRules';
 export { safeCreate } from './safeCreate';
 export { safeMount } from './safeMount';
-
-export { getCSSRules } from './getCSSRules';

--- a/packages/test-utilities/src/version.ts
+++ b/packages/test-utilities/src/version.ts
@@ -1,4 +1,0 @@
-// Do not modify this file; it is generated as part of publish.
-// The checked in version is a placeholder only and will not be updated.
-import { setVersion } from '@fluentui/set-version';
-setVersion('@fluentui/test-utilities', '0.0.0');

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "lib": ["es2017", "dom"],
-    "types": ["jest", "webpack-env"]
+    "types": ["jest"]
   },
   "include": ["src"]
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -29,7 +29,6 @@
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/node": "^10.3.2",
-    "@types/prop-types": "15.7.1",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-test-renderer": "^16.0.0",
@@ -47,7 +46,6 @@
     "@fluentui/dom-utilities": "^2.0.0-beta.2",
     "@fluentui/merge-styles": "^8.0.0-beta.5",
     "@fluentui/set-version": "^8.0.0-beta.2",
-    "prop-types": "^15.7.2",
     "tslib": "^1.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Pull request checklist

- ~~[ ] Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

While working on #16886 I noticed that `@fluentui/jest-serializer-merge-styles` and `@fluentui/test-utilities` were building ESM as well as commonjs, and that they had some unnecessary dependencies such as `@fluentui/set-version` (which isn't really relevant for these packages). So I simplified those packages to only build commonjs and drop the set-version dep. 

Also removed an unnecessary `prop-types` dependency from `@fluentui/utilities`.
