### PR TITLE
Stop TextField with multiline and autoAdjustHeight from unexpectedly scrolling

### DIFF
--- a/change/@fluentui-react-29bec282-84f8-4388-8fc2-4ac9eea955b7.json
+++ b/change/@fluentui-react-29bec282-84f8-4388-8fc2-4ac9eea955b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix scroll jump when line added or deleted",
+  "packageName": "@fluentui/react",
+  "email": "amyglave@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-c7c84cc3-8968-46d9-ae41-fbccf6ef4e32.json
+++ b/change/@fluentui-react-examples-c7c84cc3-8968-46d9-ae41-fbccf6ef4e32.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix scroll jump when line added or deleted",
+  "packageName": "@fluentui/react-examples",
+  "email": "amyglave@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/TextField/TextField.Multiline.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Multiline.Example.tsx
@@ -11,6 +11,7 @@ const columnProps: Partial<IStackProps> = {
   tokens: { childrenGap: 15 },
   styles: { root: { width: 300 } },
 };
+const scrollableRef = React.createRef<HTMLDivElement>();
 
 export const TextFieldMultilineExample: React.FunctionComponent = () => {
   const [multiline, { toggle: toggleMultiline }] = useBoolean(false);
@@ -29,7 +30,20 @@ export const TextFieldMultilineExample: React.FunctionComponent = () => {
       </Stack>
 
       <Stack {...columnProps}>
-        <TextField label="With auto adjusting height" multiline autoAdjustHeight />
+        <div
+          ref={scrollableRef}
+          style={{
+            overflowY: 'auto',
+            maxHeight: '350px',
+          }}
+        >
+          <TextField
+            label="With auto adjusting height"
+            multiline
+            autoAdjustHeight
+            scrollableContainerRef={scrollableRef}
+          />
+        </div>
         <TextField
           label="Switches from single to multiline if more than 50 characters are entered"
           multiline={multiline}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8058,6 +8058,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     prefix?: string;
     readOnly?: boolean;
     resizable?: boolean;
+    scrollableContainerRef?: React.RefObject<HTMLDivElement>;
     styles?: IStyleFunctionOrObject<ITextFieldStyleProps, ITextFieldStyles>;
     suffix?: string;
     theme?: ITheme;

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -614,9 +614,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
   private _adjustInputHeight(): void {
     if (this._textElement.current && this.props.autoAdjustHeight && this.props.multiline) {
+      const containerScrollTop = this.props.scrollableContainerRef?.current?.scrollTop ?? 0;
       const textField = this._textElement.current;
       textField.style.height = '';
       textField.style.height = textField.scrollHeight + 'px';
+      if (this.props.scrollableContainerRef?.current) {
+        this.props.scrollableContainerRef.current.scrollTop = containerScrollTop;
+      }
     }
   }
 }

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -116,6 +116,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   prefix?: string;
 
   /**
+   * Ref to the nearest scrollable ancestor of this text field. If autoAdjustHeight is enabled, passing in a
+   * ref will prevent scroll bar jumping on the container when the height of the field changes
+   */
+  scrollableContainerRef?: React.RefObject<HTMLDivElement>;
+
+  /**
    * Suffix displayed after the text field contents. This is not included in the value.
    * Ensure a descriptive label is present to assist screen readers, as the value does not include the suffix.
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16653
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Issue:
TextField with multiline and autoAdjustHeight props, will unexpectedly scroll when a user deletes a line.
This occurs because in TextField's `_adjustInputHeight()` it unsets the height of the field, and then sets it to the scroll height. This shrinks the outer scrollable container and then sets it's scroll position to the cursor position in the text field

Fix:
Add a prop: `scrollableContainerRef` to TextField.  This prop points to an ancestor container that is scrollable. 
In `_adjustInputHeight()` save the scrollTop position of the outer scrollable container. After resetting the text field's height to match the input, reset the scrollTop position of the scrollable container

``` typescript
private _adjustInputHeight(): void {
    if (this._textElement.current && this.props.autoAdjustHeight && this.props.multiline) {
      const containerScrollTop = this.props.scrollableContainerRef?.current?.scrollTop ?? 0;
      const textField = this._textElement.current;
      textField.style.height = '';
      textField.style.height = textField.scrollHeight + 'px';
      if (this.props.scrollableContainerRef?.current) {
        this.props.scrollableContainerRef.current.scrollTop = containerScrollTop;
      }
    }
```

Before:
![textFieldScroll_before](https://user-images.githubusercontent.com/10605976/108906447-c21b8780-75d5-11eb-9017-251136df411b.gif)

After:
![textFieldScroll_after](https://user-images.githubusercontent.com/10605976/108906467-c778d200-75d5-11eb-8005-86abb692b292.gif)
