### PR TITLE
adding mouse events single data point

### DIFF
--- a/change/@fluentui-react-charting-89fde89e-fad8-418f-b7e1-287a9147d984.json
+++ b/change/@fluentui-react-charting-89fde89e-fad8-418f-b7e1-287a9147d984.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added mouse events to the single data point",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-c30c7b58-00ac-4b50-b568-780f06f98de0.json
+++ b/change/@fluentui-react-examples-c30c7b58-00ac-4b50-b568-780f06f98de0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added example to support changes",
+  "packageName": "@fluentui/react-examples",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -474,17 +474,26 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     for (let i = 0; i < this._points.length; i++) {
       const legendVal: string = this._points[i].legend;
       const lineColor: string = this._points[i].color;
+      const { activePoint } = this.state;
+      const { theme } = this.props;
       if (this._points[i].data.length === 1) {
         const x1 = this._points[i].data[0].x;
         const y1 = this._points[i].data[0].y;
+        const xAxisCalloutData = this._points[i].data[0].xAxisCalloutData;
+        const circleId = `${this._circleId}${i}`;
         lines.push(
           <circle
             id={`${this._circleId}${i}`}
             key={`${this._circleId}${i}`}
-            r={3.5}
+            r={activePoint === circleId ? 5.5 : 3.5}
             cx={this._xAxisScale(x1)}
             cy={this._yAxisScale(y1)}
-            fill={lineColor}
+            fill={activePoint === circleId ? theme!.palette.white : lineColor}
+            onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+            onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+            onMouseOut={this._handleMouseOut}
+            strokeWidth={activePoint === circleId ? 2 : 0}
+            stroke={activePoint === circleId ? lineColor : ''}
           />,
         );
       }

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -123,6 +123,16 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
           ],
           color: DefaultPalette.green,
         },
+        {
+          legend: 'single point',
+          data: [
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 282000,
+            },
+          ],
+          color: DefaultPalette.yellow,
+        },
       ],
     };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17310
- [x] Include a change request file using `$ yarn change`

#### Description of changes

adding mouse events to single data point in the linechart so from know onwards user can see the callout data when hovered over the point

#### Focus areas to test
line chart

**after fix**
![image](https://user-images.githubusercontent.com/33802398/110292858-da4ac800-8013-11eb-9068-60cef2bf4d06.png)

