### PR TITLE
[v7.0] Picker Suggestions: focused dropdown option is now properly highlighted in High Contrast Mode

### DIFF
--- a/change/office-ui-fabric-react-2021-02-23-11-37-47-13879-v7.json
+++ b/change/office-ui-fabric-react-2021-02-23-11-37-47-13879-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Picker Suggestions: focused dropdown option is now properly highlighted in High Contrast Mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-23T19:37:47.728Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.styles.ts
@@ -1,4 +1,10 @@
-import { getGlobalClassNames, IStyle, hiddenContentStyle } from '../../../Styling';
+import {
+  getGlobalClassNames,
+  getHighContrastNoAdjustStyle,
+  HighContrastSelector,
+  IStyle,
+  hiddenContentStyle,
+} from '../../../Styling';
 import { ISuggestionsStyleProps, ISuggestionsStyles } from './Suggestions.types';
 
 const GlobalClassNames = {
@@ -52,6 +58,14 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
 
   const actionButtonSelectedStyles: IStyle = {
     backgroundColor: palette.themeLight,
+    selectors: {
+      [HighContrastSelector]: {
+        backgroundColor: 'Highlight',
+        borderColor: 'Highlight',
+        color: 'HighlightText',
+        ...getHighContrastNoAdjustStyle(),
+      },
+    },
   };
 
   return {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13879 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added High Contrast styling to Suggestions component which highlights a dropdown option when it's in focus.

![Suggestions-1](https://user-images.githubusercontent.com/8649804/108150032-d23cdf80-7088-11eb-8bbd-89cb2d476df4.JPG)
![Suggestions-2](https://user-images.githubusercontent.com/8649804/108150428-82124d00-7089-11eb-8eb5-9bfdead02fd5.JPG)

