### PR TITLE
Export ResponsiveMode utilities

### DIFF
--- a/change/@fluentui-react-a3995ed7-1207-479d-ad33-fc65ae0c6730.json
+++ b/change/@fluentui-react-a3995ed7-1207-479d-ad33-fc65ae0c6730.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export ResponsiveMode utilities",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-docsite-components-1a2fd095-3092-4004-9ef7-42ca249b3653.json
+++ b/change/@fluentui-react-docsite-components-1a2fd095-3092-4004-9ef7-42ca249b3653.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use proper ResponsiveMode imports",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/App/App.styles.ts
+++ b/packages/react-docsite-components/src/components/App/App.styles.ts
@@ -1,7 +1,7 @@
 import { getTheme } from '@fluentui/react/lib/Styling';
 import { IStyleFunction } from '@fluentui/react/lib/Utilities';
 import { IAppStyleProps, IAppStyles } from './App.types';
-import { ResponsiveMode } from '@fluentui/react/lib/utilities/decorators/withResponsiveMode';
+import { ResponsiveMode } from '@fluentui/react/lib/ResponsiveMode';
 
 const globalClassNames = {
   root: 'ms-App',

--- a/packages/react-docsite-components/src/components/App/App.tsx
+++ b/packages/react-docsite-components/src/components/App/App.tsx
@@ -8,7 +8,7 @@ import { Header } from '../Header/Header';
 import { INavLink, Nav } from '@fluentui/react/lib/Nav';
 import { IProcessedStyleSet } from '@fluentui/react/lib/Styling';
 import { Panel, PanelType } from '@fluentui/react/lib/Panel';
-import { ResponsiveMode, withResponsiveMode } from '@fluentui/react/lib/utilities/decorators/withResponsiveMode';
+import { ResponsiveMode, withResponsiveMode } from '@fluentui/react/lib/ResponsiveMode';
 import { showOnlyExamples } from '../../utilities/showOnlyExamples';
 import { getQueryParam } from '../../utilities/index2';
 

--- a/packages/react-docsite-components/src/components/App/App.types.ts
+++ b/packages/react-docsite-components/src/components/App/App.types.ts
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import { IStyle, IStyleFunctionOrObject, Theme } from '@fluentui/react';
-import { IWithResponsiveModeState } from '@fluentui/react/lib/utilities/decorators/withResponsiveMode';
-import { INavLink, INavLinkGroup, INavStyleProps } from '@fluentui/react/lib/Nav';
-import { IPanelStyleProps } from '@fluentui/react/lib/Panel';
+import {
+  INavLink,
+  INavLinkGroup,
+  INavStyleProps,
+  IPanelStyleProps,
+  IStyle,
+  IStyleFunctionOrObject,
+  IWithResponsiveModeState,
+  Theme,
+} from '@fluentui/react';
 import { IAppThemes } from '../../utilities/theme';
 import { IHeaderStyleProps } from '../Header/index';
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1178,6 +1178,9 @@ export function getFullColorString(color: IColor): string;
 // @public (undocumented)
 export const getIconContent: (iconName?: string | undefined) => IIconContent | null;
 
+// @public (undocumented)
+export function getInitialResponsiveMode(): ResponsiveMode;
+
 // @public
 export function getMaxHeight(target: Element | MouseEvent | Point, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
@@ -1205,6 +1208,9 @@ export function getOppositeEdge(edge: RectangleEdge): RectangleEdge;
 
 // @public
 export function getPersonaInitialsColor(props: Pick<IPersonaProps, 'primaryText' | 'text' | 'initialsColor'>): string;
+
+// @public
+export function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode;
 
 // @public
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
@@ -3330,8 +3336,6 @@ export interface IContextualMenuListProps {
     totalItemCount: number;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React.RefAttributes<HTMLDivElement>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -6096,6 +6100,9 @@ export interface INavStyles {
     root: IStyle;
 }
 
+// @public
+export function initializeResponsiveMode(element?: HTMLElement): void;
+
 export { IObjectWithKey }
 
 // @public (undocumented)
@@ -8387,6 +8394,12 @@ export interface IWindowWithSegments extends Window {
     getWindowSegments?: () => DOMRect[];
 }
 
+// @public @deprecated (undocumented)
+export interface IWithResponsiveModeState {
+    // (undocumented)
+    responsiveMode?: ResponsiveMode;
+}
+
 // @public
 export interface IWithViewportProps {
     skipViewportMeasures?: boolean;
@@ -9090,19 +9103,13 @@ export enum ResizeGroupDirection {
 
 // @public (undocumented)
 export enum ResponsiveMode {
-    // (undocumented)
     large = 2,
-    // (undocumented)
     medium = 1,
-    // (undocumented)
     small = 0,
     // (undocumented)
     unknown = 999,
-    // (undocumented)
     xLarge = 3,
-    // (undocumented)
     xxLarge = 4,
-    // (undocumented)
     xxxLarge = 5
 }
 
@@ -9273,6 +9280,9 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps>;
 
 // @public
 export function sequencesToID(keySequences: string[]): string;
+
+// @public
+export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): void;
 
 // @public
 export enum Shade {
@@ -9861,6 +9871,9 @@ export function useHeightOffset({ finalHeight }: IPositioningContainerProps, con
 // @public
 export function useKeytipRef<TElement extends HTMLElement = HTMLElement>(options: KeytipDataOptions): React.Ref<TElement>;
 
+// @public
+export const useResponsiveMode: (elementRef: React.RefObject<HTMLElement | null>) => ResponsiveMode;
+
 // @public (undocumented)
 export const useSlider: (props: ISliderProps, ref: React.Ref<HTMLDivElement>) => {
     root: {
@@ -10225,6 +10238,11 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
 
 // @public (undocumented)
 export const WeeklyDayPicker: React.FunctionComponent<IWeeklyDayPickerProps>;
+
+// @public @deprecated (undocumented)
+export function withResponsiveMode<TProps extends {
+    responsiveMode?: ResponsiveMode;
+}, TState>(ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>): any;
 
 
 export * from "@fluentui/date-time-utilities/lib/dateMath/dateMath";

--- a/packages/react/src/ResponsiveMode.ts
+++ b/packages/react/src/ResponsiveMode.ts
@@ -1,0 +1,2 @@
+export * from './utilities/hooks/useResponsiveMode';
+export * from './utilities/decorators/withResponsiveMode';

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -49,8 +49,7 @@ import { IProcessedStyleSet, concatStyleSetsWithProps } from '../../Styling';
 import { IContextualMenuItemStyleProps, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import { getItemStyles } from './ContextualMenu.classNames';
 import { useTarget, usePrevious, useMergedRefs } from '@fluentui/react-hooks';
-import { useResponsiveMode } from '../../utilities/hooks/useResponsiveMode';
-import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { useResponsiveMode, ResponsiveMode } from '../../ResponsiveMode';
 import { IPopupRestoreFocusParams } from '../../Popup';
 
 const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>();

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -4,10 +4,9 @@ import { IFocusZoneProps } from '../../FocusZone';
 import { IIconProps } from '../../Icon';
 import { ICalloutProps, ICalloutContentStyleProps } from '../../Callout';
 import { ITheme, IStyle } from '../../Styling';
-// Might need to be changed to compat button
 import { IButtonStyles } from '../../Button';
 import { IRefObject, IBaseProps, IRectangle, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
-import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
+import { IWithResponsiveModeState } from '../../ResponsiveMode';
 import { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';
 import { IVerticalDividerClassNames } from '../Divider/VerticalDivider.types';
 import {
@@ -43,6 +42,7 @@ export interface IContextualMenu {}
 export interface IContextualMenuProps
   extends IBaseProps<IContextualMenu>,
     React.RefAttributes<HTMLDivElement>,
+    // eslint-disable-next-line deprecation/deprecation
     IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -4,7 +4,7 @@ import { IDialogProps, IDialogStyleProps, IDialogStyles } from './Dialog.types';
 import { DialogType, IDialogContentProps } from './DialogContent.types';
 import { Modal, IModalProps, IDragOptions } from '../../Modal';
 import { ILayerProps } from '../../Layer';
-import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { withResponsiveMode } from '../../ResponsiveMode';
 
 const getClassNames = classNamesFunction<IDialogStyleProps, IDialogStyles>();
 
@@ -24,6 +24,7 @@ const DefaultDialogContentProps: IDialogContentProps = {
   topButtonsProps: [],
 };
 
+// eslint-disable-next-line deprecation/deprecation
 @withResponsiveMode
 export class DialogBase extends React.Component<IDialogProps, {}> {
   public static defaultProps: IDialogProps = {

--- a/packages/react/src/components/Dialog/Dialog.types.ts
+++ b/packages/react/src/components/Dialog/Dialog.types.ts
@@ -3,7 +3,7 @@ import { IModalProps } from '../../Modal';
 import { DialogBase } from './Dialog.base';
 import { DialogType, IDialogContentProps } from './DialogContent.types';
 import { IButtonProps } from '../../Button';
-import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
+import { IWithResponsiveModeState } from '../../ResponsiveMode';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
@@ -19,6 +19,7 @@ export interface IDialog {}
  */
 export interface IDialogProps
   extends React.ClassAttributes<DialogBase>,
+    // eslint-disable-next-line deprecation/deprecation
     IWithResponsiveModeState,
     IAccessiblePopupProps {
   /**

--- a/packages/react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/react/src/components/Dialog/DialogContent.base.tsx
@@ -4,7 +4,7 @@ import { DialogType, IDialogContentProps, IDialogContentStyleProps, IDialogConte
 import { IconButton } from '../../Button';
 import { DialogFooter } from './DialogFooter';
 import { IDialogFooterProps } from './DialogFooter.types';
-import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { withResponsiveMode } from '../../ResponsiveMode';
 
 const getClassNames = classNamesFunction<IDialogContentStyleProps, IDialogContentStyles>();
 
@@ -12,6 +12,7 @@ const DialogFooterType = ((<DialogFooter />) as React.ReactElement<IDialogFooter
 
 const COMPONENT_NAME = 'DialogContent';
 
+// eslint-disable-next-line deprecation/deprecation
 @withResponsiveMode
 export class DialogContentBase extends React.Component<IDialogContentProps, {}> {
   public static defaultProps: IDialogContentProps = {

--- a/packages/react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/react/src/components/Dialog/DialogContent.types.ts
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { DialogContentBase } from './DialogContent.base';
 import { IButtonProps } from '../../Button';
-import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { ResponsiveMode } from '../../ResponsiveMode';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
-
-export { ResponsiveMode }; // Exported because the type is an optional prop and not exported otherwise.
 
 /**
  * {@docCategory Dialog}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -36,7 +36,7 @@ import { Icon } from '../../Icon';
 import { ILabelStyleProps, ILabelStyles, Label } from '../../Label';
 import { IProcessedStyleSet } from '../../Styling';
 import { Panel, IPanelStyleProps, IPanelStyles } from '../../Panel';
-import { ResponsiveMode, IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
+import { ResponsiveMode, IWithResponsiveModeState, useResponsiveMode } from '../../ResponsiveMode';
 import {
   SelectableOptionMenuItemType,
   getAllSelectedOptions,
@@ -45,13 +45,13 @@ import {
 // import and use V7 Checkbox to ensure no breaking changes.
 import { Checkbox, ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
 import { getPropsWithDefaults } from '@fluentui/utilities';
-import { useResponsiveMode } from '../../utilities/hooks/useResponsiveMode';
 import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
 
 const COMPONENT_NAME = 'Dropdown';
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
 /** Internal only props interface to support mixing in responsive mode */
+// eslint-disable-next-line deprecation/deprecation
 interface IDropdownInternalProps extends Omit<IDropdownProps, 'ref'>, IWithResponsiveModeState {
   hoisted: {
     rootRef: React.Ref<HTMLDivElement>;

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -2,15 +2,13 @@ import * as React from 'react';
 import { IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IStyle, ITheme } from '../../Styling';
 import { ISelectableOption, ISelectableDroppableTextProps } from '../../SelectableOption';
-import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { ResponsiveMode } from '../../ResponsiveMode';
 import { RectangleEdge } from '../../Positioning';
 import { ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
 import { ILabelStyleProps, ILabelStyles } from '../../Label';
 import { IPanelStyleProps, IPanelStyles } from '../../Panel';
 
 export { SelectableOptionMenuItemType as DropdownMenuItemType } from '../../SelectableOption';
-
-export { ResponsiveMode }; // Exported because the type is an optional prop and not exported otherwise.
 
 /**
  * {@docCategory Dropdown}

--- a/packages/react/src/components/Modal/Modal.base.tsx
+++ b/packages/react/src/components/Modal/Modal.base.tsx
@@ -14,11 +14,10 @@ import { IDragOptions, IModalProps, IModalStyleProps, IModalStyles } from './Mod
 import { Overlay } from '../../Overlay';
 import { ILayerProps, Layer } from '../../Layer';
 import { Popup } from '../../Popup';
-import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { ResponsiveMode, useResponsiveMode } from '../../ResponsiveMode';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { Icon } from '../../Icon';
 import { DraggableZone, ICoordinates, IDragData } from '../../utilities/DraggableZone/index';
-import { useResponsiveMode } from '../../utilities/hooks/useResponsiveMode';
 import { useWindow } from '@fluentui/react-window-provider';
 import {
   useBoolean,

--- a/packages/react/src/components/Modal/Modal.types.ts
+++ b/packages/react/src/components/Modal/Modal.types.ts
@@ -6,7 +6,7 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { IIconProps } from '../../Icon';
 import { IContextualMenuProps } from '../../ContextualMenu';
 import { IOverlayProps } from '../../Overlay';
-import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import { ResponsiveMode } from '../../ResponsiveMode';
 
 export interface IDragOptions {
   /**

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -62,6 +62,7 @@ export * from './PositioningContainer';
 export * from './ProgressIndicator';
 export * from './Rating';
 export * from './ResizeGroup';
+export * from './ResponsiveMode';
 export * from './ScrollablePane';
 export * from './SearchBox';
 export * from './SelectableOption';

--- a/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
@@ -3,6 +3,7 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import { setResponsiveMode, withResponsiveMode, ResponsiveMode } from './withResponsiveMode';
 import { setSSR } from '../../Utilities';
 
+// eslint-disable-next-line deprecation/deprecation
 @withResponsiveMode
 class Example extends React.Component<any, any> {
   public render(): JSX.Element {

--- a/packages/react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.tsx
@@ -3,16 +3,26 @@ import { BaseDecorator } from './BaseDecorator';
 import { getWindow, hoistStatics, EventGroup } from '../../Utilities';
 import { WindowContext } from '../../WindowProvider';
 
+/**
+ * @deprecated Decorator usage is deprecated. Either call `getResponsiveMode` manually, or
+ * use the `useResponsiveMode` hook within a function component.
+ */
 export interface IWithResponsiveModeState {
   responsiveMode?: ResponsiveMode;
 }
 
 export enum ResponsiveMode {
+  /** Width \<= 479px */
   small = 0,
+  /** Width \> 479px and \<= 639px */
   medium = 1,
+  /** Width \> 639px and \<= 1023px */
   large = 2,
+  /** Width \> 1023px and \<= 1365px */
   xLarge = 3,
+  /** Width \> 1365px and \<= 1919px */
   xxLarge = 4,
+  /** Width \> 1919px */
   xxxLarge = 5,
   unknown = 999,
 }
@@ -31,7 +41,8 @@ let _defaultMode: ResponsiveMode | undefined;
 let _lastMode: ResponsiveMode | undefined;
 
 /**
- * Allows a server rendered scenario to provide a default responsive mode.
+ * Allows a server rendered scenario to provide a **default** responsive mode.
+ * This WILL NOT trigger any updates to components that have already consumed the responsive mode!
  */
 export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): void {
   _defaultMode = responsiveMode;
@@ -41,11 +52,13 @@ export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): v
  * Initializes the responsive mode to the current window size. This can be used to avoid
  * a re-render during first component mount since the window would otherwise not be measured
  * until after mounting.
+ *
+ * This WILL NOT trigger any updates to components that have already consumed the responsive mode!
  */
 export function initializeResponsiveMode(element?: HTMLElement): void {
-  if (typeof window !== 'undefined') {
-    const currentWindow = (element && getWindow(element)) || window;
+  const currentWindow = getWindow(element);
 
+  if (currentWindow) {
     getResponsiveMode(currentWindow);
   }
 }
@@ -54,9 +67,14 @@ export function getInitialResponsiveMode() {
   return _defaultMode || _lastMode || ResponsiveMode.large;
 }
 
+/**
+ * @deprecated Decorator usage is deprecated. Either call `getResponsiveMode` manually, or
+ * use the `useResponsiveMode` hook within a function component.
+ */
 export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveMode }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>,
 ): any {
+  // eslint-disable-next-line deprecation/deprecation
   const resultClass = class WithResponsiveMode extends BaseDecorator<TProps, IWithResponsiveModeState> {
     public static contextType = WindowContext;
     public context: React.ContextType<typeof WindowContext>;
@@ -107,6 +125,10 @@ export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveM
   return hoistStatics(ComposedComponent, resultClass);
 }
 
+/**
+ * Hook to get the current responsive mode (window size category).
+ * @param currentWindow - Use this window when determining the responsive mode.
+ */
 export function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode {
   let responsiveMode = ResponsiveMode.small;
 

--- a/packages/react/src/utilities/hooks/useResponsiveMode.tsx
+++ b/packages/react/src/utilities/hooks/useResponsiveMode.tsx
@@ -4,13 +4,17 @@ import { useOnEvent } from '@fluentui/react-hooks';
 import { ResponsiveMode, getResponsiveMode, getInitialResponsiveMode } from '../decorators/withResponsiveMode';
 import { useWindow } from '../../WindowProvider';
 
+/**
+ * Hook to get the current responsive mode (window size category).
+ * @param elementRef - Use this element's parent window when determining the responsive mode.
+ */
 export const useResponsiveMode = (elementRef: React.RefObject<HTMLElement | null>) => {
   const [lastResponsiveMode, setLastResponsiveMode] = React.useState<ResponsiveMode>(getInitialResponsiveMode);
 
   const onResize = React.useCallback(() => {
-    // Setting the same value should not cause a re-render.
     const newResponsiveMode = getResponsiveMode(getWindow(elementRef.current));
 
+    // Setting the same value should not cause a re-render.
     if (lastResponsiveMode !== newResponsiveMode) {
       setLastResponsiveMode(newResponsiveMode);
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a root export `@fluentui/react/lib/ResponsiveMode` for the responsive mode utilities, and deprecate the `withResponsiveMode` decorator and `IWithResponsiveModeState`. Also remove `ResponsiveMode` exports from Dialog and Dropdown since they have their own export now (this may break some people).

We'd previously avoided exporting these utilities because we weren't happy with the API, especially of the decorator. But the hook and utility function are a bit better, and people were using them anyway, so it's probably best to just export them to reduce deep imports.