### PR TITLE
Prototype: Accessible additional actions in listbox and tree item

### DIFF
--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -177,6 +177,11 @@ const prototypesTreeItems: TreeProps['items'] = [
     public: true,
   },
   {
+    id: 'tree-additional-actions',
+    title: { content: 'Tree additional actions', as: NavLink, to: '/prototype-tree-additional-actions' },
+    public: true,
+  },
+  {
     id: 'menulist',
     title: {
       content: 'Menu List',

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -43,6 +43,7 @@ import {
   CustomToolbarPrototype,
   AsyncShorthandPrototype,
   EmployeeCardPrototype,
+  TreeAdditionalActionsPrototype,
   MeetingOptionsPrototype,
   ParticipantsListPrototype,
   SearchPagePrototype,
@@ -110,6 +111,7 @@ const Routes = () => (
                 <Route exact path="/prototype-roster" component={RosterPrototype} />
                 <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
                 <Route exact path="/prototype-chat-messages" component={ChatMessagesPrototype} />
+                <Route exact path="/prototype-tree-additional-actions" component={TreeAdditionalActionsPrototype} />
                 <Route exact path="/prototype-custom-scrollbar" component={CustomScrollbarPrototype} />
                 <Route exact path="/prototype-custom-toolbar" component={CustomToolbarPrototype} />
                 <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />

--- a/packages/fluentui/react-northstar-prototypes/src/index.ts
+++ b/packages/fluentui/react-northstar-prototypes/src/index.ts
@@ -13,6 +13,9 @@ export const AsyncShorthandPrototype = React.lazy(() =>
 export const EmployeeCardPrototype = React.lazy(() =>
   import(/* webpackChunkName: "prototypes" */ './prototypes/employeeCard'),
 );
+export const TreeAdditionalActionsPrototype = React.lazy(() =>
+  import(/* webpackChunkName: "prototypes" */ './prototypes/TreeAdditionalActionsPrototype'),
+);
 export const MeetingOptionsPrototype = React.lazy(() =>
   import(/* webpackChunkName: "prototypes" */ './prototypes/meetingOptions'),
 );

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/components/TreeActionsModifyAriaDisable.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/components/TreeActionsModifyAriaDisable.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import { Box, Tree, Button, Flex, Text } from '@fluentui/react-northstar';
+
+const items = [
+  {
+    id: 'tree-item-0',
+    title: 'House Targaryen',
+    items: [
+      {
+        id: 'tree-item-01',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-011',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-012',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-013',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tree-item-1',
+    title: {
+      children: (C, p) => {
+        return <TreeTitleModifyAriaDisableButton />;
+      },
+    },
+    items: [],
+  },
+  {
+    id: 'tree-item-2',
+    title: 'House Targaryen 2',
+    items: [
+      {
+        id: 'tree-item-21',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-211',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-212',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-213',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tree-item-3',
+    title: 'House Targaryen 3',
+    items: [
+      {
+        id: 'tree-item-31',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-311',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-312',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-313',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const TreeTitleModifyAriaDisableButton = () => {
+  const [buttonDisabled, setButtonDisabled] = React.useState(true);
+  const buttonRef = React.useRef(null);
+  const flexRef = React.useRef(null);
+
+  return (
+    <Box
+      ref={flexRef}
+      data-is-focusable={true}
+      onKeyDown={e => {
+        if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          e.stopPropagation();
+          setButtonDisabled(false);
+          buttonRef.current.focus();
+        }
+      }}
+    >
+      <Flex fill vAlign="center">
+        <Flex.Item size={'size.quarter'}>
+          <Text content={'Tree item with button'} size="small" />
+        </Flex.Item>
+        <Button
+          data-cid={'calling_roster_button_mute_all'}
+          tabIndex={-1}
+          data-is-focusable={!buttonDisabled}
+          aria-hidden={buttonDisabled}
+          key={'muteAll'}
+          ref={buttonRef}
+          variables={{ isCallingRosterSectionAction: true }}
+          onKeyDown={e => {
+            if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              e.stopPropagation();
+              setButtonDisabled(true);
+              flexRef.current.focus();
+            }
+          }}
+          content={<Text size="small" content={'Mute all'} />}
+        />
+      </Flex>
+    </Box>
+  );
+};
+
+const TreeActionsUsingPopup = () => {
+  return (
+    <Tree
+      aria-expanded="true"
+      tabIndex={0}
+      aria-setsize={4}
+      aria-posinset={1}
+      aria-level={1}
+      data-is-focusable={true}
+      items={items}
+    />
+  );
+};
+
+export default TreeActionsUsingPopup;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/components/TreeActionsUsingPopup.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/components/TreeActionsUsingPopup.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import { Tree, Popup, Button, Flex, Text } from '@fluentui/react-northstar';
+
+const items = [
+  {
+    id: 'tree-item-0',
+    title: 'House Targaryen',
+    items: [
+      {
+        id: 'tree-item-01',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-011',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-012',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-013',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tree-item-1',
+    title: {
+      children: (C, p) => {
+        return <TreeTitleWithPopupButton />;
+      },
+    },
+    items: [],
+  },
+  {
+    id: 'tree-item-2',
+    title: 'House Targaryen 2',
+    items: [
+      {
+        id: 'tree-item-21',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-211',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-212',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-213',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tree-item-3',
+    title: 'House Targaryen 3',
+    items: [
+      {
+        id: 'tree-item-31',
+        title: 'Aerys',
+        items: [
+          {
+            id: 'tree-item-311',
+            title: 'Rhaegar',
+          },
+          {
+            id: 'tree-item-312',
+            title: 'Viserys',
+          },
+          {
+            id: 'tree-item-313',
+            title: 'Daenerys',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const TreeTitleWithPopupButton = () => {
+  const [popupOpen, setPopupOpen] = React.useState(false);
+  const wrapperRef = React.useRef(null);
+
+  return (
+    <Flex
+      data-is-focusable={true}
+      onKeyDown={e => {
+        if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          e.stopPropagation();
+          setPopupOpen(true);
+        }
+      }}
+      fill
+      vAlign="center"
+    >
+      <Flex.Item size={'size.quarter'}>
+        <Text content={'Tree item title'} size="small" />
+      </Flex.Item>
+      <Popup
+        position="above"
+        align="start"
+        offset={({ popper }) => [0, -popper.height]}
+        trapFocus
+        content={
+          <Button
+            content="Mute all"
+            aria-hidden={!popupOpen}
+            onClick={() => {
+              setPopupOpen(false);
+            }}
+            onKeyDown={e => {
+              if (e.key === 'ArrowLeft') {
+                setPopupOpen(false);
+              }
+            }}
+          />
+        }
+        onOpenChange={(e, data) => setPopupOpen(data.open)}
+        open={popupOpen}
+        target={wrapperRef.current}
+      />
+      <Button
+        data-cid={'calling_roster_button_mute_all'}
+        tabIndex={-1}
+        data-is-focusable={false}
+        aria-hidden={true}
+        key={'muteAll'}
+        ref={wrapperRef}
+        styles={{
+          visibility: popupOpen ? 'hidden' : 'visible',
+        }}
+        variables={{ isCallingRosterSectionAction: true }}
+        content={<Text size="small" content={'Mute all'} />}
+      />
+    </Flex>
+  );
+};
+
+const TreeActionsUsingPopup = () => {
+  return (
+    <Tree
+      aria-expanded="true"
+      tabIndex={0}
+      aria-setsize={4}
+      aria-posinset={1}
+      aria-level={1}
+      data-is-focusable={true}
+      items={items}
+    />
+  );
+};
+
+export default TreeActionsUsingPopup;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/index.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/index.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Provider, Segment, Header } from '@fluentui/react-northstar';
+import TreeActionsUsingPopup from './components/TreeActionsUsingPopup';
+import TreeActionsModifyAriaDisabled from './components/TreeActionsModifyAriaDisable';
+import { PrototypeSection, ComponentPrototype } from '../Prototypes';
+import { themeOverrides } from './styles';
+
+const TreeAdditionalActionsPrototype = () => {
+  return (
+    <Provider theme={themeOverrides}>
+      <Segment>
+        <Header content="Tree item navigation prototypes" />
+        <p>
+          You can navigate from three item to MuteAll button by pressing RightArrow button and back pressing LeftArrow
+        </p>
+        <PrototypeSection>
+          <ComponentPrototype
+            title="Tree item navigation - using popup"
+            description="Pressing the right arrow creates a popup in the place of the MuteAll button, which is temporarily hidden after the action. This popup button is the same as the old one, but it lies outside of the tree and is focusable."
+          >
+            <TreeActionsUsingPopup />
+          </ComponentPrototype>
+        </PrototypeSection>
+
+        <PrototypeSection>
+          <ComponentPrototype
+            title="Tree item navigation - modifying aria-hidden and data-is-focusable"
+            description="Pressing the right arrow modifies attributes aria-hidden and data-is-focusable of the MuteAll button."
+          >
+            <TreeActionsModifyAriaDisabled />
+          </ComponentPrototype>
+        </PrototypeSection>
+      </Segment>
+    </Provider>
+  );
+};
+
+export default TreeAdditionalActionsPrototype;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/styles.ts
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/TreeAdditionalActionsPrototype/styles.ts
@@ -1,0 +1,11 @@
+export const themeOverrides = {
+  componentStyles: {
+    PopupContent: {
+      root: {
+        '& .ui-popup__content__content': {
+          padding: 0,
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
#### Description of changes

Added two prototypes for tree additional actions (navigation using RightArrow)

#####  Tree item navigation - using popup
Pressing the right arrow creates a popup in the place of the MuteAll button, which is temporarily hidden after the action. This popup button is the same as the old one, but it lies outside of the tree.
#####  Tree item navigation - modifying aria-hidden and data-is-focusable
Pressing the right arrow modifies attributes aria-hidden and data-is-focusable of the MuteAll button.

#### Focus areas to test

Prototypes
