### PR TITLE
Calendar/DatePicker type and ref fixes

### DIFF
--- a/change/@fluentui-react-0198f8a9-447d-4b54-addd-f21d44fd977e.json
+++ b/change/@fluentui-react-0198f8a9-447d-4b54-addd-f21d44fd977e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Calendar/DatePicker: add ref to props where appropriate, and remove unnecessary forwardRef",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -510,7 +510,7 @@ export const Calendar: React.FunctionComponent<ICalendarProps>;
 export const Callout: React.FunctionComponent<ICalloutProps>;
 
 // @public (undocumented)
-export const CalloutContent: import("react").FunctionComponent<import("./Callout.types").ICalloutProps>;
+export const CalloutContent: React.FunctionComponent<ICalloutProps>;
 
 // @public (undocumented)
 export const CalloutContentBase: React.FunctionComponent<ICalloutProps>;

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -10,7 +10,7 @@ import { useId } from '@fluentui/react-hooks';
 
 const getClassNames = classNamesFunction<ICalendarDayStyleProps, ICalendarDayStyles>();
 
-export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const CalendarDayBase: React.FunctionComponent<ICalendarDayProps> = props => {
   const dayGrid = React.useRef<ICalendarDayGrid>(null);
 
   React.useImperativeHandle(
@@ -58,7 +58,7 @@ export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwa
     : monthAndYear;
 
   return (
-    <div className={classNames.root} id={dayPickerId} ref={forwardedRef}>
+    <div className={classNames.root} id={dayPickerId}>
       <div className={classNames.header}>
         <HeaderButtonComponentType
           // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
@@ -94,7 +94,7 @@ export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwa
       />
     </div>
   );
-});
+};
 CalendarDayBase.displayName = 'CalendarDayBase';
 
 interface ICalendarDayNavigationButtonsProps extends ICalendarDayProps {

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.tsx
@@ -1,5 +1,9 @@
+import * as React from 'react';
 import { CalendarDayBase } from './CalendarDay.base';
 import { styles } from './CalendarDay.styles';
 import { styled } from '../../../Utilities';
+import { ICalendarDayProps } from './CalendarDay.types';
 
-export const CalendarDay = styled(CalendarDayBase, styles, undefined, { scope: 'CalendarDay' });
+export const CalendarDay: React.FunctionComponent<ICalendarDayProps> = styled(CalendarDayBase, styles, undefined, {
+  scope: 'CalendarDay',
+});

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -71,246 +71,239 @@ function useFocusLogic({ componentRef }: ICalendarMonthProps) {
   return [navigatedMonthRef, calendarYearRef, focusOnNextUpdate] as const;
 }
 
-export const CalendarMonthBase = React.forwardRef(
-  (propsWithoutDefaults: ICalendarMonthProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
-    const [navigatedMonthRef, calendarYearRef, focusOnNextUpdate] = useFocusLogic(props);
-    const [isYearPickerVisible, setIsYearPickerVisible] = React.useState(false);
+export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = propsWithoutDefaults => {
+  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+  const [navigatedMonthRef, calendarYearRef, focusOnNextUpdate] = useFocusLogic(props);
+  const [isYearPickerVisible, setIsYearPickerVisible] = React.useState(false);
 
-    const animateBackwards = useAnimateBackwards(props);
+  const animateBackwards = useAnimateBackwards(props);
 
-    const {
-      navigatedDate,
-      selectedDate,
-      strings,
-      today = new Date(),
-      navigationIcons,
-      dateTimeFormatter,
-      minDate,
-      maxDate,
-      theme,
-      styles,
-      className,
-      allFocusable,
-      highlightCurrentMonth,
-      highlightSelectedMonth,
-      animationDirection,
-      yearPickerHidden,
-      onNavigateDate,
-    } = props;
+  const {
+    navigatedDate,
+    selectedDate,
+    strings,
+    today = new Date(),
+    navigationIcons,
+    dateTimeFormatter,
+    minDate,
+    maxDate,
+    theme,
+    styles,
+    className,
+    allFocusable,
+    highlightCurrentMonth,
+    highlightSelectedMonth,
+    animationDirection,
+    yearPickerHidden,
+    onNavigateDate,
+  } = props;
 
-    const selectMonthCallback = (newMonth: number): (() => void) => {
-      return () => onSelectMonth(newMonth);
-    };
+  const selectMonthCallback = (newMonth: number): (() => void) => {
+    return () => onSelectMonth(newMonth);
+  };
 
-    const onSelectNextYear = (): void => {
-      onNavigateDate(addYears(navigatedDate, 1), false);
-    };
+  const onSelectNextYear = (): void => {
+    onNavigateDate(addYears(navigatedDate, 1), false);
+  };
 
-    const onSelectPrevYear = (): void => {
-      onNavigateDate(addYears(navigatedDate, -1), false);
-    };
+  const onSelectPrevYear = (): void => {
+    onNavigateDate(addYears(navigatedDate, -1), false);
+  };
 
-    const onSelectMonth = (newMonth: number): void => {
-      // If header is clickable the calendars are overlayed, switch back to day picker when month is clicked
+  const onSelectMonth = (newMonth: number): void => {
+    // If header is clickable the calendars are overlayed, switch back to day picker when month is clicked
+    props.onHeaderSelect?.();
+    onNavigateDate(setMonth(navigatedDate, newMonth), true);
+  };
+
+  const onHeaderSelect = (): void => {
+    if (!yearPickerHidden) {
+      focusOnNextUpdate();
+      setIsYearPickerVisible(true);
+    } else {
       props.onHeaderSelect?.();
-      onNavigateDate(setMonth(navigatedDate, newMonth), true);
-    };
-
-    const onHeaderSelect = (): void => {
-      if (!yearPickerHidden) {
-        focusOnNextUpdate();
-        setIsYearPickerVisible(true);
-      } else {
-        props.onHeaderSelect?.();
-      }
-    };
-
-    const onSelectYear = (selectedYear: number) => {
-      focusOnNextUpdate();
-      const navYear = navigatedDate.getFullYear();
-      if (navYear !== selectedYear) {
-        let newNavigationDate = new Date(navigatedDate.getTime());
-        newNavigationDate.setFullYear(selectedYear);
-        // for min and max dates, adjust the new navigation date - perhaps this should be
-        // checked on the master navigation date handler (i.e. in Calendar)
-        if (maxDate && newNavigationDate > maxDate) {
-          newNavigationDate = setMonth(newNavigationDate, maxDate.getMonth());
-        } else if (minDate && newNavigationDate < minDate) {
-          newNavigationDate = setMonth(newNavigationDate, minDate.getMonth());
-        }
-        onNavigateDate(newNavigationDate, true);
-      }
-      setIsYearPickerVisible(false);
-    };
-
-    const onYearPickerHeaderSelect = (focus: boolean): void => {
-      focusOnNextUpdate();
-      setIsYearPickerVisible(false);
-    };
-
-    // navigationIcons has a default value in defaultProps, but typescript doesn't recognize this
-    const leftNavigationIcon = navigationIcons!.leftNavigation;
-    const rightNavigationIcon = navigationIcons!.rightNavigation;
-    const dateFormatter = dateTimeFormatter!;
-
-    // determine if previous/next years are in bounds
-    const isPrevYearInBounds = minDate ? compareDatePart(minDate, getYearStart(navigatedDate)) < 0 : true;
-    const isNextYearInBounds = maxDate ? compareDatePart(getYearEnd(navigatedDate), maxDate) < 0 : true;
-
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-      hasHeaderClickCallback: !!props.onHeaderSelect || !yearPickerHidden,
-      highlightCurrent: highlightCurrentMonth,
-      highlightSelected: highlightSelectedMonth,
-      animateBackwards: animateBackwards,
-      animationDirection: animationDirection,
-    });
-
-    if (isYearPickerVisible) {
-      const [onRenderYear, yearStrings] = getYearStrings(props);
-      // use navigated date for the year picker
-      return (
-        <CalendarYear
-          ref={forwardedRef}
-          key={'calendarYear'}
-          minYear={minDate ? minDate.getFullYear() : undefined}
-          maxYear={maxDate ? maxDate.getFullYear() : undefined}
-          // eslint-disable-next-line react/jsx-no-bind
-          onSelectYear={onSelectYear}
-          navigationIcons={navigationIcons}
-          // eslint-disable-next-line react/jsx-no-bind
-          onHeaderSelect={onYearPickerHeaderSelect}
-          selectedYear={
-            selectedDate ? selectedDate.getFullYear() : navigatedDate ? navigatedDate.getFullYear() : undefined
-          }
-          onRenderYear={onRenderYear}
-          strings={yearStrings}
-          componentRef={calendarYearRef}
-          styles={styles}
-          highlightCurrentYear={highlightCurrentMonth}
-          highlightSelectedYear={highlightSelectedMonth}
-          animationDirection={animationDirection}
-        />
-      );
     }
+  };
 
-    const rowIndexes = [];
-    for (let i = 0; i < strings.shortMonths.length / MONTHS_PER_ROW; i++) {
-      rowIndexes.push(i);
+  const onSelectYear = (selectedYear: number) => {
+    focusOnNextUpdate();
+    const navYear = navigatedDate.getFullYear();
+    if (navYear !== selectedYear) {
+      let newNavigationDate = new Date(navigatedDate.getTime());
+      newNavigationDate.setFullYear(selectedYear);
+      // for min and max dates, adjust the new navigation date - perhaps this should be
+      // checked on the master navigation date handler (i.e. in Calendar)
+      if (maxDate && newNavigationDate > maxDate) {
+        newNavigationDate = setMonth(newNavigationDate, maxDate.getMonth());
+      } else if (minDate && newNavigationDate < minDate) {
+        newNavigationDate = setMonth(newNavigationDate, minDate.getMonth());
+      }
+      onNavigateDate(newNavigationDate, true);
     }
+    setIsYearPickerVisible(false);
+  };
 
-    const yearString = dateFormatter.formatYear(navigatedDate);
-    const headerAriaLabel = strings.monthPickerHeaderAriaLabel
-      ? format(strings.monthPickerHeaderAriaLabel, yearString)
-      : yearString;
+  const onYearPickerHeaderSelect = (focus: boolean): void => {
+    focusOnNextUpdate();
+    setIsYearPickerVisible(false);
+  };
 
+  // navigationIcons has a default value in defaultProps, but typescript doesn't recognize this
+  const leftNavigationIcon = navigationIcons!.leftNavigation;
+  const rightNavigationIcon = navigationIcons!.rightNavigation;
+  const dateFormatter = dateTimeFormatter!;
+
+  // determine if previous/next years are in bounds
+  const isPrevYearInBounds = minDate ? compareDatePart(minDate, getYearStart(navigatedDate)) < 0 : true;
+  const isNextYearInBounds = maxDate ? compareDatePart(getYearEnd(navigatedDate), maxDate) < 0 : true;
+
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+    hasHeaderClickCallback: !!props.onHeaderSelect || !yearPickerHidden,
+    highlightCurrent: highlightCurrentMonth,
+    highlightSelected: highlightSelectedMonth,
+    animateBackwards: animateBackwards,
+    animationDirection: animationDirection,
+  });
+
+  if (isYearPickerVisible) {
+    const [onRenderYear, yearStrings] = getYearStrings(props);
+    // use navigated date for the year picker
     return (
-      <div className={classNames.root} ref={forwardedRef}>
-        <div className={classNames.headerContainer}>
-          <button
-            className={classNames.currentItemButton}
-            onClick={onHeaderSelect}
-            onKeyDown={onButtonKeyDown(onHeaderSelect)}
-            aria-label={headerAriaLabel}
-            data-is-focusable={!!props.onHeaderSelect || !yearPickerHidden}
-            tabIndex={!!props.onHeaderSelect || !yearPickerHidden ? 0 : -1}
-            type="button"
-            aria-atomic={true}
-            // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
-            aria-live="polite"
-          >
-            {yearString}
-          </button>
-          <div className={classNames.navigationButtonsContainer}>
-            <button
-              className={css(classNames.navigationButton, {
-                [classNames.disabled]: !isPrevYearInBounds,
-              })}
-              disabled={!allFocusable && !isPrevYearInBounds}
-              onClick={isPrevYearInBounds ? onSelectPrevYear : undefined}
-              onKeyDown={isPrevYearInBounds ? onButtonKeyDown(onSelectPrevYear) : undefined}
-              title={
-                strings.prevYearAriaLabel
-                  ? strings.prevYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, -1))
-                  : undefined
-              }
-              type="button"
-            >
-              <Icon iconName={getRTL() ? rightNavigationIcon : leftNavigationIcon} />
-            </button>
-            <button
-              className={css(classNames.navigationButton, {
-                [classNames.disabled]: !isNextYearInBounds,
-              })}
-              disabled={!allFocusable && !isNextYearInBounds}
-              onClick={isNextYearInBounds ? onSelectNextYear : undefined}
-              onKeyDown={isNextYearInBounds ? onButtonKeyDown(onSelectNextYear) : undefined}
-              title={
-                strings.nextYearAriaLabel
-                  ? strings.nextYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, 1))
-                  : undefined
-              }
-              type="button"
-            >
-              <Icon iconName={getRTL() ? leftNavigationIcon : rightNavigationIcon} />
-            </button>
-          </div>
-        </div>
-        <FocusZone>
-          <div className={classNames.gridContainer} role="grid" aria-label={yearString}>
-            {rowIndexes.map((rowNum: number) => {
-              const monthsForRow = strings.shortMonths.slice(rowNum * MONTHS_PER_ROW, (rowNum + 1) * MONTHS_PER_ROW);
-              return (
-                <div
-                  key={'monthRow_' + rowNum + navigatedDate.getFullYear()}
-                  role="row"
-                  className={classNames.buttonRow}
-                >
-                  {monthsForRow.map((month: string, index: number) => {
-                    const monthIndex = rowNum * MONTHS_PER_ROW + index;
-                    const indexedMonth = setMonth(navigatedDate, monthIndex);
-                    const isNavigatedMonth = navigatedDate.getMonth() === monthIndex;
-                    const isSelectedMonth = selectedDate.getMonth() === monthIndex;
-                    const isSelectedYear = selectedDate.getFullYear() === navigatedDate.getFullYear();
-                    const isInBounds =
-                      (minDate ? compareDatePart(minDate, getMonthEnd(indexedMonth)) < 1 : true) &&
-                      (maxDate ? compareDatePart(getMonthStart(indexedMonth), maxDate) < 1 : true);
-
-                    return (
-                      <button
-                        ref={isNavigatedMonth ? navigatedMonthRef : undefined}
-                        role={'gridcell'}
-                        className={css(classNames.itemButton, {
-                          [classNames.current]:
-                            highlightCurrentMonth && isCurrentMonth(monthIndex, navigatedDate.getFullYear(), today),
-                          [classNames.selected]: highlightSelectedMonth && isSelectedMonth && isSelectedYear,
-                          [classNames.disabled]: !isInBounds,
-                        })}
-                        disabled={!allFocusable && !isInBounds}
-                        key={monthIndex}
-                        onClick={isInBounds ? selectMonthCallback(monthIndex) : undefined}
-                        onKeyDown={isInBounds ? onButtonKeyDown(selectMonthCallback(monthIndex)) : undefined}
-                        aria-label={dateFormatter.formatMonth(indexedMonth, strings)}
-                        aria-selected={isNavigatedMonth}
-                        data-is-focusable={isInBounds ? true : undefined}
-                        type="button"
-                        aria-readonly={true} // prevent grid from being "editable"
-                      >
-                        {month}
-                      </button>
-                    );
-                  })}
-                </div>
-              );
-            })}
-          </div>
-        </FocusZone>
-      </div>
+      <CalendarYear
+        key={'calendarYear'}
+        minYear={minDate ? minDate.getFullYear() : undefined}
+        maxYear={maxDate ? maxDate.getFullYear() : undefined}
+        // eslint-disable-next-line react/jsx-no-bind
+        onSelectYear={onSelectYear}
+        navigationIcons={navigationIcons}
+        // eslint-disable-next-line react/jsx-no-bind
+        onHeaderSelect={onYearPickerHeaderSelect}
+        selectedYear={
+          selectedDate ? selectedDate.getFullYear() : navigatedDate ? navigatedDate.getFullYear() : undefined
+        }
+        onRenderYear={onRenderYear}
+        strings={yearStrings}
+        componentRef={calendarYearRef}
+        styles={styles}
+        highlightCurrentYear={highlightCurrentMonth}
+        highlightSelectedYear={highlightSelectedMonth}
+        animationDirection={animationDirection}
+      />
     );
-  },
-);
+  }
+
+  const rowIndexes = [];
+  for (let i = 0; i < strings.shortMonths.length / MONTHS_PER_ROW; i++) {
+    rowIndexes.push(i);
+  }
+
+  const yearString = dateFormatter.formatYear(navigatedDate);
+  const headerAriaLabel = strings.monthPickerHeaderAriaLabel
+    ? format(strings.monthPickerHeaderAriaLabel, yearString)
+    : yearString;
+
+  return (
+    <div className={classNames.root}>
+      <div className={classNames.headerContainer}>
+        <button
+          className={classNames.currentItemButton}
+          onClick={onHeaderSelect}
+          onKeyDown={onButtonKeyDown(onHeaderSelect)}
+          aria-label={headerAriaLabel}
+          data-is-focusable={!!props.onHeaderSelect || !yearPickerHidden}
+          tabIndex={!!props.onHeaderSelect || !yearPickerHidden ? 0 : -1}
+          type="button"
+          aria-atomic={true}
+          // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
+          aria-live="polite"
+        >
+          {yearString}
+        </button>
+        <div className={classNames.navigationButtonsContainer}>
+          <button
+            className={css(classNames.navigationButton, {
+              [classNames.disabled]: !isPrevYearInBounds,
+            })}
+            disabled={!allFocusable && !isPrevYearInBounds}
+            onClick={isPrevYearInBounds ? onSelectPrevYear : undefined}
+            onKeyDown={isPrevYearInBounds ? onButtonKeyDown(onSelectPrevYear) : undefined}
+            title={
+              strings.prevYearAriaLabel
+                ? strings.prevYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, -1))
+                : undefined
+            }
+            type="button"
+          >
+            <Icon iconName={getRTL() ? rightNavigationIcon : leftNavigationIcon} />
+          </button>
+          <button
+            className={css(classNames.navigationButton, {
+              [classNames.disabled]: !isNextYearInBounds,
+            })}
+            disabled={!allFocusable && !isNextYearInBounds}
+            onClick={isNextYearInBounds ? onSelectNextYear : undefined}
+            onKeyDown={isNextYearInBounds ? onButtonKeyDown(onSelectNextYear) : undefined}
+            title={
+              strings.nextYearAriaLabel
+                ? strings.nextYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, 1))
+                : undefined
+            }
+            type="button"
+          >
+            <Icon iconName={getRTL() ? leftNavigationIcon : rightNavigationIcon} />
+          </button>
+        </div>
+      </div>
+      <FocusZone>
+        <div className={classNames.gridContainer} role="grid" aria-label={yearString}>
+          {rowIndexes.map((rowNum: number) => {
+            const monthsForRow = strings.shortMonths.slice(rowNum * MONTHS_PER_ROW, (rowNum + 1) * MONTHS_PER_ROW);
+            return (
+              <div key={'monthRow_' + rowNum + navigatedDate.getFullYear()} role="row" className={classNames.buttonRow}>
+                {monthsForRow.map((month: string, index: number) => {
+                  const monthIndex = rowNum * MONTHS_PER_ROW + index;
+                  const indexedMonth = setMonth(navigatedDate, monthIndex);
+                  const isNavigatedMonth = navigatedDate.getMonth() === monthIndex;
+                  const isSelectedMonth = selectedDate.getMonth() === monthIndex;
+                  const isSelectedYear = selectedDate.getFullYear() === navigatedDate.getFullYear();
+                  const isInBounds =
+                    (minDate ? compareDatePart(minDate, getMonthEnd(indexedMonth)) < 1 : true) &&
+                    (maxDate ? compareDatePart(getMonthStart(indexedMonth), maxDate) < 1 : true);
+
+                  return (
+                    <button
+                      ref={isNavigatedMonth ? navigatedMonthRef : undefined}
+                      role={'gridcell'}
+                      className={css(classNames.itemButton, {
+                        [classNames.current]:
+                          highlightCurrentMonth && isCurrentMonth(monthIndex, navigatedDate.getFullYear(), today),
+                        [classNames.selected]: highlightSelectedMonth && isSelectedMonth && isSelectedYear,
+                        [classNames.disabled]: !isInBounds,
+                      })}
+                      disabled={!allFocusable && !isInBounds}
+                      key={monthIndex}
+                      onClick={isInBounds ? selectMonthCallback(monthIndex) : undefined}
+                      onKeyDown={isInBounds ? onButtonKeyDown(selectMonthCallback(monthIndex)) : undefined}
+                      aria-label={dateFormatter.formatMonth(indexedMonth, strings)}
+                      aria-selected={isNavigatedMonth}
+                      data-is-focusable={isInBounds ? true : undefined}
+                      type="button"
+                      aria-readonly={true} // prevent grid from being "editable"
+                    >
+                      {month}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </FocusZone>
+    </div>
+  );
+};
 CalendarMonthBase.displayName = 'CalendarMonthBase';
 
 function getYearStrings({ strings, navigatedDate, dateTimeFormatter }: ICalendarMonthProps) {

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.tsx
@@ -1,5 +1,12 @@
+import * as React from 'react';
 import { CalendarMonthBase } from './CalendarMonth.base';
 import { getStyles } from './CalendarMonth.styles';
 import { styled } from '../../../Utilities';
+import { ICalendarMonthProps } from './CalendarMonth.types';
 
-export const CalendarMonth = styled(CalendarMonthBase, getStyles, undefined, { scope: 'CalendarMonth' });
+export const CalendarMonth: React.FunctionComponent<ICalendarMonthProps> = styled(
+  CalendarMonthBase,
+  getStyles,
+  undefined,
+  { scope: 'CalendarMonth' },
+);

--- a/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -10,7 +10,7 @@ import {
 import { KeyCodes, getRTL, classNamesFunction, css, format, IRefObject } from '../../../Utilities';
 import { FocusZone } from '../../../FocusZone';
 import { Icon } from '../../../Icon';
-import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
+import { usePrevious } from '@fluentui/react-hooks';
 import { defaultCalendarNavigationIcons } from '../defaults';
 
 const getClassNames = classNamesFunction<ICalendarYearStyleProps, ICalendarYearStyles>();
@@ -45,166 +45,160 @@ interface ICalendarYearGridCell {
   focus(): void;
 }
 
-const CalendarYearGridCell = React.forwardRef(
-  (props: ICalendarYearGridCellProps, forwardedRef: React.Ref<HTMLButtonElement>) => {
-    const {
-      styles,
-      theme,
-      className,
-      highlightCurrentYear,
-      highlightSelectedYear,
-      year,
-      selected,
-      disabled,
-      componentRef,
-      onSelectYear,
-      onRenderYear,
-    } = props;
+const CalendarYearGridCell: React.FunctionComponent<ICalendarYearGridCellProps> = props => {
+  const {
+    styles,
+    theme,
+    className,
+    highlightCurrentYear,
+    highlightSelectedYear,
+    year,
+    selected,
+    disabled,
+    componentRef,
+    onSelectYear,
+    onRenderYear,
+  } = props;
 
-    const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const mergedRef = useMergedRefs(buttonRef, forwardedRef);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
 
-    React.useImperativeHandle(
-      componentRef,
-      () => ({
-        focus() {
-          buttonRef.current?.focus?.();
-        },
-      }),
-      [],
-    );
+  React.useImperativeHandle(
+    componentRef,
+    () => ({
+      focus() {
+        buttonRef.current?.focus?.();
+      },
+    }),
+    [],
+  );
 
-    const onClick = () => {
+  const onClick = () => {
+    onSelectYear?.(year);
+  };
+
+  const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
+    // eslint-disable-next-line deprecation/deprecation
+    if (ev.which === KeyCodes.enter) {
       onSelectYear?.(year);
-    };
+    }
+  };
 
-    const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
-      if (ev.which === KeyCodes.enter) {
-        onSelectYear?.(year);
-      }
-    };
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+    highlightCurrent: highlightCurrentYear,
+    highlightSelected: highlightSelectedYear,
+  });
 
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-      highlightCurrent: highlightCurrentYear,
-      highlightSelected: highlightSelectedYear,
-    });
-
-    return (
-      <button
-        className={css(classNames.itemButton, {
-          [classNames.selected]: selected,
-          [classNames.disabled]: disabled,
-        })}
-        type="button"
-        role="gridcell"
-        onClick={!disabled ? onClick : undefined}
-        onKeyDown={!disabled ? onKeyDown : undefined}
-        disabled={disabled}
-        aria-selected={selected}
-        ref={mergedRef}
-        aria-readonly={true} // prevent grid from being "editable"
-      >
-        {onRenderYear?.(year) ?? year}
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      className={css(classNames.itemButton, {
+        [classNames.selected]: selected,
+        [classNames.disabled]: disabled,
+      })}
+      type="button"
+      role="gridcell"
+      onClick={!disabled ? onClick : undefined}
+      onKeyDown={!disabled ? onKeyDown : undefined}
+      disabled={disabled}
+      aria-selected={selected}
+      ref={buttonRef}
+      aria-readonly={true} // prevent grid from being "editable"
+    >
+      {onRenderYear?.(year) ?? year}
+    </button>
+  );
+};
 CalendarYearGridCell.displayName = 'CalendarYearGridCell';
 
-const CalendarYearGrid = React.forwardRef(
-  (props: ICalendarYearGridProps, forwardedRef: React.Ref<HTMLButtonElement>) => {
-    const {
-      styles,
-      theme,
-      className,
-      fromYear,
-      toYear,
-      animationDirection,
-      animateBackwards,
-      minYear,
-      maxYear,
-      onSelectYear,
-      selectedYear,
-      componentRef,
-    } = props;
+const CalendarYearGrid: React.FunctionComponent<ICalendarYearGridProps> = props => {
+  const {
+    styles,
+    theme,
+    className,
+    fromYear,
+    toYear,
+    animationDirection,
+    animateBackwards,
+    minYear,
+    maxYear,
+    onSelectYear,
+    selectedYear,
+    componentRef,
+  } = props;
 
-    const selectedCellRef = React.useRef<ICalendarYearGridCell>(null);
-    const currentCellRef = React.useRef<ICalendarYearGridCell>(null);
+  const selectedCellRef = React.useRef<ICalendarYearGridCell>(null);
+  const currentCellRef = React.useRef<ICalendarYearGridCell>(null);
 
-    React.useImperativeHandle(
-      componentRef,
-      () => ({
-        focus() {
-          (selectedCellRef.current || currentCellRef.current)?.focus?.();
-        },
-      }),
-      [],
-    );
+  React.useImperativeHandle(
+    componentRef,
+    () => ({
+      focus() {
+        (selectedCellRef.current || currentCellRef.current)?.focus?.();
+      },
+    }),
+    [],
+  );
 
-    const renderCell = (yearToRender: number): React.ReactNode => {
-      const selected = yearToRender === selectedYear;
-      const disabled =
-        (minYear !== undefined && yearToRender < minYear) || (maxYear !== undefined && yearToRender > maxYear);
-      const current = yearToRender === new Date().getFullYear();
-
-      return (
-        <CalendarYearGridCell
-          {...props}
-          key={yearToRender}
-          year={yearToRender}
-          selected={selected}
-          current={current}
-          disabled={disabled}
-          onSelectYear={onSelectYear}
-          componentRef={selected ? selectedCellRef : current ? currentCellRef : undefined}
-          ref={forwardedRef}
-          theme={theme}
-        />
-      );
-    };
-
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-      animateBackwards: animateBackwards,
-      animationDirection: animationDirection,
-    });
-
-    const onRenderYear = (value: number) => {
-      return props.onRenderYear?.(value) ?? value;
-    };
-
-    const gridAriaLabel = `${onRenderYear(fromYear)} - ${onRenderYear(toYear)}`;
-
-    let year = fromYear;
-    const cells: React.ReactNode[][] = [];
-
-    for (let i = 0; i < (toYear - fromYear + 1) / CELLS_PER_ROW; i++) {
-      cells.push([]);
-      for (let j = 0; j < CELLS_PER_ROW; j++) {
-        cells[i].push(renderCell(year));
-        year++;
-      }
-    }
+  const renderCell = (yearToRender: number): React.ReactNode => {
+    const selected = yearToRender === selectedYear;
+    const disabled =
+      (minYear !== undefined && yearToRender < minYear) || (maxYear !== undefined && yearToRender > maxYear);
+    const current = yearToRender === new Date().getFullYear();
 
     return (
-      <FocusZone>
-        <div className={classNames.gridContainer} role="grid" aria-label={gridAriaLabel}>
-          {cells.map((cellRow: React.ReactNode[], index: number) => {
-            return (
-              <div key={'yearPickerRow_' + index + '_' + fromYear} role="row" className={classNames.buttonRow}>
-                {...cellRow}
-              </div>
-            );
-          })}
-        </div>
-      </FocusZone>
+      <CalendarYearGridCell
+        {...props}
+        key={yearToRender}
+        year={yearToRender}
+        selected={selected}
+        current={current}
+        disabled={disabled}
+        onSelectYear={onSelectYear}
+        componentRef={selected ? selectedCellRef : current ? currentCellRef : undefined}
+        theme={theme}
+      />
     );
-  },
-);
+  };
+
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+    animateBackwards: animateBackwards,
+    animationDirection: animationDirection,
+  });
+
+  const onRenderYear = (value: number) => {
+    return props.onRenderYear?.(value) ?? value;
+  };
+
+  const gridAriaLabel = `${onRenderYear(fromYear)} - ${onRenderYear(toYear)}`;
+
+  let year = fromYear;
+  const cells: React.ReactNode[][] = [];
+
+  for (let i = 0; i < (toYear - fromYear + 1) / CELLS_PER_ROW; i++) {
+    cells.push([]);
+    for (let j = 0; j < CELLS_PER_ROW; j++) {
+      cells[i].push(renderCell(year));
+      year++;
+    }
+  }
+
+  return (
+    <FocusZone>
+      <div className={classNames.gridContainer} role="grid" aria-label={gridAriaLabel}>
+        {cells.map((cellRow: React.ReactNode[], index: number) => {
+          return (
+            <div key={'yearPickerRow_' + index + '_' + fromYear} role="row" className={classNames.buttonRow}>
+              {...cellRow}
+            </div>
+          );
+        })}
+      </div>
+    </FocusZone>
+  );
+};
 CalendarYearGrid.displayName = 'CalendarYearGrid';
 
 const enum CalendarYearNavDirection {
@@ -216,74 +210,71 @@ interface ICalendarYearNavArrowProps extends ICalendarYearHeaderProps {
   direction: CalendarYearNavDirection;
 }
 
-const CalendarYearNavArrow = React.forwardRef(
-  (props: ICalendarYearNavArrowProps, forwardedRef: React.Ref<HTMLButtonElement>) => {
-    const {
-      styles,
-      theme,
-      className,
-      navigationIcons = defaultCalendarNavigationIcons,
-      strings = DefaultCalendarYearStrings,
-      direction,
-      onSelectPrev,
-      onSelectNext,
-      fromYear,
-      toYear,
-      maxYear,
-      minYear,
-    } = props;
+const CalendarYearNavArrow: React.FunctionComponent<ICalendarYearNavArrowProps> = props => {
+  const {
+    styles,
+    theme,
+    className,
+    navigationIcons = defaultCalendarNavigationIcons,
+    strings = DefaultCalendarYearStrings,
+    direction,
+    onSelectPrev,
+    onSelectNext,
+    fromYear,
+    toYear,
+    maxYear,
+    minYear,
+  } = props;
 
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-    });
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+  });
 
-    const ariaLabel =
-      direction === CalendarYearNavDirection.Previous ? strings.prevRangeAriaLabel : strings.nextRangeAriaLabel;
-    const newRangeOffset = direction === CalendarYearNavDirection.Previous ? -CELL_COUNT : CELL_COUNT;
-    const newRange = { fromYear: fromYear + newRangeOffset, toYear: toYear + newRangeOffset };
-    const ariaLabelString = ariaLabel ? (typeof ariaLabel === 'string' ? ariaLabel : ariaLabel(newRange)) : undefined;
-    const disabled =
-      direction === CalendarYearNavDirection.Previous
-        ? minYear !== undefined && fromYear < minYear
-        : maxYear !== undefined && props.fromYear + CELL_COUNT > maxYear;
+  const ariaLabel =
+    direction === CalendarYearNavDirection.Previous ? strings.prevRangeAriaLabel : strings.nextRangeAriaLabel;
+  const newRangeOffset = direction === CalendarYearNavDirection.Previous ? -CELL_COUNT : CELL_COUNT;
+  const newRange = { fromYear: fromYear + newRangeOffset, toYear: toYear + newRangeOffset };
+  const ariaLabelString = ariaLabel ? (typeof ariaLabel === 'string' ? ariaLabel : ariaLabel(newRange)) : undefined;
+  const disabled =
+    direction === CalendarYearNavDirection.Previous
+      ? minYear !== undefined && fromYear < minYear
+      : maxYear !== undefined && props.fromYear + CELL_COUNT > maxYear;
 
-    const onNavigate = () => {
-      direction === CalendarYearNavDirection.Previous ? onSelectPrev?.() : onSelectNext?.();
-    };
+  const onNavigate = () => {
+    direction === CalendarYearNavDirection.Previous ? onSelectPrev?.() : onSelectNext?.();
+  };
 
-    const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
-      if (ev.which === KeyCodes.enter) {
-        onNavigate();
-      }
-    };
+  const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
+    // eslint-disable-next-line deprecation/deprecation
+    if (ev.which === KeyCodes.enter) {
+      onNavigate();
+    }
+  };
 
-    // can be condensed, but leaving verbose for clarity due to regressions
-    const isLeftNavigation = getRTL()
-      ? direction === CalendarYearNavDirection.Next
-      : direction === CalendarYearNavDirection.Previous;
+  // can be condensed, but leaving verbose for clarity due to regressions
+  const isLeftNavigation = getRTL()
+    ? direction === CalendarYearNavDirection.Next
+    : direction === CalendarYearNavDirection.Previous;
 
-    return (
-      <button
-        className={css(classNames.navigationButton, {
-          [classNames.disabled]: disabled,
-        })}
-        onClick={!disabled ? onNavigate : undefined}
-        onKeyDown={!disabled ? onKeyDown : undefined}
-        type="button"
-        title={ariaLabelString}
-        disabled={disabled}
-        ref={forwardedRef}
-      >
-        <Icon iconName={isLeftNavigation ? navigationIcons.leftNavigation : navigationIcons.rightNavigation} />
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      className={css(classNames.navigationButton, {
+        [classNames.disabled]: disabled,
+      })}
+      onClick={!disabled ? onNavigate : undefined}
+      onKeyDown={!disabled ? onKeyDown : undefined}
+      type="button"
+      title={ariaLabelString}
+      disabled={disabled}
+    >
+      <Icon iconName={isLeftNavigation ? navigationIcons.leftNavigation : navigationIcons.rightNavigation} />
+    </button>
+  );
+};
 CalendarYearNavArrow.displayName = 'CalendarYearNavArrow';
 
-const CalendarYearNav = React.forwardRef((props: ICalendarYearHeaderProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+const CalendarYearNav: React.FunctionComponent<ICalendarYearHeaderProps> = props => {
   const { styles, theme, className } = props;
 
   const classNames = getClassNames(styles, {
@@ -292,110 +283,105 @@ const CalendarYearNav = React.forwardRef((props: ICalendarYearHeaderProps, forwa
   });
 
   return (
-    <div className={classNames.navigationButtonsContainer} ref={forwardedRef}>
+    <div className={classNames.navigationButtonsContainer}>
       <CalendarYearNavArrow {...props} direction={CalendarYearNavDirection.Previous} />
       <CalendarYearNavArrow {...props} direction={CalendarYearNavDirection.Next} />
     </div>
   );
-});
+};
 CalendarYearNav.displayName = 'CalendarYearNav';
 
-const CalendarYearTitle = React.forwardRef(
-  (props: ICalendarYearHeaderProps, forwardedRef: React.Ref<HTMLButtonElement | HTMLDivElement>) => {
-    const {
-      styles,
-      theme,
-      className,
-      fromYear,
-      toYear,
-      strings = DefaultCalendarYearStrings,
-      animateBackwards,
-      animationDirection,
-    } = props;
+const CalendarYearTitle: React.FunctionComponent<ICalendarYearHeaderProps> = props => {
+  const {
+    styles,
+    theme,
+    className,
+    fromYear,
+    toYear,
+    strings = DefaultCalendarYearStrings,
+    animateBackwards,
+    animationDirection,
+  } = props;
 
-    const onHeaderSelect = () => {
-      props.onHeaderSelect?.(true);
-    };
+  const onHeaderSelect = () => {
+    props.onHeaderSelect?.(true);
+  };
 
-    const onHeaderKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
-      if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
-        onHeaderSelect();
-      }
-    };
-
-    const onRenderYear = (year: number) => {
-      return props.onRenderYear?.(year) ?? year;
-    };
-
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-      hasHeaderClickCallback: !!props.onHeaderSelect,
-      animateBackwards: animateBackwards,
-      animationDirection: animationDirection,
-    });
-
-    if (props.onHeaderSelect) {
-      const rangeAriaLabel = strings.rangeAriaLabel;
-      const headerAriaLabelFormatString = strings.headerAriaLabelFormatString;
-      const currentDateRange = rangeAriaLabel
-        ? typeof rangeAriaLabel === 'string'
-          ? rangeAriaLabel
-          : rangeAriaLabel(props)
-        : undefined;
-
-      const ariaLabel = headerAriaLabelFormatString
-        ? format(headerAriaLabelFormatString, currentDateRange)
-        : currentDateRange;
-
-      return (
-        <button
-          ref={forwardedRef as React.Ref<HTMLButtonElement>}
-          className={classNames.currentItemButton}
-          onClick={onHeaderSelect}
-          onKeyDown={onHeaderKeyDown}
-          aria-label={ariaLabel}
-          role="button"
-          type="button"
-          aria-atomic={true}
-          // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
-          aria-live="polite"
-        >
-          {onRenderYear(fromYear)} - {onRenderYear(toYear)}
-        </button>
-      );
+  const onHeaderKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
+    // eslint-disable-next-line deprecation/deprecation
+    if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
+      onHeaderSelect();
     }
+  };
+
+  const onRenderYear = (year: number) => {
+    return props.onRenderYear?.(year) ?? year;
+  };
+
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+    hasHeaderClickCallback: !!props.onHeaderSelect,
+    animateBackwards: animateBackwards,
+    animationDirection: animationDirection,
+  });
+
+  if (props.onHeaderSelect) {
+    const rangeAriaLabel = strings.rangeAriaLabel;
+    const headerAriaLabelFormatString = strings.headerAriaLabelFormatString;
+    const currentDateRange = rangeAriaLabel
+      ? typeof rangeAriaLabel === 'string'
+        ? rangeAriaLabel
+        : rangeAriaLabel(props)
+      : undefined;
+
+    const ariaLabel = headerAriaLabelFormatString
+      ? format(headerAriaLabelFormatString, currentDateRange)
+      : currentDateRange;
 
     return (
-      <div ref={forwardedRef as React.Ref<HTMLDivElement>} className={classNames.current}>
+      <button
+        className={classNames.currentItemButton}
+        onClick={onHeaderSelect}
+        onKeyDown={onHeaderKeyDown}
+        aria-label={ariaLabel}
+        role="button"
+        type="button"
+        aria-atomic={true}
+        // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
+        aria-live="polite"
+      >
         {onRenderYear(fromYear)} - {onRenderYear(toYear)}
-      </div>
+      </button>
     );
-  },
-);
+  }
+
+  return (
+    <div className={classNames.current}>
+      {onRenderYear(fromYear)} - {onRenderYear(toYear)}
+    </div>
+  );
+};
 CalendarYearTitle.displayName = 'CalendarYearTitle';
 
-const CalendarYearHeader = React.forwardRef(
-  (props: ICalendarYearHeaderProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const { styles, theme, className, animateBackwards, animationDirection, onRenderTitle } = props;
+const CalendarYearHeader: React.FunctionComponent<ICalendarYearHeaderProps> = props => {
+  const { styles, theme, className, animateBackwards, animationDirection, onRenderTitle } = props;
 
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-      hasHeaderClickCallback: !!props.onHeaderSelect,
-      animateBackwards: animateBackwards,
-      animationDirection: animationDirection,
-    });
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+    hasHeaderClickCallback: !!props.onHeaderSelect,
+    animateBackwards: animateBackwards,
+    animationDirection: animationDirection,
+  });
 
-    return (
-      <div className={classNames.headerContainer} ref={forwardedRef}>
-        {onRenderTitle?.(props) ?? <CalendarYearTitle {...props} />}
-        <CalendarYearNav {...props} />
-      </div>
-    );
-  },
-);
+  return (
+    <div className={classNames.headerContainer}>
+      {onRenderTitle?.(props) ?? <CalendarYearTitle {...props} />}
+      <CalendarYearNav {...props} />
+    </div>
+  );
+};
 CalendarYearHeader.displayName = 'CalendarYearHeader';
 
 function useAnimateBackwards({ selectedYear, navigatedYear }: ICalendarYearProps) {
@@ -437,45 +423,43 @@ function useYearRangeState({ selectedYear, navigatedYear }: ICalendarYearProps) 
   return [fromYear, toYear, onNavNext, onNavPrevious] as const;
 }
 
-export const CalendarYearBase = React.forwardRef(
-  (props: ICalendarYearProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const animateBackwards = useAnimateBackwards(props);
-    const [fromYear, toYear, onNavNext, onNavPrevious] = useYearRangeState(props);
+export const CalendarYearBase: React.FunctionComponent<ICalendarYearProps> = props => {
+  const animateBackwards = useAnimateBackwards(props);
+  const [fromYear, toYear, onNavNext, onNavPrevious] = useYearRangeState(props);
 
-    const gridRef = React.useRef<ICalendarYearGrid>(null);
+  const gridRef = React.useRef<ICalendarYearGrid>(null);
 
-    React.useImperativeHandle(props.componentRef, () => ({
-      focus() {
-        gridRef.current?.focus?.();
-      },
-    }));
+  React.useImperativeHandle(props.componentRef, () => ({
+    focus() {
+      gridRef.current?.focus?.();
+    },
+  }));
 
-    const { styles, theme, className } = props;
+  const { styles, theme, className } = props;
 
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className,
-    });
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: className,
+  });
 
-    return (
-      <div className={classNames.root} ref={forwardedRef}>
-        <CalendarYearHeader
-          {...props}
-          fromYear={fromYear}
-          toYear={toYear}
-          onSelectPrev={onNavPrevious}
-          onSelectNext={onNavNext}
-          animateBackwards={animateBackwards}
-        />
-        <CalendarYearGrid
-          {...props}
-          fromYear={fromYear}
-          toYear={toYear}
-          animateBackwards={animateBackwards}
-          componentRef={gridRef}
-        />
-      </div>
-    );
-  },
-);
+  return (
+    <div className={classNames.root}>
+      <CalendarYearHeader
+        {...props}
+        fromYear={fromYear}
+        toYear={toYear}
+        onSelectPrev={onNavPrevious}
+        onSelectNext={onNavNext}
+        animateBackwards={animateBackwards}
+      />
+      <CalendarYearGrid
+        {...props}
+        fromYear={fromYear}
+        toYear={toYear}
+        animateBackwards={animateBackwards}
+        componentRef={gridRef}
+      />
+    </div>
+  );
+};
 CalendarYearBase.displayName = 'CalendarYearBase';

--- a/packages/react/src/components/Calendar/CalendarYear/CalendarYear.tsx
+++ b/packages/react/src/components/Calendar/CalendarYear/CalendarYear.tsx
@@ -1,5 +1,12 @@
+import * as React from 'react';
 import { getStyles } from './CalendarYear.styles';
 import { styled } from '../../../Utilities';
 import { CalendarYearBase } from './CalendarYear.base';
+import { ICalendarYearProps } from './CalendarYear.types';
 
-export const CalendarYear = styled(CalendarYearBase, getStyles, undefined, { scope: 'CalendarYear' });
+export const CalendarYear: React.FunctionComponent<ICalendarYearProps> = styled(
+  CalendarYearBase,
+  getStyles,
+  undefined,
+  { scope: 'CalendarYear' },
+);

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -249,10 +249,7 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
   return [getWeekCornerStyles, calculateRoundedStyles] as const;
 }
 
-export const CalendarDayGridBase: React.FunctionComponent<ICalendarDayGridProps> = React.forwardRef<
-  HTMLElement,
-  ICalendarDayGridProps
->((props, forwardedRef) => {
+export const CalendarDayGridBase: React.FunctionComponent<ICalendarDayGridProps> = props => {
   const navigatedDayRef = React.useRef<HTMLButtonElement>(null);
 
   const activeDescendantId = useId();
@@ -361,7 +358,7 @@ export const CalendarDayGridBase: React.FunctionComponent<ICalendarDayGridProps>
   } as const;
 
   return (
-    <FocusZone className={classNames.wrapper} elementRef={forwardedRef}>
+    <FocusZone className={classNames.wrapper}>
       <table
         className={classNames.table}
         aria-readonly="true"
@@ -404,7 +401,7 @@ export const CalendarDayGridBase: React.FunctionComponent<ICalendarDayGridProps>
       </table>
     </FocusZone>
   );
-});
+};
 CalendarDayGridBase.displayName = 'CalendarDayGridBase';
 
 /**

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
@@ -24,6 +24,13 @@ describe('CalendarDayGrid', () => {
       firstWeekOfYear: FirstWeekOfYear.FirstFullWeek,
       dateTimeFormatter: timeFormatter,
     },
-    disabledTests: ['exported-top-level', 'has-top-level-file', 'component-handles-classname'],
+    disabledTests: [
+      'component-handles-classname',
+      'exported-top-level',
+      'has-top-level-file',
+      // This component is not currently intended to handle a ref
+      'component-handles-ref',
+      'component-has-root-ref',
+    ],
   });
 });

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.tsx
@@ -1,5 +1,12 @@
+import * as React from 'react';
 import { CalendarDayGridBase } from './CalendarDayGrid.base';
 import { styles } from './CalendarDayGrid.styles';
 import { styled } from '../../Utilities';
+import { ICalendarDayGridProps } from './CalendarDayGrid.types';
 
-export const CalendarDayGrid = styled(CalendarDayGridBase, styles, undefined, { scope: 'CalendarDayGrid' });
+export const CalendarDayGrid: React.FunctionComponent<ICalendarDayGridProps> = styled(
+  CalendarDayGridBase,
+  styles,
+  undefined,
+  { scope: 'CalendarDayGrid' },
+);

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -16,32 +16,33 @@ export interface ICalendarGridDayCellProps extends ICalendarGridRowProps {
   dayIndex: number;
 }
 
-export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellProps> = ({
-  navigatedDate,
-  dateTimeFormatter,
-  allFocusable,
-  strings,
-  activeDescendantId,
-  navigatedDayRef,
-  calculateRoundedStyles,
-  weeks,
-  classNames,
-  day,
-  dayIndex,
-  weekIndex,
-  weekCorners,
-  ariaHidden,
-  customDayCellRef,
-  dateRangeType,
-  daysToSelectInDayView,
-  onSelectDate,
-  restrictedDates,
-  minDate,
-  maxDate,
-  onNavigateDate,
-  getDayInfosInRangeOfDay,
-  getRefsFromDayInfos,
-}): JSX.Element => {
+export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellProps> = props => {
+  const {
+    navigatedDate,
+    dateTimeFormatter,
+    allFocusable,
+    strings,
+    activeDescendantId,
+    navigatedDayRef,
+    calculateRoundedStyles,
+    weeks,
+    classNames,
+    day,
+    dayIndex,
+    weekIndex,
+    weekCorners,
+    ariaHidden,
+    customDayCellRef,
+    dateRangeType,
+    daysToSelectInDayView,
+    onSelectDate,
+    restrictedDates,
+    minDate,
+    maxDate,
+    onNavigateDate,
+    getDayInfosInRangeOfDay,
+    getRefsFromDayInfos,
+  } = props;
   const cornerStyle = weekCorners?.[weekIndex + '_' + dayIndex] ?? '';
   const isNavigatedDate = compareDates(navigatedDate, day.originalDate);
 

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
@@ -28,7 +28,7 @@ export interface ICalendarGridRowProps extends ICalendarDayGridProps {
   getRefsFromDayInfos(dayInfosInRange: IDayInfo[]): (HTMLElement | null)[];
 }
 
-export const CalendarGridRow = (props: ICalendarGridRowProps): JSX.Element => {
+export const CalendarGridRow: React.FunctionComponent<ICalendarGridRowProps> = props => {
   const {
     classNames,
     week,

--- a/packages/react/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
@@ -10,7 +10,7 @@ export interface ICalendarDayMonthHeaderRowProps extends ICalendarDayGridProps {
   classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 }
 
-export const CalendarMonthHeaderRow = (props: ICalendarDayMonthHeaderRowProps) => {
+export const CalendarMonthHeaderRow: React.FunctionComponent<ICalendarDayMonthHeaderRowProps> = props => {
   const { showWeekNumbers, strings, firstDayOfWeek, allFocusable, weeksToShow, weeks, classNames } = props;
   const dayLabels = strings.shortDays.slice();
   const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);

--- a/packages/react/src/components/Callout/CalloutContent.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.tsx
@@ -1,5 +1,9 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
+import { ICalloutProps } from './Callout.types';
 import { CalloutContentBase } from './CalloutContent.base';
 import { getStyles } from './CalloutContent.styles';
 
-export const CalloutContent = styled(CalloutContentBase, getStyles, undefined, { scope: 'CalloutContent' });
+export const CalloutContent: React.FunctionComponent<ICalloutProps> = styled(CalloutContentBase, getStyles, undefined, {
+  scope: 'CalloutContent',
+});


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add explicit `React.FunctionComponent` types to Calendar/DatePicker sub-components (and Callout). This helps address an issue with inferred types in .d.ts that comes up with API Extractor when upgrading to TS 4.1.

Add `ref` to `ICalendarProps` and `IDatePickerProps`, following the convention from other converted function components.

Remove `forwardRef` from all the Calendar/DatePicker sub-components. These should only be used internally (within Calendar/DatePicker) and after tracing in detail through the code, none of the current usage actually passes a ref through. IIRC this was also partially motivated by stricter checking of spread props in TS 4.1.