### PR TITLE
Horizontal bar chart: Fix issue for Rounded value to 1 if less than 1% to appear in the chart 

### DIFF
--- a/change/@fluentui-react-charting-cb2cc5b0-5053-4102-8a45-75a0a1551d3e.json
+++ b/change/@fluentui-react-charting-cb2cc5b0-5053-4102-8a45-75a0a1551d3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Horizontal bar chart: Fix issue for Rounded value to 1 if less than 1% to appear in the chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -238,6 +238,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
       value = (pointData / total) * 100;
       if (value < 0) {
         value = 0;
+      } else if (value < 1 && value !== 0) {
+        value = 1;
       }
       startingPoint.push(prevPosition);
       return (


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix issue for Rounded value to 1 if less than 1% to appear in the chart - Horizontal bar chart

#### Focus areas to test

Horizontal bar chart

#### Before fix
![image](https://user-images.githubusercontent.com/20105532/110087202-5bf2e980-7db9-11eb-94c5-da7f0470850a.png)


#### After fix
![image](https://user-images.githubusercontent.com/20105532/110087164-51385480-7db9-11eb-95fc-aabb6eda77c2.png)


