### PR TITLE
DatePicker: when initially focused, DatePicker now maintains its focus border after Calendar is closed via keyboard commands

### DIFF
--- a/change/@fluentui-react-432b922e-7097-4d9c-9221-8f7ea9c0cffe.json
+++ b/change/@fluentui-react-432b922e-7097-4d9c-9221-8f7ea9c0cffe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "DatePicker: when initially focused, DatePicker now maintains its focus border after Calendar is closed via keyboard commands",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -377,6 +377,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
           setSelectedDate(newlySelectedDate);
         }
       }
+      textFieldRef.current?.focus?.();
     };
 
     /**

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -213,7 +213,8 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
     const hasRevealButton = !!canRevealPassword && type === 'password' && _browserNeedsRevealButton();
 
-    const hasFocus = this._textElement.current === document.activeElement ? true : isFocused;
+    const hasFocus =
+      document && this._textElement.current === (document.activeElement as HTMLElement) ? true : isFocused;
 
     const classNames = (this._classNames = getClassNames(styles!, {
       theme: theme!,

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -213,11 +213,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
     const hasRevealButton = !!canRevealPassword && type === 'password' && _browserNeedsRevealButton();
 
+    const hasFocus = this._textElement.current === document.activeElement ? true : isFocused;
+
     const classNames = (this._classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       disabled,
-      focused: isFocused,
+      focused: hasFocus,
       required,
       multiline,
       hasLabel: !!label,

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -6,6 +6,7 @@ import {
   Async,
   classNamesFunction,
   DelayedRender,
+  getDocument,
   getId,
   getNativeProps,
   getWindow,
@@ -213,8 +214,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
     const hasRevealButton = !!canRevealPassword && type === 'password' && _browserNeedsRevealButton();
 
-    const hasFocus =
-      document && this._textElement.current === (document.activeElement as HTMLElement) ? true : isFocused;
+    const hasFocus = this._textElement.current === getDocument()?.activeElement ? true : isFocused;
 
     const classNames = (this._classNames = getClassNames(styles!, {
       theme: theme!,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [7222](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/7222)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- DatePicker makes use of TextField which is where the bug originates from. Whenever DatePicker's calendar opens, TextField's onBlur method triggers which causes its isFocused state (which determines the className that adds the focus border) to turn false. And whenever the calendar is closed via keyboard command, TextField's isFocused state is never set to be true again. 
- After the calendar is closed via keyboard commands, the focus is actually on the day button that was selected. Also, after closing the calendar, the `onFocus` method of `TextField` which sets `isFocused` to true doesnt run again.
- As a fix, I've returned focus back to `TextField `after calendar is closed and created a variable `hasFocus `which tracks if focus has returned to `TextField`. `hasFocus` is then passed to  `getClassNames` which returns the className that adds the focus border.

#### Focus on DatePicker BEFORE opening calendar
<img width="315" alt="Datepicker-Focus-1" src="https://user-images.githubusercontent.com/8649804/108539184-8199d200-7294-11eb-9c0f-20f08fb97768.png">

#### Focus on Datepicker with calendar open
<img width="425" alt="Datepicker-Focus-2" src="https://user-images.githubusercontent.com/8649804/108539194-86f71c80-7294-11eb-9c94-11ab0f3b2c4f.png">

#### Focus on Datepicker AFTER keyboard input/selecting a date on calendar
<img width="351" alt="Datepicker-Focus-3" src="https://user-images.githubusercontent.com/8649804/108539206-89f20d00-7294-11eb-9de1-12da5434b0ec.png">
