### PR TITLE
[v7.0] Docsite: Hides footer and signIn modal in prep for MWF stylesheet removal 

### DIFF
--- a/apps/fabric-website/src/styles/_base.scss
+++ b/apps/fabric-website/src/styles/_base.scss
@@ -95,9 +95,13 @@
   }
 
   // Hide UHF back to top button that attempts to go to a nonexistent #main-content page,
-  // and #flightPicker element which creates accessibility issues
+  // and #flightPicker element which creates accessibility issues.
+  // Hide #socialMediaContainer element which holds the footer with social media links
+  // and #signInPrompt element which contains the sign in modal
   a.m-back-to-top,
-  #flightPicker {
+  #flightPicker,
+  #socialMediaContainer,
+  #signInPrompt {
     display: none !important;
   }
 

--- a/change/@uifabric-fabric-website-7865e396-2789-4b67-9d81-cdeddd5bd482.json
+++ b/change/@uifabric-fabric-website-7865e396-2789-4b67-9d81-cdeddd5bd482.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hides modal and footer in prep for MWF stylesheet removal",
+  "packageName": "@uifabric/fabric-website",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist
cherry-pick of #17342

- [ ] Related to an existing issue: Part of #10911 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- hides sign in prompt modal and footer from view