### PR TITLE
fix(make-styles): add temporary workaround to make it work in jsdom environment

### DIFF
--- a/change/@fluentui-make-styles-dc1eff7f-a425-4dad-a7b9-9817b462ee0d.json
+++ b/change/@fluentui-make-styles-dc1eff7f-a425-4dad-a7b9-9817b462ee0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(make-styles): add temporary workaround to make it work in jsdom environment",
+  "packageName": "@fluentui/make-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/constants.ts
+++ b/packages/make-styles/src/constants.ts
@@ -1,6 +1,12 @@
 import { MakeStylesMatchedDefinitions } from './types';
 
-export const CAN_USE_CSS_VARIABLES = window.CSS && CSS.supports('color', 'var(--c)');
+/**
+ * NOTE:
+ * This is gonna be always `false` in testing environment(jest/jsdom) because jsdom is missing `supports` implementation
+ * @see https://github.com/jsdom/jsdom/issues/2026
+ */
+export const CAN_USE_CSS_VARIABLES =
+  window.CSS && typeof CSS.supports === 'function' && CSS.supports('color', 'var(--c)');
 
 export const SEQUENCE_PREFIX = '__';
 


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- make-styles uses `CSS.supports` API which is missing in jsdom. until now no test covered this - it surfaced once we added `@testing-library/jest-dom` package. I skimmed through the source but there are no parts that could trigger this change, so I guess something with dep tree might trigger this 🧐.

#### Focus areas to test

(optional)
