### PR TITLE
Add UnitTests to SwatchColorPicker

### DIFF
--- a/change/@fluentui-react-9e3c31a5-4815-4b5f-b078-c5ac063524de.json
+++ b/change/@fluentui-react-9e3c31a5-4815-4b5f-b078-c5ac063524de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add tests to swatch color picker",
+  "packageName": "@fluentui/react",
+  "email": "sareiff@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -109,4 +109,104 @@ describe('SwatchColorPicker', () => {
     );
     expect(onRenderColorCell).toHaveBeenCalledTimes(1);
   });
+
+  it('Can render the color picker when onRenderCell props is passed to swatch color picker ', () => {
+    const onRenderColorCell = jest.fn();
+    mount(
+      <SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} onRenderColorCell={onRenderColorCell} columnCount={4} />,
+    );
+    expect(onRenderColorCell).toHaveBeenCalledTimes(1);
+  });
+
+  it('Can set the selectedID ', () => {
+    const wrapper = mount(<SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} columnCount={4} selectedId={'a'} />);
+
+    const tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(1);
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+  });
+
+  it('Can clear the selectedID if isControlled', () => {
+    const props = {
+      colorCells: [DEFAULT_OPTIONS[0], DEFAULT_OPTIONS[1]],
+      columnCount: 4,
+      selectedId: 'a',
+    };
+    const wrapper = mount(<SwatchColorPicker {...props} />);
+
+    let tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(2);
+
+    // Verify initial id is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+    expect(
+      tableElements
+        .at(1)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+
+    // Update the props to set selected to undefined
+    wrapper.setProps({ ...props, selectedId: 'undefined' });
+
+    tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(2);
+
+    // Verify nothing is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+    expect(
+      tableElements
+        .at(1)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('false');
+  });
+
+  it('Can not clear the selectedID', () => {
+    const props = {
+      colorCells: DEFAULT_OPTIONS,
+      columnCount: 4,
+    };
+    const wrapper = mount(<SwatchColorPicker {...props} defaultSelectedId={'a'} />);
+
+    let tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(12);
+
+    // Verify initial id is selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+
+    // Update the props to set selected to undefined
+    wrapper.setProps({ ...props, selectedId: 'undefined' });
+
+    tableElements = findNodes(wrapper, '.ms-Button');
+    expect(tableElements.length).toEqual(12);
+
+    // Verify initial id is still selected
+    expect(
+      tableElements
+        .at(0)
+        .getDOMNode()
+        .getAttribute('aria-selected'),
+    ).toEqual('true');
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x ] Include a change request file using `$ yarn change`

#### Description of changes

With https://github.com/microsoft/fluentui/pull/17240 I am adding some behavior to the SwatchColorPicker that allows us to set the selectedId to be undefined. This behavior seems to already exist in master/V8 so I just ported over the same unit tests I added in V7 so that we ensure the behavior doesn't break.

#### Focus areas to test

(optional)
