### PR TITLE
fix(v8): Fully respect `skipViewportMeasures` in the `withViewport` decorator

### DIFF
--- a/change/@fluentui-react-6261986d-4851-4ab4-9b88-67db4deee228.json
+++ b/change/@fluentui-react-6261986d-4851-4ab4-9b88-67db4deee228.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fully disable viewport measurement with 'skipViewportMeasures'",
+  "packageName": "@fluentui/react",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8402,6 +8402,7 @@ export interface IWithResponsiveModeState {
 
 // @public
 export interface IWithViewportProps {
+    disableResizeObserver?: boolean;
     skipViewportMeasures?: boolean;
 }
 


### PR DESCRIPTION
_Cherry-pick of #15963_