### PR TITLE
Remove hard coded Card background color in favor of Design System paint API

### DIFF
--- a/change/@fluentui-web-components-a72ef440-3364-4e9a-ac54-ead7689aa485.json
+++ b/change/@fluentui-web-components-a72ef440-3364-4e9a-ac54-ead7689aa485.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove hard coded background color in favor of default design system behavior",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/card/card.styles.ts
+++ b/packages/web-components/src/card/card.styles.ts
@@ -11,7 +11,6 @@ export const CardStyles = css`
     height: var(--card-height, 100%);
     width: var(--card-width, 100%);
     box-sizing: border-box;
-    background: var(--background-color);
     border-radius: calc(var(--elevated-corner-radius) * 1px);
     ${elevation}
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
This change removes a hard coded background for the color and instead relies on existing API's to draw the background by default with an option to *not paint*. This may be helpful in scenarios where the context needs to update but the background needs to be handled separately. With the current implementation that's not as easily achieved.

#### Focus areas to test

(optional)
