### PR TITLE
fix(ContextualMenu): fix menu role hierarchy

### DIFF
--- a/change/@fluentui-react-3a8838cd-dc5f-4c76-b1e9-c4f63b37c086.json
+++ b/change/@fluentui-react-3a8838cd-dc5f-4c76-b1e9-c4f63b37c086.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix menu hierarchy in ContextualMenu, and update labelled element",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3327,6 +3327,8 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IContextualMenuListProps {
     // (undocumented)
+    ariaLabel?: string;
+    // (undocumented)
     defaultMenuItemRenderer: (item: IContextualMenuItemRenderProps) => React.ReactNode;
     // (undocumented)
     hasCheckmarks: boolean;
@@ -3334,6 +3336,8 @@ export interface IContextualMenuListProps {
     hasIcons: boolean;
     // (undocumented)
     items: IContextualMenuItem[];
+    // (undocumented)
+    labelElementId?: string;
     // (undocumented)
     role?: string;
     // (undocumented)

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -988,43 +988,43 @@ describe('Button', () => {
       }
 
       it('If button has text, contextual menu has aria-labelledBy attribute set', () => {
-        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text');
+        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text');
+        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-label')).toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-labelledBy')).toBeTruthy();
+        expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-labelledBy')).toBeTruthy();
       });
 
       it('If button has a text child, contextual menu has aria-labelledBy attribute set', () => {
-        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
-          null,
-          'Button Text',
-          true,
-        );
+        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text', true);
+        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-label')).toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-labelledBy')).not.toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-labelledBy')).not.toBeNull();
       });
 
       it('If button has no text, contextual menu has no aria-label or aria-labelledBy attributes', () => {
-        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement();
+        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement();
+        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-label')).toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-labelledBy')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-labelledBy')).toBeNull();
       });
 
       it('If button has text but ariaLabel provided in menuProps, contextual menu has aria-label set', () => {
         const explicitLabel = 'ExplicitLabel';
-        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
+        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
           { ariaLabel: explicitLabel },
           'Button Text',
         );
+        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-label')).toEqual(explicitLabel);
-        expect(contextualMenuElement.getAttribute('aria-labelledBy')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-label')).toEqual(explicitLabel);
+        expect(contextualMenuElement?.getAttribute('aria-labelledBy')).toBeNull();
       });
       it('Click on button opens the menu, escape press dismisses menu', () => {
         const callbackMock = jest.fn();
@@ -1059,14 +1059,15 @@ describe('Button', () => {
       it(`If button has text but labelElementId provided in menuProps, contextual menu has
       aria-labelledBy reflecting labelElementId`, () => {
         const explicitLabelElementId = 'id_ExplicitLabel';
-        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
+        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
           { labelElementId: explicitLabelElementId },
           'Button Text',
         );
+        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-label')).toBeNull();
-        expect(contextualMenuElement.getAttribute('aria-labelledBy')).toEqual(explicitLabelElementId);
+        expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
+        expect(contextualMenuElement?.getAttribute('aria-labelledBy')).toEqual(explicitLabelElementId);
       });
     });
   });

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -443,8 +443,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
               ref={hostElement}
             >
               <div
-                aria-label={ariaLabel}
-                aria-labelledby={labelElementId}
                 style={contextMenuStyle}
                 id={id}
                 className={this._classNames.container}
@@ -463,11 +461,13 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                   >
                     {onRenderMenuList(
                       {
+                        ariaLabel,
                         items,
                         totalItemCount,
                         hasCheckmarks,
                         hasIcons,
                         defaultMenuItemRenderer: this._defaultMenuItemRenderer,
+                        labelElementId,
                       },
                       this._onRenderMenuList,
                     )}
@@ -521,9 +521,16 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     defaultRender?: IRenderFunction<IContextualMenuListProps>,
   ): JSX.Element => {
     let indexCorrection = 0;
-    const { items, totalItemCount, hasCheckmarks, hasIcons, role } = menuListProps;
+    const { ariaLabel, items, labelElementId, totalItemCount, hasCheckmarks, hasIcons, role } = menuListProps;
     return (
-      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role={role ?? 'menu'}>
+      <ul
+        className={this._classNames.list}
+        aria-label={ariaLabel}
+        aria-labelledby={labelElementId}
+        onKeyDown={this._onKeyDown}
+        onKeyUp={this._onKeyUp}
+        role={role ?? 'menu'}
+      >
         {items.map((item, index) => {
           const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
           if (item.itemType !== ContextualMenuItemType.Divider && item.itemType !== ContextualMenuItemType.Header) {
@@ -679,7 +686,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       return (
         <li role="presentation" key={sectionProps.key || sectionItem.key || `section-${index}`}>
           <div {...groupProps}>
-            <ul className={this._classNames.list} role="menu">
+            <ul className={this._classNames.list} role="presentation">
               {sectionProps.topDivider && this._renderSeparator(index, menuClassNames, true, true)}
               {headerItem &&
                 this._renderListItem(headerItem, sectionItem.key || index, menuClassNames, sectionItem.title)}
@@ -841,7 +848,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
         executeItemClick={this._executeItemClick}
         onItemClick={this._onAnchorClick}
         onItemKeyDown={this._onItemKeyDown}
-        getSubMenuId={this._getSubMenuId}
         expandedMenuItemKey={expandedMenuItemKey}
         openSubMenu={openSubMenu}
         dismissSubMenu={this._onSubMenuDismiss}
@@ -883,7 +889,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
         onItemClick={this._onItemClick}
         onItemClickBase={this._onItemClickBase}
         onItemKeyDown={this._onItemKeyDown}
-        getSubMenuId={this._getSubMenuId}
         expandedMenuItemKey={expandedMenuItemKey}
         openSubMenu={openSubMenu}
         dismissSubMenu={this._onSubMenuDismiss}
@@ -1343,16 +1348,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     } else if (this._mounted) {
       this.props.hoisted.closeSubMenu();
     }
-  };
-
-  private _getSubMenuId = (item: IContextualMenuItem): string | undefined => {
-    let { subMenuId } = this.state;
-
-    if (item.subMenuProps && item.subMenuProps.id) {
-      subMenuId = item.subMenuProps.id;
-    }
-
-    return subMenuId;
   };
 
   private _onPointerAndTouchEvent = (ev: React.TouchEvent<HTMLElement> | PointerEvent) => {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -566,39 +566,6 @@ describe('ContextualMenu', () => {
     expect(document.querySelector('.is-expanded')).toBeTruthy();
   });
 
-  it('sets the correct aria-owns attribute for the submenu', () => {
-    const submenuId = 'testSubmenuId';
-    const items: IContextualMenuItem[] = [
-      {
-        text: 'TestText 1',
-        key: 'TestKey1',
-        subMenuProps: {
-          id: submenuId,
-          items: [
-            {
-              text: 'SubmenuText 1',
-              key: 'SubmenuKey1',
-              className: 'SubMenuClass',
-            },
-          ],
-        },
-      },
-    ];
-
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
-
-    const parentMenuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(parentMenuItem);
-    });
-    const childMenu = document.getElementById(submenuId);
-
-    expect(childMenu!.id).toBe(submenuId);
-    expect(parentMenuItem.getAttribute('aria-owns')).toBe(submenuId);
-  });
-
   it('can focus on disabled items', () => {
     const items: IContextualMenuItem[] = [
       {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -302,6 +302,8 @@ export interface IContextualMenuListProps {
   hasCheckmarks: boolean;
   hasIcons: boolean;
   defaultMenuItemRenderer: (item: IContextualMenuItemRenderProps) => React.ReactNode;
+  ariaLabel?: string;
+  labelElementId?: string;
   role?: string;
 }
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -40,7 +40,6 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
       anchorRel = anchorRel ? anchorRel : 'nofollow noopener noreferrer'; // Safe default to prevent tabjacking
     }
 
-    const subMenuId = this._getSubMenuId(item);
     const itemHasSubmenu = hasSubmenu(item);
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLAnchorElement>>(item, anchorProperties);
     const disabled = isItemDisabled(item);
@@ -80,7 +79,6 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
               rel={anchorRel}
               className={classNames.root}
               role="menuitem"
-              aria-owns={item.key === expandedMenuItemKey ? subMenuId : undefined}
               aria-haspopup={itemHasSubmenu || undefined}
               aria-expanded={itemHasSubmenu ? item.key === expandedMenuItemKey : undefined}
               aria-posinset={focusableElementIndex + 1}

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -36,8 +36,6 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       dismissMenu,
     } = this.props;
 
-    const subMenuId = this._getSubMenuId(item);
-
     const isChecked: boolean | null | undefined = getIsChecked(item);
     const canCheck: boolean = isChecked !== null;
     const defaultRole = getMenuItemAriaRole(item);
@@ -78,7 +76,6 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-label': ariaLabel,
       'aria-describedby': ariaDescribedByIds,
       'aria-haspopup': itemHasSubmenu || undefined,
-      'aria-owns': item.key === expandedMenuItemKey ? subMenuId : undefined,
       'aria-expanded': itemHasSubmenu ? item.key === expandedMenuItemKey : undefined,
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { initializeComponentRef, shallowCompare } from '../../../Utilities';
 import { IContextualMenuItemWrapperProps } from './ContextualMenuItemWrapper.types';
-import { IContextualMenuItem } from '../../../ContextualMenu';
 
 export class ContextualMenuItemWrapper extends React.Component<IContextualMenuItemWrapperProps> {
   constructor(props: IContextualMenuItemWrapperProps) {
@@ -45,13 +44,6 @@ export class ContextualMenuItemWrapper extends React.Component<IContextualMenuIt
     const { item, onItemMouseMove } = this.props;
     if (onItemMouseMove) {
       onItemMouseMove(item, ev, ev.currentTarget as HTMLElement);
-    }
-  };
-
-  protected _getSubMenuId = (item: IContextualMenuItem): string | undefined => {
-    const { getSubMenuId } = this.props;
-    if (getSubMenuId) {
-      return getSubMenuId(item);
     }
   };
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
@@ -112,7 +112,9 @@ export interface IContextualMenuItemWrapperProps extends React.ClassAttributes<I
 
   /**
    * Callback to get the subMenu ID for an IContextualMenuItem.
+   * @deprecated ID relationship between a menu button and menu isn't necessary
    */
+  // eslint-disable-next-line deprecation/deprecation
   getSubMenuId?: (item: IContextualMenuItem) => string | undefined;
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10740](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10740)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The main purpose of this PR is to fix menu nesting issues that were causing automated errors. In one case, the hierarchy went `menu > group > menu > menuitem` instead of `menu > group > menuitem`, and in another there were menus inside of menuitems through `aria-owns`.

I also moved the `aria-label` and `aria-labelledby` attributes for menus onto the element with `role="menu"` (previously they were on a random `<div>`, and not doing anything in practice).

#### Focus areas to test
ContextualMenu, Button w/ ContextualMenu
