### PR TITLE
7.0: UnifiedPicker: Implement keyboard shortcut for Cut and Delete in recipient well

### DIFF
--- a/change/@uifabric-experiments-2021-02-22-15-35-13-7.0.json
+++ b/change/@uifabric-experiments-2021-02-22-15-35-13-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Implement keyboard shortcut for Cut and Delete in recipient well",
+  "packageName": "@uifabric/experiments",
+  "email": "jaredi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-22T23:35:13.281Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -304,10 +304,18 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       // Allow the caller to handle the key down
       onKeyDown?.(ev);
 
-      // Handle copy if focus is in the selected items list
       // This is a temporary work around, it has localization issues
       // we plan on rewriting how this works in the future
-      if (ev.ctrlKey && ev.which === KeyCodes.c) {
+      const isDel = ev.which === KeyCodes.del;
+      const isCut = (ev.shiftKey && isDel) || (ev.ctrlKey && ev.which === KeyCodes.x);
+      const isBackspace = ev.which === KeyCodes.backspace;
+      const isCopy = ev.ctrlKey && ev.which === KeyCodes.c;
+      const needToCopy = isCut || isCopy;
+      const needToDelete =
+        (isBackspace && selectedItems.length > 0) || ((isCut || isDel) && focusedItemIndices.length > 0);
+
+      // Handle copy (or cut) if focus is in the selected items list
+      if (needToCopy) {
         if (focusedItemIndices.length > 0 && selectedItemsListGetItemCopyText) {
           ev.preventDefault();
           const copyItems = selection.getSelection() as T[];
@@ -324,8 +332,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         }
       }
 
-      // Handle delete of items via backspace
-      else if (ev.which === KeyCodes.backspace && selectedItems.length) {
+      // Handle delete of items via Backspace/Del/Ctrl+X
+      if (needToDelete) {
         if (
           focusedItemIndices.length === 0 &&
           input &&


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Implemented keyboard shortcut for Cut (Ctrl+X / Shift+Del) and also the keyboard shortcut for Delete

This is a backport of https://github.com/microsoft/fluentui/pull/17114

#### Focus areas to test

Cut / Copy / Paste / Delete / Backspace

