### PR TITLE
Follow up makeStylesCompat fix

### DIFF
--- a/change/@fluentui-react-flex-7437594a-e50c-4fc3-9522-2a79a4d9d5d6.json
+++ b/change/@fluentui-react-flex-7437594a-e50c-4fc3-9522-2a79a4d9d5d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use makeStylesCompat instead of makeStyles",
+  "packageName": "@fluentui/react-flex",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-flex/src/components/Flex/useFlexStyles.ts
+++ b/packages/react-flex/src/components/Flex/useFlexStyles.ts
@@ -1,10 +1,10 @@
-import { makeStyles, ax } from '@fluentui/react-make-styles';
+import { makeStylesCompat, ax } from '@fluentui/react-make-styles';
 import { FlexState } from './Flex.types';
 
 /**
  * Styles for the root slot
  */
-const useRootStyles = makeStyles<FlexState>([
+const useRootStyles = makeStylesCompat<FlexState>([
   [
     null,
     theme => ({


### PR DESCRIPTION
react-flex was a new package so did not conflict with the recent change
to the API in #17354

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
