### PR TITLE
chore(.vscode): display TS style checks as errors cause they are comp…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,12 +42,7 @@
     "**/temp": true
   },
   "editor.rulers": [120],
-  "eslint.enable": true,
   "eslint.workingDirectories": [{ "mode": "auto" }], // infer working directory based on .eslintrc/package.json location
-  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
-  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
-  "typescript.preferences.quoteStyle": "single",
-  "typescript.tsdk": "./node_modules/typescript/lib",
   "files.associations": {
     "**/package.json.hbs": "json",
     "**/*.json.hbs": "jsonc"
@@ -73,5 +68,7 @@
   "javascript.preferences.importModuleSpecifier": "relative",
   "javascript.preferences.importModuleSpecifierEnding": "index",
   "typescript.preferences.importModuleSpecifier": "relative",
-  "typescript.preferences.importModuleSpecifierEnding": "index"
+  "typescript.preferences.importModuleSpecifierEnding": "index",
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.reportStyleChecksAsWarnings": false
 }


### PR DESCRIPTION
…ile errors

#### Pull request checklist

- ~[ ] Addresses an existing issue: X~
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

[VScode marks TS "style check" options as warning](https://github.com/microsoft/vscode/pull/37616). 

This is a false positive because this "warning" will break build - compile error. Until TypeScript is unable to evaluate these checks with "warning" severity this slowing down dev velocity.

**Example:**

![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/1223799/108708985-6936eb00-7512-11eb-8abe-23d90edae987.png)
![image](https://user-images.githubusercontent.com/1223799/108708996-6fc56280-7512-11eb-8e72-ce782ad4c67a.png)




_Sidenote:_ these stylistic rules should be handled rather by eslint


#### Focus areas to test

(optional)
