### PR TITLE
Remove requirement to build component info before running northstar tests

### DIFF
--- a/packages/fluentui/react-northstar/gulpfile.ts
+++ b/packages/fluentui/react-northstar/gulpfile.ts
@@ -1,8 +1,1 @@
-import { parallel, series, task } from 'gulp';
-
-// Build off normal tasks
 import '../../../gulpfile';
-
-// Redefine test and test:watch to build info json files beforehand
-task('test', series('build:component-info', 'test:jest'));
-task('test:watch', series('build:component-info', parallel('test:jest:watch', 'watch:component-info')));


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously, it was necessary to build component info (`*.info.json`) files before running tests for react-northstar. Now that almost all of the cases where component info was used in tests are covered by `react-conformance`, we can remove the couple remaining minor component info usages in northstar conformance tests. Then we can speed up the build by getting rid of the component info build step before tests.

Most of the component info usage in `packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx` was just `info.displayName`, which can be replaced with `constructorName` already available locally.

The other component info usage was to verify that a correctly formatted className const is exported. The className calculation logic is specific to northstar (so not included in react-conformance), so it had to be duplicated from `scripts/gulp/plugins/util/getComponentInfo.ts`. The duplication is not ideal, but the build speed benefit is very much worth it.