### PR TITLE
[7.0] Allow itemSubMenuProvider to return a boolean

### DIFF
--- a/change/office-ui-fabric-react-2021-02-23-14-56-02-keyou-item-submenu-7.0.json
+++ b/change/office-ui-fabric-react-2021-02-23-14-56-02-keyou-item-submenu-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Allow itemSubMenuProvider to return a boolean",
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-23T22:56:02.219Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6198,7 +6198,7 @@ export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase
     // @deprecated
     focusZoneProps?: IFocusZoneProps;
     items?: IOverflowSetItemProps[];
-    itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+    itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | boolean | undefined;
     keytipSequences?: string[];
     onRenderItem: (item: IOverflowSetItemProps) => any;
     onRenderOverflowButton: IRenderFunction<any[]>;

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -244,7 +244,7 @@ export class OverflowSetBase extends React.Component<IOverflowSetProps, {}> impl
    * Gets the subMenu for an overflow item
    * Checks if itemSubMenuProvider has been defined, if not defaults to subMenuProps
    */
-  private _getSubMenuForItem(item: any): any[] | undefined {
+  private _getSubMenuForItem(item: any): any[] | boolean | undefined {
     if (this.props.itemSubMenuProvider) {
       return this.props.itemSubMenuProvider(item);
     }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -612,56 +612,49 @@ describe('OverflowSet', () => {
       });
 
       describe('with non-standard children keytips', () => {
-        it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
-          jest.useFakeTimers();
-
-          const overflowItemsWithSubMenuAndKeytips = [
-            item3,
-            {
-              key: 'item4',
-              name: 'Item 4',
-              keytipProps: {
-                ...overflowKeytips.overflowItemKeytip4,
-                onExecute: (el: HTMLElement) => {
-                  el.click();
-                },
-              },
-              customSubMenu: {
-                items: [
-                  {
-                    key: 'item5',
-                    name: 'Item 5',
-                    keytipProps: overflowKeytips.overflowItemKeytip5,
-                  },
-                  {
-                    key: 'item6',
-                    name: 'Item 6',
-                    keytipProps: overflowKeytips.overflowItemKeytip6,
-                    customSubMenu: {
-                      items: [
-                        {
-                          key: 'item7',
-                          name: 'Item 7',
-                          keytipProps: {
-                            content: 'X',
-                            keySequences: ['d', 'f', 'x'],
-                          },
-                        },
-                      ],
-                    },
-                  },
-                ],
+        const overflowItemsWithSubMenuAndKeytips = [
+          item3,
+          {
+            key: 'item4',
+            name: 'Item 4',
+            keytipProps: {
+              ...overflowKeytips.overflowItemKeytip4,
+              onExecute: (el: HTMLElement) => {
+                el.click();
               },
             },
-          ];
+            customSubMenu: {
+              items: [
+                {
+                  key: 'item5',
+                  name: 'Item 5',
+                  keytipProps: overflowKeytips.overflowItemKeytip5,
+                },
+                {
+                  key: 'item6',
+                  name: 'Item 6',
+                  keytipProps: overflowKeytips.overflowItemKeytip6,
+                  customSubMenu: {
+                    items: [
+                      {
+                        key: 'item7',
+                        name: 'Item 7',
+                        keytipProps: {
+                          content: 'X',
+                          keySequences: ['d', 'f', 'x'],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ];
 
-          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
-            if (item.customSubMenu) {
-              return item.customSubMenu.items;
-            }
-            return undefined;
-          };
-
+        const mountOverflowSet = (
+          itemSubMenuProvider: (item: IOverflowSetItemProps) => boolean | any[] | undefined,
+        ) => {
           overflowSet = mount(
             <div>
               <OverflowSet
@@ -675,7 +668,9 @@ describe('OverflowSet', () => {
               <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
             </div>,
           );
+        };
 
+        const validateItemSubMenuProvider = () => {
           // Set current keytip at root, like we've entered keytip mode
           const keytipTree = layerRef.current!.getKeytipTree();
           keytipTree.currentKeytip = keytipTree.root;
@@ -691,6 +686,34 @@ describe('OverflowSet', () => {
               arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
             ).toEqual(true);
           });
+        };
+
+        it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
+          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
+            if (item.customSubMenu) {
+              return item.customSubMenu.items;
+            }
+            return undefined;
+          };
+
+          mountOverflowSet(itemSubMenuProvider);
+          validateItemSubMenuProvider();
+        });
+
+        it('should respect itemSubMenuProvider that returns a boolean when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
+          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
+            if (item.customSubMenu) {
+              return true;
+            }
+            return false;
+          };
+
+          mountOverflowSet(itemSubMenuProvider);
+          validateItemSubMenuProvider();
         });
       });
     });

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -612,47 +612,50 @@ describe('OverflowSet', () => {
       });
 
       describe('with non-standard children keytips', () => {
-        const overflowItemsWithSubMenuAndKeytips = [
-          item3,
-          {
-            key: 'item4',
-            name: 'Item 4',
-            keytipProps: {
-              ...overflowKeytips.overflowItemKeytip4,
-              onExecute: (el: HTMLElement) => {
-                el.click();
+        const getOverflowItemsWithSubMenuAndKeytips = () => {
+          return [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+              },
+              customSubMenu: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                    keytipProps: overflowKeytips.overflowItemKeytip5,
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                    keytipProps: overflowKeytips.overflowItemKeytip6,
+                    customSubMenu: {
+                      items: [
+                        {
+                          key: 'item7',
+                          name: 'Item 7',
+                          keytipProps: {
+                            content: 'X',
+                            keySequences: ['d', 'f', 'x'],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
               },
             },
-            customSubMenu: {
-              items: [
-                {
-                  key: 'item5',
-                  name: 'Item 5',
-                  keytipProps: overflowKeytips.overflowItemKeytip5,
-                },
-                {
-                  key: 'item6',
-                  name: 'Item 6',
-                  keytipProps: overflowKeytips.overflowItemKeytip6,
-                  customSubMenu: {
-                    items: [
-                      {
-                        key: 'item7',
-                        name: 'Item 7',
-                        keytipProps: {
-                          content: 'X',
-                          keySequences: ['d', 'f', 'x'],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ];
+          ];
+        };
 
         const mountOverflowSet = (
+          overflowItemsWithSubMenuAndKeytips: any[],
           itemSubMenuProvider: (item: IOverflowSetItemProps) => boolean | any[] | undefined,
         ) => {
           overflowSet = mount(
@@ -698,7 +701,7 @@ describe('OverflowSet', () => {
             return undefined;
           };
 
-          mountOverflowSet(itemSubMenuProvider);
+          mountOverflowSet(getOverflowItemsWithSubMenuAndKeytips(), itemSubMenuProvider);
           validateItemSubMenuProvider();
         });
 
@@ -712,7 +715,7 @@ describe('OverflowSet', () => {
             return false;
           };
 
-          mountOverflowSet(itemSubMenuProvider);
+          mountOverflowSet(getOverflowItemsWithSubMenuAndKeytips(), itemSubMenuProvider);
           validateItemSubMenuProvider();
         });
       });

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -108,9 +108,10 @@ export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase
   /**
    * Function that will take in an IOverflowSetItemProps and return the subMenu for that item.
    * If not provided, will use 'item.subMenuProps.items' by default.
+   * Alternatively accepts a boolean, return True if the item has a menu and False if not
    * This is only used if your overflow set has keytips.
    */
-  itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+  itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | boolean | undefined;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

itemSubMenuProvider is used only for keytip code for the OverflowSet. It is used to know if an overflow item has a submenu. The function previously checked an array of "any" for existence of a submenu, however since it's just an "is defined" check a boolean works just as well. This is also needed if an overflow item's menu is deferred in any way, which means the definition of the sub menu doesn't yet exist but it should still indicate that it has a submenu

V8 change here: https://github.com/microsoft/fluentui/pull/17149

#### Focus areas to test

Added a unit test for a version of the callback that accepts a boolean
