### PR TITLE
Add clause to ignore vs code workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ rush.json
 
 # tsdoc
 tsdoc-metadata.json
+
+#vscode workspace
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ drop/
 .vs/
 *.sublime-project
 *.sublime-workspace
+*.code-workspace
 .idea
 /.settings/
 
@@ -152,6 +153,3 @@ rush.json
 
 # tsdoc
 tsdoc-metadata.json
-
-#vscode workspace
-*.code-workspace


### PR DESCRIPTION
Simply add `*.code-workspace` to gitignore to ignore VS code workspace declarations.