### PR TITLE
Checkbox: remove native props extension to reflect actual behavior

### DIFF
--- a/change/@fluentui-react-797fd847-9ce6-4eb1-b16f-b991bcc667dc.json
+++ b/change/@fluentui-react-797fd847-9ce6-4eb1-b16f-b991bcc667dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Checkbox: remove native props extension to reflect actual behavior",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-3d56f7e0-8d31-4a2e-9eb2-908092300889.json
+++ b/change/@fluentui-react-examples-3d56f7e0-8d31-4a2e-9eb2-908092300889.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Checkbox: remove native props extension to reflect actual behavior",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Checkbox/Checkbox.Other.Example.tsx
+++ b/packages/react-examples/src/react/Checkbox/Checkbox.Other.Example.tsx
@@ -7,6 +7,8 @@ import { Stack } from '@fluentui/react/lib/Stack';
 const inputProps: ICheckboxProps['inputProps'] = {
   onFocus: () => console.log('Checkbox is focused'),
   onBlur: () => console.log('Checkbox is blurred'),
+  // Passing data-* props is supported but currently requires casting
+  ...({ 'data-foo': 'bar' } as any),
 };
 // Used to add spacing between example checkboxes
 const stackTokens = { childrenGap: 10 };
@@ -27,9 +29,11 @@ export const CheckboxOtherExample: React.FunctionComponent = () => {
 
       <Checkbox label='Checkbox rendered with boxSide "end"' boxSide="end" />
 
-      <Checkbox label="Checkbox with extra props for the input" inputProps={inputProps} />
-
       <Checkbox label="Checkbox with link inside the label" onRenderLabel={_renderLabelWithLink} />
+
+      {/* Checkbox doesn't currently support passing arbitrary native props through the root.
+      However, props for the hidden checkbox input element can be passed through `inputProps`. */}
+      <Checkbox label="Checkbox with extra props for the input (including data-*)" inputProps={inputProps} />
     </Stack>
   );
 };

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -392,166 +392,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="Checkbox with extra props for the input"
-      checked={false}
-      className=
-
-          {
-            background: none;
-            opacity: 0;
-            position: absolute;
-          }
-          .ms-Fabric--isFocusVisible &:focus + label::before {
-            outline-offset: 2px;
-            outline: 1px solid #605e5c;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid WindowText;
-          }
-      data-ktp-execute-target={true}
-      id="checkbox-2"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      type="checkbox"
-    />
-    <label
-      className=
-          ms-Checkbox-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            align-items: flex-start;
-            cursor: pointer;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            position: relative;
-            user-select: none;
-          }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
-      htmlFor="checkbox-2"
-    >
-      <div
-        className=
-            ms-Checkbox-checkbox
-            {
-              align-items: center;
-              border-radius: 2px;
-              border: 1px solid #323130;
-              box-sizing: border-box;
-              display: flex;
-              flex-shrink: 0;
-              height: 20px;
-              justify-content: center;
-              margin-right: 4px;
-              overflow: hidden;
-              position: relative;
-              transition-duration: 200ms;
-              transition-property: background, border, border-color;
-              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-              width: 20px;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              -ms-high-contrast-adjust: none;
-              border-color: WindowText;
-              forced-color-adjust: none;
-            }
-        data-ktp-target={true}
-      >
-        <i
-          aria-hidden={true}
-          className=
-              ms-Checkbox-checkmark
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #ffffff;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                opacity: 0;
-                speak: none;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                -ms-high-contrast-adjust: none;
-                color: Window;
-                forced-color-adjust: none;
-              }
-          data-icon-name="CheckMark"
-        >
-          
-        </i>
-      </div>
-      <span
-        aria-hidden="true"
-        className=
-            ms-Checkbox-text
-            {
-              color: #323130;
-              font-size: 14px;
-              line-height: 20px;
-              margin-left: 4px;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              -ms-high-contrast-adjust: none;
-              color: WindowText;
-              forced-color-adjust: none;
-            }
-      >
-        Checkbox with extra props for the input
-      </span>
-    </label>
-  </div>
-  <div
-    className=
-        ms-Checkbox
-        is-enabled
-        {
-          display: flex;
-          position: relative;
-        }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #323130;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #323130;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #605e5c;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
-          color: WindowText;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
-          color: WindowText;
-        }
-  >
-    <input
-      aria-checked="false"
       aria-label="Checkbox with link inside the label"
       checked={false}
       className=
@@ -569,7 +409,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -597,7 +437,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=
@@ -712,6 +552,167 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         >
           Microsoft home page
         </a>
+      </span>
+    </label>
+  </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="Checkbox with extra props for the input (including data-*)"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-foo="bar"
+      data-ktp-execute-target={true}
+      id="checkbox-3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-3"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Checkbox with extra props for the input (including data-*)
       </span>
     </label>
   </div>

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2399,7 +2399,7 @@ export interface ICheckbox {
 }
 
 // @public
-export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement>, React.RefAttributes<HTMLDivElement> {
+export interface ICheckboxProps extends React.RefAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -2413,13 +2413,16 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
     defaultChecked?: boolean;
     defaultIndeterminate?: boolean;
     disabled?: boolean;
+    id?: string;
     indeterminate?: boolean;
     inputProps?: React.ButtonHTMLAttributes<HTMLElement | HTMLButtonElement>;
     label?: string;
+    name?: string;
     onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
     onRenderLabel?: IRenderFunction<ICheckboxProps>;
     styles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
     theme?: ITheme;
+    title?: string;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -83,47 +83,30 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       ? 'true'
       : 'false';
 
-    const slotProps = {
-      root: {
-        className: classNames.root,
-        title,
-        ref: mergedRootRefs,
-      },
-      input: {
-        className: classNames.input,
-        type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
-        ...inputProps,
-        ref: inputRef,
-        checked: !!isChecked,
-        disabled,
-        name,
-        id,
-        title,
-        onChange,
-        'data-ktp-execute-target': true,
-        'aria-disabled': disabled,
-        'aria-label': ariaLabel || label,
-        'aria-labelledby': ariaLabelledBy,
-        'aria-describedby': ariaDescribedBy,
-        'aria-posinset': ariaPositionInSet,
-        'aria-setsize': ariaSetSize,
-        'aria-checked': ariaChecked,
-      },
-      checkbox: {
-        className: classNames.checkbox,
-        'data-ktp-target': true,
-      },
-      container: {
-        className: classNames.label,
-        htmlFor: id,
-      },
+    const mergedInputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+      className: classNames.input,
+      type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
+      ...inputProps,
+      checked: !!isChecked,
+      disabled,
+      name,
+      id,
+      title,
+      onChange,
+      'aria-disabled': disabled,
+      'aria-label': ariaLabel || label,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      'aria-posinset': ariaPositionInSet,
+      'aria-setsize': ariaSetSize,
+      'aria-checked': ariaChecked,
     };
 
     return (
-      <div {...slotProps.root}>
-        <input {...slotProps.input} />
-        <label {...slotProps.container}>
-          <div {...slotProps.checkbox}>
+      <div className={classNames.root} title={title} ref={mergedRootRefs}>
+        <input {...mergedInputProps} ref={inputRef} data-ktp-execute-target={true} />
+        <label className={classNames.label} htmlFor={id}>
+          <div className={classNames.checkbox} data-ktp-target={true}>
             <Icon iconName="CheckMark" {...checkmarkIconProps} className={classNames.checkmark} />
           </div>
           {onRenderLabel(props, defaultLabelRenderer)}

--- a/packages/react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.types.ts
@@ -22,9 +22,7 @@ export interface ICheckbox {
  * Checkbox properties.
  * {@docCategory Checkbox}
  */
-export interface ICheckboxProps
-  extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement>,
-    React.RefAttributes<HTMLDivElement> {
+export interface ICheckboxProps extends React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the `ICheckbox` interface. Use this instead of `ref` for accessing
    * the public methods and properties of the component.
@@ -64,10 +62,28 @@ export interface ICheckboxProps
   onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
 
   /**
-   * Optional props that will be mixed into the input element, *before* other props are applied. This allows
-   * you to apply additional attributes to the input element, such as `data-automation-id` for automation.
-   * Note that if you provide, for example, `disabled` as well as `inputProps.disabled`, the former will take
-   * precedence over the latter.
+   * Title text applied to the root element and the hidden checkbox input.
+   * (Use `label` instead for the visible label.)
+   */
+  title?: string;
+
+  /**
+   * ID for the checkbox input.
+   */
+  id?: string;
+
+  /**
+   * Name for the checkbox input. This is intended for use with forms and NOT displayed in the UI.
+   */
+  name?: string;
+
+  /**
+   * Optional props that will be applied to the input element, *before* other props are applied.
+   * Note that if you provide, for example, `disabled` as well as `inputProps.disabled`, the
+   * top-level prop (`disabled` in this case) will take precedence.
+   *
+   * Including `data-*` props in `inputProps` is supported but currently requires casting since
+   * TS 3.7 doesn't provide a way to allow all keys with a certain prefix.
    */
   inputProps?: React.ButtonHTMLAttributes<HTMLElement | HTMLButtonElement>;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Partially addressing #16307
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#16307 pointed out that Checkbox appears to accept native props, but doesn't actually apply them anywhere. To accurately reflect this behavior, remove the native props extension from `ICheckboxProps` and update docs.

(We may want to add native props support at the root in the future, but since it's not 100% obvious where the props ought to go and the prop interaction with `inputProps`, it seemed best to just fix the misleading interface for now.)