### PR TITLE
Fix syncpack errors with northstar dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,9 +207,12 @@
           "@fluentui/styles"
         ],
         "dependencies": [
+          "@fluentui/a11y-testing",
           "@fluentui/dom-utilities",
+          "@fluentui/eslint-plugin",
           "@fluentui/react",
           "@fluentui/react-compose",
+          "@fluentui/react-conformance",
           "stylis"
         ]
       }

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -9,7 +9,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/gulp": "^4.0.6",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -9,7 +9,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/gulp": "^4.0.6",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/code-sandbox/package.json
+++ b/packages/fluentui/code-sandbox/package.json
@@ -9,7 +9,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react-northstar": "^0.52.0",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"

--- a/packages/fluentui/code-sandbox/package.json
+++ b/packages/fluentui/code-sandbox/package.json
@@ -9,7 +9,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/react-northstar": "^0.52.0",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"

--- a/packages/fluentui/docs-components/package.json
+++ b/packages/fluentui/docs-components/package.json
@@ -16,7 +16,7 @@
     "react-codesandboxer": "^3.1.3"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/gulp": "^4.0.6",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/docs-components/package.json
+++ b/packages/fluentui/docs-components/package.json
@@ -16,7 +16,7 @@
     "react-codesandboxer": "^3.1.3"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/gulp": "^4.0.6",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -50,7 +50,7 @@
     "semver": "^6.2.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/color": "^3.0.0",

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -50,7 +50,7 @@
     "semver": "^6.2.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/color": "^3.0.0",

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/scripts": "^1.0.0",
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/react": "^8.0.0",
     "gulp": "^4.0.2"
   },

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/scripts": "^1.0.0",
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react": "^8.0.0",
     "gulp": "^4.0.2"
   },

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.10.4",
     "@fluentui/docs": "^0.52.0",
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react-northstar": "^0.52.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.10.4",
     "@fluentui/docs": "^0.52.0",
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/react-northstar": "^0.52.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -26,7 +26,7 @@
     "stylis-plugin-rtl": "^1.0.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/react": "16.9.42",

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -26,7 +26,7 @@
     "stylis-plugin-rtl": "^1.0.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/react": "16.9.42",

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -22,7 +22,7 @@
     "axe-core": "3.5.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react-frame-component": "^4.1.1",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -22,7 +22,7 @@
     "axe-core": "3.5.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react-frame-component": "^4.1.1",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/simulant": "^0.2.0",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@types/simulant": "^0.2.0",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -9,7 +9,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -9,7 +9,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -9,7 +9,7 @@
     "react-is": "^16.6.3"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-is": "^16.7.1",

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -9,7 +9,7 @@
     "react-is": "^16.6.3"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-is": "^16.7.1",

--- a/packages/fluentui/react-icons-northstar/package.json
+++ b/packages/fluentui/react-icons-northstar/package.json
@@ -11,7 +11,7 @@
     "classnames": "^2.2.6"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/react": "16.9.42",
     "@types/react-is": "^16.7.1",

--- a/packages/fluentui/react-icons-northstar/package.json
+++ b/packages/fluentui/react-icons-northstar/package.json
@@ -11,7 +11,7 @@
     "classnames": "^2.2.6"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/classnames": "^2.2.9",
     "@types/react": "16.9.42",
     "@types/react-is": "^16.7.1",

--- a/packages/fluentui/react-northstar-emotion-renderer/package.json
+++ b/packages/fluentui/react-northstar-emotion-renderer/package.json
@@ -15,7 +15,7 @@
     "stylis-plugin-rtl": "^1.0.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar-emotion-renderer/package.json
+++ b/packages/fluentui/react-northstar-emotion-renderer/package.json
@@ -15,7 +15,7 @@
     "stylis-plugin-rtl": "^1.0.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar-fela-renderer/package.json
+++ b/packages/fluentui/react-northstar-fela-renderer/package.json
@@ -20,7 +20,7 @@
     "stylis": "^3.5.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar-fela-renderer/package.json
+++ b/packages/fluentui/react-northstar-fela-renderer/package.json
@@ -20,7 +20,7 @@
     "stylis": "^3.5.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar-prototypes/package.json
+++ b/packages/fluentui/react-northstar-prototypes/package.json
@@ -31,7 +31,7 @@
     "react-window": "^1.8.6"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",

--- a/packages/fluentui/react-northstar-prototypes/package.json
+++ b/packages/fluentui/react-northstar-prototypes/package.json
@@ -31,7 +31,7 @@
     "react-window": "^1.8.6"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",

--- a/packages/fluentui/react-northstar-styles-renderer/package.json
+++ b/packages/fluentui/react-northstar-styles-renderer/package.json
@@ -8,7 +8,7 @@
     "@fluentui/styles": "^0.52.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar-styles-renderer/package.json
+++ b/packages/fluentui/react-northstar-styles-renderer/package.json
@@ -8,7 +8,7 @@
     "@fluentui/styles": "^0.52.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -29,9 +29,9 @@
     "react-transition-group": "^4.3.0"
   },
   "devDependencies": {
-    "@fluentui/a11y-testing": ">= 0.1.0",
-    "@fluentui/eslint-plugin": ">= 1.0.0",
-    "@fluentui/react-conformance": ">= 0.2.3",
+    "@fluentui/a11y-testing": "*",
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@testing-library/jest-dom": "^5.1.1",
     "@types/classnames": "^2.2.9",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -29,9 +29,9 @@
     "react-transition-group": "^4.3.0"
   },
   "devDependencies": {
-    "@fluentui/a11y-testing": "^0.1.0",
-    "@fluentui/eslint-plugin": "^1.0.1",
-    "@fluentui/react-conformance": "^0.2.3",
+    "@fluentui/a11y-testing": ">= 0.1.0",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/react-conformance": ">= 0.2.3",
     "@fluentui/scripts": "^1.0.0",
     "@testing-library/jest-dom": "^5.1.1",
     "@types/classnames": "^2.2.9",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",
     "@fluentui/eslint-plugin": "^1.0.1",
-    "@fluentui/react-conformance": "^0.2.2",
+    "@fluentui/react-conformance": "^0.2.3",
     "@fluentui/scripts": "^1.0.0",
     "@testing-library/jest-dom": "^5.1.1",
     "@types/classnames": "^2.2.9",

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -10,7 +10,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -10,7 +10,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/react-telemetry/package.json
+++ b/packages/fluentui/react-telemetry/package.json
@@ -12,7 +12,7 @@
     "react-table": "^7.1.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-table": "^7.0.19",

--- a/packages/fluentui/react-telemetry/package.json
+++ b/packages/fluentui/react-telemetry/package.json
@@ -12,7 +12,7 @@
     "react-table": "^7.1.0"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-table": "^7.0.19",

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.0.1",
+    "@fluentui/eslint-plugin": ">= 1.0.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": ">= 1.0.0",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "lerna-alias": "^3.0.3-0"


### PR DESCRIPTION
In a recent release where `@fluentui/react-conformance` was bumped, it didn't get bumped in `react-northstar` since things under `packages/fluentui` are excluded from beachball bumping. This caused a syncpack error.

To prevent this from occurring again:
1. Add within-repo dev deps (`@fluentui/react-conformance`, `@fluentui/eslint-plugin`, and `@fluentui/a11y-testing`) to northstar-specific syncpack version group
2. Change the requested versions of those deps under `packages/fluentui` to use `*`, to prevent duplicates from being installed

It might be worth considering using `*` for all within-repo dev deps in the future, but that can be discussed and implemented separately. (This is a more scoped fix to address a build break.)