### PR TITLE
feat: add makeStaticStyles() to react-make-styles

### DIFF
--- a/change/@fluentui-react-make-styles-4592b673-3840-424b-bab4-2bf9e6714da5.json
+++ b/change/@fluentui-react-make-styles-4592b673-3840-424b-bab4-2bf9e6714da5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add makeStaticStyles()",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-make-styles/src/index.ts
+++ b/packages/react-make-styles/src/index.ts
@@ -1,2 +1,4 @@
-export { ax } from '@fluentui/make-styles';
+export { ax, createDOMRenderer } from '@fluentui/make-styles';
+
 export { makeStyles } from './makeStyles';
+export { makeStaticStyles } from './makeStaticStyles';

--- a/packages/react-make-styles/src/makeStaticStyles.ts
+++ b/packages/react-make-styles/src/makeStaticStyles.ts
@@ -1,0 +1,26 @@
+import {
+  MakeStaticStyles,
+  makeStaticStyles as vanillaMakeStaticStyles,
+  MakeStaticStylesOptions,
+} from '@fluentui/make-styles';
+import { useFluent } from '@fluentui/react-provider';
+
+import { useRenderer } from './useRenderer';
+
+export function makeStaticStyles<Selectors>(styles: MakeStaticStyles | MakeStaticStyles[]) {
+  const getStyles = vanillaMakeStaticStyles(styles);
+
+  if (process.env.NODE_ENV === 'test') {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
+  return function useStaticStyles(): void {
+    const { document } = useFluent();
+
+    const renderer = useRenderer(document);
+    const options: MakeStaticStylesOptions = { renderer };
+
+    return getStyles(options);
+  };
+}

--- a/packages/react-make-styles/src/makeStyles.ts
+++ b/packages/react-make-styles/src/makeStyles.ts
@@ -1,20 +1,9 @@
-import {
-  createDOMRenderer,
-  makeStyles as vanillaMakeStyles,
-  MakeStylesDefinition,
-  MakeStylesOptions,
-  MakeStylesRenderer,
-} from '@fluentui/make-styles';
+import { makeStyles as vanillaMakeStyles, MakeStylesDefinition, MakeStylesOptions } from '@fluentui/make-styles';
 import { useFluent } from '@fluentui/react-provider';
 import { useTheme } from '@fluentui/react-theme-provider';
 import { Theme } from '@fluentui/react-theme';
-import * as React from 'react';
 
-function useRenderer(document: Document | undefined): MakeStylesRenderer {
-  return React.useMemo(() => {
-    return createDOMRenderer(document);
-  }, [document]);
-}
+import { useRenderer } from './useRenderer';
 
 export function makeStyles<Selectors>(definitions: MakeStylesDefinition<Selectors, Theme>[]) {
   const getStyles = vanillaMakeStyles(definitions);

--- a/packages/react-make-styles/src/useRenderer.ts
+++ b/packages/react-make-styles/src/useRenderer.ts
@@ -1,0 +1,8 @@
+import { createDOMRenderer, MakeStylesRenderer } from '@fluentui/make-styles';
+import * as React from 'react';
+
+export function useRenderer(document: Document | undefined): MakeStylesRenderer {
+  return React.useMemo(() => {
+    return createDOMRenderer(document);
+  }, [document]);
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In #16880 `makeStaticStyles()` was introduced, but without bindings in `@fluentui/react-make-styles` that makes hard to properly connect things.

Also adds a re-export for `createDOMRenderer()` to be exported in `@fluentui/react-components`. Related to #17056.