### PR TITLE
Menu and MenuTrigger API

### DIFF
--- a/change/@fluentui-react-examples-0d85fcc7-7b97-4345-a454-5305248864d3.json
+++ b/change/@fluentui-react-examples-0d85fcc7-7b97-4345-a454-5305248864d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add MenuTrigger examples",
+  "packageName": "@fluentui/react-examples",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-15048b94-4b75-4c7c-9baf-721fadced51c.json
+++ b/change/@fluentui-react-menu-15048b94-4b75-4c7c-9baf-721fadced51c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Menu, MenuTrigger components",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItem,
+  MenuItemRadio,
+  MenuItemCheckbox,
+  MenuGroup,
+  MenuDivider,
+  MenuGroupHeader,
+} from '@fluentui/react-menu';
+import { CutIcon, PasteIcon, EditIcon, AcceptIcon } from '@fluentui/react-icons-mdl2';
+
+export const MenuExample = () => (
+  <>
+    <Menu>
+      <MenuTrigger>
+        <button>Toggle menu</button>
+      </MenuTrigger>
+
+      <MenuList>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem>Item 1</MenuItem>
+      </MenuList>
+    </Menu>
+  </>
+);
+
+export const MenuControlledExample = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <>
+      <Menu open={open} setOpen={setOpen}>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuList>
+          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Item 1</MenuItem>
+        </MenuList>
+      </Menu>
+    </>
+  );
+};
+
+export const MenuSelectionExample = () => (
+  <>
+    <Menu>
+      <MenuTrigger>
+        <button>Toggle menu</button>
+      </MenuTrigger>
+
+      <MenuList>
+        <MenuGroup>
+          <MenuGroupHeader>Checkbox group</MenuGroupHeader>
+          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut" checkmark={<AcceptIcon />}>
+            Cut
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste" checkmark={<AcceptIcon />}>
+            Paste
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit" checkmark={<AcceptIcon />}>
+            Edit
+          </MenuItemCheckbox>
+        </MenuGroup>
+        <MenuDivider />
+        <MenuGroup>
+          <MenuGroupHeader>Radio group</MenuGroupHeader>
+          <MenuItemRadio icon={<CutIcon />} name="font" value="segoe" checkmark={<AcceptIcon />}>
+            Segoe
+          </MenuItemRadio>
+          <MenuItemRadio icon={<PasteIcon />} name="font" value="calibri" checkmark={<AcceptIcon />}>
+            Caliri
+          </MenuItemRadio>
+          <MenuItemRadio icon={<EditIcon />} name="font" value="arial" checkmark={<AcceptIcon />}>
+            Arial
+          </MenuItemRadio>
+        </MenuGroup>
+      </MenuList>
+    </Menu>
+  </>
+);

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -32,9 +32,9 @@ export const MenuControlledExample = () => {
   const [open, setOpen] = React.useState(false);
   return (
     <>
-      <Menu open={open} setOpen={setOpen}>
+      <Menu open={open}>
         <MenuTrigger>
-          <button>Toggle menu</button>
+          <button onClick={() => setOpen(s => !s)}>Toggle menu</button>
         </MenuTrigger>
 
         <MenuList>

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -145,11 +145,11 @@ export interface MenuListState extends MenuListProps {
 }
 
 // @public
-export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement>, MenuListProps {
+export interface MenuProps extends MenuListProps {
+    children: React.ReactNode;
     defaultOpen?: boolean;
     menuPopup?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
     open?: boolean;
-    setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // @public (undocumented)
@@ -169,7 +169,8 @@ export interface MenuState extends MenuProps {
 export const MenuTrigger: React.ForwardRefExoticComponent<MenuTriggerProps & React.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
-export interface MenuTriggerProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+export interface MenuTriggerProps {
+    children: React.ReactElement;
 }
 
 // @public (undocumented)
@@ -206,7 +207,7 @@ export const renderMenuItemRadio: (state: MenuItemRadioState) => JSX.Element;
 export const renderMenuList: (state: MenuListState) => JSX.Element;
 
 // @public
-export const renderMenuTrigger: (state: MenuTriggerState) => JSX.Element;
+export const renderMenuTrigger: (state: MenuTriggerState) => import("react").ReactElement<any, string | ((props: any) => import("react").ReactElement<any, string | any | (new (props: any) => import("react").Component<any, any, any>)> | null) | (new (props: any) => import("react").Component<any, any, any>)>;
 
 // @public (undocumented)
 export type SelectableHandler = (e: React.MouseEvent | React.KeyboardEvent, name: string, value: string, checked: boolean) => void;

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -9,7 +9,7 @@ import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
 
-// @public (undocumented)
+// @public
 export const Menu: React.ForwardRefExoticComponent<MenuProps & React.RefAttributes<HTMLElement>>;
 
 // @public
@@ -144,8 +144,12 @@ export interface MenuListState extends MenuListProps {
     toggleCheckbox: SelectableHandler;
 }
 
-// @public (undocumented)
-export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+// @public
+export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement>, MenuListProps {
+    defaultOpen?: boolean;
+    menuPopup?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+    open?: boolean;
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // @public (undocumented)
@@ -153,14 +157,15 @@ export const menuShorthandProps: (keyof MenuProps)[];
 
 // @public (undocumented)
 export interface MenuState extends MenuProps {
-    menuList: ObjectShorthandProps<HTMLElement>;
-    menuTrigger: ObjectShorthandProps<HTMLElement>;
+    menuList: React.ReactNode;
+    menuPopup: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+    menuTrigger: React.ReactNode;
     open: boolean;
     ref: React.MutableRefObject<HTMLElement>;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-// @public (undocumented)
+// @public
 export const MenuTrigger: React.ForwardRefExoticComponent<MenuTriggerProps & React.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
@@ -255,9 +260,6 @@ export const useMenuStyles: (state: MenuState) => MenuState;
 
 // @public
 export const useMenuTrigger: (props: MenuTriggerProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuTriggerProps | undefined) => MenuTriggerState;
-
-// @public
-export const useMenuTriggerStyles: (state: MenuTriggerState) => MenuTriggerState;
 
 // @public
 export const useRootStyles: (selectors: MenuItemState) => string;

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -9,6 +9,9 @@ import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
 
+// @public (undocumented)
+export const Menu: React.ForwardRefExoticComponent<MenuProps & React.RefAttributes<HTMLElement>>;
+
 // @public
 export const MenuDivider: React.ForwardRefExoticComponent<import("@fluentui/react-utilities").ComponentProps & React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>>;
 
@@ -141,6 +144,41 @@ export interface MenuListState extends MenuListProps {
     toggleCheckbox: SelectableHandler;
 }
 
+// @public (undocumented)
+export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+}
+
+// @public (undocumented)
+export const menuShorthandProps: (keyof MenuProps)[];
+
+// @public (undocumented)
+export interface MenuState extends MenuProps {
+    menuList: ObjectShorthandProps<HTMLElement>;
+    menuTrigger: ObjectShorthandProps<HTMLElement>;
+    open: boolean;
+    ref: React.MutableRefObject<HTMLElement>;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// @public (undocumented)
+export const MenuTrigger: React.ForwardRefExoticComponent<MenuTriggerProps & React.RefAttributes<HTMLElement>>;
+
+// @public (undocumented)
+export interface MenuTriggerProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+}
+
+// @public (undocumented)
+export const menuTriggerShorthandProps: (keyof MenuTriggerProps)[];
+
+// @public (undocumented)
+export interface MenuTriggerState extends MenuTriggerProps {
+    ref: React.MutableRefObject<HTMLElement>;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// @public
+export const renderMenu: (state: MenuState) => JSX.Element;
+
 // @public
 export const renderMenuDivider: (state: MenuDividerState) => JSX.Element;
 
@@ -162,6 +200,9 @@ export const renderMenuItemRadio: (state: MenuItemRadioState) => JSX.Element;
 // @public
 export const renderMenuList: (state: MenuListState) => JSX.Element;
 
+// @public
+export const renderMenuTrigger: (state: MenuTriggerState) => JSX.Element;
+
 // @public (undocumented)
 export type SelectableHandler = (e: React.MouseEvent | React.KeyboardEvent, name: string, value: string, checked: boolean) => void;
 
@@ -172,6 +213,9 @@ export const useCheckmarkStyles: (state: MenuItemSelectableState & {
 
 // @public
 export const useIconStyles: (selectors: MenuItemState) => string;
+
+// @public
+export const useMenu: (props: MenuProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuProps | undefined) => MenuState;
 
 // @public
 export const useMenuDivider: (props: MenuDividerProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuDividerProps | undefined) => MenuDividerState;
@@ -205,6 +249,15 @@ export const useMenuItemStyles: (state: MenuItemState) => void;
 
 // @public
 export const useMenuList: (props: MenuListProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuListProps | undefined) => MenuListState;
+
+// @public
+export const useMenuStyles: (state: MenuState) => MenuState;
+
+// @public
+export const useMenuTrigger: (props: MenuTriggerProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuTriggerProps | undefined) => MenuTriggerState;
+
+// @public
+export const useMenuTriggerStyles: (state: MenuTriggerState) => MenuTriggerState;
 
 // @public
 export const useRootStyles: (selectors: MenuItemState) => string;

--- a/packages/react-menu/src/Menu.ts
+++ b/packages/react-menu/src/Menu.ts
@@ -1,0 +1,1 @@
+export * from './components/Menu/index';

--- a/packages/react-menu/src/MenuTrigger.ts
+++ b/packages/react-menu/src/MenuTrigger.ts
@@ -1,0 +1,1 @@
+export * from './components/MenuTrigger/index';

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Menu } from './Menu';
+import * as renderer from 'react-test-renderer';
+import { ReactWrapper } from 'enzyme';
+import { isConformant } from '../../common/isConformant';
+
+describe('Menu', () => {
+  isConformant({
+    Component: Menu,
+    displayName: 'Menu',
+  });
+
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  /**
+   * Note: see more visual regression tests for Menu in /apps/vr-tests.
+   */
+  it('renders a default state', () => {
+    const component = renderer.create(<Menu>Default Menu</Menu>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -3,11 +3,32 @@ import { Menu } from './Menu';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
+import { MenuTrigger } from '../MenuTrigger/index';
+import { MenuList } from '../MenuList/index';
+import { MenuItem } from '../MenuItem/index';
 
 describe('Menu', () => {
   isConformant({
+    disabledTests: [
+      'as-renders-html',
+      'as-renders-fc',
+      'component-handles-ref',
+      'component-has-root-ref',
+      'component-handles-classname',
+      'as-passes-as-value',
+    ],
     Component: Menu,
     displayName: 'Menu',
+    requiredProps: {
+      children: [
+        <MenuTrigger key="trigger">
+          <button>MenuTrigger</button>
+        </MenuTrigger>,
+        <MenuList key="item">
+          <MenuItem>Item</MenuItem>
+        </MenuList>,
+      ],
+    },
   });
 
   let wrapper: ReactWrapper | undefined;
@@ -23,7 +44,16 @@ describe('Menu', () => {
    * Note: see more visual regression tests for Menu in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    const component = renderer.create(<Menu>Default Menu</Menu>);
+    const component = renderer.create(
+      <Menu>
+        <MenuTrigger>
+          <button>Menu trigger</button>
+        </MenuTrigger>
+        <MenuList>
+          <MenuItem>Item</MenuItem>
+        </MenuList>
+      </Menu>,
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/react-menu/src/components/Menu/Menu.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useMenu } from './useMenu';
+import { MenuProps } from './Menu.types';
+import { renderMenu } from './renderMenu';
+import { useMenuStyles } from './useMenuStyles';
+
+/**
+ * Wrapper component that manages state for a popup MenuList and a MenuTrigger
+ * {@docCategory Menu }
+ */
+export const Menu = React.forwardRef<HTMLElement, MenuProps>((props, ref) => {
+  const state = useMenu(props, ref);
+
+  useMenuStyles(state);
+  return renderMenu(state);
+});
+
+Menu.displayName = 'Menu';

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -25,7 +25,7 @@ export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElem
   /**
    * Wrapper to style and add events for the popup
    */
-  menuPopup: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+  menuPopup?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }
 
 /**

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { ComponentProps, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
+import { MenuListProps } from '../MenuList/index';
+
+/**
+ * Extends and drills down Menulist props to simplify API
+ * {@docCategory Menu }
+ */
+export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement>, MenuListProps {
+  /**
+   * Whether the popup is open
+   */
+  open?: boolean;
+
+  /**
+   * Whether the popup is open by default
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Callback to open/close the popup
+   */
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /**
+   * Wrapper to style and add events for the popup
+   */
+  menuPopup: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+}
+
+/**
+ * {@docCategory Menu }
+ */
+export interface MenuState extends MenuProps {
+  /**
+   * Ref to the root slot
+   */
+  ref: React.MutableRefObject<HTMLElement>;
+
+  /**
+   * Whether the popup is open
+   */
+  open: boolean;
+
+  /**
+   * Callback to open/close the popup
+   */
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /**
+   * Internal react node that just simplifies handling children
+   */
+  menuList: React.ReactNode;
+
+  /**
+   * Internal react node that just simplifies handling children
+   */
+  menuTrigger: React.ReactNode;
+
+  /**
+   * Wrapper to style and add events for the popup
+   */
+  menuPopup: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+}

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -1,12 +1,17 @@
 import * as React from 'react';
-import { ComponentProps, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
+import { ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
 import { MenuListProps } from '../MenuList/index';
 
 /**
  * Extends and drills down Menulist props to simplify API
  * {@docCategory Menu }
  */
-export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElement>, MenuListProps {
+export interface MenuProps extends MenuListProps {
+  /**
+   * Explicitly require children
+   */
+
+  children: React.ReactNode;
   /**
    * Whether the popup is open
    */
@@ -16,11 +21,6 @@ export interface MenuProps extends ComponentProps, React.HTMLAttributes<HTMLElem
    * Whether the popup is open by default
    */
   defaultOpen?: boolean;
-
-  /**
-   * Callback to open/close the popup
-   */
-  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 
   /**
    * Wrapper to style and add events for the popup

--- a/packages/react-menu/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/react-menu/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu renders a default state 1`] = `
+<button
+  onClick={[Function]}
+>
+  Menu trigger
+</button>
+`;

--- a/packages/react-menu/src/components/Menu/index.ts
+++ b/packages/react-menu/src/components/Menu/index.ts
@@ -1,0 +1,5 @@
+export * from './Menu';
+export * from './Menu.types';
+export * from './renderMenu';
+export * from './useMenu';
+export * from './useMenuStyles';

--- a/packages/react-menu/src/components/Menu/renderMenu.tsx
+++ b/packages/react-menu/src/components/Menu/renderMenu.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import { MenuState } from './Menu.types';
+import { menuShorthandProps } from './useMenu';
+import { MenuProvider } from '../../menuContext';
+
+/**
+ * Render the final JSX of Menu
+ * {@docCategory Menu }
+ */
+export const renderMenu = (state: MenuState) => {
+  const { slots, slotProps } = getSlots(state, menuShorthandProps);
+  const { open, setOpen, onCheckedValueChange, checkedValues, defaultCheckedValues } = state;
+
+  return (
+    <MenuProvider
+      value={{ open, setOpen, onCheckedValueChange, checkedValues, defaultCheckedValues, hasMenuContext: true }}
+    >
+      <>
+        {state.menuTrigger}
+        {/** TODO use open state to control a real popup */}
+        {state.open && <slots.menuPopup {...slotProps.menuPopup} />}
+      </>
+    </MenuProvider>
+  );
+};

--- a/packages/react-menu/src/components/Menu/renderMenu.tsx
+++ b/packages/react-menu/src/components/Menu/renderMenu.tsx
@@ -16,11 +16,9 @@ export const renderMenu = (state: MenuState) => {
     <MenuProvider
       value={{ open, setOpen, onCheckedValueChange, checkedValues, defaultCheckedValues, hasMenuContext: true }}
     >
-      <>
-        {state.menuTrigger}
-        {/** TODO use open state to control a real popup */}
-        {state.open && <slots.menuPopup {...slotProps.menuPopup} />}
-      </>
+      {state.menuTrigger}
+      {/** TODO use open state to control a real popup */}
+      {state.open && <slots.menuPopup {...slotProps.menuPopup} />}
     </MenuProvider>
   );
 };

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps, useMergedRefs, useControllableValue } from '@fluentui/react-utilities';
 import { MenuProps, MenuState } from './Menu.types';
 import { MenuTrigger } from '../MenuTrigger/index';
-import { MenuList } from '../MenuList/index';
 
 export const menuShorthandProps: (keyof MenuProps)[] = ['menuPopup'];
 
@@ -42,9 +41,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   children.forEach(child => {
     if (child.type === MenuTrigger) {
       state.menuTrigger = child;
-    }
-
-    if (child.type === MenuList) {
+    } else {
       state.menuList = child;
     }
   });
@@ -54,10 +51,9 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   };
 
   const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
-  const { setOpen: setOpenProp } = state;
+  // TODO fix useControllableValue typing
   state.open = open !== undefined ? open : state.open;
   state.setOpen = (...args) => {
-    setOpenProp && setOpenProp(...args);
     setOpen(...args);
   };
 

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { makeMergeProps, resolveShorthandProps, useMergedRefs, useControllableValue } from '@fluentui/react-utilities';
+import { MenuProps, MenuState } from './Menu.types';
+import { MenuTrigger } from '../MenuTrigger/index';
+import { MenuList } from '../MenuList/index';
+
+export const menuShorthandProps: (keyof MenuProps)[] = ['menuPopup'];
+
+const mergeProps = makeMergeProps<MenuState>({ deepMerge: menuShorthandProps });
+
+/**
+ * Create the state required to render Menu.
+ *
+ * The returned state can be modified with hooks such as useMenuStyles,
+ * before being passed to renderMenu.
+ *
+ * @param props - props from this instance of Menu
+ * @param ref - reference to root HTMLElement of Menu
+ * @param defaultProps - (optional) default prop values provided by the implementing type
+ *
+ * {@docCategory Menu }
+ */
+export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuProps): MenuState => {
+  const state = mergeProps(
+    {
+      ref: useMergedRefs(ref, React.useRef(null)),
+      menuPopup: { as: 'div' },
+    },
+    defaultProps,
+    resolveShorthandProps(props, menuShorthandProps),
+  );
+
+  // TODO Better way to narrow types ?
+  const children = React.Children.toArray(state.children) as React.ReactElement[];
+
+  // TODO throw warnings in development safely
+  if (children.length !== 2) {
+    // eslint-disable-next-line no-console
+    console.warn('Menu can only take one MenuTrigger and one MenuList as children');
+  }
+
+  children.forEach(child => {
+    if (child.type === MenuTrigger) {
+      state.menuTrigger = child;
+    }
+
+    if (child.type === MenuList) {
+      state.menuList = child;
+    }
+  });
+
+  state.menuPopup.children = (Component, p) => {
+    return <Component {...p}> {state.menuList} </Component>;
+  };
+
+  const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
+  const { setOpen: setOpenProp } = state;
+  state.open = open !== undefined ? open : state.open;
+  state.setOpen = (...args) => {
+    setOpenProp && setOpenProp(...args);
+    setOpen(...args);
+  };
+
+  return state;
+};

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -53,9 +53,12 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
   // TODO fix useControllableValue typing
   state.open = open !== undefined ? open : state.open;
-  state.setOpen = (...args) => {
-    setOpen(...args);
-  };
+  state.setOpen = React.useCallback(
+    (...args) => {
+      setOpen(...args);
+    },
+    [setOpen],
+  );
 
   return state;
 };

--- a/packages/react-menu/src/components/Menu/useMenuStyles.ts
+++ b/packages/react-menu/src/components/Menu/useMenuStyles.ts
@@ -1,0 +1,30 @@
+import { makeStyles, ax } from '@fluentui/react-make-styles';
+import { MenuState } from './Menu.types';
+
+/**
+ * Styles for the popup slot
+ */
+const useMenuPopupStyles = makeStyles<MenuState>([
+  [
+    null,
+    theme => ({
+      backgroundColor: theme.alias.color.neutral.neutralBackground1,
+      minWidth: '128px',
+      minHeight: '48px',
+      maxWidth: '300px',
+      width: 'fit-content',
+      boxShadow: `${theme.alias.shadow.shadow16}`,
+      paddingTop: '4px',
+      paddingBottom: '4px',
+    }),
+  ],
+]);
+
+/**
+ * Apply styling to the Menu slots based on the state
+ * {@docCategory Menu }
+ */
+export const useMenuStyles = (state: MenuState): MenuState => {
+  state.menuPopup.className = ax(useMenuPopupStyles(state), state.menuPopup.className);
+  return state;
+};

--- a/packages/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuList.ts
@@ -8,6 +8,7 @@ import {
 } from '@fluentui/react-utilities';
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-focus-management';
 import { MenuListProps, MenuListState } from './MenuList.types';
+import { useMenuContext } from '../../menuContext';
 
 const mergeProps = makeMergeProps<MenuListState>();
 
@@ -21,12 +22,20 @@ export const useMenuList = (
 ): MenuListState => {
   const focusAttributes = useArrowNavigationGroup({ circular: true });
   const { findAllFocusable } = useFocusFinders();
+  const menuContext = useMenuContextSelectors();
+
+  if (usingPropsAndMenuContext(props, menuContext)) {
+    // TODO throw warnings in development safely
+    // eslint-disable-next-line no-console
+    console.warn('You are using both MenuList and Menu props, we recommend you to use Menu props when available');
+  }
 
   const state = mergeProps(
     {
       ref: useMergedRefs(ref, React.useRef(null)),
       role: 'menu',
       ...focusAttributes,
+      ...(menuContext.hasMenuContext && { ...menuContext }),
     },
     defaultProps,
     resolveShorthandProps(props, []),
@@ -99,4 +108,35 @@ export const useMenuList = (
   });
 
   return state;
+};
+
+/**
+ * Adds some sugar to fetching multiple context selector values
+ */
+const useMenuContextSelectors = () => {
+  const hasMenuContext = useMenuContext(context => context.hasMenuContext);
+  const checkedValues = useMenuContext(context => context.checkedValues);
+  const onCheckedValueChange = useMenuContext(context => context.onCheckedValueChange);
+  const defaultCheckedValues = useMenuContext(context => context.defaultCheckedValues);
+
+  return {
+    hasMenuContext,
+    checkedValues,
+    onCheckedValueChange,
+    defaultCheckedValues,
+  };
+};
+
+/**
+ * Helper function to detect if props and MenuContext values are both used
+ */
+const usingPropsAndMenuContext = (props: MenuListProps, contextValue: ReturnType<typeof useMenuContextSelectors>) => {
+  let isUsingPropsAndContext = false;
+  for (const val in contextValue) {
+    if (props[val as keyof Omit<typeof contextValue, 'hasMenuContext'>]) {
+      isUsingPropsAndContext = true;
+    }
+  }
+
+  return contextValue.hasMenuContext && isUsingPropsAndContext;
 };

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -6,8 +6,19 @@ import { isConformant } from '../../common/isConformant';
 
 describe('MenuTrigger', () => {
   isConformant({
+    disabledTests: [
+      'as-renders-html',
+      'as-renders-fc',
+      'component-handles-ref',
+      'component-has-root-ref',
+      'component-handles-classname',
+      'as-passes-as-value',
+    ],
     Component: MenuTrigger,
     displayName: 'MenuTrigger',
+    requiredProps: {
+      children: <button>MenuTrigger</button>,
+    },
   });
 
   let wrapper: ReactWrapper | undefined;

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { MenuTrigger } from './MenuTrigger';
+import * as renderer from 'react-test-renderer';
+import { ReactWrapper } from 'enzyme';
+import { isConformant } from '../../common/isConformant';
+
+describe('MenuTrigger', () => {
+  isConformant({
+    Component: MenuTrigger,
+    displayName: 'MenuTrigger',
+  });
+
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  /**
+   * Note: see more visual regression tests for MenuTrigger in /apps/vr-tests.
+   */
+  it('renders a default state', () => {
+    const component = renderer.create(<MenuTrigger>Default MenuTrigger</MenuTrigger>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -23,7 +23,11 @@ describe('MenuTrigger', () => {
    * Note: see more visual regression tests for MenuTrigger in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    const component = renderer.create(<MenuTrigger>Default MenuTrigger</MenuTrigger>);
+    const component = renderer.create(
+      <MenuTrigger>
+        <button>Menu trigger</button>
+      </MenuTrigger>,
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useMenuTrigger } from './useMenuTrigger';
+import { MenuTriggerProps } from './MenuTrigger.types';
+import { renderMenuTrigger } from './renderMenuTrigger';
+
+/**
+ * The MenuTrigger component wraps a potential trigger element as a child
+ * and adds the necessary event handling to open a popup menu
+ * {@docCategory MenuTrigger }
+ */
+export const MenuTrigger = React.forwardRef<HTMLElement, MenuTriggerProps>((props, ref) => {
+  const state = useMenuTrigger(props, ref);
+
+  return renderMenuTrigger(state);
+});
+
+MenuTrigger.displayName = 'MenuTrigger';

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
@@ -4,7 +4,7 @@ import { MenuTriggerProps } from './MenuTrigger.types';
 import { renderMenuTrigger } from './renderMenuTrigger';
 
 /**
- * The MenuTrigger component wraps a potential trigger element as a child
+ * Wraps a trigger element as an only child
  * and adds the necessary event handling to open a popup menu
  * {@docCategory MenuTrigger }
  */

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { ComponentProps } from '@fluentui/react-utilities';
 
 /**
  * {@docCategory MenuTrigger }
  */
-export interface MenuTriggerProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {}
+export interface MenuTriggerProps {
+  /**
+   * Explicitly require single child
+   */
+  children: React.ReactElement;
+}
 
 /**
  * {@docCategory MenuTrigger }

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ComponentProps } from '@fluentui/react-utilities';
+
+/**
+ * {@docCategory MenuTrigger }
+ */
+export interface MenuTriggerProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {}
+
+/**
+ * {@docCategory MenuTrigger }
+ */
+export interface MenuTriggerState extends MenuTriggerProps {
+  /**
+   * Ref to the root slot
+   */
+  ref: React.MutableRefObject<HTMLElement>;
+
+  /**
+   * Opens the popup
+   */
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}

--- a/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuTrigger renders a default state 1`] = `
+<button
+  onClick={[Function]}
+>
+  Menu trigger
+</button>
+`;

--- a/packages/react-menu/src/components/MenuTrigger/index.ts
+++ b/packages/react-menu/src/components/MenuTrigger/index.ts
@@ -1,0 +1,4 @@
+export * from './MenuTrigger';
+export * from './MenuTrigger.types';
+export * from './renderMenuTrigger';
+export * from './useMenuTrigger';

--- a/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { MenuTriggerState } from './MenuTrigger.types';
 
 /**
@@ -8,5 +7,5 @@ import { MenuTriggerState } from './MenuTrigger.types';
  * {@docCategory MenuTrigger }
  */
 export const renderMenuTrigger = (state: MenuTriggerState) => {
-  return <>{state.children}</>;
+  return state.children;
 };

--- a/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
@@ -1,0 +1,11 @@
+import { MenuTriggerState } from './MenuTrigger.types';
+
+/**
+ * Render the final JSX of MenuTrigger
+ *
+ * Only renders children
+ * {@docCategory MenuTrigger }
+ */
+export const renderMenuTrigger = (state: MenuTriggerState) => {
+  return state.children;
+};

--- a/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { MenuTriggerState } from './MenuTrigger.types';
 
 /**
@@ -7,5 +8,5 @@ import { MenuTriggerState } from './MenuTrigger.types';
  * {@docCategory MenuTrigger }
  */
 export const renderMenuTrigger = (state: MenuTriggerState) => {
-  return state.children;
+  return <>{state.children}</>;
 };

--- a/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
+import { useMenuContext, MenuContextValue } from '../../menuContext';
+
+export const menuTriggerShorthandProps: (keyof MenuTriggerProps)[] = [];
+
+const mergeProps = makeMergeProps<MenuTriggerState>({ deepMerge: menuTriggerShorthandProps });
+
+/**
+ * Create the state required to render MenuTrigger.
+ * Clones the only child component and adds necessary event handling behaviours to open a popup menu
+ *
+ * @param props - props from this instance of MenuTrigger
+ * @param ref - reference to root HTMLElement of MenuTrigger
+ * @param defaultProps - (optional) default prop values provided by the implementing type
+ *
+ * {@docCategory MenuTrigger }
+ */
+export const useMenuTrigger = (
+  props: MenuTriggerProps,
+  ref: React.Ref<HTMLElement>,
+  defaultProps?: MenuTriggerProps,
+): MenuTriggerState => {
+  const setOpen = useMenuContext(context => context.setOpen);
+
+  const state = mergeProps(
+    {
+      ref: useMergedRefs(ref, React.useRef(null)),
+    },
+    defaultProps,
+    resolveShorthandProps(props, menuTriggerShorthandProps),
+  );
+
+  state.setOpen = setOpen;
+
+  const child = React.Children.only(state.children);
+  state.children = React.cloneElement(child as React.ReactElement, getTriggerProps(state.setOpen));
+
+  return state;
+};
+
+// TODO this is quick 'n dirty, follow up and improve interactions
+const getTriggerProps = (setOpen: MenuContextValue['setOpen']) => {
+  const triggerProps: React.HTMLAttributes<HTMLElement> = {};
+  triggerProps.onClick = e => {
+    setOpen(s => !s);
+  };
+
+  return triggerProps;
+};

--- a/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -35,16 +35,18 @@ export const useMenuTrigger = (
   state.setOpen = setOpen;
 
   const child = React.Children.only(state.children);
-  state.children = React.cloneElement(child as React.ReactElement, getTriggerProps(state.setOpen));
+  state.children = React.cloneElement(child as React.ReactElement, getTriggerProps(state.setOpen, child.props));
 
   return state;
 };
 
 // TODO this is quick 'n dirty, follow up and improve interactions
-const getTriggerProps = (setOpen: MenuContextValue['setOpen']) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getTriggerProps = (setOpen: MenuContextValue['setOpen'], props: any) => {
   const triggerProps: React.HTMLAttributes<HTMLElement> = {};
   triggerProps.onClick = e => {
     setOpen(s => !s);
+    props.onClick(e);
   };
 
   return triggerProps;

--- a/packages/react-menu/src/index.ts
+++ b/packages/react-menu/src/index.ts
@@ -6,3 +6,5 @@ export * from './MenuDivider';
 export * from './MenuGroupHeader';
 export * from './MenuGroup';
 export * from './selectable/index';
+export * from './MenuTrigger';
+export * from './Menu';

--- a/packages/react-menu/src/menuContext.ts
+++ b/packages/react-menu/src/menuContext.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { createContext, useContextSelector, ContextSelector } from '@fluentui/react-context-selector';
+import { MenuListProps } from './components/index';
+
+const MenuContext = createContext<MenuContextValue>({
+  open: false,
+  setOpen: () => false,
+  checkedValues: {},
+  onCheckedValueChange: () => null,
+  defaultCheckedValues: {},
+  hasMenuContext: false,
+});
+
+/**
+ * Context shared between Menu and its children components
+ *
+ * Extends and drills down MenuList props to simplify API
+ */
+export interface MenuContextValue extends MenuListProps {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  hasMenuContext: boolean;
+}
+
+export const MenuProvider = MenuContext.Provider;
+
+export const useMenuContext = <T>(selector: ContextSelector<MenuContextValue, T>) =>
+  useContextSelector(MenuContext, selector);


### PR DESCRIPTION
Adds the Menu and MenuTrigger compoenents to render popup and
trigger element to control the popup

Menu renders a wrapper slot around expected `MenuList` for popup
positioning

MenuTrigger renders no DOM but clones an only child with correct popup
event handling

TODO before completing - add tests

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
