### PR TITLE
Fix publishing of webpack bundles and docs

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -42,12 +42,21 @@ steps:
     displayName: Generate version files
 
   - script: |
-      yarn run:published build test lint --production --verbose --no-cache
-    displayName: build, test, lint
+      yarn run:published build --production --no-cache
+    displayName: yarn build
 
-  - script: | # Note: --no-cache arg is OMITTED to use build cache from previous step
-      yarn run:published bundle --production --verbose
-    displayName: bundle
+  # test, lint, bundle using lage cached build from previous step (omit --no-cache)
+  - script: |
+      yarn run:published test --production
+    displayName: yarn test
+
+  - script: |
+      yarn run:published lint
+    displayName: yarn lint
+
+  - script: |
+      yarn run:published bundle --production
+    displayName: yarn bundle
 
   - script: |
       echo Making $(Build.ArtifactStagingDirectory)/api &&

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -39,23 +39,15 @@ steps:
 
   - script: |
       yarn generate-version-files
-    displayName: yarn generate-version-files
+    displayName: Generate version files
 
   - script: |
-      yarn run:published build --production
-    displayName: yarn build (Create production build)
+      yarn run:published build test lint --production --verbose --no-cache
+    displayName: build, test, lint
 
-  - script: |
-      yarn run:published test --production
-    displayName: yarn test
-
-  - script: |
-      yarn run:published lint
-    displayName: yarn lint
-
-  - script: |
-      yarn run:published bundle --production
-    displayName: yarn bundle
+  - script: | # Note: --no-cache arg is OMITTED to use build cache from previous step
+      yarn run:published bundle --production --verbose
+    displayName: bundle
 
   - script: |
       echo Making $(Build.ArtifactStagingDirectory)/api &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,12 +74,23 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
+      ## only do scoped bundle with PRs
       - script: |
-          yarn run:published build --production --no-cache &&
-          yarn run:published test --production &&
-          yarn run:published lint &&
-          yarn run:published bundle --production
+          yarn bundle --no-cache --since $(targetBranch)
         displayName: bundle (pr, scoped)
+        condition: eq(variables['isPR'], true)
+        env:
+          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
+          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
+
+      ## duplicated for master CI builds
+      - script: |
+          yarn bundle --no-cache
+        displayName: bundle (master)
+        condition: eq(variables['isPR'], false)
+        env:
+          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
+          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
 
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
 
       ## only do scoped builds with PRs
       - script: |
-          yarn buildci --no-cache --since $(targetBranch)
+          yarn run:published build test lint --production --verbose --no-cache
         displayName: build, test, lint (pr, scoped)
         condition: eq(variables['isPR'], true)
         env:
@@ -74,23 +74,10 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      ## only do scoped bundle with PRs
       - script: |
-          yarn bundle --no-cache --since $(targetBranch)
+          yarn run:published build --production --verbose --no-cache &&
+          yarn run:published bundle --production --verbose
         displayName: bundle (pr, scoped)
-        condition: eq(variables['isPR'], true)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
-
-      ## duplicated for master CI builds
-      - script: |
-          yarn bundle --no-cache
-        displayName: bundle (master)
-        condition: eq(variables['isPR'], false)
-        env:
-          BACKFILL_CACHE_PROVIDER: $(backfillProvider)
-          BACKFILL_CACHE_PROVIDER_OPTIONS: $(backfillOptions)
 
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
 
       ## only do scoped builds with PRs
       - script: |
-          yarn run:published build test lint --production --verbose --no-cache
+          yarn buildci --no-cache --since $(targetBranch)
         displayName: build, test, lint (pr, scoped)
         condition: eq(variables['isPR'], true)
         env:
@@ -75,8 +75,10 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn run:published build --production --verbose --no-cache &&
-          yarn run:published bundle --production --verbose
+          yarn run:published build --production --no-cache &&
+          yarn run:published test --production &&
+          yarn run:published lint &&
+          yarn run:published bundle --production
         displayName: bundle (pr, scoped)
 
       ## This runs regardless of scope, the app will adapt to the scope as well

--- a/change/@fluentui-azure-themes-ab2807c9-c152-4a4e-aa76-ae35c568c765.json
+++ b/change/@fluentui-azure-themes-ab2807c9-c152-4a4e-aa76-ae35c568c765.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-example-data-709145ba-945b-4e32-ad26-aa9dd693f27a.json
+++ b/change/@fluentui-example-data-709145ba-945b-4e32-ad26-aa9dd693f27a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/example-data",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-61c19197-e426-4354-b469-139742b6ec0c.json
+++ b/change/@fluentui-foundation-legacy-61c19197-e426-4354-b469-139742b6ec0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-merge-styles-42421149-06a9-4430-82d0-f2195da513c4.json
+++ b/change/@fluentui-merge-styles-42421149-06a9-4430-82d0-f2195da513c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-24fef9d5-27ba-4703-8bf3-26017113d1b3.json
+++ b/change/@fluentui-public-docsite-24fef9d5-27ba-4703-8bf3-26017113d1b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-resources-5a8e191b-1a76-44ec-97dd-8fff04f2dd59.json
+++ b/change/@fluentui-public-docsite-resources-5a8e191b-1a76-44ec-97dd-8fff04f2dd59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/public-docsite-resources",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-c6983fd9-cd2f-4ee7-9080-94ea1ceb20cc.json
+++ b/change/@fluentui-react-c6983fd9-cd2f-4ee7-9080-94ea1ceb20cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-3d3fe6f4-54a7-447a-b486-9c873274ba7a.json
+++ b/change/@fluentui-react-charting-3d3fe6f4-54a7-447a-b486-9c873274ba7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-date-time-8a1b5e96-b3ec-492a-82d0-bd58209a64ef.json
+++ b/change/@fluentui-react-date-time-8a1b5e96-b3ec-492a-82d0-bd58209a64ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-e77cb6e5-7528-4cb0-a512-0aa8b7aa5d5d.json
+++ b/change/@fluentui-react-experiments-e77cb6e5-7528-4cb0-a512-0aa8b7aa5d5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-73acaf43-d8b7-4429-8842-cf597597236b.json
+++ b/change/@fluentui-react-focus-73acaf43-d8b7-4429-8842-cf597597236b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-527df6c2-73da-4181-8064-39010a6aedc4.json
+++ b/change/@fluentui-react-hooks-527df6c2-73da-4181-8064-39010a6aedc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icon-provider-92c65419-619b-409f-9475-ec32fad1a079.json
+++ b/change/@fluentui-react-icon-provider-92c65419-619b-409f-9475-ec32fad1a079.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-822a1ec4-bc76-40af-85bc-86fe3c1a14c8.json
+++ b/change/@fluentui-react-icons-mdl2-822a1ec4-bc76-40af-85bc-86fe3c1a14c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-monaco-editor-be0ec0fe-9c0f-4137-8af6-5508c0013282.json
+++ b/change/@fluentui-react-monaco-editor-be0ec0fe-9c0f-4137-8af6-5508c0013282.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-scheme-utilities-ae9e6242-5834-4c5f-b170-c0a49959e986.json
+++ b/change/@fluentui-scheme-utilities-ae9e6242-5834-4c5f-b170-c0a49959e986.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-samples-dd095d67-ca82-4f8c-a559-5bc32f720113.json
+++ b/change/@fluentui-theme-samples-dd095d67-ca82-4f8c-a559-5bc32f720113.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix webpack bundle",
+  "packageName": "@fluentui/theme-samples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "release:fluentui:pack-nightly": "node -r ./scripts/ts-node-register ./scripts/fluentui-publish pack-nightly",
     "rename-package": "node -r ./scripts/ts-node-register ./scripts/rename-package.ts",
     "runto:lerna": "node ./scripts/monorepo/runTo.js",
-    "run:published": "node ./scripts/monorepo/runPublished.js",
+    "run:published": "node ./scripts/monorepo/runPublished.js --verbose",
     "satisfied": "satisfied --skip-invalid --ignore \"sass\"",
     "scrub": "node ./scripts/scrub.js",
     "start:legacy": "yarn workspace @fluentui/public-docsite-resources start",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "release:fluentui:pack-nightly": "node -r ./scripts/ts-node-register ./scripts/fluentui-publish pack-nightly",
     "rename-package": "node -r ./scripts/ts-node-register ./scripts/rename-package.ts",
     "runto:lerna": "node ./scripts/monorepo/runTo.js",
-    "run:published": "node ./scripts/monorepo/runPublished.js --verbose",
+    "run:published": "node ./scripts/monorepo/runPublished.js",
     "satisfied": "satisfied --skip-invalid --ignore \"sass\"",
     "scrub": "node ./scripts/scrub.js",
     "start:legacy": "yarn workspace @fluentui/public-docsite-resources start",

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -24,7 +24,10 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
   .map(([packageName]) => `--to=${packageName}`);
 
-const result = spawnSync(process.execPath, [lageBin, 'run', ...argv, ...beachballPackageScopes], {
+const lageArgs = ['run', ...argv, ...beachballPackageScopes];
+console.log(`lage ${lageArgs.join(' ')}`); // for debugging
+
+const result = spawnSync(process.execPath, [lageBin, ...lageArgs], {
   stdio: 'inherit',
   maxBuffer: 500 * 1024 * 1024,
 });

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -24,7 +24,7 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
   .map(([packageName]) => `--to=${packageName}`);
 
-const lageArgs = ['run', ...argv, ...beachballPackageScopes];
+const lageArgs = ['run', ...argv, ...beachballPackageScopes, '--verbose'];
 console.log(`lage ${lageArgs.join(' ')}`); // for debugging
 
 const result = spawnSync(process.execPath, [lageBin, ...lageArgs], {

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -24,7 +24,13 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
   .map(([packageName]) => `--to=${packageName}`);
 
-const lageArgs = ['run', ...argv, ...beachballPackageScopes, '--verbose'];
+const lageArgs = [
+  'run',
+  ...argv,
+  // default to verbose mode unless already/otherwise specified
+  ...(argv.some(arg => /^--(no-)?verbose/.test(arg)) ? [] : ['--verbose']),
+  ...beachballPackageScopes,
+];
 console.log(`lage ${lageArgs.join(' ')}`); // for debugging
 
 const result = spawnSync(process.execPath, [lageBin, ...lageArgs], {

--- a/scripts/monorepo/runTo.js
+++ b/scripts/monorepo/runTo.js
@@ -23,7 +23,7 @@ If multiple packages match a pattern, they will all be built (along with their d
     process.exit(0);
   }
 
-  const restIndex = argv.findIndex(arg => arg.startsWith('--'));
+  const restIndex = argv.findIndex((arg) => arg.startsWith('--'));
   const script = argv[0];
   const projects = restIndex === -1 ? argv.slice(1) : argv.slice(1, restIndex);
   const rest = restIndex === -1 ? [] : argv.slice(argv[restIndex] === '--' ? restIndex + 1 : restIndex);
@@ -46,7 +46,7 @@ function runTo(script, projects, rest) {
     if (allPackages[project]) {
       foundProjects.push(project);
     } else {
-      const packagesForProject = Object.keys(allPackages).filter(name => name.includes(project));
+      const packagesForProject = Object.keys(allPackages).filter((name) => name.includes(project));
       if (packagesForProject.length === 0) {
         console.log(`There is no project matching "${project}" in this repo`);
       } else if (packagesForProject.length > 1) {
@@ -59,7 +59,7 @@ function runTo(script, projects, rest) {
   }
 
   const scopes = [];
-  foundProjects.forEach(projectName => {
+  foundProjects.forEach((projectName) => {
     // --scope limits build to a specified package
     scopes.push('--scope');
     scopes.push(projectName);
@@ -67,7 +67,7 @@ function runTo(script, projects, rest) {
 
   // --include-filtered-Dependencies makes the build include dependencies
   // --stream allows the build to proceed in parallel but still in order
-  spawnSync(
+  const result = spawnSync(
     process.execPath,
     [
       lernaBin,
@@ -85,6 +85,10 @@ function runTo(script, projects, rest) {
       stdio: 'inherit',
     },
   );
+
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
 }
 
 module.exports = runTo;

--- a/scripts/monorepo/runTo.js
+++ b/scripts/monorepo/runTo.js
@@ -23,7 +23,7 @@ If multiple packages match a pattern, they will all be built (along with their d
     process.exit(0);
   }
 
-  const restIndex = argv.findIndex((arg) => arg.startsWith('--'));
+  const restIndex = argv.findIndex(arg => arg.startsWith('--'));
   const script = argv[0];
   const projects = restIndex === -1 ? argv.slice(1) : argv.slice(1, restIndex);
   const rest = restIndex === -1 ? [] : argv.slice(argv[restIndex] === '--' ? restIndex + 1 : restIndex);
@@ -46,7 +46,7 @@ function runTo(script, projects, rest) {
     if (allPackages[project]) {
       foundProjects.push(project);
     } else {
-      const packagesForProject = Object.keys(allPackages).filter((name) => name.includes(project));
+      const packagesForProject = Object.keys(allPackages).filter(name => name.includes(project));
       if (packagesForProject.length === 0) {
         console.log(`There is no project matching "${project}" in this repo`);
       } else if (packagesForProject.length > 1) {
@@ -59,7 +59,7 @@ function runTo(script, projects, rest) {
   }
 
   const scopes = [];
-  foundProjects.forEach((projectName) => {
+  foundProjects.forEach(projectName => {
     // --scope limits build to a specified package
     scopes.push('--scope');
     scopes.push(projectName);

--- a/scripts/tasks/webpack.ts
+++ b/scripts/tasks/webpack.ts
@@ -9,8 +9,9 @@ type JustArguments<T extends Record<string, unknown>> = Arguments & T;
 export function webpack() {
   const args: JustArguments<Partial<{ production: boolean }>> = argv();
   return webpackCliTask({
-    webpackCliArgs: args.production ? ['--production'] : [],
+    webpackCliArgs: args.production ? ['--mode=production'] : [],
     nodeArgs: ['--max-old-space-size=4096'],
+    env: process.env,
   });
 }
 

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -72,7 +72,7 @@ function createEntryWithPolyfill(entry, config) {
     } else if (typeof entry === 'object') {
       const newEntry = { ...entry };
 
-      Object.keys(entry).forEach((entryPoint) => {
+      Object.keys(entry).forEach(entryPoint => {
         newEntry[entryPoint] = createEntryWithPolyfill(entry[entryPoint], config);
       });
 

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -72,7 +72,7 @@ function createEntryWithPolyfill(entry, config) {
     } else if (typeof entry === 'object') {
       const newEntry = { ...entry };
 
-      Object.keys(entry).forEach(entryPoint => {
+      Object.keys(entry).forEach((entryPoint) => {
         newEntry[entryPoint] = createEntryWithPolyfill(entry[entryPoint], config);
       });
 
@@ -190,7 +190,7 @@ module.exports = {
       output,
       bundleName = path.basename(process.cwd()),
       entry = './lib/index.js',
-      isProduction = process.argv.indexOf('--production') > -1,
+      isProduction = process.argv.includes('--mode=production'),
       onlyProduction = false,
       customConfig = {},
     } = options;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17208, fixes #17213

#### Description of changes

The webpack 5 change #16447 broke bundles in production builds because the webpack CLI arg for turning on production mode has changed from `--production` to `--mode=production`. This was causing a build error, but it didn't cause the release build to fail because `scripts/runPublished.js` wasn't appropriately handling the exit code.

This PR fixes both issues, and switches the publish build/bundle to run using lage rather than lerna for consistency.