### PR TITLE
useControllableValue: Support default value initializer, improve DX

### DIFF
--- a/change/@fluentui-react-utilities-b8776595-0f82-4a46-9b74-5df55bb8c4e7.json
+++ b/change/@fluentui-react-utilities-b8776595-0f82-4a46-9b74-5df55bb8c4e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "useControllableValue should behave natively",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -168,11 +168,13 @@ export interface UseBooleanCallbacks {
 // @public
 export function useConst<T>(initialValue: T | (() => T)): T;
 
+// Warning: (ae-forgotten-export) The symbol "DefaultValue" needs to be exported by the entry point index.d.ts
+//
 // @public
-export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>): Readonly<[TValue, (update: React.SetStateAction<TValue>) => void]>;
 
 // @public (undocumented)
-export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: ChangeCallback<TElement, TValue, TEvent> | undefined): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>, onChange: ChangeCallback<TElement, TValue, TEvent>): Readonly<[TValue, (update: React.SetStateAction<TValue>, ev?: React.FormEvent<TElement>) => void]>;
 
 // @public
 export const useEventCallback: <Args extends unknown[], Return>(fn: (...args: Args) => Return) => (...args: Args) => Return;

--- a/packages/react-utilities/src/hooks/useControllableValue.test.tsx
+++ b/packages/react-utilities/src/hooks/useControllableValue.test.tsx
@@ -81,7 +81,9 @@ describe('useControllableValue', () => {
     expect(result.current[0]).toBe(second);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
-      'A component is changing an uncontrolled value to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
+      expect.stringContaining(
+        'A component is changing an uncontrolled value to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
+      ),
     );
   });
 });

--- a/packages/react-utilities/src/hooks/useControllableValue.test.tsx
+++ b/packages/react-utilities/src/hooks/useControllableValue.test.tsx
@@ -67,23 +67,19 @@ describe('useControllableValue', () => {
   });
 
   it.each([
-    ['controlled to uncontrolled', 'hello', undefined],
-    ['uncontrolled to controlled', undefined, 'hello'],
-  ])('wans when switching from %s', (_, first, second) => {
+    ['a controlled value to be uncontrolled', 'defined to an undefined', 'hello', undefined],
+    ['an uncontrolled value to be controlled', 'undefined to a defined', undefined, 'hello'],
+  ])('warns when switching from %s', (controlWarning, undefinedWarning, first, second) => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     let value: string | undefined = first;
-    const { result, rerender } = renderHook(() => useControllableValue(value, undefined));
+    const { rerender } = renderHook(() => useControllableValue(value, undefined));
 
     value = second;
     rerender();
 
-    expect(result.current[0]).toBe(second);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'A component is changing an uncontrolled value to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
-      ),
-    );
+    const expectedWarning = `A component is changing ${controlWarning}. This is likely caused by the value changing from ${undefinedWarning} value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components`;
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(expectedWarning));
   });
 });

--- a/packages/react-utilities/src/hooks/useControllableValue.test.tsx
+++ b/packages/react-utilities/src/hooks/useControllableValue.test.tsx
@@ -2,6 +2,8 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useControllableValue } from './useControllableValue';
 
 describe('useControllableValue', () => {
+  afterEach(jest.resetAllMocks);
+
   it('respects controlled value', () => {
     let value: boolean;
     let defaultValue: boolean | undefined;
@@ -24,8 +26,11 @@ describe('useControllableValue', () => {
     expect(result.current[0]).toBe(true);
   });
 
-  it('uses the default value if no controlled value is provided', () => {
-    const { result } = renderHook(() => useControllableValue(undefined, true));
+  it.each([
+    ['', true],
+    ['factory', () => true],
+  ])('uses the default value %s if no controlled value is provided', (_, defaultValue) => {
+    const { result } = renderHook(() => useControllableValue(undefined, defaultValue));
     expect(result.current[0]).toBe(true);
   });
 
@@ -59,5 +64,24 @@ describe('useControllableValue', () => {
     rerender();
 
     expect(result.current[1]).toEqual(firstResult[1]);
+  });
+
+  it.each([
+    ['controlled to uncontrolled', 'hello', undefined],
+    ['uncontrolled to controlled', undefined, 'hello'],
+  ])('wans when switching from %s', (_, first, second) => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let value: string | undefined = first;
+    const { result, rerender } = renderHook(() => useControllableValue(value, undefined));
+
+    value = second;
+    rerender();
+
+    expect(result.current[0]).toBe(second);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      'A component is changing an uncontrolled value to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components',
+    );
   });
 });

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -91,6 +91,8 @@ const useIsControlled = <TValue>(controlledValue: TValue) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       if (wasControlledRef.current !== (controlledValue !== undefined)) {
+        const error = new Error();
+
         // eslint-disable-next-line no-console
         console.error(
           [
@@ -99,6 +101,7 @@ const useIsControlled = <TValue>(controlledValue: TValue) => {
             'changing from undefined to a defined value, which should not happen.',
             'Decide between using a controlled or uncontrolled input element for the lifetime of the component.',
             'More info: https://reactjs.org/link/controlled-components',
+            error.stack,
           ].join(' '),
         );
       }

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -57,15 +57,18 @@ export function useControllableValue<
     valueRef.current = currentValue;
     onChangeRef.current = onChange;
   });
+
   // To match the behavior of the setter returned by React.useState, this callback's identity
   // should never change. This means it MUST NOT directly reference variables that can change.
   const setValueOrCallOnChange = useConst(() => (update: React.SetStateAction<TValue | undefined>, ev?: TEvent) => {
     // Assuming here that TValue is not a function, because a controllable value will typically
     // be something a user can enter as input
     const newValue = typeof update === 'function' ? (update as Function)(valueRef.current) : update;
+
     if (onChangeRef.current) {
       onChangeRef.current(ev!, newValue);
     }
+
     if (!isControlled) {
       setValue(newValue);
     }

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -7,6 +7,9 @@ export type ChangeCallback<
   TEvent extends React.SyntheticEvent<TElement> | undefined
 > = (ev: TEvent, newValue: TValue | undefined) => void;
 
+/**
+ * Default value can be a value or an initializer
+ */
 type DefaultValue<TValue> = TValue | (() => TValue);
 
 /**


### PR DESCRIPTION
* Retains existing behaviour where controlled/uncontrolled is decided on initial render but logs a warning when this changes
* Allow factory for defaultValue similar to `useState`
* Remove undefined types since values are generic anyway

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
