### PR TITLE
[v7.0] DetailsList: Updated all examples to pass 'select row' as checkButtonAriaLabel prop

### DIFF
--- a/change/@fluentui-react-examples-2021-03-02-15-18-06-bug-6397-v7.json
+++ b/change/@fluentui-react-examples-2021-03-02-15-18-06-bug-6397-v7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Updated examples to pass 'select row' as checkButtonAriaLabel prop",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-02T23:18:06.588Z"
+}

--- a/packages/react-examples/src/office-ui-fabric-react/Announced/Announced.BulkOperations.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Announced/Announced.BulkOperations.Example.tsx
@@ -65,6 +65,7 @@ export const AnnouncedBulkOperationsExample: React.FunctionComponent = () => {
         layoutMode={DetailsListLayoutMode.fixedColumns}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
       />
     </Stack>
   );

--- a/packages/react-examples/src/office-ui-fabric-react/Announced/Announced.QuickActions.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Announced/Announced.QuickActions.Example.tsx
@@ -118,6 +118,7 @@ export const AnnouncedQuickActionsExample: React.FunctionComponent = () => {
         selectionPreservedOnEmptyClick
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
       />
       <Dialog hidden={!dialogContent} onDismiss={closeRenameDialog} closeButtonAriaLabel="Close">
         {dialogContent}

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Advanced.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Advanced.Example.tsx
@@ -203,7 +203,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           ariaLabelForListHeader="Column headers. Click to sort."
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onRenderMissingItem={this._onRenderMissingItem}
         />
 

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Animation.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Animation.Example.tsx
@@ -88,7 +88,7 @@ export class DetailsListAnimationExample extends React.Component<{}, IDetailsLis
           selectionPreservedOnEmptyClick={true}
           ariaLabelForSelectionColumn="Toggle selection"
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onItemInvoked={this._onItemInvoked}
           enableUpdateAnimations={true}
           getCellValueKey={this._getCellValueKey}

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Basic.Example.tsx
@@ -86,7 +86,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
             selectionPreservedOnEmptyClick={true}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
             onItemInvoked={this._onItemInvoked}
           />
         </MarqueeSelection>

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Compact.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Compact.Example.tsx
@@ -82,7 +82,7 @@ export class DetailsListCompactExample extends React.Component<{}, IDetailsListC
             onItemInvoked={this._onItemInvoked}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
           />
         </MarqueeSelection>
       </Fabric>

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -35,7 +35,7 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
       />
     );
   }

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomFooter.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomFooter.Example.tsx
@@ -49,7 +49,7 @@ export class DetailsListCustomFooterExample extends React.Component<{}, {}> {
         selectionPreservedOnEmptyClick={true}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsFooter={this._onRenderDetailsFooter}
       />
     );

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
@@ -69,7 +69,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
         getGroupHeight={this._getGroupHeight}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomRows.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.CustomRows.Example.tsx
@@ -15,12 +15,7 @@ export class DetailsListCustomRowsExample extends React.Component<{}, {}> {
 
   public render() {
     return (
-      <DetailsList
-        items={this._items}
-        setKey="set"
-        onRenderRow={this._onRenderRow}
-        checkButtonAriaLabel="Row checkbox"
-      />
+      <DetailsList items={this._items} setKey="set" onRenderRow={this._onRenderRow} checkButtonAriaLabel="select row" />
     );
   }
 

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Documents.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Documents.Example.tsx
@@ -231,7 +231,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
               enterModalSelectionOnTouch={true}
               ariaLabelForSelectionColumn="Toggle selection"
               ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-              checkButtonAriaLabel="Row checkbox"
+              checkButtonAriaLabel="select row"
             />
           </MarqueeSelection>
         ) : (

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.DragDrop.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.DragDrop.Example.tsx
@@ -103,7 +103,7 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
             columnReorderOptions={this.state.isColumnReorderEnabled ? this._getColumnReorderOptions() : undefined}
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            checkButtonAriaLabel="select row"
           />
         </MarqueeSelection>
       </div>

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -106,7 +106,7 @@ export class DetailsListGroupedExample extends React.Component<{}, IDetailsListG
           columns={this._columns}
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
-          checkButtonAriaLabel="Row checkbox"
+          checkButtonAriaLabel="select row"
           onRenderDetailsHeader={this._onRenderDetailsHeader}
           groupProps={{
             showEmptyGroups: true,

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Large.Example.tsx
@@ -55,7 +55,7 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         columns={this._columns}
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         ariaLabelForSelectionColumn="Toggle selection"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
@@ -45,7 +45,7 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
         initialFocusedIndex={this.state.initialFocusedIndex}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-        checkButtonAriaLabel="Row checkbox"
+        checkButtonAriaLabel="select row"
       />
     );
   }

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -879,6 +879,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1284,6 +1285,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1689,6 +1691,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2094,6 +2097,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2499,6 +2503,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2904,6 +2909,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3309,6 +3315,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3714,6 +3721,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4119,6 +4127,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4524,6 +4533,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         >
                           <div
                             aria-checked={false}
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -677,6 +677,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1218,6 +1219,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1759,6 +1761,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2300,6 +2303,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2841,6 +2845,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3382,6 +3387,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3923,6 +3929,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4464,6 +4471,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5005,6 +5013,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5546,6 +5555,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1650,7 +1650,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2056,7 +2056,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2462,7 +2462,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2868,7 +2868,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3274,7 +3274,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3680,7 +3680,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4086,7 +4086,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4492,7 +4492,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4898,7 +4898,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5304,7 +5304,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -944,7 +944,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1407,7 +1407,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1870,7 +1870,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2333,7 +2333,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2796,7 +2796,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3259,7 +3259,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3722,7 +3722,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4185,7 +4185,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4648,7 +4648,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5111,7 +5111,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         >
                           <div
                             aria-checked={false}
-                            aria-label="Row checkbox"
+                            aria-label="select row"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1170,7 +1170,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1633,7 +1633,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2096,7 +2096,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2559,7 +2559,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3022,7 +3022,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3485,7 +3485,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3948,7 +3948,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4411,7 +4411,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4874,7 +4874,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5337,7 +5337,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1156,7 +1156,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1620,7 +1620,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2084,7 +2084,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2548,7 +2548,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3012,7 +3012,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3476,7 +3476,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3940,7 +3940,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4404,7 +4404,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4868,7 +4868,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5332,7 +5332,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -701,7 +701,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1148,7 +1148,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1595,7 +1595,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2042,7 +2042,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2489,7 +2489,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2936,7 +2936,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3383,7 +3383,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3830,7 +3830,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4277,7 +4277,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4724,7 +4724,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -922,7 +922,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1385,7 +1385,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1848,7 +1848,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2311,7 +2311,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2774,7 +2774,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -1061,7 +1061,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1478,7 +1478,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1895,7 +1895,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2312,7 +2312,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2729,7 +2729,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3146,7 +3146,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3563,7 +3563,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3980,7 +3980,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4397,7 +4397,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4814,7 +4814,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -708,7 +708,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1114,7 +1114,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1521,7 +1521,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1927,7 +1927,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2334,7 +2334,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2740,7 +2740,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3147,7 +3147,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3553,7 +3553,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3960,7 +3960,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4366,7 +4366,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1369,7 +1369,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1777,7 +1777,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2185,7 +2185,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2593,7 +2593,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3001,7 +3001,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3409,7 +3409,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3817,7 +3817,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4225,7 +4225,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4633,7 +4633,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5041,7 +5041,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           >
                             <div
                               aria-checked={false}
-                              aria-label="Row checkbox"
+                              aria-label="select row"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1786,7 +1786,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -2268,7 +2268,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -3600,7 +3600,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4082,7 +4082,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4564,7 +4564,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   >
                                     <div
                                       aria-checked={false}
-                                      aria-label="Row checkbox"
+                                      aria-label="select row"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1443,7 +1443,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1917,7 +1917,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2391,7 +2391,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2865,7 +2865,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3339,7 +3339,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3813,7 +3813,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4287,7 +4287,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4761,7 +4761,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5235,7 +5235,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5709,7 +5709,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 >
                                   <div
                                     aria-checked={false}
-                                    aria-label="Row checkbox"
+                                    aria-label="select row"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -810,7 +810,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1347,7 +1347,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1884,7 +1884,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2421,7 +2421,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2958,7 +2958,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3495,7 +3495,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4032,7 +4032,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4569,7 +4569,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5106,7 +5106,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       >
                         <div
                           aria-checked={false}
-                          aria-label="Row checkbox"
+                          aria-label="select row"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost


### PR DESCRIPTION
Cherry-pick of #17179 
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [6397](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/6397)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Passed missing `checkButtonAriaLabel` prop to `DetailsList` in `Announced` examples.
- Updated all pre-existing examples to pass 'select row' as `checkButtonAriaLabel` prop
