### PR TITLE
[v7.0] BasePicker: added high contrast styling to SASS file when picker is disabled

### DIFF
--- a/change/office-ui-fabric-react-2021-03-02-11-26-00-10297-v7.json
+++ b/change/office-ui-fabric-react-2021-03-02-11-26-00-10297-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "BasePicker: added high contrast styling to sass file when picker is disabled",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-02T19:26:00.008Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
@@ -27,6 +27,23 @@
       border: 2px solid $inputFocusBorderAltColor;
     }
   }
+
+  &.inputDisabled {
+    @include high-contrast {
+      position: relative;
+      border-color: GrayText;
+      &:after {
+        pointer-events: none;
+        content: '';
+        position: absolute;
+        left: 0px;
+        top: 0px;
+        bottom: 0px;
+        right: 0px;
+        background-color: Window;
+      }
+    }
+  }
 }
 
 .pickerInput {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -1020,7 +1020,12 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
         })
       : {
           root: css('ms-BasePicker', className ? className : ''),
-          text: css('ms-BasePicker-text', legacyStyles.pickerText, this.state.isFocused && legacyStyles.inputFocused),
+          text: css(
+            'ms-BasePicker-text',
+            legacyStyles.pickerText,
+            this.state.isFocused && legacyStyles.inputFocused,
+            disabled && legacyStyles.inputDisabled,
+          ),
           input: css('ms-BasePicker-input', legacyStyles.pickerInput, inputProps && inputProps.className),
           screenReaderText: legacyStyles.screenReaderOnly,
         };


### PR DESCRIPTION
#### Pull request checklist

- [x] Related to existing bug [10297](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10297)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added high contrast styling to legacy SASS file to fix a11y issue below

**Issue:** 
![CustomPickerIssue-1](https://user-images.githubusercontent.com/8649804/109562103-d60e3000-7a92-11eb-8cf7-210e22e898f3.JPG)

**Fix:**
![CustomPickerIssue-2](https://user-images.githubusercontent.com/8649804/109562151-e0c8c500-7a92-11eb-87b8-02ae8692dde0.JPG)



