### PR TITLE
PeoplePicker: Fixing the need to press backspace key twice when removing multiple items

### DIFF
--- a/change/@fluentui-react-b1f77879-fd67-4aab-8b92-37195dbd2aa3.json
+++ b/change/@fluentui-react-b1f77879-fd67-4aab-8b92-37195dbd2aa3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "PeoplePicker: Fixing the need to press backspace key twice when removing multiple items.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
@@ -114,7 +114,6 @@ export interface IContextualMenuItemWrapperProps extends React.ClassAttributes<I
    * Callback to get the subMenu ID for an IContextualMenuItem.
    * @deprecated ID relationship between a menu button and menu isn't necessary
    */
-  // eslint-disable-next-line deprecation/deprecation
   getSubMenuId?: (item: IContextualMenuItem) => string | undefined;
 
   /**

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -164,7 +164,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
         // Reset focus and selection so that selected item stays in sync if something
         // has been removed
         if (this.state.items.length < oldState.items.length) {
-          this.selection.setIndexSelected(currentSelectedIndex, true, true);
+          this.selection.setIndexSelected(currentSelectedIndex, false, true);
           this.resetFocus(currentSelectedIndex);
         }
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17081
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was an issue where when having multiple items on a `PeoplePicker` removing more than one via the use of backspace resulted in having to press backspace twice after the first item. This was caused because we were setting the selected indices after deleting in such a way that `Selection` was being left with an exempted items count of 1. This in turn caused the `PeoplePicker` to think that there was a selected item though there wasn't any, which in turn caused the first backspace to be eaten.