### PR TITLE
Generate NOTICE.txt files for convergence

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -75,6 +75,10 @@ steps:
       flattenFolders: true
 
   - script: |
+      yarn copy-notices
+    displayName: Copy NOTICE to converged packages
+
+  - script: |
       yarn run:published build --production --no-cache
     displayName: yarn build
 

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -56,6 +56,24 @@ steps:
       yarn generate-version-files
     displayName: Generate version files
 
+  # The contents of this file is configured in the component governence tab of ADO
+  - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
+    displayName: 'Generate NOTICE file for convergence'
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download NOTICE.txt'
+    inputs:
+      downloadType: specific
+      itemPattern: '**/NOTICE.txt'
+
+  - task: CopyFiles@2
+    displayName: 'Copy NOTICE to @fluentui/react-components'
+    inputs:
+      SourceFolder: '$(System.ArtifactsDirectory)'
+      Contents: '**/NOTICE.txt'
+      TargetFolder: '$(Build.SourcesDirectory)/packages/react-components'
+      flattenFolders: true
+
   - script: |
       yarn run:published build --production --no-cache
     displayName: yarn build

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",
     "codepen": "cd packages/react && node ../../scripts/local-codepen.js",
+    "copy-notices": "node scripts/copy-notices.js",
     "create-component": "plop --plopfile ./scripts/create-component/create-component.ts --dest . --require ./scripts/ts-node-register",
     "create-package": "plop --plopfile ./scripts/create-package/plopfile.ts --dest . --require ./scripts/ts-node-register",
     "format": "node scripts/format.js",

--- a/scripts/copy-notices.js
+++ b/scripts/copy-notices.js
@@ -1,0 +1,33 @@
+const monorepo = require('./monorepo');
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Copies NOTICE.txt files from `@fluentui/react-components` to all of its internal production dependencies
+ */
+async function copyNotices() {
+  const noticeFilePath = path.resolve(monorepo.findGitRoot(), 'packages/react-components', 'NOTICE.txt');
+
+  if (!fs.existsSync(noticeFilePath)) {
+    throw new Error('NOTICE.txt file does not exsit in packages/react-components');
+  }
+
+  console.log(`NOTICE.txt exists in ${noticeFilePath}`);
+
+  const dependencyNames = await monorepo.getDependencies('@fluentui/react-components', { production: true });
+  const copyLocations = dependencyNames.map(dependencyName =>
+    path.resolve(monorepo.findGitRoot(), 'packages', dependencyName.replace('@fluentui/', ''), 'NOTICE.txt'),
+  );
+
+  copyLocations.forEach(copyLocation => {
+    console.log('copying NOTICE.txt to', copyLocation);
+    fs.copyFileSync(noticeFilePath, copyLocation);
+  });
+}
+
+if (require.main === module) {
+  copyNotices().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/dependency-graph-generator/index.js
+++ b/scripts/dependency-graph-generator/index.js
@@ -3,7 +3,7 @@ const parser = require('dotparser');
 const readFileSync = require('fs').readFileSync;
 const spawnSync = require('child_process').spawnSync;
 const findGitRoot = require('../monorepo/index').findGitRoot;
-const getDevDependencies = require('../monorepo/index').getDevDependencies;
+const getDependencies = require('../monorepo/index').getDependencies;
 const path = require('path');
 const os = require('os');
 
@@ -26,7 +26,7 @@ async function main(argv) {
   // if dev dependencies should be added
   const includeDevDependencies = argv['include-dev'];
   if (!includeDevDependencies) {
-    ignoreDevDependencies = await getDevDependencies(rootPackage);
+    ignoreDevDependencies = await getDependencies(rootPackage, { dev: true });
   }
 
   _generateGraphforRepo(dotFilePath);

--- a/scripts/monorepo/getDependencies.js
+++ b/scripts/monorepo/getDependencies.js
@@ -19,7 +19,7 @@ function flattenPackageGraph(rootPackages, projectGraph, packageList = []) {
  * @param {string} options.dev include dev dependencies
  * @param {string} options.production include production dependencies
  */
-async function getDependencies(packageName, options = {}) {
+async function getDependencies(packageName, options = { production: true }) {
   const lernaProject = new Project(path.resolve(findGitRoot(), 'packages'));
   const projectPackages = await lernaProject.getPackages();
 

--- a/scripts/monorepo/getDependencies.js
+++ b/scripts/monorepo/getDependencies.js
@@ -16,8 +16,8 @@ function flattenPackageGraph(rootPackages, projectGraph, packageList = []) {
 /**
  * Returns all the dependencies of a given package name
  * @param {string} packageName including `@fluentui/` prefix
- * @param {String} options.dev include dev dependencies
- * @param {String} options.production include production dependnecies
+ * @param {string} options.dev include dev dependencies
+ * @param {string} options.production include production dependencies
  */
 async function getDependencies(packageName, options = {}) {
   const lernaProject = new Project(path.resolve(findGitRoot(), 'packages'));

--- a/scripts/monorepo/getDependencies.js
+++ b/scripts/monorepo/getDependencies.js
@@ -14,10 +14,12 @@ function flattenPackageGraph(rootPackages, projectGraph, packageList = []) {
 }
 
 /**
- * Returns all the dev dependencies of a given package name
+ * Returns all the dependencies of a given package name
  * @param {string} packageName including `@fluentui/` prefix
+ * @param {String} options.dev include dev dependencies
+ * @param {String} options.production include production dependnecies
  */
-async function getDevDependencies(packageName) {
+async function getDependencies(packageName, options = {}) {
   const lernaProject = new Project(path.resolve(findGitRoot(), 'packages'));
   const projectPackages = await lernaProject.getPackages();
 
@@ -26,7 +28,17 @@ async function getDevDependencies(packageName) {
 
   const devDependencies = allDepsGraph.filter(dep => !productionDepsGraph.includes(dep));
 
-  return devDependencies;
+  let res = [];
+
+  if (options.dev) {
+    res = res.concat(devDependencies);
+  }
+
+  if (options.production) {
+    res = res.concat(productionDepsGraph);
+  }
+
+  return res;
 }
 
-module.exports = getDevDependencies;
+module.exports = getDependencies;

--- a/scripts/monorepo/index.js
+++ b/scripts/monorepo/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  getDevDependencies: require('./getDevDependencies'),
+  getDependencies: require('./getDependencies'),
   findGitRoot: require('./findGitRoot'),
   findRepoDeps: require('./findRepoDeps'),
   getAllPackageInfo: require('./getAllPackageInfo'),


### PR DESCRIPTION
This PR uses an internal build task to generate third party NOTICE files
from the component governance instance on the repo. The CG instance has
been configured to only generate third party notices for converged.

Modifies a few utility functions, but the goal is to auto generate
NOTICE.txt in `react-components` and then copy that file across all
converged packages that are released as a part of the suite

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
