### PR TITLE
CartesianChart accessibility fixes (cherry-pick of #16828)

### DIFF
--- a/change/@fluentui-react-examples-2021-02-04-14-24-25-Chart-accessibility-fixes.json
+++ b/change/@fluentui-react-examples-2021-02-04-14-24-25-Chart-accessibility-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "CartesianChart accessibility: support custom attribute on `svg`; hide axis labels from screen readers",
+  "packageName": "@fluentui/react-examples",
+  "email": "mibes@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-04T22:24:25.879Z"
+}

--- a/change/@uifabric-charting-2021-02-04-14-24-25-Chart-accessibility-fixes.json
+++ b/change/@uifabric-charting-2021-02-04-14-24-25-Chart-accessibility-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "CartesianChart accessibility: support custom attribute on `svg`; hide axis labels from screen readers",
+  "packageName": "@fluentui/react-charting",
+  "email": "mibes@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-04T22:24:18.017Z"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -105,7 +105,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
   }
 
   public render(): JSX.Element {
-    const { calloutProps, points, chartType, chartHoverProps, svgFocusZoneProps } = this.props;
+    const { calloutProps, points, chartType, chartHoverProps, svgFocusZoneProps, svgProps } = this.props;
     if (this.props.parentRef) {
       this._fitParentContainer();
     }
@@ -231,7 +231,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
       >
         <FocusZone direction={focusDirection} {...svgFocusZoneProps}>
-          <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }}>
+          <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }} {...svgProps}>
             <g
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -316,6 +316,11 @@ export interface ICartesianChartProps {
    * Callout customization props
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * props for the svg; use this to include aria-* or other attributes on the tag
+   */
+  svgProps?: React.SVGProps<SVGSVGElement>;
 }
 
 export interface IYValueHover {

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -135,7 +135,8 @@ export function createNumericXAxis(xAxisParams: IXAxisParams) {
   if (xAxisElement) {
     d3Select(xAxisElement)
       .call(xAxis)
-      .selectAll('text');
+      .selectAll('text')
+      .attr('aria-hidden', 'true');
   }
   return xAxisScale;
 }
@@ -160,7 +161,8 @@ export function createDateXAxis(xAxisParams: IXAxisParams, tickParams: ITickPara
   if (xAxisElement) {
     d3Select(xAxisElement)
       .call(xAxis)
-      .selectAll('text');
+      .selectAll('text')
+      .attr('aria-hidden', 'true');
   }
   return xAxisScale;
 }
@@ -189,7 +191,8 @@ export function createStringXAxis(xAxisParams: IXAxisParams, tickParams: ITickPa
   if (xAxisParams.xAxisElement) {
     d3Select(xAxisParams.xAxisElement)
       .call(xAxis)
-      .selectAll('text');
+      .selectAll('text')
+      .attr('aria-hidden', 'true');
   }
   return xAxisScale;
 }
@@ -252,6 +255,7 @@ export function createYAxis(yAxisParams: IYAxisParams, isRtl: boolean) {
     ? d3Select(yAxisElement)
         .call(yAxis)
         .selectAll('text')
+        .attr('aria-hidden', 'true')
     : '';
   return yAxisScale;
 }
@@ -375,7 +379,7 @@ export function silceOrAppendToArray(array: string[], value: string): string[] {
 }
 
 /**
- * This method used for wrapping of x axis lables (tick values).
+ * This method used for wrapping of x axis labels (tick values).
  * It breaks down given text value by space separated and calculates the total height needed to display all the words.
  * That value = removal value. This value needs to be remove from total svg height, svg will shrink and
  * total text will be displayed.

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -192,6 +192,9 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 />
               ) : null
             }
+            svgProps={{
+              'aria-label': 'Example chart with metadata per month',
+            }}
           />
         </div>
       </>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15935, fixes #15925
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #16828

For screen readers, allow a label for the chart by allowing the caller to specify attributes for the `svg`. Also hide the axis labels from screen readers by using `aria-hidden`.