### PR TITLE
User/v sivsar/bacompadd mouse event topoint

### DIFF
--- a/change/@fluentui-react-examples-95ebab76-a281-4435-be81-a6cc8e0a4441.json
+++ b/change/@fluentui-react-examples-95ebab76-a281-4435-be81-a6cc8e0a4441.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding changes to support fixes",
+  "packageName": "@fluentui/react-examples",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-f9e3031f-6a7d-4e25-bb74-66ba30390ac8.json
+++ b/change/@uifabric-charting-f9e3031f-6a7d-4e25-bb74-66ba30390ac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding mouse events single data point, backward compatible",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -473,17 +473,26 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     for (let i = 0; i < this._points.length; i++) {
       const legendVal: string = this._points[i].legend;
       const lineColor: string = this._points[i].color;
+      const { activePoint } = this.state;
+      const { theme } = this.props;
       if (this._points[i].data.length === 1) {
         const x1 = this._points[i].data[0].x;
         const y1 = this._points[i].data[0].y;
+        const xAxisCalloutData = this._points[i].data[0].xAxisCalloutData;
+        const circleId = `${this._circleId}${i}`;
         lines.push(
           <circle
             id={`${this._circleId}${i}`}
             key={`${this._circleId}${i}`}
-            r={3.5}
+            r={activePoint === circleId ? 5.5 : 3.5}
             cx={this._xAxisScale(x1)}
             cy={this._yAxisScale(y1)}
-            fill={lineColor}
+            fill={activePoint === circleId ? theme!.palette.white : lineColor}
+            onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+            onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+            onMouseOut={this._handleMouseOut}
+            strokeWidth={activePoint === circleId ? 2 : 0}
+            stroke={activePoint === circleId ? lineColor : ''}
           />,
         );
       }

--- a/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
@@ -123,6 +123,16 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
           ],
           color: DefaultPalette.green,
         },
+        {
+          legend: 'single point',
+          data: [
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 282000,
+            },
+          ],
+          color: DefaultPalette.yellow,
+        },
       ],
     };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17310
- [x] Include a change request file using `$ yarn change`

#### Description of changes

already raised https://github.com/microsoft/fluentui/pull/17311, but this PR have target branch 7.0

adding mouse events to single data point in the linechart so from know onwards user can see the callout data when hovered over the point

#### Focus areas to test
line chart

**after fix**
![image](https://user-images.githubusercontent.com/33802398/110292858-da4ac800-8013-11eb-9068-60cef2bf4d06.png)

