### PR TITLE
Bug fix - Cypress dialog tests were failling on timeout

### DIFF
--- a/packages/fluentui/e2e/tests/dialogInDialog.spec.ts
+++ b/packages/fluentui/e2e/tests/dialogInDialog.spec.ts
@@ -43,6 +43,7 @@ describe('Dialog in Dialog', () => {
   it('A click on overlay should close only the last opened "Dialog"', () => {
     cy.clickOn(outerTrigger);
     cy.clickOn(innerTrigger);
+    cy.exist(innerHeader);
 
     cy.clickOn(overlayPoint);
     cy.exist(outerHeader);
@@ -72,6 +73,8 @@ describe('Dialog in Dialog', () => {
 
     cy.clickOn(innerTrigger); // opens nested dialog
     cy.exist(innerHeader);
+    // TODO this test was failling on timeout. Cypress was probably too fast and components weren't ready.
+    cy.wait(50);
 
     cy.clickOn(innerHeader);
 
@@ -85,6 +88,8 @@ describe('Dialog in Dialog', () => {
 
     // click on dialog content to move focus to body
     cy.clickOn(outerHeader);
+    // TODO this test was failling on timeout. Cypress was probably too fast and components weren't ready.
+    cy.wait(50);
     cy.nothingIsFocused();
 
     // press ESC again and check if the last dialog is closed and focus is on trigger

--- a/packages/fluentui/e2e/tests/dialogInDialogWithDropdown.spec.ts
+++ b/packages/fluentui/e2e/tests/dialogInDialogWithDropdown.spec.ts
@@ -45,6 +45,8 @@ describe('Dialog in Dialog', () => {
 
     cy.clickOn(dropdownIndicator);
     cy.visible(dropdownList);
+    // TODO this test was failling on timeout. Cypress was probably too fast and components weren't ready.
+    cy.wait(50);
     cy.waitForSelectorAndPressKey(dropdownList, '{esc}');
 
     cy.visible(dropdownSelector);
@@ -56,6 +58,8 @@ describe('Dialog in Dialog', () => {
     cy.clickOn(outerTrigger);
     cy.clickOn(innerTrigger);
 
+    // TODO this test was failling on timeout. Cypress was probably too fast and components weren't ready.
+    cy.wait(50);
     cy.clickOn(innerHeader);
     cy.waitForSelectorAndPressKey(innerHeader, '{esc}');
 

--- a/packages/fluentui/e2e/tests/popupInPopup.spec.ts
+++ b/packages/fluentui/e2e/tests/popupInPopup.spec.ts
@@ -22,6 +22,7 @@ describe('Popup in Popup', () => {
     cy.visible(popupContentNested);
 
     cy.clickOn(popupContentNested);
+    cy.wait(50);
 
     // check that focus moved to body after clicking on Popup content
     cy.nothingIsFocused();
@@ -33,6 +34,7 @@ describe('Popup in Popup', () => {
 
     // click on popup content to move focus to body
     cy.clickOn(popupContent);
+    cy.wait(50);
     cy.nothingIsFocused();
 
     // press ESC again and check if the last popup is closed and focus is on trigger

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation.spec.ts
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation.spec.ts
@@ -66,6 +66,6 @@ describe('Tree keyboard navigation', () => {
     cy.isFocused(selectors.treeItemAt(1));
 
     cy.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'Tab'); // expect Tab key to still function as default
-    cy.nothingIsFocused;
+    cy.nothingIsFocused();
   });
 });


### PR DESCRIPTION
#### Description of changes

Tests are randomly crashing on timeouts. Cypress was probably too fast and components weren't ready. I added `wait` function to potentially vulnerable places

#### Focus areas to test

e2e tests - dialog component tests
