### PR TITLE
Still trigger deprecated `onChanged` property of Toggle

### DIFF
--- a/change/@fluentui-react-dbda8e69-21d6-41e3-8492-e871d9c396f4.json
+++ b/change/@fluentui-react-dbda8e69-21d6-41e3-8492-e871d9c396f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Still trigger deprecated `onChanged` property of Toggle until it is removed",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -25,6 +25,8 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
       // eslint-disable-next-line deprecation/deprecation
       onAriaLabel,
       onChange,
+      // eslint-disable-next-line deprecation/deprecation
+      onChanged,
       onClick: onToggleClick,
       onText,
       role,
@@ -32,7 +34,17 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
       theme,
     } = props;
 
-    const [checked, setChecked] = useControllableValue(controlledChecked, defaultChecked, onChange);
+    const [checked, setChecked] = useControllableValue(
+      controlledChecked,
+      defaultChecked,
+      React.useCallback(
+        (ev, isChecked) => {
+          onChange?.(ev, isChecked);
+          onChanged?.(isChecked);
+        },
+        [onChange, onChanged],
+      ),
+    );
 
     const classNames = getClassNames(styles!, {
       theme: theme!,

--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -38,7 +38,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
       controlledChecked,
       defaultChecked,
       React.useCallback(
-        (ev, isChecked) => {
+        (ev: React.MouseEvent<HTMLElement>, isChecked: boolean) => {
           onChange?.(ev, isChecked);
           onChanged?.(isChecked);
         },


### PR DESCRIPTION
The `onChanged` property of `Toggle` is deprecated, but still exists in the typings. However, nothing in code was actually triggering the callback, which can cause regressions that are not caught at build time.

#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

