### PR TITLE
Pin popper to patch version to avoid breaking TS

### DIFF
--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -17,7 +17,7 @@
     "@fluentui/react-proptypes": "^0.52.0",
     "@fluentui/state": "^0.52.0",
     "@fluentui/styles": "^0.52.0",
-    "@popperjs/core": "~2.8.0",
+    "@popperjs/core": "~2.4.3",
     "@uifabric/utilities": "^7.32.3",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -17,7 +17,7 @@
     "@fluentui/react-proptypes": "^0.52.0",
     "@fluentui/state": "^0.52.0",
     "@fluentui/styles": "^0.52.0",
-    "@popperjs/core": "^2.4.3",
+    "@popperjs/core": "~2.8.0",
     "@uifabric/utilities": "^7.32.3",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,10 +2984,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.7.0.tgz#5f7760965170f7f1e2910d2498c5be88b47a2a8c"
   integrity sha512-V3WyEc8ZyAuOQ2fpFuTuYYOd2tV4NePeSdxaHYgYAOs7ERLxlcFi2XsmgI5LJFdAUmJKXsg8jaIiVTkTHQygQw==
 
-"@popperjs/core@~2.8.0":
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.6.tgz#ad75ebe8dbecfa145af3c7e4d0ae98016458d005"
-  integrity sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==
+"@popperjs/core@~2.4.3":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
+  integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
 "@quid/stylis-plugin-focus-visible@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,15 +2979,15 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@^2.4.3":
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.6.tgz#ad75ebe8dbecfa145af3c7e4d0ae98016458d005"
-  integrity sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==
-
 "@popperjs/core@^2.5.4":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.7.0.tgz#5f7760965170f7f1e2910d2498c5be88b47a2a8c"
   integrity sha512-V3WyEc8ZyAuOQ2fpFuTuYYOd2tV4NePeSdxaHYgYAOs7ERLxlcFi2XsmgI5LJFdAUmJKXsg8jaIiVTkTHQygQw==
+
+"@popperjs/core@~2.8.0":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.6.tgz#ad75ebe8dbecfa145af3c7e4d0ae98016458d005"
+  integrity sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==
 
 "@quid/stylis-plugin-focus-visible@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Poppoer recently moved to supporting typesript import type in a minor
version

https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.0/lib/types.d.ts
https://cdn.jsdelivr.net/npm/@popperjs/core@2.8.6/lib/types.d.ts

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
