### PR TITLE
Allow SwatchColorPicker to be updated with undefined for selectedID

### DIFF
--- a/change/office-ui-fabric-react-2021-03-02-08-42-05-sareiff-clearcolorpicker.json
+++ b/change/office-ui-fabric-react-2021-03-02-08-42-05-sareiff-clearcolorpicker.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update swatch colorpicker to allow for unselected",
+  "packageName": "office-ui-fabric-react",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-02T16:42:05.547Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -10041,10 +10041,12 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     // (undocumented)
     static defaultProps: ISwatchColorPickerProps;
     // (undocumented)
-    render(): JSX.Element | null;
+    static getDerivedStateFromProps(newProps: ISwatchColorPickerProps, state: ISwatchColorPickerState): {
+        selectedIndex: number | undefined;
+    } | null;
     // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: ISwatchColorPickerProps): void;
-}
+    render(): JSX.Element | null;
+    }
 
 // @public (undocumented)
 export const TagItem: React.FunctionComponent<ITagItemProps>;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -54,6 +54,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       ? _getSelectedIndex(newProps.colorCells, newProps.selectedId)
       : undefined;
 
+    // If not controlled, we do not want to allow updates to selectedIndex to be undefined
     if (!newProps.isControlled && newSelectedIndex === undefined) {
       return null;
     }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -49,6 +49,19 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     });
   });
 
+  public static getDerivedStateFromProps(newProps: ISwatchColorPickerProps, state: ISwatchColorPickerState) {
+    const newSelectedIndex = newProps.selectedId
+      ? _getSelectedIndex(newProps.colorCells, newProps.selectedId)
+      : undefined;
+    if (newSelectedIndex !== state.selectedIndex) {
+      return {
+        selectedIndex: newSelectedIndex,
+      };
+    }
+
+    return null;
+  }
+
   constructor(props: ISwatchColorPickerProps) {
     super(props);
 
@@ -84,19 +97,6 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     this.state = {
       selectedIndex,
     };
-  }
-
-  public static getDerivedStateFromProps(newProps: ISwatchColorPickerProps, state: ISwatchColorPickerState) {
-    const newSelectedIndex = newProps.selectedId
-      ? _getSelectedIndex(newProps.colorCells, newProps.selectedId)
-      : undefined;
-    if (newSelectedIndex !== state.selectedIndex) {
-      return {
-        selectedIndex: newSelectedIndex,
-      };
-    }
-
-    return null;
   }
 
   public componentWillUnmount() {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -78,7 +78,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
 
     let selectedIndex: number | undefined;
     if (props.selectedId) {
-      selectedIndex = this._getSelectedIndex(props.colorCells, props.selectedId);
+      selectedIndex = _getSelectedIndex(props.colorCells, props.selectedId);
     }
 
     this.state = {
@@ -86,12 +86,17 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     };
   }
 
-  public UNSAFE_componentWillReceiveProps(newProps: ISwatchColorPickerProps): void {
-    if (newProps.selectedId !== undefined) {
-      this.setState({
-        selectedIndex: this._getSelectedIndex(newProps.colorCells, newProps.selectedId),
-      });
+  public static getDerivedStateFromProps(newProps: ISwatchColorPickerProps, state: ISwatchColorPickerState) {
+    const newSelectedIndex = newProps.selectedId
+      ? _getSelectedIndex(newProps.colorCells, newProps.selectedId)
+      : undefined;
+    if (newSelectedIndex !== state.selectedIndex) {
+      return {
+        selectedIndex: newSelectedIndex,
+      };
     }
+
+    return null;
   }
 
   public componentWillUnmount() {
@@ -163,17 +168,6 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       this.props.onCellFocused();
     }
   };
-
-  /**
-   * Get the selected item's index
-   * @param items - The items to search
-   * @param selectedId - The selected item's id to find
-   * @returns - The index of the selected item's id, -1 if there was no match
-   */
-  private _getSelectedIndex(items: IColorCellProps[], selectedId: string): number | undefined {
-    const selectedIndex = findIndex(items, item => item.id === selectedId);
-    return selectedIndex >= 0 ? selectedIndex : undefined;
-  }
 
   /**
    * Render a color cell
@@ -376,4 +370,15 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       }
     }
   };
+}
+
+/**
+ * Get the selected item's index
+ * @param items - The items to search
+ * @param selectedId - The selected item's id to find
+ * @returns - The index of the selected item's id, -1 if there was no match
+ */
+function _getSelectedIndex(items: IColorCellProps[], selectedId: string): number | undefined {
+  const selectedIndex = findIndex(items, item => item.id === selectedId);
+  return selectedIndex >= 0 ? selectedIndex : undefined;
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -53,6 +53,11 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     const newSelectedIndex = newProps.selectedId
       ? _getSelectedIndex(newProps.colorCells, newProps.selectedId)
       : undefined;
+
+    if (!newProps.isControlled && newSelectedIndex === undefined) {
+      return null;
+    }
+
     if (newSelectedIndex !== state.selectedIndex) {
       return {
         selectedIndex: newSelectedIndex,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { SwatchColorPicker } from './SwatchColorPicker';
+import { ISwatchColorPickerProps } from './SwatchColorPicker.types';
 import { IColorCellProps } from './ColorPickerGridCell.types';
 import { expectNodes, findNodes } from '../../common/testUtilities';
 
@@ -102,22 +103,22 @@ describe('SwatchColorPicker', () => {
 
   it('Can set the selectedID ', () => {
     const wrapper = mount(
-      <SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} columnCount={4} isControlled={true} selectedId={'a'} />,
+      <SwatchColorPicker
+        colorCells={[DEFAULT_OPTIONS[0], DEFAULT_OPTIONS[1]]}
+        columnCount={4}
+        isControlled={true}
+        selectedId={'a'}
+      />,
     );
 
     const tableElements = findNodes(wrapper, '.ms-Button');
-    expect(tableElements.length).toEqual(1);
-    expect(
-      tableElements
-        .at(0)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('true');
+    expect(tableElements.length).toEqual(2);
+    expect(tableElements.at(0).prop('aria-selected')).toEqual(true);
   });
 
-  it('Can clear the selectedID if isControlled', () => {
+  it('Can clear the selectedID if controlled', () => {
     const colorChanged = jest.fn();
-    const props = {
+    const props: ISwatchColorPickerProps = {
       colorCells: [DEFAULT_OPTIONS[0], DEFAULT_OPTIONS[1]],
       columnCount: 4,
       selectedId: 'a',
@@ -130,42 +131,22 @@ describe('SwatchColorPicker', () => {
     expect(tableElements.length).toEqual(2);
 
     // Verify initial id is selected
-    expect(
-      tableElements
-        .at(0)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('true');
-    expect(
-      tableElements
-        .at(1)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('false');
+    expect(tableElements.at(0).prop('aria-selected')).toEqual(true);
+    expect(tableElements.at(1).prop('aria-selected')).toEqual(false);
 
     // Update the props to set selected to undefined
-    wrapper.setProps({ ...props, selectedId: 'undefined' });
+    wrapper.setProps({ selectedId: undefined });
 
     tableElements = findNodes(wrapper, '.ms-Button');
     expect(tableElements.length).toEqual(2);
 
     // Verify nothing is selected
-    expect(
-      tableElements
-        .at(0)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('false');
-    expect(
-      tableElements
-        .at(1)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('false');
+    expect(tableElements.at(0).prop('aria-selected')).toEqual(false);
+    expect(tableElements.at(1).prop('aria-selected')).toEqual(false);
   });
 
-  it('Can not clear the selectedID', () => {
-    const props = {
+  it('Cannot clear the selectedID if uncontrolled', () => {
+    const props: ISwatchColorPickerProps = {
       colorCells: DEFAULT_OPTIONS,
       columnCount: 4,
       selectedId: 'a',
@@ -176,25 +157,15 @@ describe('SwatchColorPicker', () => {
     expect(tableElements.length).toEqual(12);
 
     // Verify initial id is selected
-    expect(
-      tableElements
-        .at(0)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('true');
+    expect(tableElements.at(0).prop('aria-selected')).toEqual(true);
 
     // Update the props to set selected to undefined
-    wrapper.setProps({ ...props, selectedId: 'undefined' });
+    wrapper.setProps({ selectedId: undefined });
 
     tableElements = findNodes(wrapper, '.ms-Button');
     expect(tableElements.length).toEqual(12);
 
     // Verify initial id is still selected
-    expect(
-      tableElements
-        .at(0)
-        .getDOMNode()
-        .getAttribute('aria-selected'),
-    ).toEqual('true');
+    expect(tableElements.at(0).prop('aria-selected')).toEqual(true);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -99,4 +99,102 @@ describe('SwatchColorPicker', () => {
     );
     expect(onRenderColorCell).toHaveBeenCalledTimes(1);
   });
+
+  it('Can set the selectedID ', () => {
+    const wrapper = mount(
+      <SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} columnCount={4} isControlled={true} selectedId={'a'} />,
+    );
+
+    const tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(1);
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+  });
+
+  it('Can clear the selectedID if isControlled', () => {
+    const colorChanged = jest.fn();
+    const props = {
+      colorCells: [DEFAULT_OPTIONS[0], DEFAULT_OPTIONS[1]],
+      columnCount: 4,
+      selectedId: 'a',
+      onColorChanged: colorChanged,
+      isControlled: true,
+    };
+    const wrapper = mount(<SwatchColorPicker {...props} />);
+
+    let tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(2);
+
+    // Verify initial id is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+    expect(
+      tableElements
+        .at(1)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+
+    // Update the props to set selected to undefined
+    wrapper.setProps({ ...props, selectedId: 'undefined' });
+
+    tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(2);
+
+    // Verify nothing is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+    expect(
+      tableElements
+        .at(1)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+  });
+
+  it('Can not clear the selectedID', () => {
+    const props = {
+      colorCells: DEFAULT_OPTIONS,
+      columnCount: 4,
+      selectedId: 'a',
+    };
+    const wrapper = mount(<SwatchColorPicker {...props} />);
+
+    let tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(12);
+
+    // Verify initial id is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+
+    // Update the props to set selected to undefined
+    wrapper.setProps({ ...props, selectedId: 'undefined' });
+
+    tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(12);
+
+    // Verify initial id is still selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The SwatchColorPicker only updates the selectedID when you set it to a new ID and not when you set it to be undefined. We have a use case in Office where we want no item in a SwatchColorPicker to be selected. I swapped UNSAFE_componentWillReceiveProps for getDerivedStateFromProps in the process and updated it so the state is also set when undefined is passed. If preferred, I can not update to getDerivedStateFromProps, let me know.


#### Focus areas to test

SwatchColorPicker
