### PR TITLE
fix(react/Button): remove aria-owns for menu buttons

### DIFF
--- a/change/@fluentui-react-42828047-89ff-48ca-a6c2-34faa6c88c6a.json
+++ b/change/@fluentui-react-42828047-89ff-48ca-a6c2-34faa6c88c6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switch menu buttton to aria-controls to remove nesting",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-218fa268-2a2e-437f-a9b3-c1d47273491e.json
+++ b/change/@fluentui-react-examples-218fa268-2a2e-437f-a9b3-c1d47273491e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update snapshots for button with menu",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-31c91f40-99ca-4492-a1f1-b005e7161977.json
+++ b/change/@fluentui-react-tabs-31c91f40-99ca-4492-a1f1-b005e7161977.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot changes for menu button",
+  "packageName": "@fluentui/react-tabs",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
@@ -1464,9 +1464,9 @@ Array [
           </span>
         </button>
         <button
+          aria-controls={null}
           aria-expanded={false}
           aria-haspopup={true}
-          aria-owns={null}
           className=
               ms-Button
               ms-Button--action

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -920,10 +920,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 0
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -1459,10 +1459,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 1
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -1998,10 +1998,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 2
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -2537,10 +2537,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 3
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -3076,10 +3076,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 4
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -3615,10 +3615,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 5
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -4154,10 +4154,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 6
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -4693,10 +4693,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 7
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -5232,10 +5232,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 8
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon
@@ -5771,10 +5771,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           <div>
                             Item 9
                             <button
+                              aria-controls={null}
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Show actions"
-                              aria-owns={null}
                               className=
                                   ms-Button
                                   ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -104,10 +104,10 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
               >
                 <button
+                  aria-controls={null}
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="More links"
-                  aria-owns={null}
                   className=
                       ms-Button
                       ms-Button--icon
@@ -1958,10 +1958,10 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
               >
                 <button
+                  aria-controls={null}
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="More links"
-                  aria-owns={null}
                   className=
                       ms-Button
                       ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -1097,10 +1097,10 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     }
               >
                 <button
+                  aria-controls={null}
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="More links"
-                  aria-owns={null}
                   className=
                       ms-Button
                       ms-Button--icon
@@ -1949,10 +1949,10 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     }
               >
                 <button
+                  aria-controls={null}
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="More links"
-                  aria-owns={null}
                   className=
                       ms-Button
                       ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -80,10 +80,10 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     }
               >
                 <button
+                  aria-controls={null}
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="More items"
-                  aria-owns={null}
                   className=
                       ms-Button
                       ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/Button.Command.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Command.Example.tsx.shot
@@ -2,9 +2,9 @@
 
 exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
 <button
+  aria-controls={null}
   aria-expanded={false}
   aria-haspopup={true}
-  aria-owns={null}
   className=
       ms-Button
       ms-Button--action

--- a/packages/react-examples/src/react/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -23,9 +23,9 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
       }
 >
   <button
+    aria-controls={null}
     aria-expanded={false}
     aria-haspopup={true}
-    aria-owns={null}
     className=
         ms-Button
         ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/Button.ContextualMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.ContextualMenu.Example.tsx.shot
@@ -2,9 +2,9 @@
 
 exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 1`] = `
 <button
+  aria-controls={null}
   aria-expanded={false}
   aria-haspopup={true}
-  aria-owns={null}
   className=
       ms-Button
       ms-Button--default

--- a/packages/react-examples/src/react/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Icon.Example.tsx.shot
@@ -152,10 +152,10 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
       </span>
     </button>
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
       aria-label="Emoji"
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -69,9 +69,9 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -829,10 +829,10 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="More commands"
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -68,9 +68,9 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 }
           >
             <button
+              aria-controls={null}
               aria-expanded={false}
               aria-haspopup={true}
-              aria-owns={null}
               className=
                   ms-Button
                   ms-Button--commandBar
@@ -832,10 +832,10 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 }
           >
             <button
+              aria-controls={null}
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="More commands"
-              aria-owns={null}
               className=
                   ms-Button
                   ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
@@ -211,9 +211,9 @@ exports[`Component Examples renders CommandBar.Lazy.Example.tsx correctly 1`] = 
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -433,9 +433,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -296,10 +296,10 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
       </span>
     </button>
     <button
+      aria-controls={null}
       aria-describedby="ktp-layer-id ktp-2-a"
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--default

--- a/packages/react-examples/src/react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -445,10 +445,10 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 }
           >
             <button
+              aria-controls={null}
               aria-describedby="ktp-layer-id ktp-l-k"
               aria-expanded={false}
               aria-haspopup={true}
-              aria-owns={null}
               className=
                   ms-Button
                   ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Overflow.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Overflow.Example.tsx.shot
@@ -455,10 +455,10 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
           }
     >
       <button
+        aria-controls={null}
         aria-describedby="ktp-layer-id ktp-r"
         aria-expanded={false}
         aria-haspopup={true}
-        aria-owns={null}
         className=
             ms-Button
             ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -277,9 +277,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
         }
   >
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -22,9 +22,9 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
         }
   >
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--icon

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -191,9 +191,9 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         }
   >
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--commandBar
@@ -763,10 +763,10 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         }
   >
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
       aria-label="More items"
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -530,10 +530,10 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       onMouseLeave={[Function]}
     >
       <button
+        aria-controls={null}
         aria-expanded={false}
         aria-haspopup={true}
         aria-label="More items"
-        aria-owns={null}
         className=
             ms-Button
             ms-Button--commandBar

--- a/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
@@ -1993,9 +1993,9 @@ Array [
           </span>
         </button>
         <button
+          aria-controls={null}
           aria-expanded={false}
           aria-haspopup={true}
-          aria-owns={null}
           className=
               ms-Button
               ms-Button--action

--- a/packages/react-tabs/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-tabs/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -1733,9 +1733,9 @@ exports[`Tabs renders Tabs with overflow 1`] = `
       </span>
     </button>
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--action

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -72,9 +72,9 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--icon
@@ -1263,9 +1263,9 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--icon
@@ -1495,9 +1495,9 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--icon
@@ -1727,9 +1727,9 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--icon
@@ -2226,9 +2226,9 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                   }
             >
               <button
+                aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-owns={null}
                 className=
                     ms-Button
                     ms-Button--icon

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -254,7 +254,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     } else if (this.props.menuProps) {
       assign(buttonProps, {
         'aria-expanded': !menuHidden,
-        'aria-owns': !menuHidden ? this._labelId + '-menu' : null,
+        'aria-controls': !menuHidden ? this._labelId + '-menu' : null,
         'aria-haspopup': true,
       });
     }

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -978,7 +978,7 @@ describe('Button', () => {
         ReactTestUtils.Simulate.click(button);
 
         // get the menu id from the button's aria attribute
-        const menuId = button.getAttribute('aria-owns');
+        const menuId = button.getAttribute('aria-controls');
         expect(menuId).toBeTruthy();
 
         const menuDOM = button.ownerDocument!.getElementById(menuId as string);
@@ -1042,7 +1042,7 @@ describe('Button', () => {
         ReactTestUtils.Simulate.click(button);
 
         // get the menu id from the button's aria attribute
-        const menuId = button.getAttribute('aria-owns');
+        const menuId = button.getAttribute('aria-controls');
         expect(menuId).toBeTruthy();
 
         const contextualMenuElement = button.ownerDocument!.getElementById(menuId as string);

--- a/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -125,9 +125,9 @@ exports[`Button renders ActionButton correctly 1`] = `
 
 exports[`Button renders CommandBarButton correctly 1`] = `
 <button
+  aria-controls={null}
   aria-expanded={false}
   aria-haspopup={true}
-  aria-owns={null}
   className=
       ms-Button
       ms-Button--commandBar

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present in DOM when hidden (snapshot) 1`] = `
 <button
+  aria-controls={null}
   aria-expanded={false}
   aria-haspopup={true}
-  aria-owns={null}
   className=
       ms-Button
       ms-Button--default

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1733,9 +1733,9 @@ exports[`Pivot renders Pivot with overflow 1`] = `
       </span>
     </button>
     <button
+      aria-controls={null}
       aria-expanded={false}
       aria-haspopup={true}
-      aria-owns={null}
       className=
           ms-Button
           ms-Button--action


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Related to #17266: does the same fix, but for buttons.

As a summary, buttons generally shouldn't contain anything but presentational nodes and text. While this isn't being flagged because it's using aria-owns instead of DOM nesting, it's still safest to remove `aria-owns`.

#### Focus areas to test

Button + ContextualMenu
