### PR TITLE
Use env vars for VR tests Screener endpoints

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,8 @@ jobs:
       - script: yarn workspace @fluentui/docs vr:test
         displayName: start FUI N* VR Test
         env:
+          SCREENER_ENDPOINT: $(screenerApiUri)
+          SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
           SCREENER_API_KEY: $(screener.key)
 
       - template: .devops/templates/cleanup.yml

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -1,6 +1,19 @@
 import fetch from 'node-fetch';
 import { ScreenerRunnerConfig } from './screener.types';
 
+const environment = {
+  screener: {
+    /**
+     *  Screener API endpoint used to create the tasks.
+     **/
+    apiUri: process.env.SCREENER_ENDPOINT,
+    /**
+     *  Screener Proxy endpoint used to orchestrate the GitHub checks for Screener.
+     **/
+    proxyUri: process.env.SCREENER_PROXY_ENDPOINT,
+  },
+};
+
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -29,7 +42,7 @@ async function scheduleScreenerBuild(
     pullRequest: buildInfo.pullRequest,
   };
 
-  const response = await fetch(process.env.SCREENER_ENDPOINT, {
+  const response = await fetch(environment.screener.apiUri, {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',
@@ -68,7 +81,7 @@ async function scheduleScreenerBuild(
 async function notifyIntegration(commit: string, url: string) {
   const payload = { commit, url };
 
-  await fetch(process.env.SCREENER_PROXY_ENDPOINT, {
+  await fetch(environment.screener.proxyUri, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -1,9 +1,6 @@
 import fetch from 'node-fetch';
 import { ScreenerRunnerConfig } from './screener.types';
 
-const SCREENER_ENDPOINT = 'https://screener.io/api/v2/projects';
-const SCREENER_PROXY_ENDPOINT = 'https://screener-proxy.vercel.app/api/ci';
-
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -32,7 +29,7 @@ async function scheduleScreenerBuild(
     pullRequest: buildInfo.pullRequest,
   };
 
-  const response = await fetch(SCREENER_ENDPOINT, {
+  const response = await fetch(process.env.SCREENER_ENDPOINT, {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',
@@ -71,7 +68,7 @@ async function scheduleScreenerBuild(
 async function notifyIntegration(commit: string, url: string) {
   const payload = { commit, url };
 
-  await fetch(SCREENER_PROXY_ENDPOINT, {
+  await fetch(process.env.SCREENER_PROXY_ENDPOINT, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Contributes towards #16850

#### Description of changes

Conversion of the two hardcoded URLs we have for Screener and the Screener proxy to env vars set in ADO. This will smoothen the migration process of Screener Proxy and make our lives easier if we ever need to change one of the endpoints again.
I already set both vars in ADO for the values we have currently.
