### PR TITLE
Peoplepicker quickfix

### DIFF
--- a/change/@fluentui-react-c37ef2b3-ec2c-4c41-bc08-d65c63e9b5d6.json
+++ b/change/@fluentui-react-c37ef2b3-ec2c-4c41-bc08-d65c63e9b5d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds role=\"presentation\" to BasePicker div for screen reader accessibility",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-089995db-9b7a-4dd7-8f81-ebf517c8a605.json
+++ b/change/@fluentui-react-examples-089995db-9b7a-4dd7-8f81-ebf517c8a605.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds role=\"presentation\" to BasePicker div for screen reader accessibility",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -87,6 +87,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -52,6 +52,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                 &:hover {
                   border-color: #323130;
                 }
+            role="presentation"
           >
             <input
               aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <span
             className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"
@@ -291,6 +292,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               &:hover {
                 border-color: #323130;
               }
+          role="presentation"
         >
           <input
             aria-autocomplete="both"

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -292,7 +292,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
         >
           {this.getSuggestionsAlert(classNames.screenReaderText)}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={classNames.text}>
+            <div className={classNames.text} role="presentation">
               {items.length > 0 && (
                 <span id={this._ariaMap.selectedItems} className={classNames.itemsWrapper} role={'list'}>
                   {this.renderItems()}

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`PeoplePicker renders correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
+        role="presentation"
       >
         <input
           aria-autocomplete="both"
@@ -150,6 +151,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
             &:hover {
               border-color: #323130;
             }
+        role="presentation"
       >
         <span
           className=

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`TagPicker renders correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
+        role="presentation"
       >
         <span
           className=
@@ -358,6 +359,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
+        role="presentation"
       >
         <span
           className=

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`BasePicker renders correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
+        role="presentation"
       >
         <input
           aria-autocomplete="both"
@@ -97,6 +98,7 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
+        role="presentation"
       >
         <input
           aria-autocomplete="both"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14477, #15060, and [8834](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/8834)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds `role="presentation"` to the `<div>` between the combobox and input in PeoplePicker. This resolves the specific issue on Chrome/Edge Chromium with NVDA where NVDA does not navigate to the combobox in browse mode.

Note: this does not address ARIA v1.1 combobox issues with other screen readers.
