### PR TITLE
Fix: Adding scss imports to side effects list

### DIFF
--- a/change/@fluentui-react-a05c8808-7415-4ed5-8da4-5dbc705715a8.json
+++ b/change/@fluentui-react-a05c8808-7415-4ed5-8da4-5dbc705715a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "The package.json sideEffects array now correctly tags scss files as having side effects, so that they aren't dropped by the bundler accidentally.",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,6 +6,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "sideEffects": [
+    "*.scss*",
     "lib/version.js"
   ],
   "repository": {


### PR DESCRIPTION
When running esbuild against a project which references `@fluentui/react` or `office-ui-fabric-react`, warnings will be generated from the PeoplePicker and FloatingPicker pulling in scss files. These styles were never converted to merge-styles, and without being tagged as having side effects, will be dropped by the bundler when tree shaken.

While the Typescript imports will import something like:

```ts
import "PeoplePicker.scss";
```

The actual javascript files dropped in `lib` will import from `PeoplePicker.scss.js` given that the build pipeline will drop ts files into the src folder. That's why the sideEffect entry has an astrisk at the end.

Verified locally that running esbuild with this sideEffect listed fixes the warning.
