### PR TITLE
fix(Popup): make sure `updatePosition` is always defined in `renderContent`

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updating various icons, `ArrowSortIcon`, `BreakoutRoomIcon`, `CalendarAgendaIcon`, `CallControlCloseTrayIcon`, `PlayIcon`, `TenantPersonalIcon` @notandrew ([#16723](https://github.com/microsoft/fluentui/pull/16723))
 - Fix touch scroll for `Dialog` @assuncaocharles ([#17054](https://github.com/microsoft/fluentui/pull/17054))
 - Prevent scrollable parent element or viewport scroll when an item is seleted in `Dropdown` @yuanboxue-amber ([#17222](https://github.com/microsoft/fluentui/pull/17222))
+- Fix `Popup` to make sure `updatePosition` is always defined in `renderContent` @yuanboxue-amber ([#17377](https://github.com/microsoft/fluentui/pull/17377))
 
 ## Features
 - For `Tree`, add keyboard navigation based on the first letter of the text content of tree items @yuanboxue-amber ([#16994](https://github.com/microsoft/fluentui/pull/16994))

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -48,9 +48,7 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
   });
 
   const scheduleUpdate = React.useCallback(() => {
-    if (popperRef.current) {
-      popperRef.current.updatePosition();
-    }
+    popperRef.current?.updatePosition();
   }, []);
 
   const child = usesRenderProps

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -47,10 +47,16 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     arrowRef.current = props.pointerTargetRef?.current as HTMLElement;
   });
 
+  const scheduleUpdate = React.useCallback(() => {
+    if (popperRef.current) {
+      popperRef.current.updatePosition();
+    }
+  }, []);
+
   const child = usesRenderProps
     ? (props.children as PopperChildrenFn)({
         placement: computedPlacement,
-        scheduleUpdate: popperRef.current?.updatePosition,
+        scheduleUpdate,
       })
     : (props.children as React.ReactElement);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

As title.
Popup has this prop: `renderContent?: (updatePosition: Function) => ShorthandValue<PopupContentProps>;`
Currently the `updatePosition` could be undefined, which causes problems. This PR make sure it is always defined 

#### Focus areas to test

(optional)
