### PR TITLE
fix(Dropdown): prevent scrollable parent scroll when selecting an item

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `dropdownSelectedItem` has tiny icon when the content is long @yuanboxue-amber ([#16795](https://github.com/microsoft/fluentui/pull/16795))
 - Updating various icons, `ArrowSortIcon`, `BreakoutRoomIcon`, `CalendarAgendaIcon`, `CallControlCloseTrayIcon`, `PlayIcon`, `TenantPersonalIcon` @notandrew ([#16723](https://github.com/microsoft/fluentui/pull/16723))
 - Fix touch scroll for `Dialog` @assuncaocharles ([#17054](https://github.com/microsoft/fluentui/pull/17054))
+- Prevent scrollable parent element or viewport scroll when an item is seleted in `Dropdown` @yuanboxue-amber ([#17222](https://github.com/microsoft/fluentui/pull/17222))
 
 ## Features
 - For `Tree`, add keyboard navigation based on the first letter of the text content of tree items @yuanboxue-amber ([#16994](https://github.com/microsoft/fluentui/pull/16994))

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -1519,7 +1519,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
 
             // Replicating same config that Downshift uses
             const actions = computeScrollIntoView(nodeToScroll, {
-              boundary: menu,
+              boundary: menu, // Explicitly set boundary to avoid unnecessary scrolling by checking all parent elements
               scrollMode: 'if-needed',
               block: 'nearest',
               inline: 'nearest',

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -1519,6 +1519,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
 
             // Replicating same config that Downshift uses
             const actions = computeScrollIntoView(nodeToScroll, {
+              boundary: menu,
               scrollMode: 'if-needed',
               block: 'nearest',
               inline: 'nearest',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In `Dropdown` we uses `Downshift`'s `scrollIntoView` to make sure the highlighted item is always in the view when the user opens dropdown.
Inside `scrollIntoView`, we use `computeScrollIntoView` to know how much we should scroll. However, if there's no `boundary` passed into `computeScrollIntoView`, all the parent elements of the target is checked, and sometimes it could scroll the viewport. 

For example:
![before](https://user-images.githubusercontent.com/28751745/109544259-a1689b80-7ac7-11eb-9a16-0c3387a2398a.gif)
The code can be found in this [codesandbox](https://codesandbox.io/s/ecstatic-lake-umf9t?file=/src/App.js)
Note: `positionFixed: true` on dropdown popper is important for this behavior to appear.

This PR adds a boundary to `computeScrollIntoView`, to make sure only the dropdown menu is checked for scrolling.
Behavior after fix:
![after](https://user-images.githubusercontent.com/28751745/109544336-b7765c00-7ac7-11eb-9a87-987206676514.gif)


#### Focus areas to test

(optional)
