### PR TITLE
U/angon/fix drag drop

### DIFF
--- a/change/@fluentui-react-experiments-39f806e1-dc55-4bd3-a9fe-049c5f184fff.json
+++ b/change/@fluentui-react-experiments-39f806e1-dc55-4bd3-a9fe-049c5f184fff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "In UnifiedPicker, prevent items from being copied in drag and drop by specifying effect allowed is 'move'",
+  "packageName": "@fluentui/react-experiments",
+  "email": "angon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -247,6 +247,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     /* eslint-disable-next-line eqeqeq */
     const draggedItemIndex = itemIndex != null ? itemIndex! : -1;
     setDraggedIndex(draggedItemIndex);
+    if (event && event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+    }
+
     if (event) {
       const dataList = event?.dataTransfer?.items;
       if (serializeItemsForDrag && customClipboardType) {
@@ -263,7 +267,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (event && !isInDropAction) {
       // If we have a move event, and we still have selected items (indicating that we
       // haven't already moved items within the well) we should remove the item(s)
-      if (event.dataTransfer?.dropEffect === 'move' && focusedItemIndices.length > 0) {
+      if (
+        (event.dataTransfer?.dropEffect === 'move' || event.dataTransfer?.dropEffect === 'copy') &&
+        focusedItemIndices.length > 0
+      ) {
         const itemsToRemove = focusedItemIndices.includes(draggedIndex)
           ? (getSelectedItems() as T[])
           : [selectedItems[draggedIndex]];

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -267,10 +267,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (event && !isInDropAction) {
       // If we have a move event, and we still have selected items (indicating that we
       // haven't already moved items within the well) we should remove the item(s)
-      if (
-        (event.dataTransfer?.dropEffect === 'move' || event.dataTransfer?.dropEffect === 'copy') &&
-        focusedItemIndices.length > 0
-      ) {
+      if (event.dataTransfer?.dropEffect === 'move' && focusedItemIndices.length > 0) {
         const itemsToRemove = focusedItemIndices.includes(draggedIndex)
           ? (getSelectedItems() as T[])
           : [selectedItems[draggedIndex]];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Browsers have some heuristic to determine the dropEffect (copy, move, etc.). Recently we found a bug where in some cases chromium was setting the dropEffect to copy instead of move, and therefore the item drag and dropped was not being deleted from drag source.

* The solution is adding effectAllowed to be only 'move' in _onDragStart
* As a precaution (and since we don't have a 'copy' feature for dragging items) I thought I would add a double safeguard and specify that either 'move' or 'copy' dropEffect should have the same behavior in _onDragEnd
    * We don't really need this since effectAllowed seems to be solving the issue, so if you feel we should not add this in case we decide to implement 'copy' later (doubtful?) I can remove that

#### Focus areas to test

(optional)
