### PR TITLE
Fix format --since in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,11 +37,13 @@ jobs:
           yarn prelint
         displayName: prelint (satisfied, syncpack, lint-files)
 
-      ## Only check formatting in PR (it's less important to check formatting of all files in CI)
       - script: |
-          yarn format --since $(targetBranch) --check
+          if [[ -n "$(targetBranch)" ]]; then
+            yarn format --since $(targetBranch) --check
+          else
+            yarn format --all --check
+          fi
         displayName: check formatting
-        condition: variables.isPR
 
       ## Danger.js checks for Fluent UI N*
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
 
       - task: Bash@3
         inputs:
-          inputs:
           filePath: yarn-ci.sh
         displayName: yarn
 
@@ -33,11 +32,16 @@ jobs:
           yarn checkchange
         displayName: check change
 
-      ## manually call this since lage is now used and it calls lint per package, not per repo
+      ## Manually call prelint since lage calls lint per package, not per repo
       - script: |
-          yarn prelint &&
+          yarn prelint
+        displayName: prelint (satisfied, syncpack, lint-files)
+
+      ## Only check formatting in PR (it's less important to check formatting of all files in CI)
+      - script: |
           yarn format --since $(targetBranch) --check
-        displayName: do syncpack, lint-files, and prettier checks
+        displayName: check formatting
+        condition: variables.isPR
 
       ## Danger.js checks for Fluent UI N*
       - script: |


### PR DESCRIPTION
#17281 broke the "do syncpack, lint-files, and prettier checks" step in master builds since `$(targetBranch)` isn't set there and the `--since` arg is now required/strict.

~~The simplest workaround (implemented here) is to just not check formatting in master builds.~~
EDIT: Updated to check all files in master builds. This is slower but the speed of this build is less important.

Other alternatives (which we could change to in the future if desired):
- ~~Check all files: thorough, but adds probably ~3 minutes to build~~ *now implemented*
- Disable check in master: fast, less validation
- Check since `HEAD~1`: fast, but if a formatting error is introduced and then another PR is merged after that, the build would appear to "recover" when in fact things are still in a bad state
- Check since `HEAD~10` or some other arbitrary number: decent balance of options above