### PR TITLE
Allow itemSubMenuProvider to return a boolean

### DIFF
--- a/change/@fluentui-react-de07a84d-570b-4433-9012-abd982f58f0e.json
+++ b/change/@fluentui-react-de07a84d-570b-4433-9012-abd982f58f0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow itemSubMenuProvider to return a boolean",
+  "packageName": "@fluentui/react",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6129,7 +6129,7 @@ export interface IOverflowSetProps extends React.RefAttributes<HTMLElement> {
     className?: string;
     componentRef?: IRefObject<IOverflowSet>;
     items?: IOverflowSetItemProps[];
-    itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+    itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | boolean | undefined;
     keytipSequences?: string[];
     onRenderItem: (item: IOverflowSetItemProps) => any;
     onRenderOverflowButton: IRenderFunction<any[]>;

--- a/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -607,47 +607,50 @@ describe('OverflowSet', () => {
       });
 
       describe('with non-standard children keytips', () => {
-        const overflowItemsWithSubMenuAndKeytips = [
-          item3,
-          {
-            key: 'item4',
-            name: 'Item 4',
-            keytipProps: {
-              ...overflowKeytips.overflowItemKeytip4,
-              onExecute: (el: HTMLElement) => {
-                el.click();
+        const getOverflowItemsWithSubMenuAndKeytips = () => {
+          return [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+              },
+              customSubMenu: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                    keytipProps: overflowKeytips.overflowItemKeytip5,
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                    keytipProps: overflowKeytips.overflowItemKeytip6,
+                    customSubMenu: {
+                      items: [
+                        {
+                          key: 'item7',
+                          name: 'Item 7',
+                          keytipProps: {
+                            content: 'X',
+                            keySequences: ['d', 'f', 'x'],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
               },
             },
-            customSubMenu: {
-              items: [
-                {
-                  key: 'item5',
-                  name: 'Item 5',
-                  keytipProps: overflowKeytips.overflowItemKeytip5,
-                },
-                {
-                  key: 'item6',
-                  name: 'Item 6',
-                  keytipProps: overflowKeytips.overflowItemKeytip6,
-                  customSubMenu: {
-                    items: [
-                      {
-                        key: 'item7',
-                        name: 'Item 7',
-                        keytipProps: {
-                          content: 'X',
-                          keySequences: ['d', 'f', 'x'],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ];
+          ];
+        };
 
         const mountOverflowSet = (
+          overflowItemsWithSubMenuAndKeytips: IOverflowSetItemProps[],
           itemSubMenuProvider: (item: IOverflowSetItemProps) => boolean | any[] | undefined,
         ) => {
           overflowSet = mount(
@@ -692,7 +695,7 @@ describe('OverflowSet', () => {
             return undefined;
           };
 
-          mountOverflowSet(itemSubMenuProvider);
+          mountOverflowSet(getOverflowItemsWithSubMenuAndKeytips(), itemSubMenuProvider);
           validateItemSubMenuProvider();
         });
 
@@ -706,7 +709,7 @@ describe('OverflowSet', () => {
             return false;
           };
 
-          mountOverflowSet(itemSubMenuProvider);
+          mountOverflowSet(getOverflowItemsWithSubMenuAndKeytips(), itemSubMenuProvider);
           validateItemSubMenuProvider();
         });
       });

--- a/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -607,56 +607,49 @@ describe('OverflowSet', () => {
       });
 
       describe('with non-standard children keytips', () => {
-        it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
-          jest.useFakeTimers();
-
-          const overflowItemsWithSubMenuAndKeytips = [
-            item3,
-            {
-              key: 'item4',
-              name: 'Item 4',
-              keytipProps: {
-                ...overflowKeytips.overflowItemKeytip4,
-                onExecute: (el: HTMLElement) => {
-                  el.click();
-                },
-              },
-              customSubMenu: {
-                items: [
-                  {
-                    key: 'item5',
-                    name: 'Item 5',
-                    keytipProps: overflowKeytips.overflowItemKeytip5,
-                  },
-                  {
-                    key: 'item6',
-                    name: 'Item 6',
-                    keytipProps: overflowKeytips.overflowItemKeytip6,
-                    customSubMenu: {
-                      items: [
-                        {
-                          key: 'item7',
-                          name: 'Item 7',
-                          keytipProps: {
-                            content: 'X',
-                            keySequences: ['d', 'f', 'x'],
-                          },
-                        },
-                      ],
-                    },
-                  },
-                ],
+        const overflowItemsWithSubMenuAndKeytips = [
+          item3,
+          {
+            key: 'item4',
+            name: 'Item 4',
+            keytipProps: {
+              ...overflowKeytips.overflowItemKeytip4,
+              onExecute: (el: HTMLElement) => {
+                el.click();
               },
             },
-          ];
+            customSubMenu: {
+              items: [
+                {
+                  key: 'item5',
+                  name: 'Item 5',
+                  keytipProps: overflowKeytips.overflowItemKeytip5,
+                },
+                {
+                  key: 'item6',
+                  name: 'Item 6',
+                  keytipProps: overflowKeytips.overflowItemKeytip6,
+                  customSubMenu: {
+                    items: [
+                      {
+                        key: 'item7',
+                        name: 'Item 7',
+                        keytipProps: {
+                          content: 'X',
+                          keySequences: ['d', 'f', 'x'],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ];
 
-          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
-            if (item.customSubMenu) {
-              return item.customSubMenu.items;
-            }
-            return undefined;
-          };
-
+        const mountOverflowSet = (
+          itemSubMenuProvider: (item: IOverflowSetItemProps) => boolean | any[] | undefined,
+        ) => {
           overflowSet = mount(
             <div>
               <OverflowSet
@@ -670,7 +663,9 @@ describe('OverflowSet', () => {
               <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
             </div>,
           );
+        };
 
+        const validateItemSubMenuProvider = () => {
           // Set current keytip at root, like we've entered keytip mode
           const keytipTree = layerRef.current!.getKeytipTree();
           keytipTree.currentKeytip = keytipTree.root;
@@ -685,6 +680,34 @@ describe('OverflowSet', () => {
               arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
             ).toEqual(true);
           });
+        };
+
+        it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
+          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
+            if (item.customSubMenu) {
+              return item.customSubMenu.items;
+            }
+            return undefined;
+          };
+
+          mountOverflowSet(itemSubMenuProvider);
+          validateItemSubMenuProvider();
+        });
+
+        it('should respect itemSubMenuProvider that returns a boolean when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
+          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
+            if (item.customSubMenu) {
+              return true;
+            }
+            return false;
+          };
+
+          mountOverflowSet(itemSubMenuProvider);
+          validateItemSubMenuProvider();
         });
       });
     });

--- a/packages/react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/react/src/components/OverflowSet/OverflowSet.types.ts
@@ -88,9 +88,10 @@ export interface IOverflowSetProps extends React.RefAttributes<HTMLElement> {
   /**
    * Function that will take in an IOverflowSetItemProps and return the subMenu for that item.
    * If not provided, will use 'item.subMenuProps.items' by default.
+   * Alternatively accepts a boolean, return True if the item has a menu and False if not
    * This is only used if your overflow set has keytips.
    */
-  itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+  itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | boolean | undefined;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

itemSubMenuProvider is used only for keytip code for the OverflowSet. It is used to know if an overflow item has a submenu. The function previously checked an array of "any" for existence of a submenu, however since it's just an "is defined" check a boolean works just as well. This is also needed if an overflow item's menu is deferred in any way, which means the definition of the sub menu doesn't yet exist but it should still indicate that it has a submenu

V7 change here: https://github.com/microsoft/fluentui/pull/17150

#### Focus areas to test

Added a unit test for a version of the callback that accepts a boolean
