### PR TITLE
[5.0] Fix Breadcrumb and CommandBar visual tests

### DIFF
--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -2,11 +2,11 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities';
+import { getTallWideDecorator } from '../utilities';
 import { Breadcrumb } from 'office-ui-fabric-react';
 
 storiesOf('Breadcrumb', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(getTallWideDecorator('610px'))
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities';
+import { getTallWideDecorator } from '../utilities';
 import { CommandBar } from 'office-ui-fabric-react';
 
 const items = [
@@ -87,7 +87,7 @@ const farItems = [
 ];
 
 storiesOf('CommandBar', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(getTallWideDecorator('750px'))
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/utilities/FabricDecorator.tsx
+++ b/apps/vr-tests/src/utilities/FabricDecorator.tsx
@@ -29,6 +29,14 @@ export const FabricDecoratorTallFixedWdith = (story) => (
   </Fabric>
 );
 
+export const getTallWideDecorator = (width: string) => (story) => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px 10px 120px', width }}>
+      {story()}
+    </div>
+  </div>
+);
+
 export const FabricDecoratorFixedWidth = (story) => (
   <Fabric style={ { display: 'flex' } }>
     <div className='testWrapper' style={ { padding: '10px', width: '300px' } }>


### PR DESCRIPTION
Apparently sometime between the most recent change to 5.0 and now, something changed on the screener side which caused the width allowed for Breadcrumb and CommandBar visual test cases to be reduced. Fix by adding a decorator with an explicit width.