### PR TITLE
Modify format command for pre-commit hooks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       ## manually call this since lage is now used and it calls lint per package, not per repo
       - script: |
           yarn prelint &&
-          yarn format $(targetBranch) --check
+          yarn format --commit-hash $(targetBranch) --check
         displayName: do syncpack, lint-files, and prettier checks
 
       ## Danger.js checks for Fluent UI N*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       ## manually call this since lage is now used and it calls lint per package, not per repo
       - script: |
           yarn prelint &&
-          yarn format --commit-hash $(targetBranch) --check
+          yarn format --commit $(targetBranch) --check
         displayName: do syncpack, lint-files, and prettier checks
 
       ## Danger.js checks for Fluent UI N*

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -11,10 +11,10 @@ const nonEslintPrettierExtensions = prettierExtensions.filter(ext => !eslintExte
 // https://www.npmjs.com/package/lint-staged
 module.exports = {
   // Run eslint in fix mode followed by prettier
-  [`*.{${eslintExtensions.join(',')}}`]: ['node ./scripts/lint-staged/eslint', 'prettier --write'],
+  [`*.{${eslintExtensions.join(',')}}`]: ['node ./scripts/lint-staged/eslint', 'node ./scripts/format.js'],
 
   // Run prettier on non-eslintable files (ignores handled by .prettierignore)
-  [`*.{${nonEslintPrettierExtensions.join(',')}}`]: 'prettier --write',
+  [`*.{${nonEslintPrettierExtensions.join(',')}}`]: 'node ./scripts/format.js',
 
   'common/changes/*.json': 'node ./scripts/lint-staged/auto-convert-change-files',
 

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -42,10 +42,13 @@ async function main() {
 
 function parseArgs() {
   return require('yargs')
-    .usage('Usage: format [commitHash] [options]')
+    .usage('Usage: format [files] [options]')
     .example('format', 'Run format only on changed files')
-    .example('format HEAD~3', 'Run format only on changed files since HEAD~3')
+    .example('format --commit HEAD~3', 'Run format only on changed files since HEAD~3')
     .options({
+      commit: {
+        description: 'Run format on files in commit only',
+      },
       all: {
         description: 'Run format on all files',
         boolean: true,
@@ -65,7 +68,7 @@ function parseArgs() {
 async function runOnChanged(options) {
   const { paths, queue } = options;
   const prettierIntroductionCommit = 'HEAD~1';
-  const passedDiffTarget = parsedArgs._.length ? parsedArgs._[0] : prettierIntroductionCommit;
+  const passedDiffTarget = parsedArgs.commit || prettierIntroductionCommit;
 
   const cmd = `git --no-pager diff ${passedDiffTarget} --diff-filter=AM --name-only --stat-name-width=0`;
 


### PR DESCRIPTION
Currently the pre-commit hooks run prettier directly instead of the
format command. This was problematic before the single version policy
for prettier where prettier v2 was actually used by pre-commit hooks
since it was a dependency on storybook and v1 prettier was only a
dependency on the scripts package

Modified the format comand to accept an extra `--commit` option so that
filnames can be used as positional arguments which also aligns with
how prettier CLI works. Now pre-commit hooks should be running the
same logic as our scripts and CI

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
