### PR TITLE
Fix release CI test

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -62,7 +62,7 @@ steps:
 
   # test, lint, bundle using lage cached build from previous step (omit --no-cache)
   - script: |
-      yarn run:published test --production
+      yarn run:published test
     displayName: yarn test
 
   - script: |


### PR DESCRIPTION
Recently #17161 changed `react-menu` to use native `jest` command for
testing which does not support the `--production` flag

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
