### PR TITLE
Fix intermittent issue with Dropdown tests

### DIFF
--- a/change/@fluentui-react-06aaa39e-6cf3-460a-8a34-e0330a7433a5.json
+++ b/change/@fluentui-react-06aaa39e-6cf3-460a-8a34-e0330a7433a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix intermittent issue with Dropdown tests",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -48,6 +48,9 @@ describe('Dropdown', () => {
       wrapper.unmount();
       wrapper = undefined;
     }
+    if ((setTimeout as any).mock) {
+      jest.useRealTimers();
+    }
 
     document.body.innerHTML = '';
   });
@@ -67,6 +70,10 @@ describe('Dropdown', () => {
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
       spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      // There's intermittent variation (maybe measurement-related) on different computers,
+      // so use fake timers to make it more predictable even though we never advance the timers.
+      jest.useFakeTimers();
+
       const ref = React.createRef<IDropdown>();
       wrapper = mount(<Dropdown options={RENDER_OPTIONS} componentRef={ref} />);
       ref.current!.focus(true);
@@ -483,6 +490,10 @@ describe('Dropdown', () => {
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
       spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      // There's intermittent variation (maybe measurement-related) on different computers,
+      // so use fake timers to make it more predictable even though we never advance the timers.
+      jest.useFakeTimers();
+
       const ref = React.createRef<IDropdown>();
       wrapper = mount(<Dropdown multiSelect options={RENDER_OPTIONS} componentRef={ref} />);
       ref.current!.focus(true);


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

#16331 seems to have introduced intermittent snapshot variations in the Dropdown tests (sometimes `width: 10` shows up on the callout element in CI, but I haven't seen that locally). I'm guessing this is timing- or measurement-related, so try using fake timers for those tests to prevent the components from updating in the background before the snapshot runs.