### PR TITLE
chore: remove dependency on react-compose

### DIFF
--- a/change/@fluentui-react-link-5802d116-b636-4aae-923e-22e32165f7c4.json
+++ b/change/@fluentui-react-link-5802d116-b636-4aae-923e-22e32165f7c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove dependency on @fluentui/react-compose",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.13",
-    "@fluentui/react-compose": "^1.0.0-beta.16",
     "@fluentui/react-make-styles": "^9.0.0-alpha.0",
     "@fluentui/react-theme-provider": "^9.0.0-alpha.0",
     "@fluentui/react-utilities": "^9.0.0-alpha.0",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes dependency on `@fluentui/react-compose` in `@fluentui/react-link` as it's not used in any way. Related to #17056.