### PR TITLE
Add a required prop to react/checkbox

### DIFF
--- a/change/@fluentui-react-784a2f2d-2621-4994-8ff3-6d5265edf5db.json
+++ b/change/@fluentui-react-784a2f2d-2621-4994-8ff3-6d5265edf5db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a required property to checkboxes",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2420,6 +2420,7 @@ export interface ICheckboxProps extends React.RefAttributes<HTMLDivElement> {
     name?: string;
     onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
     onRenderLabel?: IRenderFunction<ICheckboxProps>;
+    required?: boolean;
     styles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
     theme?: ITheme;
     title?: string;

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -10,6 +10,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
   (props, forwardedRef) => {
     const {
       disabled,
+      required,
       inputProps,
       name,
       ariaLabel,
@@ -89,6 +90,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       ...inputProps,
       checked: !!isChecked,
       disabled,
+      required,
       name,
       id,
       title,

--- a/packages/react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.types.ts
@@ -57,6 +57,11 @@ export interface ICheckboxProps extends React.RefAttributes<HTMLDivElement> {
   disabled?: boolean;
 
   /**
+   * Required state of the checkbox.
+   */
+  required?: boolean;
+
+  /**
    * Callback that is called when the checked value has changed.
    */
   onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13710
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds a `required` prop to the v8 Checkbox component, and passes it through to the input.