### PR TITLE
7.0: Check for null or undefined when creating a generic item from input

### DIFF
--- a/change/@uifabric-experiments-36089f17-37e3-4324-8c39-087053b8a4d7.json
+++ b/change/@uifabric-experiments-36089f17-37e3-4324-8c39-087053b8a4d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker: Add null check to onValidateInput/createGenericItem functionality",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -379,7 +379,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _onValidateInput = React.useCallback(() => {
     if (onValidateInput && createGenericItem) {
       const itemToConvert = createGenericItem(queryString, onValidateInput(queryString));
-      _onSuggestionSelected(undefined, { item: itemToConvert, isSelected: false });
+      if (itemToConvert !== null && itemToConvert !== undefined) {
+        _onSuggestionSelected(undefined, { item: itemToConvert, isSelected: false });
+      }
     }
   }, [onValidateInput, createGenericItem, queryString, _onSuggestionSelected]);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #17320 

If createGenericItem returns null or undefined, we shouldn't try to add the item.