### PR TITLE
Remove unneeded scripts from package.json

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -5,11 +5,10 @@
   "description": "A11y Tests for Fluent UI React",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "just": "just-scripts",
-    "test": "just-scripts test",
     "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },
   "dependencies": {

--- a/change/@fluentui-api-docs-ca2d6f26-db9d-4993-a95a-7f985e4340ed.json
+++ b/change/@fluentui-api-docs-ca2d6f26-db9d-4993-a95a-7f985e4340ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/api-docs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-e0a3fd5e-5086-459d-9972-d2fb2bda0713.json
+++ b/change/@fluentui-dom-utilities-e0a3fd5e-5086-459d-9972-d2fb2bda0713.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-a9ca8a80-07cb-4128-8398-ce045fffb676.json
+++ b/change/@fluentui-font-icons-mdl2-a9ca8a80-07cb-4128-8398-ce045fffb676.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-4ed1970e-671c-46bb-8f25-f629fcc43a71.json
+++ b/change/@fluentui-foundation-legacy-4ed1970e-671c-46bb-8f25-f629fcc43a71.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-994ff539-b332-4987-821f-b65df60a86bb.json
+++ b/change/@fluentui-make-styles-994ff539-b332-4987-821f-b65df60a86bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-a3434f88-2730-41cc-a725-c6ee6919b221.json
+++ b/change/@fluentui-react-accordion-a3434f88-2730-41cc-a725-c6ee6919b221.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-accordion",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-f5ab18de-4c69-4f44-8303-64e404e787af.json
+++ b/change/@fluentui-react-avatar-f5ab18de-4c69-4f44-8303-64e404e787af.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-90825a1c-c06d-44cb-b1de-377df4ba5cb8.json
+++ b/change/@fluentui-react-badge-90825a1c-c06d-44cb-b1de-377df4ba5cb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-d8698f37-643b-4542-95ff-9c53abd595fa.json
+++ b/change/@fluentui-react-button-d8698f37-643b-4542-95ff-9c53abd595fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-fe2a3d3c-a627-4d49-9716-871901a8b44c.json
+++ b/change/@fluentui-react-cards-fe2a3d3c-a627-4d49-9716-871901a8b44c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove webpack bundle",
+  "packageName": "@fluentui/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-3d00b59d-e4bf-4df0-972a-9c75bcb2fcc0.json
+++ b/change/@fluentui-react-checkbox-3d00b59d-e4bf-4df0-972a-9c75bcb2fcc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-eff96b48-5e9c-472a-883b-09f57b9970a6.json
+++ b/change/@fluentui-react-components-eff96b48-5e9c-472a-883b-09f57b9970a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-42f3d05d-48ad-4657-aa11-0b85c7f46427.json
+++ b/change/@fluentui-react-context-selector-42f3d05d-48ad-4657-aa11-0b85c7f46427.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-2786d852-dfee-45ea-970c-09cbf572b0c4.json
+++ b/change/@fluentui-react-docsite-components-2786d852-dfee-45ea-970c-09cbf572b0c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-ea44c752-9b47-479c-9a56-f21995cea052.json
+++ b/change/@fluentui-react-file-type-icons-ea44c752-9b47-479c-9a56-f21995cea052.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-flex-324ba159-9fe6-4306-840c-6ff5569504e2.json
+++ b/change/@fluentui-react-flex-324ba159-9fe6-4306-840c-6ff5569504e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-flex",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-management-21067ce7-0d71-4f74-a4a2-65e4be86f0ec.json
+++ b/change/@fluentui-react-focus-management-21067ce7-0d71-4f74-a4a2-65e4be86f0ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-focus-management",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-32d32ebf-56d6-4989-8711-c710c201d379.json
+++ b/change/@fluentui-react-icon-provider-32d32ebf-56d6-4989-8711-c710c201d379.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-4ddaacba-0233-4a99-8b04-b00aed9729cb.json
+++ b/change/@fluentui-react-icons-mdl2-branded-4ddaacba-0233-4a99-8b04-b00aed9729cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-e4b755c1-c2cd-4e0c-a88c-9873d1a883e5.json
+++ b/change/@fluentui-react-icons-mdl2-e4b755c1-c2cd-4e0c-a88c-9873d1a883e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-6e4cf8de-e549-4155-bf44-7b86865b59f3.json
+++ b/change/@fluentui-react-image-6e4cf8de-e549-4155-bf44-7b86865b59f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-d8699bc4-1552-4feb-942c-2a69e68ec7ff.json
+++ b/change/@fluentui-react-link-d8699bc4-1552-4feb-942c-2a69e68ec7ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-1805bea6-bd13-4c29-a325-140dc61c06fe.json
+++ b/change/@fluentui-react-make-styles-1805bea6-bd13-4c29-a325-140dc61c06fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-c8874d85-36d7-440e-aa8a-d244c64ebe20.json
+++ b/change/@fluentui-react-menu-c8874d85-36d7-440e-aa8a-d244c64ebe20.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-e7e22419-0c2b-4e08-86e9-af3ea6f39359.json
+++ b/change/@fluentui-react-provider-e7e22419-0c2b-4e08-86e9-af3ea6f39359.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-5a070c78-fe5f-434a-b96e-b3c237d872c6.json
+++ b/change/@fluentui-react-shared-contexts-5a070c78-fe5f-434a-b96e-b3c237d872c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-e3b3e205-99f9-4241-a67f-57910a9e27b3.json
+++ b/change/@fluentui-react-slider-e3b3e205-99f9-4241-a67f-57910a9e27b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-slider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-c2a04154-6e4f-4cff-944f-23075b1e09ab.json
+++ b/change/@fluentui-react-tabs-c2a04154-6e4f-4cff-944f-23075b1e09ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-5cb7df30-ebc4-4c3d-94ea-530dee126658.json
+++ b/change/@fluentui-react-text-5cb7df30-ebc4-4c3d-94ea-530dee126658.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-c7a2f1fd-418d-44ef-828e-1f3a89861628.json
+++ b/change/@fluentui-react-theme-c7a2f1fd-418d-44ef-828e-1f3a89861628.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toggle-1e69cbed-6f41-4c43-a485-afe723c7e8db.json
+++ b/change/@fluentui-react-toggle-1e69cbed-6f41-4c43-a485-afe723c7e8db.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-toggle",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-c7f7b458-2f2e-4af3-bc29-7b6194c51993.json
+++ b/change/@fluentui-react-tooltip-c7f7b458-2f2e-4af3-bc29-7b6194c51993.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-7a68b5f8-f6c1-4a3a-aafd-3a520d6f5778.json
+++ b/change/@fluentui-react-utilities-7a68b5f8-f6c1-4a3a-aafd-3a520d6f5778.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-8a6088e3-0c46-4912-8d29-d8618b4a632f.json
+++ b/change/@fluentui-react-window-provider-8a6088e3-0c46-4912-8d29-d8618b4a632f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-437a3e4b-9501-429c-899e-c03a80ead046.json
+++ b/change/@fluentui-set-version-437a3e4b-9501-429c-899e-c03a80ead046.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/set-version",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-05efef6c-13ae-4cf0-8161-eeeb29f54732.json
+++ b/change/@fluentui-style-utilities-05efef6c-13ae-4cf0-8161-eeeb29f54732.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/style-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-0b809774-0341-4ef6-944e-54bb0ee56ad8.json
+++ b/change/@fluentui-test-utilities-0b809774-0341-4ef6-944e-54bb0ee56ad8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-ccf439e8-851e-4e62-9cd4-1613cae6833b.json
+++ b/change/@fluentui-theme-ccf439e8-851e-4e62-9cd4-1613cae6833b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-c0a735ca-2c83-44a0-a3bc-0808ef3d3794.json
+++ b/change/@fluentui-utilities-c0a735ca-2c83-44a0-a3bc-0808ef3d3794.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-5dd4219f-8685-437f-88ef-829575af1487.json
+++ b/change/@fluentui-webpack-utilities-5dd4219f-8685-437f-88ef-829575af1487.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded scripts",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -11,11 +11,10 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
+    "clean": "just-scripts clean",
     "just": "just-scripts",
-    "clean": "just-scripts clean"
+    "lint": "just-scripts lint",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/dom-utilities/package.json
+++ b/packages/dom-utilities/package.json
@@ -15,14 +15,12 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
-    "start-test": "just-scripts jest-watch",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "start": "just-scripts dev:storybook"
+    "start-test": "just-scripts jest-watch",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -15,12 +15,11 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style"
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -16,13 +16,12 @@
   "scripts": {
     "build": "just-scripts build",
     "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
+    "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/make-styles/package.json
+++ b/packages/make-styles/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "test": "just-scripts test",
     "test:watch": "just-scripts jest-watch"
   },

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -15,13 +15,11 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -15,14 +15,13 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev:storybook",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
+    "start": "just-scripts dev:storybook",
+    "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-cards/webpack.config.js
+++ b/packages/react-cards/webpack.config.js
@@ -1,5 +1,0 @@
-const resources = require('../../scripts/webpack/webpack-resources');
-
-module.exports = resources.createBundleConfig({
-  output: 'FluentUIReactCards',
-});

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "bundle:storybook": "just-scripts storybook:build",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",

--- a/packages/react-context-selector/package.json
+++ b/packages/react-context-selector/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/react-docsite-components/package.json
+++ b/packages/react-docsite-components/package.json
@@ -12,13 +12,12 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev"
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "start": "just-scripts dev",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-file-type-icons/package.json
+++ b/packages/react-file-type-icons/package.json
@@ -15,12 +15,11 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style"
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-focus-management/package.json
+++ b/packages/react-focus-management/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/react-icon-provider/package.json
+++ b/packages/react-icon-provider/package.json
@@ -20,7 +20,6 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "test": "just-scripts test"
   },
   "devDependencies": {

--- a/packages/react-icons-mdl2-branded/package.json
+++ b/packages/react-icons-mdl2-branded/package.json
@@ -15,12 +15,10 @@
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook"
+    "lint": "just-scripts lint"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -20,7 +20,6 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -15,15 +15,14 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
+    "start-test": "just-scripts jest-watch",
     "start": "just-scripts dev:storybook",
-    "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
-    "start-test": "just-scripts jest-watch"
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -19,8 +19,8 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start-test": "just-scripts jest-watch",
     "start": "just-scripts dev:storybook",
+    "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },

--- a/packages/react-make-styles/package.json
+++ b/packages/react-make-styles/package.json
@@ -15,13 +15,11 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -15,13 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "lint": "just-scripts lint"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-shared-contexts/package.json
+++ b/packages/react-shared-contexts/package.json
@@ -15,11 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "just": "just-scripts",
-    "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
     "update-snapshots": "just-scripts jest -u"
   },

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-theme/package.json
+++ b/packages/react-theme/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
@@ -23,7 +22,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-toggle/package.json
+++ b/packages/react-toggle/package.json
@@ -15,15 +15,14 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
+    "start-test": "just-scripts jest-watch",
     "start": "just-scripts dev:storybook",
-    "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
-    "start-test": "just-scripts jest-watch"
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/set-version/package.json
+++ b/packages/set-version/package.json
@@ -12,11 +12,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
     "code-style": "just-scripts code-style",
-    "just": "just-scripts"
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/style-utilities/package.json
+++ b/packages/style-utilities/package.json
@@ -16,13 +16,12 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
+    "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -11,13 +11,12 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "just-scripts dev",
-    "start-test": "just-scripts jest-watch"
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "start-test": "just-scripts jest-watch",
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,12 +15,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch",
     "update-snapshots": "just-scripts jest -u"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,13 +15,12 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test",
-    "just": "just-scripts",
-    "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
+    "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/webpack-utilities/package.json
+++ b/packages/webpack-utilities/package.json
@@ -9,12 +9,10 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "lint": "just-scripts lint",
-    "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
-    "start": "node ../../node_modules/typescript/bin/tsc -w --outDir lib -m commonjs -t es5",
-    "just": "just-scripts"
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.0.1",

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
Remove `bundle` and `start` scripts where not needed (and sort scripts where already modified).

Remove webpack bundle from `@fluentui/react-cards` now that it's converged-only and we're mostly not using webpack bundles for converged.

Remove leftover `update-api` scripts (a couple packages were added with an old template after my initial `update-api` removal change).