### PR TITLE
Text: Making styles respect semantic colors

### DIFF
--- a/change/@fluentui-react-d6ba8e29-3717-4152-b2c3-3bb5f16412fa.json
+++ b/change/@fluentui-react-d6ba8e29-3717-4152-b2c3-3bb5f16412fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Text: Making styles respect semantic colors.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-de081d6f-db15-42e4-866d-dae47e5b7f31.json
+++ b/change/@fluentui-react-examples-de081d6f-db15-42e4-866d-dae47e5b7f31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@fluentui/react-examples",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-1e1cc689-510f-433f-84ff-f9107c702aeb.json
+++ b/change/@fluentui-react-experiments-1e1cc689-510f-433f-84ff-f9107c702aeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -44,6 +45,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -38,6 +38,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Link.Basic.Example.tsx.shot
@@ -8,6 +8,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -200,6 +201,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Separator.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Separator.Basic.Example.tsx.shot
@@ -49,6 +49,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -137,6 +138,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -225,6 +227,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -313,6 +316,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -422,6 +426,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -530,6 +535,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -638,6 +644,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -746,6 +753,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Separator.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Separator.Icon.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Separator.Icon.Example.tsx correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Separator.Theming.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Separator.Theming.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Separator.Theming.Example.tsx correctly 1`] 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Text.Block.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Block.Example.tsx.shot
@@ -8,6 +8,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -24,6 +25,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -40,6 +42,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -56,6 +59,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -731,6 +731,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -978,6 +979,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -1225,6 +1227,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1472,6 +1475,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1719,6 +1723,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;
@@ -1966,6 +1971,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 16px;
@@ -2213,6 +2219,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 18px;
@@ -2460,6 +2467,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 20px;
@@ -2707,6 +2715,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 28px;
@@ -2954,6 +2963,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 68px;

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -731,6 +731,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: inline;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;
@@ -980,6 +981,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: inline;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;
@@ -1229,6 +1231,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: inline;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;

--- a/packages/react-examples/src/react/__snapshots__/Text.Wrap.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Wrap.Example.tsx.shot
@@ -49,6 +49,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -65,6 +66,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -103,6 +105,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -119,6 +122,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/react-experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/react-experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;
@@ -137,6 +138,7 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;
@@ -212,6 +214,7 @@ exports[`VerticalPersona renders the coin with the passed coinProps 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;

--- a/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`PersonaCoin renders a coin with the initials JB 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -131,6 +132,7 @@ exports[`PersonaCoin renders a correct persona 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -166,6 +168,7 @@ exports[`PersonaCoin renders a red coin 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -399,6 +402,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;

--- a/packages/react/src/components/Text/Text.styles.ts
+++ b/packages/react/src/components/Text/Text.styles.ts
@@ -4,13 +4,14 @@ import { ITheme } from '../../Styling';
 
 export const TextStyles: ITextComponent['styles'] = (props: ITextProps, theme: ITheme): ITextStylesReturnType => {
   const { as, className, block, nowrap, variant } = props;
-  const { fonts } = theme;
+  const { fonts, semanticColors } = theme;
   const variantObject = fonts[variant || 'medium'];
 
   return {
     root: [
       variantObject,
       {
+        color: variantObject.color || semanticColors.bodyText,
         display: block ? (as === 'td' ? 'table-cell' : 'block') : 'inline',
         mozOsxFontSmoothing: variantObject.MozOsxFontSmoothing,
         webkitFontSmoothing: variantObject.WebkitFontSmoothing,

--- a/packages/react/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/react/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Text renders Text with {0} as its children correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        color: #323130;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
@@ -26,6 +27,7 @@ exports[`Text renders default Text correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        color: #323130;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13595
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Using `semanticColors` as a default fallback for `Text` coloring so it is themable.
