### PR TITLE
Docsite: Hides footer and signIn modal in prep for MWF stylesheet removal

### DIFF
--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -95,7 +95,9 @@
   // Hide UHF back to top button that attempts to go to a nonexistent #main-content page,
   // and #flightPicker element which creates accessibility issues
   a.m-back-to-top,
-  #flightPicker {
+  #flightPicker,
+  #socialMediaContainer,
+  #signInPrompt {
     display: none !important;
   }
 

--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -93,7 +93,9 @@
   }
 
   // Hide UHF back to top button that attempts to go to a nonexistent #main-content page,
-  // and #flightPicker element which creates accessibility issues
+  // and #flightPicker element which creates accessibility issues.
+  // Hide #socialMediaContainer element which holds the footer with social media links
+  // and #signInPrompt element which contains the sign in modal
   a.m-back-to-top,
   #flightPicker,
   #socialMediaContainer,

--- a/change/@fluentui-public-docsite-1018168c-ecdb-4261-aae6-d70c6ed35ab0.json
+++ b/change/@fluentui-public-docsite-1018168c-ecdb-4261-aae6-d70c6ed35ab0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hides modal and footer in prep for MWF stylesheet removal",
+  "packageName": "@fluentui/public-docsite",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Related to an existing issue: Fixes #10911 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- hides sign in prompt modal and footer from view