### PR TITLE
chore: fix release-fluentui pipeline to pull for releasing official docsite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ yarn.lock @ecraig12345 @dzearing @xugao
 *.config.js @ecraig12345
 *.sh @ecraig12345
 *.yml @ecraig12345
+azure-pipelines.release-fluentui.yml @layershifter @ling1726
 tsconfig.json @ecraig12345
 lerna.json @ecraig12345
 .codesandbox @ecraig12345

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -131,6 +131,15 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
+      - task: CmdLine@2
+        displayName: Checkout branch for pull
+        condition: and(succeeded(), eq(variables.publishOfficial, true))
+        inputs:
+          script: |
+            BRANCH_NAME=`echo $(Build.SourceBranch) | sed "s/refs\/heads\///"`
+            git checkout $BRANCH_NAME
+            git pull
+
       - task: Bash@3
         displayName: Yarn
         inputs:


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Publishing pipeline of fluent contains 2 job: 1. build and release; 2 release docsite

When using the pipeline to publish, the 1st job will make changes (version updates), and changes will be pushed to the publishing branch.
I discovered when the docsite release job (2nd job) is running, it checkes out the head before the pushed commit in the 1st job. This is not good.

I added a step to pull the newest head on the 2nd job for official release

#### Focus areas to test

(optional)
