### PR TITLE
DetailsList: Updated all examples to pass 'select row' as checkButtonAriaLabel prop

### DIFF
--- a/change/@fluentui-react-examples-a28f8f47-4f23-4cb1-bdf8-330ab6e0aa2c.json
+++ b/change/@fluentui-react-examples-a28f8f47-4f23-4cb1-bdf8-330ab6e0aa2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Updated examples to pass 'select row' as checkButtonAriaLabel prop",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Announced/Announced.BulkOperations.Example.tsx
+++ b/packages/react-examples/src/react/Announced/Announced.BulkOperations.Example.tsx
@@ -65,6 +65,7 @@ export const AnnouncedBulkOperationsExample: React.FunctionComponent = () => {
         layoutMode={DetailsListLayoutMode.fixedColumns}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
       />
     </Stack>
   );

--- a/packages/react-examples/src/react/Announced/Announced.QuickActions.Example.tsx
+++ b/packages/react-examples/src/react/Announced/Announced.QuickActions.Example.tsx
@@ -112,6 +112,7 @@ export const AnnouncedQuickActionsExample: React.FunctionComponent = () => {
         selectionPreservedOnEmptyClick
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
       />
       <Dialog hidden={!dialogContent} onDismiss={closeRenameDialog} closeButtonAriaLabel="Close">
         {dialogContent}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
@@ -203,7 +203,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           ariaLabelForListHeader="Column headers. Click to sort."
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onRenderMissingItem={this._onRenderMissingItem}
         />
 

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Animation.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Animation.Example.tsx
@@ -88,7 +88,7 @@ export class DetailsListAnimationExample extends React.Component<{}, IDetailsLis
           selectionPreservedOnEmptyClick={true}
           ariaLabelForSelectionColumn="Toggle selection"
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onItemInvoked={this._onItemInvoked}
           enableUpdateAnimations={true}
           getCellValueKey={this._getCellValueKey}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
@@ -86,7 +86,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
             selectionPreservedOnEmptyClick={true}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
             onItemInvoked={this._onItemInvoked}
           />
         </MarqueeSelection>

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Compact.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Compact.Example.tsx
@@ -82,7 +82,7 @@ export class DetailsListCompactExample extends React.Component<{}, IDetailsListC
             onItemInvoked={this._onItemInvoked}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
           />
         </MarqueeSelection>
       </Fabric>

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -35,7 +35,7 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
       />
     );
   }

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomFooter.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomFooter.Example.tsx
@@ -49,7 +49,7 @@ export class DetailsListCustomFooterExample extends React.Component<{}, {}> {
         selectionPreservedOnEmptyClick={true}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsFooter={this._onRenderDetailsFooter}
       />
     );

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
@@ -69,7 +69,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
         getGroupHeight={this._getGroupHeight}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomRows.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomRows.Example.tsx
@@ -15,12 +15,7 @@ export class DetailsListCustomRowsExample extends React.Component<{}, {}> {
 
   public render() {
     return (
-      <DetailsList
-        items={this._items}
-        setKey="set"
-        onRenderRow={this._onRenderRow}
-        checkButtonAriaLabel="Row checkbox"
-      />
+      <DetailsList items={this._items} setKey="set" onRenderRow={this._onRenderRow} checkButtonAriaLabel="select row" />
     );
   }
 

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
@@ -225,7 +225,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
               enterModalSelectionOnTouch={true}
               ariaLabelForSelectionColumn="Toggle selection"
               ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-              checkButtonAriaLabel="Row checkbox"
+              checkButtonAriaLabel="select row"
             />
           </MarqueeSelection>
         ) : (

--- a/packages/react-examples/src/react/DetailsList/DetailsList.DragDrop.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.DragDrop.Example.tsx
@@ -103,7 +103,7 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
             columnReorderOptions={this.state.isColumnReorderEnabled ? this._getColumnReorderOptions() : undefined}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
           />
         </MarqueeSelection>
       </div>

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -105,7 +105,7 @@ export class DetailsListGroupedExample extends React.Component<{}, IDetailsListG
           columns={this._columns}
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onRenderDetailsHeader={this._onRenderDetailsHeader}
           groupProps={{
             showEmptyGroups: true,

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Large.Example.tsx
@@ -49,7 +49,7 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         columns={this._columns}
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         ariaLabelForSelectionColumn="Toggle selection"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
@@ -45,7 +45,7 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
         initialFocusedIndex={this.state.initialFocusedIndex}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
       />
     );
   }

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -877,6 +877,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1280,6 +1281,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1683,6 +1685,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2086,6 +2089,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2489,6 +2493,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2892,6 +2897,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3295,6 +3301,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3698,6 +3705,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4101,6 +4109,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4504,6 +4513,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -675,6 +675,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1213,6 +1214,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1751,6 +1753,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2289,6 +2292,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2827,6 +2831,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3365,6 +3370,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3903,6 +3909,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4441,6 +4448,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4979,6 +4987,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5517,6 +5526,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1643,7 +1643,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2047,7 +2047,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2451,7 +2451,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2855,7 +2855,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3259,7 +3259,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3663,7 +3663,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4067,7 +4067,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4471,7 +4471,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4875,7 +4875,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5279,7 +5279,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -942,7 +942,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1403,7 +1403,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1864,7 +1864,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2325,7 +2325,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2786,7 +2786,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3247,7 +3247,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3708,7 +3708,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4169,7 +4169,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4630,7 +4630,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5091,7 +5091,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1168,7 +1168,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1629,7 +1629,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2090,7 +2090,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2551,7 +2551,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3012,7 +3012,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3473,7 +3473,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3934,7 +3934,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4395,7 +4395,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4856,7 +4856,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5317,7 +5317,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1154,7 +1154,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1616,7 +1616,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2078,7 +2078,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2540,7 +2540,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3002,7 +3002,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3464,7 +3464,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3926,7 +3926,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4388,7 +4388,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4850,7 +4850,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5312,7 +5312,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -699,7 +699,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1140,7 +1140,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1581,7 +1581,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2022,7 +2022,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2463,7 +2463,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2904,7 +2904,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3345,7 +3345,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3786,7 +3786,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4227,7 +4227,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4668,7 +4668,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -920,7 +920,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1381,7 +1381,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1842,7 +1842,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2303,7 +2303,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2764,7 +2764,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -1059,7 +1059,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1474,7 +1474,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1889,7 +1889,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2304,7 +2304,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2719,7 +2719,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3134,7 +3134,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3549,7 +3549,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3964,7 +3964,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4379,7 +4379,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4794,7 +4794,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -706,7 +706,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1110,7 +1110,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1515,7 +1515,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1919,7 +1919,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2324,7 +2324,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2728,7 +2728,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3133,7 +3133,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3537,7 +3537,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3942,7 +3942,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4346,7 +4346,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1367,7 +1367,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1773,7 +1773,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2179,7 +2179,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2585,7 +2585,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2991,7 +2991,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3397,7 +3397,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3803,7 +3803,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4209,7 +4209,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4615,7 +4615,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5021,7 +5021,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1786,7 +1786,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -2266,7 +2266,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -3598,7 +3598,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4078,7 +4078,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4558,7 +4558,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1441,7 +1441,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1913,7 +1913,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2385,7 +2385,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2857,7 +2857,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3329,7 +3329,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3801,7 +3801,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4273,7 +4273,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4745,7 +4745,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5217,7 +5217,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5689,7 +5689,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -808,7 +808,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1343,7 +1343,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1878,7 +1878,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2413,7 +2413,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2948,7 +2948,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3483,7 +3483,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4018,7 +4018,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4553,7 +4553,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5088,7 +5088,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [6397](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/6397)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Passed missing `checkButtonAriaLabel` prop to `DetailsList` in `Announced` examples.
- Updated all pre-existing examples to pass 'select row' as `checkButtonAriaLabel` prop
