### PR TITLE
7.0: UnifiedPicker: Add check for if we are in a drop action to onDragEnd

### DIFF
--- a/change/@uifabric-experiments-2021-02-22-15-52-15-fixdnd7.0.json
+++ b/change/@uifabric-experiments-2021-02-22-15-52-15-fixdnd7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add a check for if we are in a drop action to the UnifiedPicker drag end",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-22T23:52:15.918Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -160,6 +160,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   let insertIndex = -1;
+  let isInDropAction = false;
   const _dropItemsAt = (newItems: T[]): void => {
     let indicesToRemove: number[] = [];
     // If we are moving items within the same picker, remove them from their old places as well
@@ -170,6 +171,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     dropItemsAt(insertIndex, newItems, indicesToRemove);
     unselectAll();
     insertIndex = -1;
+    isInDropAction = false;
   };
 
   const _onDragOverAutofill = (event?: React.DragEvent<HTMLDivElement>) => {
@@ -179,6 +181,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDropAutoFill = (event?: React.DragEvent<HTMLDivElement>) => {
+    isInDropAction = true;
     event?.preventDefault();
     if (onDropAutoFill) {
       onDropAutoFill(event);
@@ -193,6 +196,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDropList = (item?: any, event?: DragEvent): void => {
+    isInDropAction = true;
     /* indexOf compares using strict equality
        if the item is something where properties can change frequently, then the
        itemsAreEqual prop should be overloaded
@@ -261,7 +265,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragEnd = (item?: any, event?: DragEvent): void => {
-    if (event) {
+    // Because these calls are async, it's possible for us to get the drag end call while
+    // we're in the middle of a drop action, so don't run the delete code if that's the case
+    if (event && !isInDropAction) {
       // If we have a move event, and we still have selected items (indicating that we
       // haven't already moved items within the well) we should remove the item(s)
       if (event.dataTransfer?.dropEffect === 'move' && focusedItemIndices.length > 0) {
@@ -275,6 +281,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       dataList?.clear();
     }
     setDraggedIndex(-1);
+    isInDropAction = false;
   };
 
   const defaultDragDropEvents: IDragDropEvents = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

v8 - #17121 

Because everything is async, sometimes the onDragEnd code was going into the remove section while we were dropping items within the same well. This led to issues because essentially we were removing items twice.

I added a boolean that is set to true while we are dropping, then set to false after drag end or drop is completed.
