### PR TITLE
Switch popup focus to useEffect, add setTimeout for React 16

### DIFF
--- a/change/@fluentui-react-376cb4fd-778f-4da0-900e-eb3d7200f6d4.json
+++ b/change/@fluentui-react-376cb4fd-778f-4da0-900e-eb3d7200f6d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switch popup focus to useEffect, add setTimeout for React 16",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17403
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There's a React issue where focus called in the cleanup function for `useEffect` and `useLayoutEffect` does not trigger React's internal events. This is fixed in React 17 for `useEffect`, but there's no indication that it will ever be changed for `useLayoutEffect`. This affects the Popup, because focus is currently returned to the original trigger in the `useLayoutEffect` cleanup function.

This PR makes two changes to address that:
1. Switch the Popup focus logic to `useEffect` so it will work in React 17 whenever we update
2. Wrap the `.focus()` function in a `setTimeout` for now, so it'll work in the meantime

I tested the `document.activeElement` query in `useLayoutEffect` vs. `useEffect`, and I got the same results in each when checking in Modal, Dialog, and DatePicker.

#### Focus areas to test

Modal, Dialog, Datepicker in packages/react
