### PR TITLE
[web-components] Update card background color to from view

### DIFF
--- a/change/@fluentui-web-components-2b72f1e1-54cc-4ce3-a0ab-8f0fad6abc7c.json
+++ b/change/@fluentui-web-components-2b72f1e1-54cc-4ce3-a0ab-8f0fad6abc7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update card background color attribute to reflect from view",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-web-components-2d194f07-d13e-4044-a57b-25def72e8123.json
+++ b/change/@fluentui-web-components-2d194f07-d13e-4044-a57b-25def72e8123.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/card/index.ts
+++ b/packages/web-components/src/card/index.ts
@@ -32,6 +32,7 @@ export class FluentCard extends FluentDesignSystemProvider {
    */
   @attr({
     attribute: 'card-background-color',
+    mode: 'fromView',
   })
   public cardBackgroundColor: string;
   private cardBackgroundColorChanged(prev: string | void, next: string | void): void {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This change updates the card-background-color attribute to leverage the fromView attr mode. In certain cases where you want to extend the card and set a default value, reflecting the default attribute back to the DOM will cause an additional unnecessary update. By setting the mode to fromView we avoid reflecting the default value unnecessarily.
#### Focus areas to test

(optional)
