### PR TITLE
feat(ToolbarMenuItem): add ToolbarMenuItemContent to wrap content in span (⚠️ DOM change)

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `onKeyDown` handler for `TreeItem` allowing key navigation more than A-Z @yuanboxue-amber ([#17073](https://github.com/microsoft/fluentui/pull/17073))
 - Added `ArchiveIcon`, `ContactCardIcon`, `DoorArrowLeftIcon`, `FluidFileIcon`, `GridIcon`, `ShieldKeyholeIcon`, `WandIcon` @notandrew ([#17152](https://github.com/microsoft/fluentui/pull/17152))
 - Added `autoSize` prop to make `Popper` responsive @yuanboxue-amber ([#17159](https://github.com/microsoft/fluentui/pull/17159))
+- Add `ToolbarMenuItemContent` to wrap content in span @yuanboxue-amber ([#17264](https://github.com/microsoft/fluentui/pull/17264))
 
 ## Performance
 

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -48,6 +48,7 @@ import { ToolbarVariablesContext, ToolbarVariablesProvider } from './toolbarVari
 import { ToolbarMenuItemSubmenuIndicator } from './ToolbarMenuItemSubmenuIndicator';
 import { ToolbarMenuItemActiveIndicator } from './ToolbarMenuItemActiveIndicator';
 import { ToolbarItemSubscribedValue, ToolbarMenuContext } from './toolbarMenuContext';
+import { ToolbarMenuItemContent } from './ToolbarMenuItemContent';
 
 export interface ToolbarMenuItemProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
   /**
@@ -336,7 +337,9 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
         ) : (
           <>
             {createShorthand(composeOptions.slots.icon, icon, { defaultProps: () => slotProps.icon })}
-            {content}
+            {createShorthand(composeOptions.slots.content, content, {
+              defaultProps: () => getA11yProps('content', slotProps.content),
+            })}
             {active &&
               createShorthand(composeOptions.slots.activeIndicator, activeIndicator, {
                 defaultProps: () => slotProps.activeIndicator,
@@ -443,6 +446,7 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
       submenuIndicator: ToolbarMenuItemSubmenuIndicator,
       activeIndicator: ToolbarMenuItemActiveIndicator,
       popup: Popup,
+      content: ToolbarMenuItemContent,
     },
     slotProps: props => ({
       icon: {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -461,6 +461,7 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
       popup: {
         trapFocus: true,
       },
+      content: {},
     }),
 
     shorthandConfig: {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
@@ -6,7 +6,7 @@ import { Box, BoxProps, BoxStylesProps } from '../Box/Box';
 interface ToolbarMenuItemContentOwnProps {}
 export interface ToolbarMenuItemContentProps extends ToolbarMenuItemContentOwnProps, BoxProps {}
 
-export type ToolbarMenuItemContentStylesProps = {};
+export type ToolbarMenuItemContentStylesProps = never;
 export const toolbarMenuItemContentClassName = 'ui-toolbar__menuitemcontent';
 
 /**

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
@@ -1,0 +1,34 @@
+import { compose } from '@fluentui/react-bindings';
+
+import { commonPropTypes } from '../../utils';
+import { Box, BoxProps, BoxStylesProps } from '../Box/Box';
+
+interface ToolbarMenuItemContentOwnProps {}
+export interface ToolbarMenuItemContentProps extends ToolbarMenuItemContentOwnProps, BoxProps {}
+
+export type ToolbarMenuItemContentStylesProps = {};
+export const toolbarMenuItemContentClassName = 'ui-toolbar__menuitemcontent';
+
+/**
+ * A ToolbarMenuItemContent allows a user to have a dedicated component that can be targeted from the theme.
+ */
+export const ToolbarMenuItemContent = compose<
+  'span',
+  ToolbarMenuItemContentProps,
+  ToolbarMenuItemContentStylesProps,
+  BoxProps,
+  BoxStylesProps
+>(Box, {
+  className: toolbarMenuItemContentClassName,
+  displayName: 'ToolbarMenuItemContent',
+
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+  overrideStyles: true,
+});
+
+ToolbarMenuItemContent.defaultProps = {
+  as: 'span',
+};
+ToolbarMenuItemContent.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -188,6 +188,7 @@ export * from './components/Toolbar/ToolbarItemIcon';
 export * from './components/Toolbar/ToolbarMenu';
 export * from './components/Toolbar/ToolbarMenuDivider';
 export * from './components/Toolbar/ToolbarMenuItem';
+export * from './components/Toolbar/ToolbarMenuItemContent';
 export * from './components/Toolbar/ToolbarMenuItemIcon';
 export * from './components/Toolbar/ToolbarMenuItemSubmenuIndicator';
 export * from './components/Toolbar/ToolbarMenuItemActiveIndicator';

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -72,6 +72,7 @@ import { ToolbarDividerStylesProps } from '../../components/Toolbar/ToolbarDivid
 import { ToolbarItemStylesProps } from '../../components/Toolbar/ToolbarItem';
 import { ToolbarCustomItemStylesProps } from '../../components/Toolbar/ToolbarCustomItem';
 import { ToolbarMenuItemStylesProps } from '../../components/Toolbar/ToolbarMenuItem';
+import { ToolbarMenuItemContentStylesProps } from '../../components/Toolbar/ToolbarMenuItemContent';
 import { ToolbarMenuDividerStylesProps } from '../../components/Toolbar/ToolbarMenuDivider';
 import { ToolbarMenuRadioGroupStylesProps } from '../../components/Toolbar/ToolbarMenuRadioGroup';
 import { ToolbarMenuStylesProps } from '../../components/Toolbar/ToolbarMenu';
@@ -185,6 +186,7 @@ export type TeamsThemeStylesProps = {
   ToolbarRadioGroup: ToolbarRadioGroupStylesProps;
   ToolbarMenu: ToolbarMenuStylesProps;
   ToolbarMenuItem: ToolbarMenuItemStylesProps;
+  ToolbarMenuItemContent: ToolbarMenuItemContentStylesProps;
   ToolbarMenuDivider: ToolbarMenuDividerStylesProps;
   ToolbarMenuRadioGroup: ToolbarMenuRadioGroupStylesProps;
   TooltipContent: TooltipContentStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuItemContent-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuItemContent-test.ts
@@ -1,0 +1,10 @@
+import { isConformant } from 'test/specs/commonTests';
+
+import { ToolbarMenuItemContent } from 'src/components/Toolbar/ToolbarMenuItemContent';
+
+describe('ToolbarMenuItemContent', () => {
+  isConformant(ToolbarMenuItemContent, {
+    testPath: __filename,
+    constructorName: 'ToolbarMenuItemContent',
+  });
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

## ⚠️ This could potentially affect toolbar item styles

#### Description of changes

As title.
This change is to make ToolbarMenuItem consistent with MenuItem by wrapping it in `<span>`
- before, toolbarMenuItem is text node
![image](https://user-images.githubusercontent.com/28751745/110103621-6c4d9900-7da6-11eb-801a-82b008648236.png)

- after, it is wrapped in span
![image](https://user-images.githubusercontent.com/28751745/110103502-4de79d80-7da6-11eb-9458-67eeddbe3ac9.png)

#### Focus areas to test

(optional)
