### PR TITLE
[Callout] Fix callout global focus handler cleanup

### DIFF
--- a/change/@fluentui-react-5d4e463e-b2eb-48b1-ad11-d3dedb4c123d.json
+++ b/change/@fluentui-react-5d4e463e-b2eb-48b1-ad11-d3dedb4c123d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix cleanup of global focus handlers",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously, the async method to set up the global handlers to handle focus on `Callout` was returning the cleanup method, rather than the `useEffect` hook itself. This means the the cleanup method never got called, and the global event handlers just stayed around indefinitely.

This change fixes that mistake and returns a proper cleanup method from the `useEffect` hook.

#### Focus areas to test

(optional)
