### PR TITLE
[6.0] Fix Breadcrumb and CommandBar visual tests

### DIFF
--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities';
+import { getTallWideDecorator } from '../utilities';
 import { Breadcrumb } from 'office-ui-fabric-react';
 
 const noOp = () => undefined;
 
 storiesOf('Breadcrumb', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(getTallWideDecorator('610px'))
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities';
+import { getTallWideDecorator } from '../utilities';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
 
 const items: ICommandBarItemProps[] = [
@@ -67,7 +67,7 @@ const farItems: ICommandBarItemProps[] = [
 ];
 
 storiesOf('CommandBar', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(getTallWideDecorator('750px'))
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/utilities/FabricDecorator.tsx
+++ b/apps/vr-tests/src/utilities/FabricDecorator.tsx
@@ -26,6 +26,14 @@ export const FabricDecoratorTallFixedWidth = (story: RenderFunction) => (
   </div>
 );
 
+export const getTallWideDecorator = (width: string) => (story: RenderFunction) => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px 10px 120px', width }}>
+      {story()}
+    </div>
+  </div>
+);
+
 export const FabricDecoratorFixedWidth = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>


### PR DESCRIPTION
Apparently sometime between the most recent change to `6.0` and now, something changed on the screener side which caused the width allowed for Breadcrumb and CommandBar visual test cases to be reduced. Fix by adding a decorator with an explicit width.