### PR TITLE
Modify useControllableValue to use object arg

### DIFF
--- a/change/@fluentui-react-menu-c5889b3d-2788-4bfa-9502-f015d2a2a42e.json
+++ b/change/@fluentui-react-menu-c5889b3d-2788-4bfa-9502-f015d2a2a42e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use updated useControllableValue",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-4f40eea2-69af-4ab9-985d-7d5f17787edb.json
+++ b/change/@fluentui-react-utilities-4f40eea2-69af-4ab9-985d-7d5f17787edb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Modify useControllableValue signature to use object options",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuList.ts
@@ -83,7 +83,10 @@ export const useMenuList = (
     [findAllFocusable, state.ref],
   );
 
-  const [checkedValues, setCheckedValues] = useControllableValue(state.checkedValues, state.defaultCheckedValues);
+  const [checkedValues, setCheckedValues] = useControllableValue({
+    controlledValue: state.checkedValues,
+    defaultUncontrolledValue: state.defaultCheckedValues,
+  });
   state.checkedValues = checkedValues;
   const { onCheckedValueChange } = state;
   state.toggleCheckbox = useEventCallback(

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -168,13 +168,20 @@ export interface UseBooleanCallbacks {
 // @public
 export function useConst<T>(initialValue: T | (() => T)): T;
 
-// Warning: (ae-forgotten-export) The symbol "DefaultValue" needs to be exported by the entry point index.d.ts
-//
 // @public
-export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>): Readonly<[TValue, (update: React.SetStateAction<TValue>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>({ controlledValue, defaultUncontrolledValue, onChange, }: UseControllableValueOptions<TValue, TElement, TEvent>): readonly [TValue, React.Dispatch<TValue>];
 
 // @public (undocumented)
-export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>, onChange: ChangeCallback<TElement, TValue, TEvent>): Readonly<[TValue, (update: React.SetStateAction<TValue>, ev?: React.FormEvent<TElement>) => void]>;
+export interface UseControllableValueOptions<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined> {
+    // (undocumented)
+    controlledValue?: TValue;
+    // Warning: (ae-forgotten-export) The symbol "DefaultValue" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    defaultUncontrolledValue: DefaultValue<TValue>;
+    // (undocumented)
+    onChange?: (event: TEvent, value: TValue) => void;
+}
 
 // @public
 export const useEventCallback: <Args extends unknown[], Return>(fn: (...args: Args) => Return) => (...args: Args) => Return;

--- a/packages/react-utilities/src/hooks/useControllableValue.test.tsx
+++ b/packages/react-utilities/src/hooks/useControllableValue.test.tsx
@@ -9,7 +9,9 @@ describe('useControllableValue', () => {
     let defaultValue: boolean | undefined;
 
     value = true;
-    const { result, rerender } = renderHook(() => useControllableValue(value, defaultValue));
+    const { result, rerender } = renderHook(() =>
+      useControllableValue({ controlledValue: value, defaultUncontrolledValue: defaultValue }),
+    );
     expect(result.current[0]).toBe(true);
 
     value = false;
@@ -29,23 +31,25 @@ describe('useControllableValue', () => {
   it.each([
     ['', true],
     ['factory', () => true],
-  ])('uses the default value %s if no controlled value is provided', (_, defaultValue) => {
-    const { result } = renderHook(() => useControllableValue(undefined, defaultValue));
+  ])('uses the default value %s if no controlled value is provided', (_, defaultUncontrolledValue) => {
+    const { result } = renderHook(() => useControllableValue({ defaultUncontrolledValue }));
     expect(result.current[0]).toBe(true);
   });
 
   it('does not change value when the default value changes', () => {
-    let defaultValue = true;
-    const { result, rerender } = renderHook(() => useControllableValue(undefined, defaultValue));
+    let defaultUncontrolledValue = true;
+    const { result, rerender } = renderHook(() => useControllableValue({ defaultUncontrolledValue }));
 
-    defaultValue = false;
+    defaultUncontrolledValue = false;
     rerender();
 
     expect(result.current[0]).toBe(true);
   });
 
   it('returns the same setter callback', () => {
-    const { result, rerender } = renderHook(() => useControllableValue('hello', 'world'));
+    const { result, rerender } = renderHook(() =>
+      useControllableValue({ controlledValue: 'hello', defaultUncontrolledValue: 'world' }),
+    );
     const firstResult = result.current;
 
     rerender();
@@ -54,13 +58,13 @@ describe('useControllableValue', () => {
   });
 
   it('returns the same setter callback even if param values change', () => {
-    let value = 'hello';
-    let defaultValue = 'world';
-    const { result, rerender } = renderHook(() => useControllableValue(value, defaultValue));
+    let controlledValue = 'hello';
+    let defaultUncontrolledValue = 'world';
+    const { result, rerender } = renderHook(() => useControllableValue({ controlledValue, defaultUncontrolledValue }));
     const firstResult = result.current;
 
-    value = 'foo';
-    defaultValue = 'bar';
+    controlledValue = 'foo';
+    defaultUncontrolledValue = 'bar';
     rerender();
 
     expect(result.current[1]).toEqual(firstResult[1]);
@@ -73,7 +77,9 @@ describe('useControllableValue', () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     let value: string | undefined = first;
-    const { rerender } = renderHook(() => useControllableValue(value, undefined));
+    const { rerender } = renderHook(() =>
+      useControllableValue({ controlledValue: value, defaultUncontrolledValue: '' }),
+    );
 
     value = second;
     rerender();

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -23,26 +23,13 @@ type DefaultValue<TValue> = TValue | (() => TValue);
  * is passed the previous value and returns the new value.
  * @see https://reactjs.org/docs/uncontrolled-components.html
  */
-export function useControllableValue<TValue, TElement extends HTMLElement>(
-  controlledValue: TValue,
-  defaultUncontrolledValue: DefaultValue<TValue>,
-): Readonly<[TValue, (update: React.SetStateAction<TValue>) => void]>;
 export function useControllableValue<
   TValue,
   TElement extends HTMLElement,
   TEvent extends React.SyntheticEvent<TElement> | undefined
 >(
-  controlledValue: TValue,
-  defaultUncontrolledValue: DefaultValue<TValue>,
-  onChange: ChangeCallback<TElement, TValue, TEvent>,
-): Readonly<[TValue, (update: React.SetStateAction<TValue>, ev?: React.FormEvent<TElement>) => void]>;
-export function useControllableValue<
-  TValue,
-  TElement extends HTMLElement,
-  TEvent extends React.SyntheticEvent<TElement> | undefined
->(
-  controlledValue: TValue,
-  defaultUncontrolledValue: DefaultValue<TValue>,
+  controlledValue?: TValue,
+  defaultUncontrolledValue?: DefaultValue<TValue>,
   onChange?: ChangeCallback<TElement, TValue, TEvent>,
 ) {
   const [value, setValue] = React.useState<TValue | undefined>(defaultUncontrolledValue);

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -41,7 +41,10 @@ export function useControllableValue<
   controlledValue,
   defaultUncontrolledValue,
   onChange,
-}: UseControllableValueOptions<TValue, TElement, TEvent>): readonly [TValue, React.Dispatch<TValue>] {
+}: UseControllableValueOptions<TValue, TElement, TEvent>): readonly [
+  TValue,
+  (update: React.SetStateAction<TValue>, ev?: TEvent) => void,
+] {
   const [value, setValue] = React.useState<TValue>(defaultUncontrolledValue);
   const isControlled = useIsControlled(controlledValue);
   const currentValue = isControlled ? (controlledValue as TValue) : value;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Follow up of #17293. There is no way to make the first argument optional and the second required.The hook still **forces** all values to be union typed with `undefined`

Modifies the signature of `useControllableValue` to use and object arg. This makes the signature a lot more sane from a TS and DX perspective. 



```typescript
// Can't specify uncontrolled without setting undefined
// typed always as boolean | true
const [uncontrolledValue, _] = useControllableValue(undefined, true)

// After
const [uncontrolledValue] = useControllableValue({defaultValue: true});
const [controlledValue] = useControllableValue({controlledValue, defaultValue: true});

// Native useState for comparison
const [possibleUndefined] = React.useState<boolean | undefined>(undefined)

```

#### Focus areas to test

(optional)
