### PR TITLE
Fix UPP layout when header component is present

### DIFF
--- a/change/@fluentui-react-examples-52769c1b-c8fb-459b-9c64-62f44fb63e7b.json
+++ b/change/@fluentui-react-examples-52769c1b-c8fb-459b-9c64-62f44fb63e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding a header component (To button) to the UPP edit example",
+  "packageName": "@fluentui/react-examples",
+  "email": "angon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-f5ba1f3d-6147-444b-8479-829adeeeb850.json
+++ b/change/@fluentui-react-experiments-f5ba1f3d-6147-444b-8479-829adeeeb850.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing layout of UPP when there is header component present",
+  "packageName": "@fluentui/react-experiments",
+  "email": "angon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -393,6 +393,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
         defaultDragDropEnabled={false}
         onKeyDown={_onKeyDown}
         onValidateInput={_onValidateInput}
+        itemListAriaLabel="Recipient list"
         headerComponent={
           <div className={classNames.to} data-is-focusable>
             To

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -21,6 +21,23 @@ import {
 import { IInputProps } from '@fluentui/react';
 import { FloatingPeopleSuggestions } from '@fluentui/react-experiments/lib/FloatingPeopleSuggestionsComposite';
 import { KeyCodes } from '@fluentui/react-experiments/lib/Utilities';
+import { mergeStyleSets } from '@fluentui/react/lib/Styling';
+
+const classNames = mergeStyleSets({
+  to: {
+    display: 'inline-block',
+    position: 'relative',
+    height: 32,
+    lineHeight: 32,
+    margin: '4px',
+    minWidth: '52px',
+    padding: '0 4px',
+    textAlign: 'center',
+    color: '#005A9E',
+    backgroundColor: '#EFF6FC',
+    borderRadius: '2px',
+  },
+});
 
 const _suggestions = [
   {
@@ -376,6 +393,11 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
         defaultDragDropEnabled={false}
         onKeyDown={_onKeyDown}
         onValidateInput={_onValidateInput}
+        headerComponent={
+          <div className={classNames.to} data-is-focusable>
+            To
+          </div>
+        }
       />
     </>
   );

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
@@ -42,12 +42,11 @@ describe('SelectedItemsList', () => {
         />,
       );
       expect(wrapper.exists()).toBeTruthy();
-      expect(wrapper.find('div').length).toEqual(3);
+      expect(wrapper.find('div').length).toEqual(2);
       expect(
         wrapper
           .find('div')
           .first()
-          .childAt(0)
           .text(),
       ).toEqual('a');
       expect(
@@ -76,12 +75,11 @@ describe('SelectedItemsList', () => {
       />,
     );
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.find('div').length).toEqual(3);
+    expect(wrapper.find('div').length).toEqual(2);
     expect(
       wrapper
         .find('div')
         .first()
-        .childAt(0)
         .text(),
     ).toEqual('da');
     expect(
@@ -103,12 +101,11 @@ describe('SelectedItemsList', () => {
       />,
     );
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.find('div').length).toEqual(3);
+    expect(wrapper.find('div').length).toEqual(2);
     expect(
       wrapper
         .find('div')
         .first()
-        .childAt(0)
         .text(),
     ).toEqual('Person A');
     expect(

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -61,27 +61,23 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   const SelectedItem = props.onRenderItem;
   return (
     <>
-      {items.length > 0 && (
-        <div role={'listbox'} aria-orientation={'horizontal'} aria-multiselectable={'true'}>
-          {SelectedItem &&
-            renderedItems.map((item: TItem, index: number) => (
-              <SelectedItem
-                item={item}
-                index={index}
-                // To keep react from complaining for duplicate elements with the same key
-                // we will append the index to the key so that we have unique key for each item
-                key={item.key !== undefined ? item.key + '_' + index : index}
-                selected={props.focusedItemIndices?.includes(index)}
-                removeButtonAriaLabel={props.removeButtonAriaLabel}
-                onRemoveItem={onRemoveItemCallbacks[index]}
-                onItemChange={_replaceItem}
-                dragDropEvents={dragDropEvents}
-                dragDropHelper={dragDropHelper}
-                createGenericItem={props.createGenericItem}
-              />
-            ))}
-        </div>
-      )}
+      {SelectedItem &&
+        renderedItems.map((item: TItem, index: number) => (
+          <SelectedItem
+            item={item}
+            index={index}
+            // To keep react from complaining for duplicate elements with the same key
+            // we will append the index to the key so that we have unique key for each item
+            key={item.key !== undefined ? item.key + '_' + index : index}
+            selected={props.focusedItemIndices?.includes(index)}
+            removeButtonAriaLabel={props.removeButtonAriaLabel}
+            onRemoveItem={onRemoveItemCallbacks[index]}
+            onItemChange={_replaceItem}
+            dragDropEvents={dragDropEvents}
+            dragDropHelper={dragDropHelper}
+            createGenericItem={props.createGenericItem}
+          />
+        ))}
     </>
   );
 };

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -522,7 +522,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Cancel"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1054,7 +1053,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Cancel"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1591,7 +1589,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Cancel"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -2123,7 +2120,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Cancel"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -180,7 +180,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Add"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -713,7 +712,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Add"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1251,7 +1249,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Add"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1784,7 +1781,6 @@ Array [
                   text-align: center;
                 }
             data-icon-name="Add"
-            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -3,11 +3,7 @@
 exports[`SelectedPeopleList renders nothing if nothing is provided 1`] = `null`;
 
 exports[`SelectedPeopleList renders personas that are passed in 1`] = `
-<div
-  aria-multiselectable="true"
-  aria-orientation="horizontal"
-  role="listbox"
->
+Array [
   <div
     aria-labelledby="selectedItemPersona-id__0"
     className=
@@ -184,6 +180,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
                   text-align: center;
                 }
             data-icon-name="Add"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -526,6 +523,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
                   text-align: center;
                 }
             data-icon-name="Cancel"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -538,7 +536,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
         </span>
       </button>
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="selectedItemPersona-id__8"
     className=
@@ -715,6 +713,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
                   text-align: center;
                 }
             data-icon-name="Add"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1057,6 +1056,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
                   text-align: center;
                 }
             data-icon-name="Cancel"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1069,16 +1069,12 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
         </span>
       </button>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`SelectedPeopleList renders personas that are passed in as default 1`] = `
-<div
-  aria-multiselectable="true"
-  aria-orientation="horizontal"
-  role="listbox"
->
+Array [
   <div
     aria-labelledby="selectedItemPersona-id__16"
     className=
@@ -1255,6 +1251,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
                   text-align: center;
                 }
             data-icon-name="Add"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1597,6 +1594,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
                   text-align: center;
                 }
             data-icon-name="Cancel"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -1609,7 +1607,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
         </span>
       </button>
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="selectedItemPersona-id__24"
     className=
@@ -1786,6 +1784,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
                   text-align: center;
                 }
             data-icon-name="Add"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -2128,6 +2127,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
                   text-align: center;
                 }
             data-icon-name="Cancel"
+            role="presentation"
             style={
               Object {
                 "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -2140,6 +2140,6 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
         </span>
       </button>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -377,7 +377,6 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                           text-align: center;
                         }
                     data-icon-name="Add"
-                    role="presentation"
                     style={
                       Object {
                         "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -811,7 +810,6 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                           text-align: center;
                         }
                     data-icon-name="Cancel"
-                    role="presentation"
                     style={
                       Object {
                         "fontFamily": "\\"FabricMDL2Icons\\"",

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -41,11 +41,9 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
             ms-BasePicker-text
             ms-UnifiedPicker-text
             {
-              align-items: center;
               border: 1px solid #a19f9d;
               box-sizing: border-box;
               display: flex;
-              flex-wrap: wrap;
               flex: 1 1 auto;
               min-height: 32px;
               min-width: 180px;
@@ -171,11 +169,9 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
             ms-BasePicker-text
             ms-UnifiedPicker-text
             {
-              align-items: center;
               border: 1px solid #a19f9d;
               box-sizing: border-box;
               display: flex;
-              flex-wrap: wrap;
               flex: 1 1 auto;
               min-height: 32px;
               min-width: 180px;
@@ -191,6 +187,14 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
         <div
           aria-multiselectable="true"
           aria-orientation="horizontal"
+          className=
+              ms-UnifiedPicker-listDiv
+              ms-UnifiedPicker-listDiv
+              {
+                display: inline-flex;
+                flex-wrap: wrap;
+                flex: 1 1 auto;
+              }
           role="listbox"
         >
           <div
@@ -373,6 +377,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                           text-align: center;
                         }
                     data-icon-name="Add"
+                    role="presentation"
                     style={
                       Object {
                         "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -806,6 +811,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                           text-align: center;
                         }
                     data-icon-name="Cancel"
+                    role="presentation"
                     style={
                       Object {
                         "fontFamily": "\\"FabricMDL2Icons\\"",
@@ -819,65 +825,65 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
               </button>
             </div>
           </div>
-        </div>
-        <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          className=
-              ms-BasePicker-div
-              ms-UnifiedPicker-div
-              {
-                display: flex;
-                flex: 1 1 auto;
-              }
-          onDragOver={[Function]}
-          onDrop={[Function]}
-          role="combobox"
-        >
-          <input
-            aria-autocomplete="list"
-            autoCapitalize="off"
-            autoComplete="off"
+          <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className=
-                ms-BasePicker-input
-                ms-UnifiedPicker-input
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border: none;
                   display: flex;
-                  flex-grow: 1;
                   flex: 1 1 auto;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 34px;
-                  margin-bottom: 1px;
-                  margin-left: 1px;
-                  margin-right: 1px;
-                  margin-top: 1px;
-                  outline: none;
-                  padding-bottom: 0px;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
                 }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            value=""
-          />
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            role="combobox"
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="off"
+              autoComplete="off"
+              className=
+                  ms-BasePicker-input
+                  ms-UnifiedPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    display: flex;
+                    flex-grow: 1;
+                    flex: 1 1 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 34px;
+                    margin-bottom: 1px;
+                    margin-left: 1px;
+                    margin-right: 1px;
+                    margin-top: 1px;
+                    outline: none;
+                    padding-bottom: 0px;
+                    padding-left: 6px;
+                    padding-right: 6px;
+                    padding-top: 0;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
+              data-lpignore={true}
+              disabled={false}
+              onChange={[Function]}
+              onClick={[Function]}
+              onCompositionEnd={[Function]}
+              onCompositionStart={[Function]}
+              onCompositionUpdate={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
@@ -7,6 +7,7 @@ export interface IUnifiedPickerStyles {
   pickerInput: IStyle;
   pickerDiv: IStyle;
   selectionZone: IStyle;
+  listDiv: IStyle;
 }
 
 const GlobalClassNames = {
@@ -14,6 +15,7 @@ const GlobalClassNames = {
   pickerInput: 'ms-UnifiedPicker-input',
   pickerDiv: 'ms-UnifiedPicker-div',
   selectionZone: 'ms-UnifiedPicker-selectionZone',
+  listDiv: 'ms-UnifiedPicker-listDiv',
 };
 
 export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles => {
@@ -33,8 +35,6 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
       {
         display: 'flex',
         flex: '1 1 auto',
-        flexWrap: 'wrap',
-        alignItems: 'center',
         boxSizing: 'border-box',
         border: `1px solid ${neutralTertiary}`,
         minWidth: '180px',
@@ -77,6 +77,14 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
       classNames.selectionZone,
       {
         display: 'flex',
+        flex: '1 1 auto',
+      },
+    ],
+    listDiv: [
+      classNames.listDiv,
+      {
+        display: 'inline-flex',
+        flexWrap: 'wrap',
         flex: '1 1 auto',
       },
     ],

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -579,6 +579,35 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onRemoveSuggestion: _onFloatingSuggestionRemoved,
     });
 
+  const renderPickerInput = () => {
+    return (
+      <div
+        aria-owns={isSuggestionsShown ? 'suggestion-list' : undefined}
+        aria-expanded={isSuggestionsShown}
+        aria-haspopup="listbox"
+        role="combobox"
+        className={css('ms-BasePicker-div', classNames.pickerDiv)}
+        onDrop={_onDropAutoFill}
+        onDragOver={_onDragOverAutofill}
+      >
+        <Autofill
+          {...(inputProps as IInputProps)}
+          className={css('ms-BasePicker-input', classNames.pickerInput)}
+          ref={input}
+          onFocus={_onInputFocus}
+          onClick={_onInputClick}
+          onInputValueChange={_onInputChange}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            isSuggestionsShown && focusItemIndex >= 0 ? 'FloatingSuggestionsItemId-' + focusItemIndex : undefined
+          }
+          disabled={false}
+          onPaste={_onPaste}
+        />
+      </div>
+    );
+  };
+
   const _canAddItems = () => true;
 
   return (
@@ -600,35 +629,18 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         >
           <div className={css('ms-BasePicker-text', classNames.pickerText)}>
             {headerComponent}
-            {_renderSelectedItemsList()}
-            {_canAddItems() && (
+            {selectedItems.length > 0 && (
               <div
-                aria-owns={isSuggestionsShown ? 'suggestion-list' : undefined}
-                aria-expanded={isSuggestionsShown}
-                aria-haspopup="listbox"
-                role="combobox"
-                className={css('ms-BasePicker-div', classNames.pickerDiv)}
-                onDrop={_onDropAutoFill}
-                onDragOver={_onDragOverAutofill}
+                className={css('ms-UnifiedPicker-listDiv', classNames.listDiv)}
+                role={'listbox'}
+                aria-orientation={'horizontal'}
+                aria-multiselectable={'true'}
               >
-                <Autofill
-                  {...(inputProps as IInputProps)}
-                  className={css('ms-BasePicker-input', classNames.pickerInput)}
-                  ref={input}
-                  onFocus={_onInputFocus}
-                  onClick={_onInputClick}
-                  onInputValueChange={_onInputChange}
-                  aria-autocomplete="list"
-                  aria-activedescendant={
-                    isSuggestionsShown && focusItemIndex >= 0
-                      ? 'FloatingSuggestionsItemId-' + focusItemIndex
-                      : undefined
-                  }
-                  disabled={false}
-                  onPaste={_onPaste}
-                />
+                {_renderSelectedItemsList()}
+                {_canAddItems() && renderPickerInput()}
               </div>
             )}
+            {_canAddItems() && selectedItems.length === 0 && renderPickerInput()}
           </div>
         </SelectionZone>
       </FocusZone>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -32,6 +32,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onInputChange,
     customClipboardType,
     onValidateInput,
+    itemListAriaLabel,
   } = props;
 
   const {
@@ -635,6 +636,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                 role={'listbox'}
                 aria-orientation={'horizontal'}
                 aria-multiselectable={'true'}
+                aria-label={itemListAriaLabel}
               >
                 {_renderSelectedItemsList()}
                 {_canAddItems() && renderPickerInput()}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
@@ -124,4 +124,9 @@ export interface IUnifiedPickerProps<T> {
    * A function used to validate if raw text entered into the well can be added
    */
   onValidateInput?: (input: string) => boolean;
+
+  /**
+   * An ARIA label for the div that is the parent of the items.
+   */
+  itemListAriaLabel?: string;
 }

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -41,11 +41,9 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
             ms-BasePicker-text
             ms-UnifiedPicker-text
             {
-              align-items: center;
               border: 1px solid #a19f9d;
               box-sizing: border-box;
               display: flex;
-              flex-wrap: wrap;
               flex: 1 1 auto;
               min-height: 32px;
               min-width: 180px;
@@ -171,11 +169,9 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
             ms-BasePicker-text
             ms-UnifiedPicker-text
             {
-              align-items: center;
               border: 1px solid #a19f9d;
               box-sizing: border-box;
               display: flex;
-              flex-wrap: wrap;
               flex: 1 1 auto;
               min-height: 32px;
               min-width: 180px;
@@ -191,6 +187,14 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
         <div
           aria-multiselectable="true"
           aria-orientation="horizontal"
+          className=
+              ms-UnifiedPicker-listDiv
+              ms-UnifiedPicker-listDiv
+              {
+                display: inline-flex;
+                flex-wrap: wrap;
+                flex: 1 1 auto;
+              }
           role="listbox"
         >
           <div>
@@ -203,65 +207,65 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
             green
              
           </div>
-        </div>
-        <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          className=
-              ms-BasePicker-div
-              ms-UnifiedPicker-div
-              {
-                display: flex;
-                flex: 1 1 auto;
-              }
-          onDragOver={[Function]}
-          onDrop={[Function]}
-          role="combobox"
-        >
-          <input
-            aria-autocomplete="list"
-            autoCapitalize="off"
-            autoComplete="off"
+          <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className=
-                ms-BasePicker-input
-                ms-UnifiedPicker-input
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border: none;
                   display: flex;
-                  flex-grow: 1;
                   flex: 1 1 auto;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 34px;
-                  margin-bottom: 1px;
-                  margin-left: 1px;
-                  margin-right: 1px;
-                  margin-top: 1px;
-                  outline: none;
-                  padding-bottom: 0px;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
                 }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            value=""
-          />
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            role="combobox"
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="off"
+              autoComplete="off"
+              className=
+                  ms-BasePicker-input
+                  ms-UnifiedPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    display: flex;
+                    flex-grow: 1;
+                    flex: 1 1 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 34px;
+                    margin-bottom: 1px;
+                    margin-left: 1px;
+                    margin-right: 1px;
+                    margin-top: 1px;
+                    outline: none;
+                    padding-bottom: 0px;
+                    padding-left: 6px;
+                    padding-right: 6px;
+                    padding-top: 0;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
+              data-lpignore={true}
+              disabled={false}
+              onChange={[Function]}
+              onClick={[Function]}
+              onCompositionEnd={[Function]}
+              onCompositionStart={[Function]}
+              onCompositionUpdate={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Problem
When there is a header component in the layout, the items container div (once we add items so it becomes multiline) takes its own row creating space above it and gives the input its own row too: 
![image](https://user-images.githubusercontent.com/15259586/110694038-fc238680-819c-11eb-871c-cb20dd35786e.png)


#### Description of changes

- For the storybook example UPP with edit, I added a header component of a To button so that we can see how the layout will actually look.
- In the Unified Picker, in order to have the input not take its own line if there are items, I changed the rendering to be conditional:
     * If there are selected items, create a parent div with role listbox that contains the items and the input
     * If there are 0 items, just render the input by itself
- I made the styling of the listDiv to display inline-flex so that it takes the same row as the To button: 
![image](https://user-images.githubusercontent.com/15259586/110694150-1eb59f80-819d-11eb-9166-4735fc0914f8.png)


- I also added an aria label to the div parent to the items because items with role listbox require one.

#### Focus areas to test

- I checked the Accessibility Insights and there are no errors now
- The layout seems to work correctly both with and without recipients
