### PR TITLE
RFC: Standard package output folders

### DIFF
--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -18,7 +18,7 @@ We should avoid output folder changes occuring simply because we output less for
 
 ## Detailed Design or Proposal
 
-Proposed standard folders in a published JavaScript package (does not imply they will all be present - only applicable output folders will be present):
+Proposed standard folders in a published JavaScript package (only applicable output folders would be present):
 
 - `lib` - esm
 - `lib-commonjs` - commonjs

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -14,32 +14,30 @@ This is one of those small details that other partners will emulate and adopt. I
 
 ## Problem statement
 
-Without having a standard output folder locations within an npm package, the content is a harder to predict. Structuring our packages in a consistent way reducees friction in understanding what a package contains and what's is missing.
+Today, `lib` contains esm JavaScript output, except for node-only packages which drop CommonJS modules in them. This obfuscates what `lib` actually contains. We should have some standards and stick to patterns which add clarity to what output format is used.
 
 ## Detailed Design or Proposal
 
-Proposed standard output folders in a published JavaScript package (only applicable output folders would be present):
+We've historically used the following standard output folders in a published JavaScript package (only applicable output folders would be present):
 
 - `lib` - esm (as we've had for a long time)
 - `lib-commonjs` - commonjs (only needed while Node <= 13.2.0 is supported)
 - `lib-amd` - amd (hopefully we can drop someday)
 - `dist` - bundles and static content
 
-Examples:
-
-A node library like `jest-serializer-merge-styles` which only requires CommonJS would only have `lib-commonjs` output folder. Later when we want to switch to only ESM, we'd only have a `lib` output folder.
+If this seems reasonable to folks, we should just stick with this and stay consistent. If a library needs to output CommonJS, it should go inthe `lib-commonjs` folder.
 
 A library like `react-button` which might be consumed by Node and bundlers likely will need both ESM and CommonJS, until Node 13.2.0 or greater is the minimum requirement. Its output will have both a `lib` and `lib-commonjs` folder.
 
-If in the future, we wanted to include processed TypeScript output, perhaps we'd add a `lib-ts` to the mix.
+Once 13.2.0 becomes the minimum Node requirement, there is little reason to build CommonJS at all, and I anticipate we'll be removing that folder.
 
 ### Pros and Cons
 
 #### Pros
 
 - Almost no difference from what we currently have - only the `build:commonjs-only` task needs to be modified to output to `lib-commonjs`.
-- Our partners won't really notice changes here at all, since this has been the convention we've used for a long time.
-- ESM is becoming the standard that all platforms will snap to, hence why `lib` and not `lib-esm`
+- Our partners won't really notice changes here at all, since this has been the convention we've used for a long time for nearly all the packages currently being consumed.
+- ESM is becoming the standard that all platforms will snap to, hence why `lib` and not `lib-esm`.
 - Changes in output won't change the folder structure
 - Unchanging folder structures mean that full builds are required less
 - End users can predict which folders contain what format

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -14,7 +14,7 @@ This is one of those small details that other partners will emulate and adopt. I
 
 ## Problem statement
 
-Today, `lib` contains esm JavaScript output, except for node-only packages which drop CommonJS modules in them. This obfuscates what `lib` actually contains. We should have some standards and stick to patterns which add clarity to what output format is used.
+Today, `lib` contains esm JavaScript output, except for node-only packages which will drop CommonJS modules in them. This obfuscates what `lib` actually contains. We should adopt standards which add clarity to what output format is used.
 
 ## Detailed Design or Proposal
 

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -10,7 +10,7 @@ There are multiple javascript formats we may include in our npm packages: `commo
 
 We should adopt a predictable folder structure within the published npm package for these formats. That way consumers of our packages can know exactly where things are and which folders have what things in as few steps as possible.
 
-This is one of those small details that other partners will emulate and adopt. If we can be consistent, many packages exported by Microsoft will likely follow guidance because it is really minutia, but ends up adding to more predictability at scale.
+This is one of those small details that other partners will emulate and adopt. If we can be consistent, many packages exported by our partners will likely follow guidance because it is really minutia, but ends up adding to more predictability at scale.
 
 ## Problem statement
 

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -20,12 +20,12 @@ Today, `lib` contains esm JavaScript output, except for node-only packages which
 
 We've historically used the following standard output folders in a published JavaScript package (only applicable output folders would be present):
 
-- `lib` - esm (as we've had for a long time)
-- `lib-commonjs` - commonjs (only needed while Node <= 13.2.0 is supported)
-- `lib-amd` - amd (hopefully we can drop someday)
-- `dist` - bundles and static content
+- `/lib` - esm (as we've had for a long time)
+- `/lib-commonjs` - commonjs (only needed while Node <= 13.2.0 is supported)
+- `/lib-amd` - amd (hopefully we can drop someday)
+- `/dist` - bundles and static content
 
-If this seems reasonable to folks, we should just stick with this and stay consistent. If a library needs to output CommonJS, it should go inthe `lib-commonjs` folder.
+If this seems reasonable, we should adopt and stay consistent to stay predictable to consumers. If a library needs to output CommonJS, it should be output within the `lib-commonjs` folder.
 
 A library like `react-button` which might be consumed by Node and bundlers likely will need both ESM and CommonJS, until Node 13.2.0 or greater is the minimum requirement. Its output will have both a `lib` and `lib-commonjs` folder.
 
@@ -52,12 +52,10 @@ Once 13.2.0 becomes the minimum Node requirement, there is little reason to buil
 
 Many libraries in OSS have kept `lib` representing CommonJS and have added `es` to the mix as the folder for containing esm. This is very likely because they've existed for a while and didn't want to change their existing folder structure. We could also consider this convention. React itself avoids `lib` and explicitly uses `cjs` to indicate the output format. (It also has no ESM flavor.)
 
-#### Alternative proposal:
-
-* `cjs` - CommonJS
-* `es` - esm
-* `amd` - amd
-* `dist` - statics and bundles
+* `/cjs` - CommonJS
+* `/es` - esm
+* `/amd` - amd
+* `/dist` - statics and bundles
 
 #### Pros:
 
@@ -85,3 +83,4 @@ Many libraries in OSS have kept `lib` representing CommonJS and have added `es` 
 ## Discarded Solutions
 
 The current solution of using `lib` for either CommonJS or ESM depending on which platforms are (currently) supported should be replaced with something that doesn't mean different things in different contexts.
+

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -1,0 +1,43 @@
+# RFC: Standard package output folders
+
+---
+
+_List contributors to the proposal: @dzearing_
+
+## Summary
+
+There are multiple javascript formats we may include in our npm packages: `commonjs`, `esm`, and `amd`, in addition to static assets like pre-made bundles and images.
+
+We should adopt a predictable folder structure within the published npm package for these formats. That way consumers of our packages can know exactly where things are and which folders have what things in as few steps as possible.
+
+## Problem statement
+
+Recently a change to a library to use the `build:commonjs-only` build step changed the `commonjs` output folder from `lib-commonjs` to `lib`. This in turn caused a partner to hit friction because on syncing the change, their `lib` folder still had `esm`. In debugging why they hit this, developers unfamiliar with the change didn't know why the package.json `main` entry was changed to `lib` and had to hunt down if the change was intentional or not.
+
+We should avoid output folder changes occuring simply because we output less formats. There is no need for additional friction for end users when simply having some standards here can avoid confusion.
+
+## Detailed Design or Proposal
+
+Proposed standard folders in a published package (does not imply they will all be present - only applicable output folders will be present):
+
+`lib` - esm
+`lib-commonjs` - commonjs
+`lib-amd` - amd
+`dist` - bundles and static content
+
+### Pros and Cons
+
+#### Pros
+
+- ESM is becoming the standard that all platforms will snap to, hence why `lib` and not `lib-esm`
+- Changes in output won't change the folder structure
+- Unchanging folder structures mean that full builds are required less
+- End users can predict which folders contain what format
+
+#### Cons
+
+None that I see
+
+## Discarded Solutions
+
+The current solution of "use `lib` for commonjs if that's the only output flavor" should be discarded. It creates unpredictability and changes expectations as soon as we move the library to esm.

--- a/rfcs/build-system/02_standard_package_output_folders.md
+++ b/rfcs/build-system/02_standard_package_output_folders.md
@@ -18,12 +18,12 @@ We should avoid output folder changes occuring simply because we output less for
 
 ## Detailed Design or Proposal
 
-Proposed standard folders in a published package (does not imply they will all be present - only applicable output folders will be present):
+Proposed standard folders in a published JavaScript package (does not imply they will all be present - only applicable output folders will be present):
 
-`lib` - esm
-`lib-commonjs` - commonjs
-`lib-amd` - amd
-`dist` - bundles and static content
+- `lib` - esm
+- `lib-commonjs` - commonjs
+- `lib-amd` - amd
+- `dist` - bundles and static content
 
 ### Pros and Cons
 
@@ -33,11 +33,13 @@ Proposed standard folders in a published package (does not imply they will all b
 - Changes in output won't change the folder structure
 - Unchanging folder structures mean that full builds are required less
 - End users can predict which folders contain what format
+- Scalable. If we need other formats in our JS packages, we can update add more formats.
+- `CommonJS` was the standard of the past. More and more, modern node libraries will be moving to ESM as Node 13.2.0+ now supports it. I anticipate this format to phase out over the next few years as AMD has.
 
 #### Cons
 
-None that I see
+No obvious cons.
 
 ## Discarded Solutions
 
-The current solution of "use `lib` for commonjs if that's the only output flavor" should be discarded. It creates unpredictability and changes expectations as soon as we move the library to esm.
+The current solution of "use `lib` folder for `commonjs` format javascript if that's the only output flavor" should be discarded. It creates unpredictability and changes expectations as soon as we move the library to esm.


### PR DESCRIPTION
Standardize javascript package output folders for better predictability and clarity over what folder contains what format.

* `lib/*` - ESM
* `lib-commonjs/*` - CommonJS
* `lib-amd/*` - AMD
* `dist/*` - bundles and static content

This isn't really a change from what we have, except for projects built with the `build:commonJSOnly` task (wasn't being used until recently) which drops commonjs in `lib` (probably by accident, because we didn't document the convention.) For everything else this has been the convention with the Just tooling, and with the web-build-tools tooling prior to that. The last time we changed it was when ESM became officially supported.

I did include an alternative that seems a little more inline with the output folder naming of a few OSS libraries, but I don't think the work involved and potential for impact on customers merits major deviation. It creates unexpected confusion when we shift the package structure.

Recent conversation with @ecraig12345 and @JustSlone led to formalizing this detail as an RFC.
