### PR TITLE
Add version 8 info to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://img.shields.io/azure-devops/build/uifabric/fabricpublic/84/master?style=flat-square)](https://dev.azure.com/uifabric/fabricpublic/_build/latest?definitionId=84&branchName=master) ![GitHub contributors](https://img.shields.io/github/contributors/microsoft/fluentui?style=flat-square) ![GitHub top language](https://img.shields.io/github/languages/top/microsoft/fluentui?style=flat-square) [![Twitter Follow](https://img.shields.io/twitter/follow/fluentui?logo=twitter&style=flat-square)](https://twitter.com/FluentUI?ref_src=twsrc%5Etfw)
 
+> :tada: :tada: :tada: **Version 8 of `@fluentui/react` is now available on npm!** :tada: :tada: :tada:
+>
+> See the [release notes](https://github.com/microsoft/fluentui/wiki/Version-8-release-notes) for more info, and please file an issue if you have any problems.
+
 Fluent UI web represents a collection of utilities, React components, and web components for building web applications.
 
 This repo is home to 3 separate projects today. Mixing components between projects is not currently supported. The goal of these projects is to dedupe functionality and enable interoperability over time. For now, choose the project that best suits your needs.

--- a/change/@fluentui-react-f62e2e6a-18a1-4c2c-b175-6e4b2982f10b.json
+++ b/change/@fluentui-react-f62e2e6a-18a1-4c2c-b175-6e4b2982f10b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add link to version 8 release notes in readme",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,6 +6,8 @@
 
 Fluent UI React is a collection of robust React-based components designed to make it simple for you to create consistent web experiences using the Fluent Design Language.
 
+**What's changed in version 8? See the [release notes](https://github.com/microsoft/fluentui/wiki/Version-8-release-notes).**
+
 ## Learn about Fluent UI
 
 [Fluent UI React current release documentation](https://developer.microsoft.com/en-us/fluentui)


### PR DESCRIPTION
Add a banner about version 8 to the github repo readme (we can remove this in a couple months). Open to suggestions on wording and formatting.

Add a link to the release notes in the `@fluentui/react` readme.