### PR TITLE
Compound Components Context 

### DIFF
--- a/packages/react-utilities/src/hooks/useEffectAfterMount.test.ts
+++ b/packages/react-utilities/src/hooks/useEffectAfterMount.test.ts
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useState } from 'react';
+import { useEffectAfterMount } from './useEffectAfterMount';
+
+function useMountTest(valueOverride: unknown) {
+  const [value, setValue] = useState<unknown>(undefined);
+
+  useEffectAfterMount(() => {
+    setValue(valueOverride);
+  }, [valueOverride]);
+
+  return value;
+}
+
+describe('useEffectAfterMount', () => {
+  it('should run only after mount', () => {
+    const { result, rerender } = renderHook(({ value }) => useMountTest(value), {
+      initialProps: { value: 'ignored value' },
+    });
+    expect(result.current).toBe(undefined);
+    rerender({ value: 'value' });
+    expect(result.current).toBe('value');
+  });
+});

--- a/packages/react-utilities/src/hooks/useEffectAfterMount.ts
+++ b/packages/react-utilities/src/hooks/useEffectAfterMount.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, DependencyList, EffectCallback } from 'react';
+
+/**
+ * Similar to React.useEffect, only difference is that the callback is not invoked on mount.
+ *
+ * A common use case is the invocation of external callbacks to ensure controlled component.
+ * @example
+ *  useEffectAfterMount(() => {
+ *    props.onChange?.(value)
+ *  }, [value, props.onChange])
+ * @param callback effect to be invoked when dependencies change
+ * @param dependencies dependency list to determine when the effect should run
+ */
+export function useEffectAfterMount(callback: EffectCallback, dependencies: DependencyList = []) {
+  const justMounted = useRef(true);
+  useEffect(() => {
+    if (!justMounted.current) {
+      return callback();
+    }
+    justMounted.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+}


### PR DESCRIPTION
## Problem

```jsx
const accordion = (
  <Accordion>
    <AccordionItem>
      <AccordionHeader>
         Header 1
      </AccordionHeader>
      <AccordionPanel>
        Panel 1
      </AccordionPanel>
    </AccordionItem>
    <AccordionItem>
      <AccordionHeader>
         Header 2
      </AccordionHeader>
      <AccordionPanel>
        Panel 2
      </AccordionPanel>
    </AccordionItem>
  </Accordion>
)
```

To ensure behavior the `Accordion` component must know the amount of opened `AccordionItem`, since by default the `Accordion` allows only one `AccordionItem` to be opened at a time.  This requires the `Accordion` component to know the amount of `AccordionItem` and to control the opened state of each of them.


## Solution

The idea would be to have something similar to [@reach/descendants](https://github.com/reach/reach-ui/tree/develop/packages/descendants).

That would serve also for other future problems that might appear with compound components such as: Menu, MenuItem, Accordion, AccordionItem, Tab, TabItem, etc,.
 