### PR TITLE
azure-themes: update error styles for azure-themes (light)

### DIFF
--- a/change/@fluentui-react-examples-2021-03-12-15-07-02-azure-theme-error-messaging.json
+++ b/change/@fluentui-react-examples-2021-03-12-15-07-02-azure-theme-error-messaging.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add example for TextField with error message",
+  "packageName": "@fluentui/react-examples",
+  "email": "mhdahman@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-12T20:07:02.617Z"
+}

--- a/change/@uifabric-azure-themes-2021-03-12-15-07-02-azure-theme-error-messaging.json
+++ b/change/@uifabric-azure-themes-2021-03-12-15-07-02-azure-theme-error-messaging.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update error styles for azure-themes (light)",
+  "packageName": "@uifabric/azure-themes",
+  "email": "mhdahman@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-12T20:07:00.208Z"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -41,6 +41,7 @@ export namespace BaseColors {
   export const RED_F63747 = '#f63747';
   export const RED_F1707B = '#F1707B';
   export const RED_E00B1C = '#e00b1c';
+  export const RED_A4262C = '#a4262c';
   export const RED_442726 = '#442726';
   export const RED_61050C = '#61050c';
   export const RED_800000 = '#800002';
@@ -518,7 +519,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
     hyperlinkHovered: BaseColors.BLUE_004578,
     hyperlinkBackgroundHovered: BaseColors.TRANSPARENT,
     success: BaseColors.GREEN_428000,
-    error: BaseColors.RED_E00B1C,
+    error: BaseColors.RED_A4262C,
     placeholder: BaseColors.GRAY_8A8886,
   },
   statusBar: {
@@ -618,7 +619,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
     disabled: BaseColors.GRAY_C8C6C4,
     hover: BaseColors.GRAY_605E5C,
     accent: BaseColors.BLUE_0078D4,
-    error: BaseColors.RED_E00B1C,
+    error: BaseColors.RED_A4262C,
     dirty: BaseColors.PURPLE_8A2DA5,
   },
   choiceGroup: {

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -7,7 +7,7 @@ import {
 
 export const inputHeight = '18px';
 export const borderWidth = '1px';
-export const borderWidthError = '2px';
+export const borderWidthError = '1px';
 export const borderSolid = 'solid';
 export const borderNone = 'none';
 export const dropDownItemHeight = '32px';

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -130,6 +130,7 @@ const Example = () => (
       <TextField disabled value="disabled text" />
       <TextField placeholder="Hello" />
       <TextField label="Standard" multiline rows={3} />
+      <TextField errorMessage="Error message!" />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>


### PR DESCRIPTION
Cherry-pick of #17399

### Pull request checklist

- [x] Addresses an existing issue: `bug7632227`
- [x] Include a change request file using `$ yarn change`

### Description of changes

This PR:

- updates the following error styles for `azure-themes` (**light theme only**):
  - error message text color
  - input border color
  - input border width
- updates the story book examples to include a text field with error message

### Focus areas to test

The changes are applicable to the following components:

**TextField**

**Before**

<img width="215" alt="Screen Shot 2021-03-12 at 3 17 11 PM" src="https://user-images.githubusercontent.com/79171711/110993957-09c84000-8346-11eb-85e9-183978e21343.png">


**After**

<img width="188" alt="Screen Shot 2021-03-12 at 3 11 30 PM" src="https://user-images.githubusercontent.com/79171711/110993736-ad652080-8345-11eb-9c73-42eb5a57358e.png">


---

**Dropdown**

Before

<img width="328" alt="Screen Shot 2021-03-12 at 3 15 42 PM" src="https://user-images.githubusercontent.com/79171711/110993866-e00f1900-8345-11eb-9472-3277368c8cf8.png">


After

<img width="366" alt="Screen Shot 2021-03-12 at 3 11 26 PM" src="https://user-images.githubusercontent.com/79171711/110993773-bc4bd300-8345-11eb-9973-7b9e3dbf75cb.png">

---

**Combobox**

Before

<img width="342" alt="Screen Shot 2021-03-12 at 3 15 38 PM" src="https://user-images.githubusercontent.com/79171711/110993856-db4a6500-8345-11eb-9d7f-0fb985f05cfa.png">


After

<img width="336" alt="Screen Shot 2021-03-12 at 3 11 23 PM" src="https://user-images.githubusercontent.com/79171711/110993784-bfdf5a00-8345-11eb-8e8f-55115154122b.png">


