### PR TITLE
Removes errouneous export in component scaffolding

### DIFF
--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -4,13 +4,13 @@ import { {{componentName}}State } from './{{componentName}}.types';
 /**
  * Styles for the root slot
  */
-export const useRootStyles = makeStyles<{{componentName}}State>([]);
+const useRootStyles = makeStyles<{{componentName}}State>([]);
 
 /** Applies style classnames to slots */
 export const use{{componentName}}Styles = (state: {{componentName}}State) => {
   const rootClassName = useRootStyles(state);
 
   state.className = ax(rootClassName, state.className);
-  
+
   return state
 };


### PR DESCRIPTION
Removes errouneous export of root styles in `scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs`