### PR TITLE
Update beachball to hopefully fix dist-tags for 7.0 publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "vrtest": "cd apps && cd vr-tests && yarn screener"
   },
   "devDependencies": {
-    "beachball": "^1.36.0",
+    "beachball": "1.53.0",
     "cross-env": "^5.1.4",
     "lerna": "^3.15.0",
-    "lage": "0.24.0",
+    "lage": "0.29.0",
     "lint-staged": "^10.2.9",
     "sass-loader": "^6.0.6",
     "satisfied": "^1.1.1",
@@ -84,7 +84,7 @@
     "peer": false,
     "source": [
       "package.json",
-      "apps/*/package.json",
+      "{apps,packages}/*/package.json",
       "scripts/package.json"
     ]
   }

--- a/scripts/monorepo/runTo.js
+++ b/scripts/monorepo/runTo.js
@@ -67,7 +67,7 @@ function runTo(script, projects, rest) {
 
   // --include-filtered-Dependencies makes the build include dependencies
   // --stream allows the build to proceed in parallel but still in order
-  spawnSync(
+  const result = spawnSync(
     process.execPath,
     [
       lernaBin,
@@ -85,6 +85,10 @@ function runTo(script, projects, rest) {
       stdio: 'inherit',
     },
   );
+
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
 }
 
 module.exports = runTo;

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -35,7 +35,6 @@
     "@types/webpack-env": "1.15.1",
     "async": "^2.6.1",
     "autoprefixer": "^9.7.6",
-    "beachball": "^1.36.0",
     "chalk": "^2.1.0",
     "circular-dependency-plugin": "^5.0.2",
     "clean-css": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5325,10 +5325,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.36.0.tgz#646bc89b1d212f896fc5f4ca55ad10f0cb85357a"
-  integrity sha512-l5qB/tJ+jZwwHtAQT2j3cAJ+iRifDIBUY6iDoGA4at/cyY5g1TDfp+A6MXushMZ/HWg+Xbh7+Ro9rjzEXjriJQ==
+beachball@1.53.0:
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.53.0.tgz#dbbbce5766257fe38e08c76728df8a347560060e"
+  integrity sha512-jSWEYPn16aNIXJYTDbtHxmG+0tYzHPZFQ+JYvRRPKaC7rO/BtdCh64i20LbygxtyPf2FKAjDxPQ7FJS732k4cQ==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"
@@ -5341,7 +5341,9 @@ beachball@^1.36.0:
     prompts "~2.1.0"
     semver "^6.1.1"
     toposort "^2.0.2"
-    yargs-parser "^13.1.0"
+    uuid "^8.3.1"
+    workspace-tools "^0.12.3"
+    yargs-parser "^20.2.4"
 
 before-after-hook@^2.0.0:
   version "2.1.0"
@@ -11942,10 +11944,10 @@ kleur@^3.0.2, kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lage@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-0.24.0.tgz#3c7667fcde30418e64a3b8477673a588a93ae463"
-  integrity sha512-wxh1RRt3RfA5uL6dSJfkg2dKGLuY9D9/xeLR7vj7/G5PWteo2QbDI+KlnPrfHsE1YXvriIElbD4w4jkxratozA==
+lage@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-0.29.0.tgz#60820354be3abc8cf8ec5fb62eb0fbc23113c154"
+  integrity sha512-ePx6Hh3+q5nYrvO1FXrXKbr17j9ip4NioFDf2lJqXCA07ENz8CIpynI6WEaSOY3jfqyJfI25FQczGF7OtLFewg==
   dependencies:
     "@microsoft/task-scheduler" "^2.7.0"
     abort-controller "^3.0.0"
@@ -11959,7 +11961,7 @@ lage@0.24.0:
     git-url-parse "^11.1.2"
     npmlog "^4.1.2"
     p-profiler "^0.2.1"
-    workspace-tools "^0.10.1"
+    workspace-tools "^0.10.3"
     yargs-parser "^18.1.3"
 
 last-run@^1.1.0:
@@ -18616,10 +18618,10 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^8.1.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
-  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
+uuid@^8.1.0, uuid@^8.3.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"
@@ -19069,10 +19071,27 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-workspace-tools@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.10.1.tgz#326e92a4247d9f909e8a4017d56dbe4bb4361497"
-  integrity sha512-4qLbcBJuULUBkRK5aS4O4q3DEMmtKMyGGVftCMGUvS0TGeb9ni1HnuxUzGGaQyhds4RFr83aX3foJA3+RB2Uag==
+workspace-tools@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.10.3.tgz#1517ecd97bc4f34c586be6a160da6d8a3a6c3c87"
+  integrity sha512-5DV0C38UBwDRQ9GDINatw2UELbaK/IeBgEpvERpf7vNIfiG0GHInrNhm0jXfiS8sLOpp340m64+tF4L3UHpVrw==
+  dependencies:
+    "@pnpm/lockfile-file" "^3.0.7"
+    "@pnpm/logger" "^3.2.2"
+    "@yarnpkg/lockfile" "^1.1.0"
+    find-up "^4.1.0"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^9.0.0"
+    git-url-parse "^11.1.2"
+    globby "^11.0.0"
+    jju "^1.4.0"
+    multimatch "^4.0.0"
+    read-yaml-file "^2.0.0"
+
+workspace-tools@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.12.3.tgz#71da0c7acdd65576cb7f666aca132abdbe5c3eb9"
+  integrity sha512-Toq4VI4GJw5naWxgXNU5/mmuu6PeiCRRZDkVOoeJacqQ6r0zRGWVBxE4YXQp2SADTKdC1ATwqsE+6bcJTZUmpA==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"
@@ -19314,6 +19333,11 @@ yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.4:
+  version "20.2.6"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.6.tgz#69f920addf61aafc0b8b89002f5d66e28f2d8b20"
+  integrity sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
In #17191 I tried to make `@fluentui` packages in `7.0` that also exist in `master` publish under `dist-tag` `lts-7` instead of latest, but apparently it didn't work. Try upgrading beachball and see if that fixes it.

*(avoid the bot: not relevant to master)*