### PR TITLE
Fix create-package and create-component

### DIFF
--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}.ts.hbs
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { useMergedRefs } from '@fluentui/react-hooks';
+import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { {{componentName}}Props, {{componentName}}State } from './{{componentName}}.types';
 
 /**

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -44,7 +44,6 @@
     "react-test-renderer": ""
   },
   "dependencies": {
-    "@fluentui/react-hooks": "",
     "@fluentui/react-make-styles": "",
     "@fluentui/react-theme-provider": "",
     "@fluentui/react-utilities": "",


### PR DESCRIPTION
Follow fix of #17091 which removed react-hooks as a dependency of
converged packages

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
