### PR TITLE
Fix/storybook build

### DIFF
--- a/change/@fluentui-react-examples-b8b7f4f8-b21e-4780-a47f-9c760d8bb005.json
+++ b/change/@fluentui-react-examples-b8b7f4f8-b21e-4780-a47f-9c760d8bb005.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix storybook build for react-components",
+  "packageName": "@fluentui/react-examples",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/.storybook/main.js
+++ b/packages/react-examples/.storybook/main.js
@@ -3,8 +3,6 @@ import custom from '@fluentui/scripts/storybook/webpack.config';
 import * as path from 'path';
 import * as webpack from 'webpack';
 
-const packageName = path.basename(process.cwd());
-
 export default {
   addons: [
     '@storybook/addon-a11y',
@@ -15,7 +13,6 @@ export default {
       options: { escapeHTML: false },
     },
   ],
-  stories: packageName === 'react-components' ? ['../src/react-components/**/*.stories.mdx'] : [],
   webpackFinal: (/** @type {webpack.Configuration} */ config) => {
     const customConfig = custom(config);
 

--- a/packages/react-examples/.storybook/preview.js
+++ b/packages/react-examples/.storybook/preview.js
@@ -42,6 +42,16 @@ addParameters({
 
 configure(loadStories, module);
 
+function getStoryOrder(storyName) {
+  const order = ['Concepts/Introduction', 'Concepts', 'Components'];
+  for (let i = 0; i < order.length; i++) {
+    if (storyName.startsWith(order[i])) {
+      return i;
+    }
+  }
+  return order.length;
+}
+
 /**
  * @typedef {{
  *   default: { title: string };
@@ -66,17 +76,30 @@ function loadStories() {
     // Note that the regex intentionally goes only one directory below the package name
     // (the first `\w+`, which will be the component name) to avoid picking up "next" examples
     // which are under src/pkg-name/ComponentName/next/ComponentName.
-    contexts.push(require.context('../src', true, /(REACT_DEPS)\/\w+\/[\w.]+\.(Example|stories)\.tsx$/));
+    contexts.push(
+      require.context('../src', true, /(REACT_DEPS|PACKAGE_NAME)\/\w+\/[\w.]+\.(Example|stories)\.(tsx|mdx)$/),
+    );
   }
 
   for (const req of contexts) {
-    req.keys().forEach(key => {
+    req.keys().forEach((key) => {
       generateStoriesFromExamples(key, stories, req);
     });
   }
 
   // convert stories Set to array
-  const sorted = [...stories.values()].sort((s1, s2) => (s1.default.title > s2.default.title ? 1 : -1));
+  const sorted = [...stories.values()].sort((s1, s2) => {
+    const order1 = getStoryOrder(s1.default.title);
+    const order2 = getStoryOrder(s2.default.title);
+    if (order1 < order2) {
+      // the lowest order goes first
+      return -1;
+    }
+    if (order1 > order2) {
+      return 1;
+    }
+    return s1.default.title > s2.default.title ? 1 : -1;
+  });
   return sorted;
 }
 
@@ -96,6 +119,12 @@ function generateStoriesFromExamples(key, stories, req) {
     return;
   }
 
+  if (key.endsWith('.mdx')) {
+    // out out of the custom naming for mdx, use meta information
+    stories.set(key, req(key));
+    return;
+  }
+
   const componentName = segments.length === 3 ? segments[1] : `${segments[2]} (${segments[1]})`;
 
   if (!stories.has(componentName)) {
@@ -106,10 +135,7 @@ function generateStoriesFromExamples(key, stories, req) {
     });
   }
 
-  const storyName = segments
-    .slice(-1)[0]
-    .replace('.tsx', '')
-    .replace(/\./g, '_');
+  const storyName = segments.slice(-1)[0].replace('.tsx', '').replace(/\./g, '_');
 
   const story = stories.get(componentName);
   const exampleModule = /** @type {(key: string) => ComponentModule} */ (req)(key);

--- a/packages/react-examples/.storybook/preview.js
+++ b/packages/react-examples/.storybook/preview.js
@@ -82,7 +82,7 @@ function loadStories() {
   }
 
   for (const req of contexts) {
-    req.keys().forEach((key) => {
+    req.keys().forEach(key => {
       generateStoriesFromExamples(key, stories, req);
     });
   }
@@ -135,7 +135,10 @@ function generateStoriesFromExamples(key, stories, req) {
     });
   }
 
-  const storyName = segments.slice(-1)[0].replace('.tsx', '').replace(/\./g, '_');
+  const storyName = segments
+    .slice(-1)[0]
+    .replace('.tsx', '')
+    .replace(/\./g, '_');
 
   const story = stories.get(componentName);
   const exampleModule = /** @type {(key: string) => ComponentModule} */ (req)(key);


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

When storybook was built for react-components, it contained only mdx stories, no code examples were shown. This was caused by mixing `stories` config (storybook 6) with legacy `configure()` (storybook 5).

#### Focus areas to test

In `react-components` run `yarn bundle` or `yarn just storybook:build`. Storybook will be built into `dist/storybook`.