### PR TITLE
Add separate pipeline for CI and fix cleanup

### DIFF
--- a/.devops/templates/variables.yml
+++ b/.devops/templates/variables.yml
@@ -1,9 +1,26 @@
+parameters:
+  - name: deployBasePath
+    type: string
+    default: ''
+
+  - name: azureSubscription
+    type: string
+    default: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+
+  # Skip the component governance detection step (injected by a pipeline decorator from an
+  # internal extension) by default because we run it separately. Since all our pipelines
+  # in each branch install the same packages, only one pipeline (currently the daily release)
+  # needs to run detection.
+  - name: skipComponentGovernanceDetection
+    type: boolean
+    default: true
+
 variables:
-  deployBasePath: "pr-deploy-site/${{ variables['Build.SourceBranch'] }}"
+  deployBasePath: ${{ coalesce(parameters.deployBasePath, 'pr-deploy-site/$(Build.SourceBranch)') }}
 
   deployHost: 'fabricweb.z5.web.core.windows.net'
 
-  azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+  azureSubscription: ${{ parameters.azureSubscription }}
 
   ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master') }}:
     isPR: true
@@ -11,5 +28,4 @@ variables:
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
     isPR: false
 
-  backfillProvider: 'azure-blob'
-  backfillOptions: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
+  skipComponentGovernanceDetection: ${{ parameters.skipComponentGovernanceDetection }}

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -4,6 +4,9 @@ pr:
 trigger:
   - master
 
+variables:
+  - template: .devops/templates/variables.yml
+
 jobs:
   - job: build_react
     timeoutInMinutes: 75

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -9,6 +9,9 @@ workspace:
 
 name: '$(targetNpmVersion) ($(Rev:r))'
 
+variables:
+  - template: .devops/templates/variables.yml
+
 steps:
   - template: .devops/templates/tools.yml
 

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -24,23 +24,20 @@ steps:
   # @fluentui/perf-test needs build and bundle steps
   - script: |
       yarn lage build --to @fluentui/perf-test --to perf-test --verbose --no-cache
-    displayName: build  @fluentui v0
-    env:
-      BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-      BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
+    displayName: build to perf-test
 
   # Fluent perf-test must run before Fabric perf-test until they are consolidated.
   # @fluentui/perf-test Baseline
   - script: |
       yarn perf:test:base
-    condition: eq(variables['isPR'], false)
+    condition: not(variables.isPR)
     workingDirectory: packages/fluentui/perf-test
     displayName: Perf Test Base (Fluent)
 
   # @fluentui/perf-test PR
   - script: |
       yarn perf:test
-    condition: eq(variables['isPR'], true)
+    condition: variables.isPR
     workingDirectory: packages/fluentui/perf-test
     displayName: Perf Test (Fluent)
 
@@ -79,18 +76,18 @@ steps:
 
   - script: |
       yarn stats:build
-    condition: eq(variables['isPR'], false)
+    condition: not(variables.isPR)
     displayName: Bundle Statistics (master only)
 
   - script: |
       yarn perf
-    condition: eq(variables['isPR'], false)
+    condition: not(variables.isPR)
     displayName: Performance Tests (master only)
 
   # HEADS UP: also see tag-version-prefix in fluentui-publish.js
   - script: |
       yarn stats:save --tag=`git tag --points-at HEAD | grep ^@fluentui/react-northstar_v | grep -o 'northstar_v.*'`
-    condition: eq(variables['isPR'], false)
+    condition: not(variables.isPR)
     displayName: Save Statistics to DB (master only)
     env:
       STATS_URI: $(STATS_URI)

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -22,9 +22,10 @@ resources:
 variables:
   # below are variables that cannot be configured at queue time
   - group: 'Github and NPM secrets'
+  - template: .devops/templates/variables.yml
+    parameters:
+      deployBasePath: 0.0.0-nightly
   - name: docsiteVersion # used by docsite
-    value: 0.0.0-nightly
-  - name: deployBasePath # used by docsite
     value: 0.0.0-nightly
   - name: officialRelease # used by docsite
     value: true

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -7,6 +7,10 @@ name: 'v8_$(Date:yyyyMMdd)$(Rev:.r)'
 
 variables:
   - group: 'Github and NPM secrets'
+  - template: .devops/templates/variables.yml
+    parameters:
+      azureSubscription: 'UI Fabric (private)'
+      skipComponentGovernanceDetection: false
 
 pool: 'Self Host Ubuntu'
 
@@ -31,6 +35,17 @@ steps:
       git config user.email "fluentui-internal@service.microsoft.com"
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
+
+  # This step has no dependencies, so do it early in the build in case other steps fail
+  - task: AzureUpload@2
+    displayName: Upload demo images
+    inputs:
+      azureSubscription: $(azureSubscription)
+      BlobPrefix: 'assets'
+      CacheControl: 'public, max-age=600000'
+      ContainerName: 'fabric-website' # this container has a CDN
+      SourcePath: 'packages/fluentui/docs/src/public'
+      storage: fabricweb
 
   - task: Bash@3
     inputs:
@@ -143,11 +158,21 @@ steps:
     displayName: Upload Package Manifest
     inputs:
       SourcePath: 'package-manifest'
-      azureSubscription: 'UI Fabric (private)'
+      azureSubscription: $(azureSubscription)
       storage: fabricweb
       ContainerName: 'fabric'
       BlobPrefix: 'package-manifest'
       Gzip: false
+
+  # This would usually be run automatically (via a pipeline decorator from an extension), but the
+  # thorough cleanup step prevents it from working. So run it manually here.
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    inputs:
+      sourceScanPath: $(Agent.BuildDirectory)
+    condition: succeeded()
+    timeoutInMinutes: 5
+    continueOnError: true
 
   - template: .devops/templates/cleanup.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,17 @@
 pr:
   - master
 
-trigger:
-  - master
+# There's a separate pipeline for CI which also uses this file, but with a trigger override in the UI
+# https://dev.azure.com/uifabric/fabricpublic/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=164&view=Tab_Triggers
+trigger: none
 
 variables:
+  - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+      - name: sinceArg
+        value: --since $(targetBranch)
+
   - group: fabric-variables
+
   - template: .devops/templates/variables.yml
 
 pool: 'Self Host Ubuntu'
@@ -37,35 +43,21 @@ jobs:
       - script: |
           yarn danger ci
         displayName: danger
-        condition: eq(variables['isPR'], true)
+        condition: variables.isPR
         env:
           DANGER_GITHUB_API_TOKEN: $(DANGER_GITHUB_API_TOKEN)
 
-      ## only do scoped builds with PRs
       - script: |
-          yarn buildci --no-cache --since $(targetBranch)
-        displayName: build, test, lint (pr, scoped)
-        condition: eq(variables['isPR'], true)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
-
-      ## duplicated build step, but without --since flag for master CI builds
-      - script: |
-          yarn buildci --no-cache
-        displayName: build, test, lint (master)
-        condition: eq(variables['isPR'], false)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
+          yarn buildci --no-cache $(sinceArg)
+        displayName: build, test, lint
 
       - template: .devops/templates/cleanup.yml
+        parameters:
+          checkForChangedFiles: false
 
   - job: Deploy
     workspace:
       clean: all
-    variables:
-      - template: .devops/templates/variables.yml
     steps:
       - template: .devops/templates/tools.yml
 
@@ -74,23 +66,9 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      ## only do scoped bundle with PRs
       - script: |
-          yarn bundle --no-cache --since $(targetBranch)
-        displayName: bundle (pr, scoped)
-        condition: eq(variables['isPR'], true)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
-
-      ## duplicated for master CI builds
-      - script: |
-          yarn bundle --no-cache
-        displayName: bundle (master)
-        condition: eq(variables['isPR'], false)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
+          yarn bundle --no-cache $(sinceArg)
+        displayName: bundle
 
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |
@@ -118,20 +96,9 @@ jobs:
           githubDescription: 'Click "Details" to go to the deployed demo site for this pull request'
           githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
-      - task: AzureUpload@2
-        displayName: Upload demo images (master)
-        condition: eq(variables['isPR'], false)
-        inputs:
-          azureSubscription: $(azureSubscription)
-          BlobPrefix: 'assets'
-          CacheControl: 'public, max-age=600000'
-          ContainerName: 'fabric-website' # this container has a CDN
-          SourcePath: 'packages/fluentui/docs/src/public'
-          storage: fabricweb
-
       - template: .devops/templates/cleanup.yml
 
-  - job: ScreenerFluent
+  - job: ScreenerNorthstar
     workspace:
       clean: all
     steps:
@@ -178,7 +145,5 @@ jobs:
         displayName: run VR Test
         env:
           SCREENER_API_KEY: $(screener.key)
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
 
       - template: .devops/templates/cleanup.yml


### PR DESCRIPTION
### Partially separating PR/CI pipelines

Change our main pipeline file to only include a trigger for PRs, and have CI use a [separate pipeline](https://dev.azure.com/uifabric/fabricpublic/_build?definitionId=164&_a=summary) which uses the same file but with a [trigger override in the UI](https://dev.azure.com/uifabric/fabricpublic/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=164&view=Tab_Triggers). This has multiple benefits:
- Makes it easier to get meaningful [analytics data](https://dev.azure.com/uifabric/fabricpublic/_build?definitionId=84&view=ms.vss-pipelineanalytics-web.new-build-definition-pipeline-analytics-view-cardmetrics) about build failure rates
- Fixes Teams notifications for failed builds: we can use the Azure Pipelines bot to subscribe to only the CI pipeline (since the bot doesn't have branch filters, for the combined pipeline I had it set it up to email the channel if master or 7.0 build failed...but then the email got too bulky for Teams to display)
- Allows us to restrict what resources the PR pipeline can access (future, not set up today)

Along with this, I added better conditional logic to reduce duplication of pipeline steps between PR and CI.

### Fixing component governance detection

I also noticed that my previous attempt in #17147 to address the "Directory not empty" error caused the automatic component governance detection task to fail (this is injected by a pipeline decorator from an extension, and only runs against master). This causes confusing [warnings](https://dev.azure.com/uifabric/fabricpublic/_build/results?buildId=191796&view=results) and means component governance detection doesn't work. 

As a workaround, I started setting a variable `skipComponentGovernanceDetection: true` in the shared variables template by default (per their docs this should prevent the decorator from running). Then I added a manual run of the component governance detection task in the release build only. Running the task in only one pipeline should be fine since the point of the task is to check installed packages, and we install the same packages in all our pipelines in each branch.