### PR TITLE
Update colors for FloatingSuggestionsComposite items and header footer items

### DIFF
--- a/change/@fluentui-react-experiments-7f0616fb-9297-431e-ad50-502886514b0a.json
+++ b/change/@fluentui-react-experiments-7f0616fb-9297-431e-ad50-502886514b0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update colors for the FloatingSuggestionsComposite items",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
@@ -12,7 +12,6 @@ import {
 const GlobalClassNames = {
   actionButton: 'ms-FloatingSuggestionsHeaderFooterItem-actionButton',
   buttonSelected: 'ms-FloatingSuggestionsHeaderFooterItem-buttonSelected',
-  suggestionsTitle: 'ms-FloatingSuggestionsHeaderFooterItem-suggestionsTitle',
 };
 
 export const getStyles = (
@@ -24,7 +23,7 @@ export const getStyles = (
     throw new Error('theme is undefined or null in FloatingSuggestionsItem getStyles function.');
   }
 
-  const { semanticColors } = theme;
+  const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
@@ -38,9 +37,10 @@ export const getStyles = (
         selectors: {
           [HighContrastSelector]: {
             color: 'WindowText',
+            ...getHighContrastNoAdjustStyle(),
           },
           '&:hover': {
-            color: semanticColors.menuItemTextHovered,
+            background: palette.neutralLighter,
           },
         },
       },
@@ -48,10 +48,15 @@ export const getStyles = (
     buttonSelected: [
       classNames.buttonSelected,
       {
-        background: semanticColors.menuItemBackgroundPressed,
+        background: palette.themeLighter,
         selectors: {
-          ':hover': {
-            background: semanticColors.menuDivider,
+          '&:hover': {
+            background: palette.themeLight,
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'HighlightText',
+              ...getHighContrastNoAdjustStyle(),
+            },
           },
           [HighContrastSelector]: {
             background: 'Highlight',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -22,8 +22,7 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
   }
 
   const { isSelected } = props;
-  const { palette, semanticColors, fonts } = theme;
-  const { neutralDark, neutralLight, neutralSecondary } = palette;
+  const { palette, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
@@ -38,10 +37,13 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
         overflow: 'hidden',
         selectors: {
           '&:hover': {
-            background: semanticColors.menuItemBackgroundHovered,
+            background: palette.neutralLighter,
           },
           '&:hover .ms-FloatingSuggestionsItem-closeButton': {
             display: 'block',
+          },
+          '&:active, &:focus': {
+            background: palette.themeLight,
           },
         },
       },
@@ -57,18 +59,15 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
           [HighContrastSelector]: {
             color: 'WindowText',
           },
-          '&:hover': {
-            color: semanticColors.menuItemTextHovered,
-          },
         },
       },
       isSelected && [
         classNames.isSelected,
         {
-          background: semanticColors.menuItemBackgroundPressed,
+          background: palette.themeLighter,
           selectors: {
             ':hover': {
-              background: semanticColors.menuDivider,
+              background: palette.themeLight,
             },
             [HighContrastSelector]: {
               background: 'Highlight',
@@ -83,14 +82,11 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
       classNames.closeButton,
       {
         display: 'none',
-        color: neutralSecondary,
         padding: '0 4px',
         height: 'auto',
         width: 32,
         selectors: {
-          ':hover, :active': {
-            background: neutralLight,
-            color: neutralDark,
+          ':hover': {
             [HighContrastSelector]: {
               background: 'Highlight',
               color: 'HighlightText',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -98,6 +98,22 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
           },
         },
       },
+      isSelected && [
+        classNames.isSelected,
+        {
+          background: palette.themeLighter,
+          selectors: {
+            ':hover': {
+              background: palette.themeLight,
+            },
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'HighlightText',
+              ...getHighContrastNoAdjustStyle(),
+            },
+          },
+        },
+      ],
     ],
     displayText: [
       classNames.displayText,

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -68,6 +68,11 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
           selectors: {
             ':hover': {
               background: palette.themeLight,
+              [HighContrastSelector]: {
+                background: 'Highlight',
+                color: 'HighlightText',
+                ...getHighContrastNoAdjustStyle(),
+              },
             },
             [HighContrastSelector]: {
               background: 'Highlight',
@@ -88,13 +93,10 @@ export const getStyles = (props: IFloatingSuggestionItemStylesProps): IFloatingS
         selectors: {
           ':hover': {
             [HighContrastSelector]: {
-              background: 'Highlight',
-              color: 'HighlightText',
+              background: 'Window',
+              color: 'WindowText',
               ...getHighContrastNoAdjustStyle(),
             },
-          },
-          [HighContrastSelector]: {
-            color: 'WindowText',
           },
         },
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v7 - #17016 
Update the colors to be what was used in the old picker, to maintain compatibility with the old one and because some of the colors did not go well together.
