### PR TITLE
Fix Slider issues with keyboard control

### DIFF
--- a/change/office-ui-fabric-react-2021-03-03-01-44-42-fix-slider-with-keyboard-control.json
+++ b/change/office-ui-fabric-react-2021-03-03-01-44-42-fix-slider-with-keyboard-control.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Slider Keyboard Controls when `props.value` changes",
+  "packageName": "office-ui-fabric-react",
+  "email": "shrbalaji@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-02T20:14:42.680Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -343,7 +343,7 @@ export class SliderBase extends React.Component<ISliderProps, ISliderState> impl
   };
 
   private _onKeyDown = (event: KeyboardEvent): void => {
-    let value: number | undefined = this.state.value;
+    let { value = this.state.value } = this.props;
     const { max, min, step } = this.props;
 
     let diff: number | undefined = 0;
@@ -380,11 +380,15 @@ export class SliderBase extends React.Component<ISliderProps, ISliderState> impl
     }
 
     const newValue: number = Math.min(max as number, Math.max(min as number, value! + diff!));
-
     this._updateValue(newValue, newValue);
 
     event.preventDefault();
     event.stopPropagation();
+
+    // Disable renderedValue override.
+    this.setState({
+      renderedValue: undefined,
+    });
   };
 
   private _clearOnKeyDownTimer = (): void => {


### PR DESCRIPTION
* Reset the renderedValue after updateValue is called.
* Override Slider's state value with props when available

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16918 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Fixes `props.value` not being respected in Slider Component, when using keyboard controls.
- Fixes slider handler position, by resetting the `renderedValue` after updating state (similar to mouseOut and touchEnd events)