### PR TITLE
useIsomorphicLayout effect with useEventCallback

### DIFF
--- a/change/@fluentui-react-utilities-146f93a7-120e-4cc7-a12b-9541d23520e7.json
+++ b/change/@fluentui-react-utilities-146f93a7-120e-4cc7-a12b-9541d23520e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "useIsomorphicLayout effect with useEventCallback",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -180,6 +180,9 @@ export const useEventCallback: <Args extends unknown[], Return>(fn: (...args: Ar
 // @public
 export function useId(prefix?: string, providedId?: string): string;
 
+// @public (undocumented)
+export const useIsomorphicLayoutEffect: typeof React.useEffect;
+
 // @public
 export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T>;
 

--- a/packages/react-utilities/src/hooks/index.ts
+++ b/packages/react-utilities/src/hooks/index.ts
@@ -3,4 +3,5 @@ export * from './useConst';
 export * from './useControllableValue';
 export * from './useEventCallback';
 export { useId } from './useId';
+export * from './useIsomorphicLayoutEffect';
 export * from './useMergedRefs';

--- a/packages/react-utilities/src/hooks/useEventCallback.test.ts
+++ b/packages/react-utilities/src/hooks/useEventCallback.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useEventCallback } from './useEventCallback';
 
@@ -40,5 +41,19 @@ describe('useEventCallback', () => {
     expect(firstRender).toBe(secondRender);
     expect(firstRenderResult).toBe(2);
     expect(secondRenderResult).toBe(0);
+  });
+
+  it('should run before other layout effects', () => {
+    // Arrange
+    const useTestHook = () => {
+      const callback = useEventCallback(jest.fn());
+      React.useLayoutEffect(() => callback(), [callback]);
+    };
+
+    // Act
+    const { result } = renderHook(() => useTestHook());
+
+    // Assert
+    expect(result.error).toBeUndefined();
   });
 });

--- a/packages/react-utilities/src/hooks/useEventCallback.ts
+++ b/packages/react-utilities/src/hooks/useEventCallback.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
  * https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback
@@ -18,7 +19,7 @@ export const useEventCallback = <Args extends unknown[], Return>(fn: (...args: A
     throw new Error('Cannot call an event handler while rendering');
   });
 
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     callbackRef.current = fn;
   }, [fn]);
 

--- a/packages/react-utilities/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react-utilities/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+const isSSR =
+  typeof window === 'undefined' || /ServerSideRendering/.test(window.navigator && window.navigator.userAgent);
+
+// useLayoutEffect() produces a warning with SSR rendering
+// https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a
+export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect;


### PR DESCRIPTION
useEventCallback currently uses useEffect which is always run before a
useLayoutEfect call. The following situation is undesireable

```typescript
const useTestHook = () => {
  const callback = useEventCallback(() => null);
  // This will throw because useEffect has not assigned a callback ref yet !!
  React.useLayoutEffect(() => callback(), [callback])
}
```
Additionally adds a useIsomorphicLayoutEffect hook that is safe for SSR

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
