### PR TITLE
chore: enforce exact semver when installing deps from cli

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
 package-lock=false
+save-exact=true


### PR DESCRIPTION
#### Pull request checklist

- ~Addresses an existing issue~
- ~Include a change request file using `$ yarn change`~

#### Description of changes

- enforce `yarn add` to use `-E` (to install explicit version of any dependency)
- while yarn pinpoints version in `yarn.lock` its a common best practice to be explicit in package.json

#### Focus areas to test

(optional)
