### PR TITLE
useControllableValue should not return undefined typed

### DIFF
--- a/change/@fluentui-react-utilities-49d95591-0791-47e9-8b28-06703c55158e.json
+++ b/change/@fluentui-react-utilities-49d95591-0791-47e9-8b28-06703c55158e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "useControllableValue return type non nullable",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -171,10 +171,7 @@ export function useConst<T>(initialValue: T | (() => T)): T;
 // Warning: (ae-forgotten-export) The symbol "DefaultValue" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>): Readonly<[TValue, (update: React.SetStateAction<TValue>) => void]>;
-
-// @public (undocumented)
-export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>, onChange: ChangeCallback<TElement, TValue, TEvent>): Readonly<[TValue, (update: React.SetStateAction<TValue>, ev?: React.FormEvent<TElement>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue, defaultUncontrolledValue: DefaultValue<TValue>, onChange?: ChangeCallback<TElement, TValue, TEvent>): readonly [NonNullable<TValue>, (update: React.SetStateAction<TValue | undefined>, ev?: TEvent | undefined) => void];
 
 // @public
 export const useEventCallback: <Args extends unknown[], Return>(fn: (...args: Args) => Return) => (...args: Args) => Return;

--- a/packages/react-utilities/src/hooks/useControllableValue.ts
+++ b/packages/react-utilities/src/hooks/useControllableValue.ts
@@ -23,19 +23,6 @@ type DefaultValue<TValue> = TValue | (() => TValue);
  * is passed the previous value and returns the new value.
  * @see https://reactjs.org/docs/uncontrolled-components.html
  */
-export function useControllableValue<TValue, TElement extends HTMLElement>(
-  controlledValue: TValue,
-  defaultUncontrolledValue: DefaultValue<TValue>,
-): Readonly<[TValue, (update: React.SetStateAction<TValue>) => void]>;
-export function useControllableValue<
-  TValue,
-  TElement extends HTMLElement,
-  TEvent extends React.SyntheticEvent<TElement> | undefined
->(
-  controlledValue: TValue,
-  defaultUncontrolledValue: DefaultValue<TValue>,
-  onChange: ChangeCallback<TElement, TValue, TEvent>,
-): Readonly<[TValue, (update: React.SetStateAction<TValue>, ev?: React.FormEvent<TElement>) => void]>;
 export function useControllableValue<
   TValue,
   TElement extends HTMLElement,
@@ -74,7 +61,7 @@ export function useControllableValue<
     }
   });
 
-  return [currentValue, setValueOrCallOnChange] as const;
+  return [currentValue as NonNullable<TValue>, setValueOrCallOnChange] as const;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds constraint that the return of `useControllableValue` should never be undefined since the `controlledValue` and `defaultUncontrolledValue`  args are always required.

One consequence is that `defaultUncontrolledValue` cannot be undefined when `uncontrolledValue. 

```typescript
// no longer allowed
useControllableValue(undefined, undefined)

// return will be typed to defaultUncontrolledValue
[alwaysDefined] = useControllableValue(undefined, true)

// return will be typed to controlledvalue -> possible but not recommended
[alwaysDefined] = useControllableValue(true, undefined)
```
#### Focus areas to test

(optional)
