### PR TITLE
Quick fix for Grouped DetailsList and Groupedlist row index errors

### DIFF
--- a/change/@fluentui-react-ddc39884-3e55-43d9-aabd-b8e99bcddaac.json
+++ b/change/@fluentui-react-ddc39884-3e55-43d9-aabd-b8e99bcddaac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove incorrect rowindex and rowcount for grouped detailslist and groupedlist, fix remaining automated a11y errors",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-0a51d21a-710c-4ed9-b58e-b515f57bee3c.json
+++ b/change/@fluentui-react-examples-0a51d21a-710c-4ed9-b58e-b515f57bee3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot updates for detailslist",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -924,7 +924,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={1}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -1339,7 +1338,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={2}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -1754,7 +1752,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={3}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -2169,7 +2166,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={4}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -2584,7 +2580,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={5}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -2999,7 +2994,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={6}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -3414,7 +3408,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={7}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -3829,7 +3822,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={8}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -4244,7 +4236,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={9}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -4659,7 +4650,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={10}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1242,8 +1242,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-labelledby="GroupHeader9"
                           aria-level={1}
-                          aria-rowcount={4}
-                          aria-rowindex={2}
                           aria-selected={false}
                           className=
                               ms-GroupHeader
@@ -1651,7 +1649,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                               >
                                 <div
                                   aria-level={2}
-                                  aria-rowindex={1}
                                   aria-selected={false}
                                   className=
                                       ms-FocusZone
@@ -2131,7 +2128,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                               >
                                 <div
                                   aria-level={2}
-                                  aria-rowindex={2}
                                   aria-selected={false}
                                   className=
                                       ms-FocusZone
@@ -2632,8 +2628,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-labelledby="GroupHeader11"
                           aria-level={1}
-                          aria-rowcount={4}
-                          aria-rowindex={3}
                           aria-selected={false}
                           className=
                               ms-GroupHeader
@@ -3054,8 +3048,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           aria-expanded={true}
                           aria-labelledby="GroupHeader13"
                           aria-level={1}
-                          aria-rowcount={4}
-                          aria-rowindex={4}
                           aria-selected={false}
                           className=
                               ms-GroupHeader
@@ -3463,7 +3455,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                               >
                                 <div
                                   aria-level={2}
-                                  aria-rowindex={3}
                                   aria-selected={false}
                                   className=
                                       ms-FocusZone
@@ -3943,7 +3934,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                               >
                                 <div
                                   aria-level={2}
-                                  aria-rowindex={4}
                                   aria-selected={false}
                                   className=
                                       ms-FocusZone
@@ -4423,7 +4413,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                               >
                                 <div
                                   aria-level={2}
-                                  aria-rowindex={5}
                                   aria-selected={false}
                                   className=
                                       ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -897,8 +897,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         aria-expanded={true}
                         aria-labelledby="GroupHeader4"
                         aria-level={1}
-                        aria-rowcount={11}
-                        aria-rowindex={2}
                         aria-selected={false}
                         className=
                             ms-GroupHeader
@@ -1306,7 +1304,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={1}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -1778,7 +1775,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={2}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -2250,7 +2246,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={3}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -2722,7 +2717,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={4}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -3194,7 +3188,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={5}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -3666,7 +3659,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={6}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -4138,7 +4130,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={7}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -4610,7 +4601,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={8}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -5082,7 +5072,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={9}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -5554,7 +5543,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={10}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -444,7 +444,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     aria-label="group 0"
                     className="ms-List"
                     id="GroupedListSection2"
-                    role="group"
+                    role="rowgroup"
                   >
                     <div
                       className="ms-List-surface"
@@ -463,7 +463,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={1}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -991,7 +990,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={2}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -1519,7 +1517,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={3}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -2430,7 +2427,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     aria-label="group 1"
                     className="ms-List"
                     id="GroupedListSection5"
-                    role="group"
+                    role="rowgroup"
                   >
                     <div
                       className="ms-List-surface"
@@ -2449,7 +2446,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={4}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -2977,7 +2973,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={5}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -3505,7 +3500,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={6}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -4416,7 +4410,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                     aria-label="group 2"
                     className="ms-List"
                     id="GroupedListSection8"
-                    role="group"
+                    role="rowgroup"
                   >
                     <div
                       className="ms-List-surface"
@@ -4435,7 +4429,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={7}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -4963,7 +4956,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={8}
                             aria-selected={false}
                             className=
                                 ms-FocusZone
@@ -5491,7 +5483,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                         >
                           <div
                             aria-level={2}
-                            aria-rowindex={9}
                             aria-selected={false}
                             className=
                                 ms-FocusZone

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -282,7 +282,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         data-selection-index={itemIndex}
         data-selection-touch-invoke={true}
         data-item-index={itemIndex}
-        aria-rowindex={itemIndex + 1}
+        aria-rowindex={groupNestingDepth ? undefined : itemIndex + 1}
         aria-level={(groupNestingDepth && groupNestingDepth + 1) || undefined}
         data-automationid="DetailsRow"
         style={{ minWidth: rowWidth }}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -6898,8 +6898,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         aria-expanded={true}
                         aria-labelledby="GroupHeader19"
                         aria-level={1}
-                        aria-rowcount={3}
-                        aria-rowindex={2}
                         className=
                             ms-GroupHeader
                             {
@@ -7131,7 +7129,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={1}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -7318,7 +7315,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={2}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -7526,8 +7522,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         aria-expanded={true}
                         aria-labelledby="GroupHeader21"
                         aria-level={1}
-                        aria-rowcount={3}
-                        aria-rowindex={3}
                         className=
                             ms-GroupHeader
                             {
@@ -7759,7 +7753,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={3}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -7946,7 +7939,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={4}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone
@@ -8133,7 +8125,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                             >
                               <div
                                 aria-level={2}
-                                aria-rowindex={5}
                                 aria-selected={false}
                                 className=
                                     ms-FocusZone

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -82,8 +82,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       compact,
       ariaPosInSet,
       ariaSetSize,
-      ariaRowCount,
-      ariaRowIndex,
       useFastIcons,
     } = this.props;
 
@@ -121,8 +119,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         role="row"
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
-        aria-rowcount={ariaRowCount}
-        aria-rowindex={ariaRowIndex}
+        // aria-rowindex is omitted because the default calculated index
+        // is better than an incorrect declared index
         data-is-focusable={true}
         onKeyUp={this._onKeyUp}
         aria-label={group.ariaLabel}

--- a/packages/react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListSection.tsx
@@ -250,7 +250,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         {onRenderGroupHeader(groupHeaderProps, this._onRenderGroupHeader)}
         {group && group.isCollapsed ? null : hasNestedGroups ? (
           <List
-            role="group"
+            role="presentation"
             ref={this._list}
             items={group ? group.children : []}
             onRenderCell={this._renderSubGroup}
@@ -340,7 +340,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
     return (
       <List
-        role={groupProps && groupProps.role ? groupProps.role : 'group'}
+        role={groupProps && groupProps.role ? groupProps.role : 'rowgroup'}
         aria-label={group?.name}
         items={items}
         onRenderCell={this._onRenderGroupCell(onRenderCell, groupNestingDepth)}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10869](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10869/)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR cleans up a few remaining semantic issues with grouped detailslist and groupedlist, and adds a workaround for incorrect indices with grouped rows. Specifically:

- Removes some `role="rowgroup"` roles to avoid nested rowgroups, which are technically not allowed (automated issue only, no practical impact)
- Switches from `role="group"` to `role="rowgroup"` on treegrid -- that was my mistake earlier, I used the tree semantics instead of the correct grid/treegrid role
- Removes `aria-rowindex` and `-rowcount` entirely from any use of grouped rows with detailslist or groupedlist.
   
   This allows browser and screen readers to calculate that information correctly in all non-virtualized grids, and even in virtualized grids the linear off-by-x announcements will still be better than the values we provide now, which jump all over the place between detailslist rows and group headers. The biggest win here is now JAWS can navigate the grouped detailslist properly in scan mode, whereas before it missed a number of rows due to incorrect index values.
