### PR TITLE
Horizontal bar chart: Fix issue for Rounded value to 1 if less than 1% to appear in the chart

### DIFF
--- a/change/@uifabric-charting-5a633e21-bf66-4ef7-9e4c-f39d965c0b4c.json
+++ b/change/@uifabric-charting-5a633e21-bf66-4ef7-9e4c-f39d965c0b4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Horizontal bar chart: Fix issue for Rounded value to 1 if less than 1% to appear in the chart",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -256,6 +256,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
       value = (pointData / total) * 100;
       if (value < 0) {
         value = 0;
+      } else if (value < 1 && value !== 0) {
+        value = 1;
       }
       startingPoint.push(prevPosition);
       return (


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes
#### cherry-pick of https://github.com/microsoft/fluentui/pull/17292

Fix issue for Rounded value to 1 if less than 1% to appear in the chart - Horizontal bar chart

#### Focus areas to test

Horizontal bar chart

#### Before fix
![image](https://user-images.githubusercontent.com/20105532/110087420-a4aaa280-7db9-11eb-9c48-d07678700362.png)


#### After fix (If we have value less than 1 % - showing that as value =1)
![image](https://user-images.githubusercontent.com/20105532/110085137-bfc7e300-7db6-11eb-9852-aa7c73cfd9c6.png)

