### PR TITLE
Fix Loader rendering with emotion renderer

### DIFF
--- a/packages/fluentui/react-northstar-emotion-renderer/src/invokeKeyframes.ts
+++ b/packages/fluentui/react-northstar-emotion-renderer/src/invokeKeyframes.ts
@@ -38,8 +38,10 @@ export function invokeKeyframes(cache: EmotionCache, styles: ICSSInJSStyle) {
 
         if (style.keyframe) {
           styles[property] = keyframes(cache, style.keyframe, style.params);
+          continue;
         }
 
+        styles[property] = keyframes(cache, style as AnimationName['keyframe'], style.params);
         continue;
       }
 

--- a/packages/fluentui/react-northstar-emotion-renderer/src/invokeKeyframes.ts
+++ b/packages/fluentui/react-northstar-emotion-renderer/src/invokeKeyframes.ts
@@ -1,6 +1,6 @@
 import { serializeStyles } from '@emotion/serialize';
 import { EmotionCache } from '@emotion/utils';
-import { AnimationName, ICSSInJSStyle } from '@fluentui/styles';
+import { AnimationKeyFrame, AnimationName, ICSSInJSStyle } from '@fluentui/styles';
 
 import { isStyleObject } from './utils';
 
@@ -41,7 +41,7 @@ export function invokeKeyframes(cache: EmotionCache, styles: ICSSInJSStyle) {
           continue;
         }
 
-        styles[property] = keyframes(cache, style as AnimationName['keyframe'], style.params);
+        styles[property] = keyframes(cache, style as AnimationKeyFrame, style.params);
         continue;
       }
 

--- a/packages/fluentui/react-northstar-emotion-renderer/test/__snapshots__/emotionRenderer-test.ts.snap
+++ b/packages/fluentui/react-northstar-emotion-renderer/test/__snapshots__/emotionRenderer-test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`emotionRenderer animations are not applied if animations are disabled 1`] = ``;
 
-exports[`emotionRenderer animations object value is wrapped in keyframe ittribute 1`] = `
+exports[`emotionRenderer animations object value is wrapped in keyframe attribute 1`] = `
 .fui-e3vlrl {
   -webkit-animation-name: animation-1q8eu9e;
   animation-name: animation-1q8eu9e;

--- a/packages/fluentui/react-northstar-emotion-renderer/test/__snapshots__/emotionRenderer-test.ts.snap
+++ b/packages/fluentui/react-northstar-emotion-renderer/test/__snapshots__/emotionRenderer-test.ts.snap
@@ -2,6 +2,38 @@
 
 exports[`emotionRenderer animations are not applied if animations are disabled 1`] = ``;
 
+exports[`emotionRenderer animations object value is wrapped in keyframe ittribute 1`] = `
+.fui-e3vlrl {
+  -webkit-animation-name: animation-1q8eu9e;
+  animation-name: animation-1q8eu9e;
+}
+@-webkit-keyframes animation-1q8eu9e {
+  from {
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes animation-1q8eu9e {
+  from {
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+`;
+
 exports[`emotionRenderer array returned by keyframe results in CSS fallback values 1`] = `
 .fui-m7zzi0 {
   -webkit-animation-name: animation-avzz4x;

--- a/packages/fluentui/react-northstar-emotion-renderer/test/emotionRenderer-test.ts
+++ b/packages/fluentui/react-northstar-emotion-renderer/test/emotionRenderer-test.ts
@@ -105,6 +105,22 @@ describe('emotionRenderer', () => {
     expect(document).toMatchSnapshot();
   });
 
+  test('animations object value is wrapped in keyframe attribute', () => {
+    const styles: ICSSInJSStyle = {
+      animationName: {
+        from: {
+          transform: 'rotate(0deg)',
+        },
+        to: {
+          transform: 'rotate(360deg)',
+        },
+      },
+    };
+
+    createEmotionRenderer().renderRule(styles, defaultRendererParam);
+    expect(document).toMatchSnapshot();
+  });
+
   test('marginLeft is rendered into marginRight due to RTL', () => {
     createEmotionRenderer().renderRule({ marginLeft: '10px' }, { ...defaultRendererParam, direction: 'rtl' });
     expect(document).toMatchSnapshot();

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Loader/loaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Loader/loaderStyles.ts
@@ -30,8 +30,10 @@ export const loaderStyles: ComponentSlotStylesPrepared<LoaderStylesProps, Loader
   svg: ({ props: p, theme: t, variables: v }: ComponentStyleFunctionParam<LoaderStylesProps, LoaderVariables>) => {
     const outerAnimation: ICSSInJSStyle = {
       animationName: {
-        to: {
-          opacity: 1,
+        keyframe: {
+          to: {
+            opacity: 1,
+          },
         },
       },
       animationDelay: '1.5s',
@@ -47,8 +49,10 @@ export const loaderStyles: ComponentSlotStylesPrepared<LoaderStylesProps, Loader
     };
     const svgAnimation: ICSSInJSStyle = {
       animationName: {
-        to: {
-          transform: `translate3d(0, ${v.svgTranslatePosition[p.size]}, 0)`,
+        keyframe: {
+          to: {
+            transform: `translate3d(0, ${v.svgTranslatePosition[p.size]}, 0)`,
+          },
         },
       },
       animationDelay: '0s',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Loader/loaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Loader/loaderStyles.ts
@@ -30,10 +30,8 @@ export const loaderStyles: ComponentSlotStylesPrepared<LoaderStylesProps, Loader
   svg: ({ props: p, theme: t, variables: v }: ComponentStyleFunctionParam<LoaderStylesProps, LoaderVariables>) => {
     const outerAnimation: ICSSInJSStyle = {
       animationName: {
-        keyframe: {
-          to: {
-            opacity: 1,
-          },
+        to: {
+          opacity: 1,
         },
       },
       animationDelay: '1.5s',
@@ -49,10 +47,8 @@ export const loaderStyles: ComponentSlotStylesPrepared<LoaderStylesProps, Loader
     };
     const svgAnimation: ICSSInJSStyle = {
       animationName: {
-        keyframe: {
-          to: {
-            transform: `translate3d(0, ${v.svgTranslatePosition[p.size]}, 0)`,
-          },
+        to: {
+          transform: `translate3d(0, ${v.svgTranslatePosition[p.size]}, 0)`,
         },
       },
       animationDelay: '0s',

--- a/packages/fluentui/styles/src/types.ts
+++ b/packages/fluentui/styles/src/types.ts
@@ -25,7 +25,7 @@ export type ObjectOrFunc<TResult, TArg = {}> = ((arg: TArg) => TResult) | TResul
 // CSS in JS
 // ========================================================
 
-type AnimationKeyFrame = Record<'from' | 'to' | string, ICSSInJSStyle>;
+export type AnimationKeyFrame = Record<'from' | 'to' | string, ICSSInJSStyle>;
 
 export interface AnimationName<P = Record<string, any>> {
   keyframe?: AnimationKeyFrame | ((params: P) => AnimationKeyFrame);


### PR DESCRIPTION
#### Description of changes

Loader styles fixed. It didn't work properly with Emotion renderer.


#### Focus areas to test
Loader with the Emotion renderer enabled (for enabling localStorage.setItem("fluentRenderer", "emotion"))
