### PR TITLE
UnifiedPicker: Check for null or undefined when creating a generic item from input

### DIFF
--- a/change/@fluentui-react-experiments-cf1160d6-3b0b-4f8f-ad96-b25505045eb9.json
+++ b/change/@fluentui-react-experiments-cf1160d6-3b0b-4f8f-ad96-b25505045eb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker: Add null check to onValidateInput/createGenericItem functionality",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -372,7 +372,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _onValidateInput = React.useCallback(() => {
     if (onValidateInput && createGenericItem) {
       const itemToConvert = createGenericItem(queryString, onValidateInput(queryString));
-      _onSuggestionSelected(undefined, { item: itemToConvert, isSelected: false });
+      if (itemToConvert !== null && itemToConvert !== undefined) {
+        _onSuggestionSelected(undefined, { item: itemToConvert, isSelected: false });
+      }
     }
   }, [onValidateInput, createGenericItem, queryString, _onSuggestionSelected]);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If createGenericItem returns null or undefined, we shouldn't try to add the item.