### PR TITLE
Improve conformance test error messages

### DIFF
--- a/change/@fluentui-react-conformance-078c90e2-ac6d-4aef-a8f2-7ad0f6abc619.json
+++ b/change/@fluentui-react-conformance-078c90e2-ac6d-4aef-a8f2-7ad0f6abc619.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve conformance test error messages",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -380,7 +380,7 @@ export const defaultErrorMessages = {
       displayName,
       overview: `doesn't have a top level export in:${EOL}${testErrorPath(indexFile)}`,
       suggestions: [
-        `Make sure that your component's ${resolveInfo('index.ts')} file contains ${resolveInfo(exportInfo)}`,
+        `Make sure that your component's ${resolveInfo('index.ts')} file contains \`${resolveInfo(exportInfo)}\``,
         `Check if your component is internal and consider enabling ${resolveInfo(
           'isInternal',
         )} in your isConformant test.`,

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -1,9 +1,7 @@
 import { IsConformantOptions } from './types';
-import { ComponentDoc } from 'react-docgen-typescript';
 
 import chalk from 'chalk';
-import * as os from 'os';
-import parseDocblock from './utils/parseDocblock';
+import { EOL } from 'os';
 
 import * as _ from 'lodash';
 import * as path from 'path';
@@ -12,312 +10,244 @@ import * as path from 'path';
 
 /**
  * General structure of isConformant error messages:
- * 1. Call __defaultErrorMessage()__ and pass in the `testName`, `displayName`, and the `errorMessage`.
- *    It will return:
  *
- *    `testName`
+ * ```txt
+ * It appears that `displayName` [has some issue].
  *
- *    It appears that `displayName` does not have a `errorMessage`
+ * To resolve this issue:
+ * 1. suggestion
+ * 2. suggestion
  *
- * 2. Call __resolveErrorMessages()__ and pass in a array of `resolveErrorMessages` to help solve the error.
- *    It will return:
+ * Also check the original error message in case there's some other issue:
  *
- *    To resolve this issue:
- *    [`resolveErrorMessages`]
- *
- * 3. Call __receivedErrorMessage__ and pass in the `error` caught from the isConformant test.
- *    It will return:
- *
- *    Here's the full error message:
- *
- *    `error`
- *
- * 4. Reference __errorMessageColors__ and color code the passed arguments for `errorMessage` and
- *    `resolveErrorMessages` array accordingly.
+ * `error`
+ * ```
  */
 export const defaultErrorMessages = {
-  'has-docblock': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'has-docblock': (testInfo: IsConformantOptions, error: Error, docblock: string, wordCount: number | undefined) => {
     const { displayName, componentPath } = testInfo;
-    const { testErrorName, testErrorInfo, testErrorPath, resolveInfo } = errorMessageColors;
-    const fileName = path.basename(componentPath);
-    const docblock = parseDocblock(componentInfo.description);
-    const docBlockLength = _.words(docblock.description).length.toString();
+    const { testErrorInfo, testErrorPath, resolveInfo } = errorMessageColors;
 
-    // Message Description: Handles scenario where there is no existing docblock in the componentPath.
-    //
-    // It appears that "displayName" doesn't have a docblock in the file:: "componentPath".
-    // To resolve this issue:
-    // 1. Consider adding a descriptive 5 to 25 word docblock in "fileName".
-    if (_.words(docblock.description).length === 0) {
-      console.log(
-        defaultErrorMessage(
-          `has-docblock`,
-          displayName,
-          'docblock in the file: ' + paragraph() + testErrorPath(componentPath),
-        ) +
-          resolveErrorMessages([
-            `Consider adding a descriptive ${resolveInfo('5')} to ${resolveInfo('25')} word docblock in ${resolveInfo(
-              fileName,
-            )}`,
-          ]),
-        receivedErrorMessage(error),
-      );
+    if (wordCount === undefined) {
+      // Parsing error or something--need to just look at the original error
+      return getErrorMessage({
+        displayName,
+        overview: `has an invalid docblock in the file:${EOL}${testErrorPath(componentPath)}`,
+        error,
+      });
     }
 
-    // Message Description: Handles scenario where a docblock is received but doesn't meet the min and max requirements.
+    if (wordCount === 0) {
+      // Message Description: Handles scenario where there is no existing docblock in the componentPath.
+      //
+      // It appears that "displayName" doesn't have a docblock in the file: "componentPath".
+      // To resolve this issue:
+      // 1. Consider adding a 5 to 25 word doc comment on the component.
+      return getErrorMessage({
+        displayName,
+        overview: `doesn't have a docblock in the file:${EOL}${testErrorPath(componentPath)}`,
+        suggestions: [
+          `Consider adding a ${resolveInfo('5')} to ${resolveInfo('25')} word doc comment on the component`,
+        ],
+        error,
+      });
+    }
+
+    // Message Description: Handles scenario where a docblock exists but doesn't meet the min and max requirements.
     //
     // It appears that "displayName" doesn't have a docblock between 5 and 25 words.
-    // It has a word count of: "docBlockLength"
-    // Here is "displayName"'s docblock: "docblock.description"
-    // To resolve this issue:
-    // 1. Make sure that your docblock meets the required word count of 5 to 25 words.
-    else {
-      console.log(
-        defaultErrorMessage(
-          `has-docblock`,
-          displayName,
-          `docblock between 5 and 25 words. It has a word count of: ${testErrorInfo(docBlockLength)}` +
-            paragraph() +
-            `Here is ${testErrorName(displayName + `'s`)} docblock: ` +
-            paragraph() +
-            testErrorInfo(docblock.description),
-        ) +
-          resolveErrorMessages([
-            `Make sure that your docblock meets the required word count of ${resolveInfo('5')} to ${resolveInfo(
-              `25`,
-            )} words.`,
-          ]),
-        receivedErrorMessage(error),
-      );
-    }
-    failedTests.push('has-docblock');
+    // It has a word count of "docBlockLength". Here is the docblock: "docblock.description"
+    return getErrorMessage({
+      displayName,
+      overview: `docblock is not between ${resolveInfo('5')} and ${resolveInfo('25')} words.`,
+      details: [`It has a word count of ${testErrorInfo('' + wordCount)}. Here is the docblock:`, '', docblock],
+      error,
+    });
   },
-
-  'exports-component': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'exports-component': (testInfo: IsConformantOptions, error: Error, exportNames: string[]) => {
     const { componentPath, displayName } = testInfo;
     const { testErrorPath, resolveInfo } = errorMessageColors;
-    const fileName = path.basename(componentPath);
 
     // Message Description: There are no matching exported components that match the displayName.
     //
-    // It appears that "Component" doesn't have a export in: "componentPath"
-    // Here are the available exported component's from your file: "componentFile"
+    // It appears that "Component" is not exported from: "componentPath"
+    // The available exports are:
     // To resolve this issue:
-    // 1. Make sure that your component's "fileName" file contains an export for "displayName".
-    // 2. Check to see if you component uses export default and consider enabling useDefaultExport in your
+    // 1. Make sure that your component's file contains an export for "displayName".
+    // 2. Check to see if your component uses export default and consider enabling useDefaultExport in your
     // isConformant test.
-    console.log(
-      defaultErrorMessage(
-        `exports-component`,
-        displayName,
-        'export in: ' + paragraph() + testErrorPath(componentPath),
-      ) +
-        resolveErrorMessages([
-          `Make sure that your component's ${resolveInfo(fileName)} file contains an export for ${resolveInfo(
-            displayName,
-          )}.`,
-          `Check to see if you component uses ${resolveInfo('export default')} and consider enabling ${resolveInfo(
-            'useDefaultExport',
-          )} in your isConformant test.`,
-        ]),
-      receivedErrorMessage(error),
-    );
-    failedTests.push('exports-component');
+    return getErrorMessage({
+      displayName,
+      overview: `is not exported from:${EOL}${testErrorPath(componentPath)}`,
+      details: [`The available exports are: ${exportNames.join(', ')}`],
+      suggestions: [
+        `Make sure that your component's file contains an export for ${resolveInfo(displayName)}.`,
+        testInfo.useDefaultExport
+          ? `Make sure your component file has ${resolveInfo(displayName)} as its default export.`
+          : `Check to see if your component uses ${resolveInfo('export default')} and consider enabling ${resolveInfo(
+              'useDefaultExport',
+            )} in your isConformant test.`,
+      ],
+      error,
+    });
   },
 
-  'component-renders': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
-    const { displayName, componentPath, requiredProps } = testInfo;
-    const { testErrorInfo, testErrorPath, resolveInfo } = errorMessageColors;
-    const typesFile = componentPath.replace('tsx', 'types.ts');
+  'component-renders': (testInfo: IsConformantOptions, error: Error) => {
+    const { displayName, requiredProps } = testInfo;
+    const { testErrorInfo, resolveInfo } = errorMessageColors;
 
     // Message Description: Handles scenario where a invalid return is received and the user provides requiredProps.
     //
-    // It appears that displayName doesn't have a valid return.
+    // It appears that displayName doesn't render successfully.
     // It currently is receiving the requiredProps: "requiredProps"
-    // Check to see if you are including all of the required props in your types file: "typesFile"
     // To resolve this issue:
-    // 1. Make sure that your are including all of the required props to render in isConformant.
-    // 2. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 3. Check to see if your component works as expected with mount and safeMount.
+    // 1. Make sure you're including all of the required props to render in isConformant.
+    // 2. Make sure that your component's implementation contains a valid return statement.
+    // 3. Check to see if your component works as expected with Enzyme's mount().
     if (requiredProps) {
-      const formatRequiredProps = () => {
-        return Object.entries(requiredProps)
-          .map(([propName, propValue]) => `${propName}: ${propValue}`)
-          .join(',\n');
-      };
+      const formattedRequiredProps = Object.entries(requiredProps)
+        .map(([propName, propValue]) => `  ${propName}: ${propValue}`)
+        .join(',' + EOL);
 
-      console.log(
-        defaultErrorMessage(
-          `component-renders`,
-          displayName,
-          'valid return. It currently is receiving the requiredProps:' +
-            paragraph() +
-            testErrorInfo(formatRequiredProps()) +
-            paragraph() +
-            'Check to see if you are including all of the required props in your types file: ' +
-            paragraph() +
-            testErrorPath(typesFile),
-        ) +
-          resolveErrorMessages([
-            `Make sure that your are including all of the required props to render in isConformant ${resolveInfo(
-              'requiredProps',
-            )}.`,
-            `Make sure that your component's ${resolveInfo(
-              displayName + '.base.tsx',
-            )} file contains a valid return statement.`,
-            `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-              'safeMount',
-            )}.`,
-          ]),
-        receivedErrorMessage(error),
-      );
+      return getErrorMessage({
+        displayName,
+        overview: "doesn't render successfully.",
+        details: ['It currently is receiving the requiredProps:', testErrorInfo(formattedRequiredProps)],
+        suggestions: [
+          `Make sure you're including all of the required props to render in isConformant ${resolveInfo(
+            'requiredProps',
+          )}.`,
+          `Make sure that your component's implementation contains a valid return statement.`,
+          `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
+        ],
+        error,
+      });
     }
 
     // Message Description: Handles scenario where an invalid return is received and there are no requiredProps.
     //
-    // It appears that "displayName" doesn't have a valid return and is not receiving any requiredProps.
-    // Check to see if you are missing any required props in your component's types file: "typesFile"
+    // It appears that "displayName" doesn't render successfully and is not receiving any requiredProps.
     // To resolve this issue:
     // 1. Make sure that your are including all of the required props to render in isConformant requiredProps.
-    // 2. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 3. Check to see if your component works as expected with mount and safeMount.
-    else {
-      console.log(
-        defaultErrorMessage(
-          `component-renders`,
-          displayName,
-          'valid return and is not receiving any requiredProps.' +
-            paragraph() +
-            `Check to see if you are missing any required props in your component's types file:` +
-            paragraph() +
-            testErrorPath(typesFile),
-        ) +
-          resolveErrorMessages([
-            `Make sure that your are including all of the required props to render in isConformant ` +
-              resolveInfo('requiredProps') +
-              '.',
-            `Make sure that your component's ${resolveInfo(
-              displayName + '.base.tsx',
-            )} file contains a valid return statement.`,
-            `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-              'safeMount',
-            )}.`,
-          ]),
-        receivedErrorMessage(error),
-      );
-    }
-    failedTests.push('component-renders');
+    // 2. Make sure that your component's implementation contains a valid return statement.
+    // 3. Check to see if your component works as expected with Enzyme's mount().
+    return getErrorMessage({
+      displayName,
+      overview: "doesn't render successfully and is not receiving any requiredProps.",
+      suggestions: [
+        `Make sure that your are including all of the required props to render in isConformant ` +
+          resolveInfo('requiredProps') +
+          '.',
+        `Make sure that your component's implementation contains a valid return statement.`,
+        `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
+      ],
+      error,
+    });
   },
 
-  'component-has-displayname': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'component-has-displayname': (testInfo: IsConformantOptions, error: Error) => {
     const { componentPath, Component, displayName } = testInfo;
     const { testErrorInfo, testErrorPath, resolveInfo } = errorMessageColors;
     const constructorName = Component.prototype?.constructor.name;
     const componentDisplayName = Component.displayName || constructorName;
-    const fileName = path.basename(componentPath);
 
     // Message Description: Handles scenario where the component's display name is undefined.
     //
     // It appears that "displayName" doesn't have a display name in: "componentPath"
     // To resolve this issue:
-    // 1. Make sure that "fileName" contains "displayName".displayName = '"displayName"'
-    // 2. Check to see if something is removing "displayName"'s displayName.
-    if (componentDisplayName === (null || 'Styledundefined')) {
-      console.log(
-        defaultErrorMessage(
-          `component-has-displayname`,
-          displayName,
-          'display name in:' + paragraph() + testErrorPath(componentPath),
-        ) +
-          resolveErrorMessages([
-            `Make sure that ${resolveInfo(fileName)} contains ${resolveInfo(
-              displayName + `.displayName = '` + displayName + `'`,
-            )}`,
-            `Check to see if something is removing ${resolveInfo(displayName + `'s`)} displayName.`,
-          ]) +
-          receivedErrorMessage(error),
-      );
+    // 1. Make sure the component file contains "displayName".displayName = '"displayName"'
+    // 2. Check to see if a wrapper isn't propagating "displayName"'s displayName.
+    if (!componentDisplayName || componentDisplayName === 'Styledundefined') {
+      return getErrorMessage({
+        displayName,
+        overview: `doesn't have a display name in:${EOL}${testErrorPath(componentPath)}`,
+        suggestions: [
+          `Make sure the component file contains ${resolveInfo(`${displayName}.displayName = '${displayName}'`)}`,
+          `Check to see if a wrapper isn't propagating ${resolveInfo(displayName)}'s displayName.`,
+        ],
+        error,
+      });
     }
 
     // Message Description: Handles scenario where the component's display name doesn't match isConformant's displayName
     //
-    // It appears that "displayName" doesn't have a correct display name. It received: "componentDisplayName"
+    // It appears that "displayName" has an incorrect display name. It received: "componentDisplayName"
     // To resolve this issue:
-    // 1. Make sure that "fileName" contains "displayName".displayName = '"displayName"'
-    else {
-      console.log(
-        defaultErrorMessage(
-          `component-has-displayname`,
-          displayName,
-          `correct display name. It received: ${testErrorInfo(componentDisplayName.replace('Styled', ''))}`,
-        ) +
-          resolveErrorMessages([
-            `Make sure that ${resolveInfo(fileName)} contains ${resolveInfo(
-              displayName + `.displayName = '` + displayName + `'`,
-            )}`,
-          ]) +
-          receivedErrorMessage(error),
-      );
-    }
-    failedTests.push('component-has-displayname');
+    // 1. Make sure the component file contains "displayName".displayName = '"displayName"'
+    return getErrorMessage({
+      displayName,
+      overview: `has an incorrect display name. It received: ${testErrorInfo(
+        componentDisplayName.replace('Styled', ''),
+      )}`,
+      suggestions: [
+        `Make sure the component file contains ${resolveInfo(`${displayName}.displayName = '${displayName}'`)}`,
+      ],
+      error,
+    });
   },
 
-  'component-handles-ref': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'component-handles-ref': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Handles scenario where the ref is not defined when passed to the component.
     //
-    // It appears that "displayName" doesn't have a defined ref value.
+    // It appears that "displayName" doesn't handle the ref prop.
     // To resolve this issue:
-    // 1. Check if your component has a ref.
-    // 2. If you component is a function component make sure that your are using forwardRef.
+    // 1. Check if your component has a ref prop.
+    // 2. For function components, make sure that you are using forwardRef.
     // 3. Check if your component passes ref to an inner component and add targetComponent to isConformant in
     //    your test file.
-    console.log(
-      defaultErrorMessage(`component-handles-ref`, displayName, `defined ref value.`) +
-        resolveErrorMessages([
-          `Check if your component has a ${resolveInfo('ref')}.`,
-          `If you component is a function component make sure that your are using ${resolveInfo('forwardRef')}.`,
-          `Check if your component uses an element ref and add ${resolveInfo(
-            `elementRefName: 'elementRef'`,
-          )} to isConformant in your test file.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
+    // 4. If your component uses an "elementRef" prop instead of "ref", add elementRefName: 'elementRef' to
+    //    isConformant in your test file.
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't handle the "ref" prop.`,
+      suggestions: [
+        `Check if your component has a ${resolveInfo('ref')} prop.`,
+        `For function components, make sure that you are using ${resolveInfo('forwardRef')}.`,
+        `Check if your component passes the ref to an inner component and add ${resolveInfo('targetComponent')} ` +
+          'to isConformant in your test file.',
+        `If your component uses an "elementRef" prop instead of "ref", add ${resolveInfo(
+          `elementRefName: 'elementRef'`,
+        )} to isConformant in your test file.`,
+      ],
+      error,
+    });
   },
 
-  'component-has-root-ref': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'component-has-root-ref': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Handles scenario where the ref doesn't match the DOM node.
     //
-    // It appears that "displayName" doesn't have a ref that matches the components DOM node.
+    // It appears that "displayName" doesn't apply the ref prop to its root DOM node.
     // To resolve this issue:
-    // 1. Make sure that you are applying the ref to the root element in your component.
+    // 1. Make sure you're applying the ref to the root element in your component.
     // 2. Check if your component uses an element ref and add elementRefName: 'elementRef' to isConformant in
     //    your test file.
     // 3. Check if your component passes ref to an inner component and add targetComponent to isConformant in
     //    your test file.
-    console.log(
-      defaultErrorMessage(`component-has-root-ref`, displayName, `ref that matches the components DOM node.`) +
-        resolveErrorMessages([
-          `Make sure that you are applying the ref to the ${resolveInfo('root element')} in your component.`,
-          `Check if your component uses an element ref and add ${resolveInfo(
-            `elementRefName: 'elementRef'`,
-          )} to isConformant in your test file.`,
-          `Check if your component passes ref to an inner component and add ${resolveInfo(
-            `targetComponent`,
-          )} to isConformant in your test file.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't apply the "ref" prop to its root DOM node.`,
+      suggestions: [
+        `Make sure you're applying the ref to the ${resolveInfo('root element')} in your component.`,
+        `Check if your component uses an element ref and add ${resolveInfo(
+          `elementRefName: 'elementRef'`,
+        )} to isConformant in your test file.`,
+        `Check if your component passes ref to an inner component and add ${resolveInfo(
+          `targetComponent`,
+        )} to isConformant in your test file.`,
+      ],
+      error,
+    });
   },
 
   'component-handles-classname': (
     testInfo: IsConformantOptions,
-    error: string,
+    error: Error,
     testClassName: string,
     classNames: string[] | undefined,
     componentHTML: string,
@@ -344,34 +274,31 @@ export const defaultErrorMessages = {
     // 1. Make sure that your component accepts a className prop.
     // 2. Make sure that nothing is overwriting the className prop (it should be merged with defaults).
     // 3. Make sure that your component is applying the className to the root.
-    console.log(
-      defaultErrorMessage(
-        `component-handles-classname`,
-        displayName,
-        `properly applied className prop.` +
-          paragraph(2) +
-          `After passing a test className ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
-            displayName,
-          )} it received:` +
-          paragraph() +
-          failedError(`className='${formatObject(classNames || ['undefined'])}'`) +
-          paragraph(2) +
-          `The className should contain "${testClassName}"` +
-          (debugHTML ? `${paragraph(2)}Partial HTML:\n${debugHTML}` : ''),
-      ) +
-        resolveErrorMessages([
-          `Make sure that your component ${resolveInfo('accepts a className prop')}.`,
-          `Make sure that nothing is ${resolveInfo('overwriting')} the className prop ` +
-            `(it should be merged with defaults).`,
-          `Make sure that your ${resolveInfo('component is applying')} the className to the root.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't have a properly applied 'className' prop.`,
+      details: [
+        `After passing a test className ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
+          displayName,
+        )} it received:`,
+        `    ${failedError(`className='${formatObject(classNames || ['undefined'])}'`)}`,
+        '',
+        `The className should contain "${testClassName}"`,
+        ...(debugHTML ? ['', 'Partial HTML:', debugHTML] : []),
+      ],
+      suggestions: [
+        `Make sure that your component ${resolveInfo('accepts a className prop')}.`,
+        `Make sure that nothing is ${resolveInfo('overwriting')} the className prop ` +
+          `(it should be merged with defaults).`,
+        `Make sure that your ${resolveInfo('component is applying')} the className to the root.`,
+      ],
+      error,
+    });
   },
 
   'component-preserves-default-classname': (
     testInfo: IsConformantOptions,
-    error: string,
+    error: Error,
     testClassName: string,
     defaultClassName: string,
     classNames: string[] | undefined,
@@ -385,37 +312,30 @@ export const defaultErrorMessages = {
     // After passing a test className "testComponentClassName" to "displayName" it received a className:
     // className='"classNames"'
     //
-    // Since "displayName" has a default className: "defaultClassName" it should have been merged into:
-    // className='"classNames" "defaultClassName"'
+    // Since "displayName" has a default className "defaultClassName" it should have been merged with
+    // the user-supplied className.
     //
     // To resolve this issue:
     // 1. Check the placement of your className and ensure that it is merged with defaults.
-    console.log(
-      defaultErrorMessage(
-        `component-handles-classname`,
-        displayName,
-        `overwrites default classNames with the user-supplied className.` +
-          paragraph(2) +
-          `After passing a test classname ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
-            displayName,
-          )} it received a className:` +
-          paragraph() +
-          failedError(`className='${classNames?.join(' ')}'`) +
-          paragraph(2) +
-          `Since ${testErrorName(displayName)} has a default className: ${testErrorInfo(
-            defaultClassName,
-          )} it should have been merged into:` +
-          paragraph() +
-          testErrorInfo(`className="${classNames?.join(' ')} ${defaultClassName}"`),
-      ) +
-        resolveErrorMessages([
-          `Check the placement of your className and ensure that it is ${resolveInfo('merged')} with defaults.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
+    return getErrorMessage({
+      displayName,
+      overview: `overwrites default classNames with the user-supplied className.`,
+      details: [
+        `After passing a test classname ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
+          displayName,
+        )} it received a className:` + `    ${failedError(`className='${classNames?.join(' ')}'`)}`,
+        `Since ${testErrorName(displayName)} has a default className "${testErrorInfo(
+          defaultClassName,
+        )}" it should have been with the user-supplied className.`,
+      ],
+      suggestions: [
+        `Check the placement of your className and ensure that it is ${resolveInfo('merged')} with defaults.`,
+      ],
+      error,
+    });
   },
 
-  'name-matches-filename': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'name-matches-filename': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName, componentPath } = testInfo;
     const { testErrorInfo, resolveInfo } = errorMessageColors;
     const fileName = path.basename(componentPath, path.extname(componentPath));
@@ -426,27 +346,29 @@ export const defaultErrorMessages = {
     // It received a filename called "filename" instead of "displayName".
     // To resolve this issue:
     // 1. Make sure that your component's filename matches the isConformant displayName: "displayName".
-    console.log(
-      defaultErrorMessage(
-        `name-matches-filename`,
-        displayName,
-        'matching filename.' +
-          paragraph() +
-          `It received a filename called ${testErrorInfo(fileName)} instead of ${testErrorInfo(displayName)}`,
-      ) +
-        resolveErrorMessages([
-          `Make sure that your component's filename matches the isConformant displayName: ${resolveInfo(displayName)}`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('name-matches-filename');
+    return getErrorMessage({
+      displayName,
+      overview: "doesn't have a matching filename.",
+      details: [
+        `It received a filename called ${testErrorInfo(fileName)} instead of ${testErrorInfo(displayName)}.`,
+        `(full path: ${componentPath})`,
+      ],
+      suggestions: [
+        `Make sure that your component's filename matches the isConformant displayName: ${resolveInfo(displayName)}`,
+      ],
+      error,
+    });
   },
 
-  'exported-top-level': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'exported-top-level': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName, componentPath } = testInfo;
     const { testErrorPath, resolveInfo } = errorMessageColors;
     const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
     const indexFile = path.join(rootPath, 'src', 'index');
+
+    const exportInfo = testInfo.useDefaultExport
+      ? `export { default as ${displayName} } from './${displayName};`
+      : `export * from './${displayName}';`;
 
     // Message Description: Handles scenario where the displayName doesn't exist in the index file.
     //
@@ -454,26 +376,20 @@ export const defaultErrorMessages = {
     // To resolve this issue:
     // 1. Make sure that your component's index'.ts file contains "export * from './"displayName"';
     // 2.Check if your component is internal and consider enabling isInternal in your isConformant test.
-    console.log(
-      defaultErrorMessage(
-        `exported-top-level`,
-        displayName,
-        'top level export in:' + paragraph() + testErrorPath(indexFile),
-      ) +
-        resolveErrorMessages([
-          `Make sure that your component's ${resolveInfo('index.ts')} file contains ${resolveInfo(
-            `export * from './` + displayName + `';`,
-          )}`,
-          `Check if your component is internal and consider enabling ${resolveInfo(
-            'isInternal',
-          )} in your isConformant test.`,
-        ]),
-      receivedErrorMessage(error),
-    );
-    failedTests.push('exported-top-level');
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't have a top level export in:${EOL}${testErrorPath(indexFile)}`,
+      suggestions: [
+        `Make sure that your component's ${resolveInfo('index.ts')} file contains ${resolveInfo(exportInfo)}`,
+        `Check if your component is internal and consider enabling ${resolveInfo(
+          'isInternal',
+        )} in your isConformant test.`,
+      ],
+      error,
+    });
   },
 
-  'has-top-level-file': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'has-top-level-file': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName, componentPath } = testInfo;
     const { testErrorPath, resolveInfo } = errorMessageColors;
     const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
@@ -485,24 +401,20 @@ export const defaultErrorMessages = {
     // To resolve this issue:
     // 1. Make sure that your component's index'.ts file contains "export * from './"displayName"';
     // 2.Check if your component is internal and consider enabling isInternal in your isConformant test.
-    console.log(
-      defaultErrorMessage(
-        `has-top-level-file`,
-        displayName,
-        'top level file in:' + paragraph() + testErrorPath(topLevelFile),
-      ) +
-        resolveErrorMessages([
-          `Make sure that your component's folder and name match it's displayName: ${resolveInfo(displayName)}`,
-          `Check if your component is internal and consider enabling ${resolveInfo(
-            'isInternal',
-          )} in your isConformant test.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('has-top-level-file');
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't have a top level file in:${EOL}${testErrorPath(topLevelFile)}`,
+      suggestions: [
+        `Make sure that your component's folder and name match its displayName: ${resolveInfo(displayName)}`,
+        `Check if your component is internal and consider enabling ${resolveInfo(
+          'isInternal',
+        )} in your isConformant test.`,
+      ],
+      error,
+    });
   },
 
-  'is-static-property-of-parent': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'is-static-property-of-parent': (testInfo: IsConformantOptions, error: Error) => {
     const { componentPath, displayName } = testInfo;
     const { testErrorInfo, resolveInfo } = errorMessageColors;
     const componentFolder = componentPath.replace(path.basename(componentPath) + path.extname(componentPath), '');
@@ -510,263 +422,170 @@ export const defaultErrorMessages = {
 
     // Message Description: Handles scenario where the child component is not a static property of the parent..
     //
-    // It appears that "displayName" doesn't have a existing static property in: "dirName"
+    // It appears that "displayName" is not a static property of its parent (inferred from the directory name).
     // To resolve this issue:
-    // 1. Include the child component: "displayName" as a static property of the parent: "dirName".
+    // 1. Include the child component: "displayName" as a static property of "dirName".
     // 2.Check to see if "displayName" is a parent component but contained in a directory with a different name.
-    console.log(
-      defaultErrorMessage(
-        `is-static-property-of-parent`,
-        displayName,
-        `existing static property in: ${testErrorInfo(dirName)}`,
-      ) +
-        resolveErrorMessages([
-          `Include the child component: ${resolveInfo(displayName)} as a static property of the parent: ${resolveInfo(
-            dirName,
-          )}.`,
-          `Check to see if ${resolveInfo(
-            displayName,
-          )} is a parent component but contained in a directory with a different name.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('is-static-property-of-parent');
+    return getErrorMessage({
+      displayName,
+      overview: `is not a static property of its parent ${testErrorInfo(dirName)} (inferred from the directory name)`,
+      suggestions: [
+        `Include the child component ${resolveInfo(displayName)} as a static property of ${resolveInfo(dirName)}.`,
+        `Check to see if ${resolveInfo(
+          displayName,
+        )} is a parent component but contained in a directory with a different name.`,
+      ],
+      error,
+    });
   },
 
-  'kebab-aria-attributes': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  // Note: the original error isn't included in params since the test's final checks are narrowly scoped
+  'kebab-aria-attributes': (testInfo: IsConformantOptions, invalidProps: string[]) => {
     const { displayName } = testInfo;
-    const { testErrorName, testErrorInfo, resolveInfo } = errorMessageColors;
-    const props = Object.keys(componentInfo.props);
-    const ariaProps = [];
-    const kebabAriaProps = [];
-    const ariaPropsDif = [];
-
-    for (const prop of props) {
-      if (prop.startsWith('aria') && !/^aria-[a-z]+$/.test(prop)) {
-        ariaProps.push(prop);
-        kebabAriaProps.push(prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase());
-      }
-    }
-
-    for (let i = 0; i < ariaProps.length; i++) {
-      ariaPropsDif.push(ariaProps[i] + ' → ' + testErrorInfo(kebabAriaProps[i]));
-    }
+    const { testErrorName } = errorMessageColors;
+    const ariaPropsDiff = invalidProps.map(prop => {
+      const replacement = prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+      return prop + ' → ' + replacement;
+    });
 
     // Message Description: Handles scenario where an aria prop doesn't match kebab-casing.
     //
-    // It appears that "displayName" doesn't have a aria attribute that uses kebab-casing.
-    // The received aria attributes should be renamed to: "ariaPropsDif"
-    // To resolve this issue:
-    // 1. Make sure that Sliders aria attribute props are using kebab-case.
-    console.log(
-      defaultErrorMessage(
-        `kebab-aria-attributes`,
-        displayName,
-        'aria attribute that uses kebab-casing.' +
-          paragraph() +
-          'The received aria attributes should be renamed to:' +
-          paragraph() +
-          testErrorName(formatObject(ariaPropsDif)),
-      ) +
-        resolveErrorMessages([
-          `Make sure that ${resolveInfo(displayName + 's')} aria attribute props are using kebab-case.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('kebab-aria-attributes');
+    // It appears that "displayName" has aria prop(s) that don't use kebab-casing.
+    // They should be renamed as follows: "ariaPropsDiff"
+    return getErrorMessage({
+      displayName,
+      overview: `has aria prop(s) that don't use kebab-casing.`,
+      details: ['They should be renamed as follows:', testErrorName(formatObject(ariaPropsDiff))],
+    });
   },
 
-  'consistent-callback-names': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
-    const { displayName, testOptions = {} } = testInfo;
+  // Note: the original error isn't included in params since the test's final checks are narrowly scoped
+  'consistent-callback-names': (testInfo: IsConformantOptions, invalidProps: string[]) => {
+    const { displayName } = testInfo;
     const { testErrorInfo, resolveInfo } = errorMessageColors;
-    const propNames = Object.keys(componentInfo.props);
-    const ignoreProps = testOptions['consistent-callback-names']?.ignoreProps || [];
-    const callbackNames = [];
-
-    for (const propName of propNames) {
-      if (!ignoreProps.includes(propName) && /^on(?!Render[A-Z])[A-Z]/.test(propName)) {
-        const words = propName.slice(2).match(/[A-Z][a-z]+/g);
-        if (words) {
-          const lastWord = words[words.length - 1];
-          if (!lastWord.endsWith('ed')) {
-            callbackNames.push(propName);
-          }
-        }
-      }
-    }
 
     // Message Description: Handles scenario where the second word in a callback ends with 'ed'.
     //
-    // It appears that "displayName" doesn't have a consistent callback name.
-    // The received callback needs to be renamed: "callbackNames"
+    // It appears that "displayName" uses non-standard callback naming.
+    // These callback(s) need to be renamed: "callbackNames"
     // To resolve this issue:
-    // 1. Rename "displayName"'s callback props that don't end with "ed".
-    // 2. Include the prop in TestOptions ignoreProps.
-    console.log(
-      defaultErrorMessage(
-        `consistent-callback-names`,
-        displayName,
-        'consistent callback name.' +
-          paragraph() +
-          'The received callback needs to be renamed:' +
-          paragraph() +
-          testErrorInfo(formatObject(callbackNames)),
-      ) +
-        resolveErrorMessages([
-          `Rename ${resolveInfo(displayName + `'s`)} callback props to include "ed".`,
-          `Include the prop in TestOptions ${resolveInfo('ignoreProps')}.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('consistent-callback-names');
+    // 1. Rename "displayName"'s callback props to use present tense (no "ed" ending).
+    // 2. If the name is correct, add the prop to isConformant testOptions['consistent-callback-names'].ignoreProps.
+    return getErrorMessage({
+      displayName,
+      overview: 'uses non-standard callback naming.',
+      details: ['These callback(s) need to be renamed:', testErrorInfo(formatObject(invalidProps))],
+      suggestions: [
+        `Rename ${resolveInfo(displayName + `'s`)} callback props to use present tense (no "ed" ending)`,
+        `If the name is correct, add the prop to isConformant ${resolveInfo(
+          "testOptions['consistent-callback-names'].ignoreProps",
+        )}.`,
+      ],
+    });
   },
 
-  'as-renders-fc': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'as-renders-fc': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Receives an error when attempting to render as a functional component
     // or pass as to the next component.
     //
-    // It appears that "displayName" doesn't have a valid return.
+    // It appears that "displayName" "as" prop doesn't properly handle a function component.
     // To resolve this issue:
     // 1. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 2. If your component handles a forwardRef you will need to enable isConformant's asPropHandlesRef.
-    // 3. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 4. Check to see if your component works as expected with mount and safe mount.
-    console.log(
-      defaultErrorMessage(`as-renders-fc`, displayName, `valid return.`) +
-        resolveErrorMessages([
-          `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
-          `If your component handles a forwardRef you will need to enable isConformant's ${resolveInfo(
-            'asPropHandlesRef',
-          )}.`,
-          `Make sure that your component's ${resolveInfo(
-            displayName + '.base.tsx',
-          )} file contains a valid return statement.`,
-          `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-            'safeMount',
-          )}.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('as-renders-fc');
+    // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
+    // 3. Make sure that your component's implementation contains a valid return statement.
+    // 4. Check to see if your component works as expected with Enzyme's mount().
+    return getErrorMessage({
+      displayName,
+      overview: `"as" prop doesn't properly handle a function component.`,
+      suggestions: [
+        `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
+        `If your component uses forwardRef you will need to enable isConformant's ${resolveInfo('asPropHandlesRef')}.`,
+        `Make sure that your component code contains a valid return statement.`,
+        `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
+      ],
+      error,
+    });
   },
 
-  'as-renders-react-class': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'as-renders-react-class': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Receives an error when attempting to render as a class component
     // or pass as to the next component.
     //
-    // It appears that "displayName" doesn't have a valid return.
+    // It appears that "displayName" "as" prop doesn't properly handle a class component.
     // To resolve this issue:
     // 1. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 2. If your component handles a forwardRef you will need to enable isConformant's asPropHandlesRef.
-    // 3. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 4. Check to see if your component works as expected with mount and safe mount.
-    console.log(
-      defaultErrorMessage(`as-renders-react-class`, displayName, `valid return.`) +
-        resolveErrorMessages([
-          `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
-          `If your component handles a forwardRef you will need to enable isConformant's ${resolveInfo(
-            'asPropHandlesRef',
-          )}.`,
-          `Make sure that your component's ${resolveInfo(
-            displayName + '.base.tsx',
-          )} file contains a valid return statement.`,
-          `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-            'safeMount',
-          )}.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('as-renders-react-class');
+    // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
+    // 3. Make sure that your component's implementation contains a valid return statement.
+    // 4. Check to see if your component works as expected with Enzyme's mount().
+    return getErrorMessage({
+      displayName,
+      overview: `"as" prop doesn't properly handle a class component.`,
+      suggestions: [
+        `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
+        `If your component uses forwardRef you will need to enable isConformant's ${resolveInfo('asPropHandlesRef')}.`,
+        `Make sure that your component's implementation contains a valid return statement.`,
+        `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
+      ],
+      error,
+    });
   },
 
-  'as-passes-as-value': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'as-passes-as-value': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Receives an error when attempting to render as a functional component
     // or pass as to the next component.
     //
-    // It appears that "displayName" doesn't have a valid return.
+    // It appears that "displayName" doesn't pass extra props to the component it renders as.
     // To resolve this issue:
-    // 1. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 2. If your component handles a forwardRef you will need to enable isConformant's asPropHandlesRef.
-    // 3. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 4. Check to see if your component works as expected with mount and safe mount.
-    console.log(
-      defaultErrorMessage(`as-passes-as-value`, displayName, `valid return.`) +
-        resolveErrorMessages([
-          `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
-          `If your component handles a forwardRef you will need to enable isConformant's ${resolveInfo(
-            'asPropHandlesRef',
-          )}.`,
-          `Make sure that your component's ${resolveInfo(
-            displayName + '.base.tsx',
-          )} file contains a valid return statement.`,
-          `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-            'safeMount',
-          )}.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('as-passes-as-value');
+    // 1. Ensure that you are spreading extra props to the "as" component when rendering.
+    // 2. Ensure that there is not a problem rendering the component in isConformant (check previous test results).
+    return getErrorMessage({
+      displayName,
+      overview: `doesn't pass extra props to the component it renders as.`,
+      suggestions: [
+        `Ensure that you are ${resolveInfo('spreading extra props')} to the "as" component when rendering.`,
+        `Ensure that there is not a problem rendering the component (check previous test results).`,
+      ],
+      error,
+    });
   },
 
-  'as-renders-html': (componentInfo: ComponentDoc, testInfo: IsConformantOptions, error: string) => {
+  'as-renders-html': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;
 
     // Message Description: Receives an error when attempting to render as a functional component
     // or pass as to the next component.
     //
-    // It appears that "displayName" doesn't have a 'as' property that can render HTML tags.
+    // It appears that "displayName" "as" prop doesn't properly handle HTML tags.
     // To resolve this issue:
     // 1. Make sure that your component can correctly render as HTML tags.
     // 2. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 3. Make sure that your component's "displayName".base.tsx file contains a valid return statement.
-    // 4. Check to see if your component works as expected with mount and safe mount.
-    console.log(
-      defaultErrorMessage(`as-renders-html`, displayName, `'as' property that can render HTML tags.`) +
-        resolveErrorMessages([
-          `Make sure that your component can correctly render as ${resolveInfo(' HTML tags')}.`,
-          `Check if you are missing any ${resolveInfo('requiredProps')} within the isConformant in your test file.`,
-          `Make sure that your component's ${resolveInfo(
-            displayName + '.base.tsx',
-          )} file contains a valid return statement.`,
-          `Check to see if your component works as expected with ${resolveInfo('mount')} and ${resolveInfo(
-            'safeMount',
-          )}.`,
-        ]) +
-        receivedErrorMessage(error),
-    );
-    failedTests.push('as-renders-html');
-  },
-
-  'display-failed-tests': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    const { displayName } = testInfo;
-    const { failedText, failedDisplayname, sectionBackground } = errorMessageColors;
-
-    if (failedTests.length > 0) {
-      console.log(
-        paragraph() +
-          failedDisplayname(displayName) +
-          failedText(' failed during the following isConformant tests:') +
-          paragraph() +
-          sectionBackground(formatObject(failedTests)),
-      );
-    }
+    // 3. Make sure that your component's implementation contains a valid return statement.
+    // 4. Check to see if your component works as expected with Enzyme's mount().
+    return getErrorMessage({
+      displayName,
+      overview: `"as" prop doesn't properly handle HTML tags.`,
+      suggestions: [
+        `Make sure that your component can correctly render as ${resolveInfo('HTML tags')}.`,
+        `Check if you are missing any ${resolveInfo('requiredProps')} within the isConformant in your test file.`,
+        `Make sure that your component's implementation contains a valid return statement.`,
+        `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
+      ],
+      error,
+    });
   },
 };
 
-// An array of all the failed isConformant tests for the component.
-const failedTests: string[] = [];
-
-// Console message colors used in the test.
+/** Console message colors used in the test. */
 const errorMessageColors = {
   // Colors for the defaultErrorMessage section.
   testErrorText: chalk.yellow,
@@ -778,68 +597,49 @@ const errorMessageColors = {
   resolveInfo: chalk.hex('#e00000'),
   // Colors for the receivedErrorMessage section.
   receivedErrorHeader: chalk.white.bold.bgRed,
-  // Colors for the display-failed-tests section.
-  failedText: chalk.white.bold,
+  // Other colors.
   failedError: chalk.red,
-  failedDisplayname: chalk.red.bold.underline,
   // Color for section headers.
   sectionBackground: chalk.white.bold.italic.bgHex('#2e2e2e'),
 };
 
-/** Generates the message for resolving the test error.
- *  @param resolveMessages Why the test is failing.
- */
-function resolveErrorMessages(resolveMessages: string[]) {
-  const { resolveText, sectionBackground } = errorMessageColors;
-  const resolveMessage = [];
+function getErrorMessage(params: {
+  /** Component display name */
+  displayName: string;
+  /** Overall error description */
+  overview: string;
+  /** More details about the error (single line spacing, so include empty strings for blank lines) */
+  details?: string[];
+  /** Suggestions for fixing the error */
+  suggestions?: string[];
+  /** Original error */
+  error?: Error;
+}) {
+  const { testErrorText, testErrorName, resolveText, sectionBackground, receivedErrorHeader } = errorMessageColors;
+  const { displayName, overview, details = [], error, suggestions } = params;
 
-  if (resolveMessages.length > 1) {
-    for (let i = 0; i < resolveMessages.length; i++) {
-      resolveMessage.push(paragraph() + resolveText(i + 1 + '. ' + resolveMessages[i]));
-    }
-  } else {
-    resolveMessage.push(paragraph() + resolveText(resolveMessages[0]));
+  const messageParts = [testErrorText(`It appears that ${testErrorName(displayName)} ${overview}`), ...details];
+
+  if (suggestions) {
+    messageParts.push(
+      sectionBackground('Possible solutions:'),
+      suggestions.map((msg, i) => resolveText(i + 1 + '. ' + msg)).join(EOL),
+    );
   }
 
-  return paragraph() + sectionBackground('To resolve this issue:') + resolveMessage.join('') + paragraph();
+  if (error) {
+    messageParts.push(
+      `Also check the ${receivedErrorHeader('original error message')} in case there's some other issue:`,
+      error.stack || error.message || String(error),
+    );
+  }
+
+  return messageParts.join(EOL + EOL);
 }
 
 /**
- * Generates the starting default error message: ( "It appears that __displayName__ doesn't have a __errorMessage__." )
- * @param testName The conformance test's name.
- * @param displayName The component's name.
- * @param errorMessage Why the test is failing.
- */
-function defaultErrorMessage(testName: string, displayName: string, errorMessage: string) {
-  const { testErrorText, testErrorName, sectionBackground } = errorMessageColors;
-
-  return (
-    paragraph() +
-    sectionBackground(testName) +
-    paragraph() +
-    testErrorText(`It appears that ${testErrorName(displayName)} doesn't have a ${errorMessage}`) +
-    paragraph()
-  );
-}
-
-/** Generates caught error message in defaultTests.
- *  @param error The caught error message in defaultTests.
- */
-function receivedErrorMessage(error: string) {
-  const { receivedErrorHeader } = errorMessageColors;
-
-  return paragraph() + receivedErrorHeader(`Here's the full error message:`) + paragraph() + error + paragraph(2);
-}
-
-/** Generates a paragraph.
- *  @param numberOfParagraphs The number of paragraphs to generate.
- */
-const paragraph = (numberOfParagraphs?: number) => {
-  return os.EOL.repeat(numberOfParagraphs || 2);
-};
-
-/** Formats a given object to be displayed in the console.
- *  @param obj The object to format.
+ * Formats a given object to be displayed in the console.
+ * @param obj The object to format.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function formatObject(obj: any) {
@@ -852,7 +652,7 @@ function formatObject(obj: any) {
     } else {
       results.push(`${obj[0]}`);
     }
-    return results.join('\n');
+    return results.join(EOL);
   } else {
     return 'received undefined';
   }

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -14,7 +14,7 @@ import * as path from 'path';
  * ```txt
  * It appears that `displayName` [has some issue].
  *
- * To resolve this issue:
+ * Possible solutions:
  * 1. suggestion
  * 2. suggestion
  *
@@ -41,7 +41,7 @@ export const defaultErrorMessages = {
       // Message Description: Handles scenario where there is no existing docblock in the componentPath.
       //
       // It appears that "displayName" doesn't have a docblock in the file: "componentPath".
-      // To resolve this issue:
+      // Possible solutions:
       // 1. Consider adding a 5 to 25 word doc comment on the component.
       return getErrorMessage({
         displayName,
@@ -72,7 +72,7 @@ export const defaultErrorMessages = {
     //
     // It appears that "Component" is not exported from: "componentPath"
     // The available exports are:
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your component's file contains an export for "displayName".
     // 2. Check to see if your component uses export default and consider enabling useDefaultExport in your
     // isConformant test.
@@ -100,7 +100,7 @@ export const defaultErrorMessages = {
     //
     // It appears that displayName doesn't render successfully.
     // It currently is receiving the requiredProps: "requiredProps"
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure you're including all of the required props to render in isConformant.
     // 2. Make sure that your component's implementation contains a valid return statement.
     // 3. Check to see if your component works as expected with Enzyme's mount().
@@ -127,7 +127,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where an invalid return is received and there are no requiredProps.
     //
     // It appears that "displayName" doesn't render successfully and is not receiving any requiredProps.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your are including all of the required props to render in isConformant requiredProps.
     // 2. Make sure that your component's implementation contains a valid return statement.
     // 3. Check to see if your component works as expected with Enzyme's mount().
@@ -154,7 +154,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the component's display name is undefined.
     //
     // It appears that "displayName" doesn't have a display name in: "componentPath"
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure the component file contains "displayName".displayName = '"displayName"'
     // 2. Check to see if a wrapper isn't propagating "displayName"'s displayName.
     if (!componentDisplayName || componentDisplayName === 'Styledundefined') {
@@ -172,7 +172,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the component's display name doesn't match isConformant's displayName
     //
     // It appears that "displayName" has an incorrect display name. It received: "componentDisplayName"
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure the component file contains "displayName".displayName = '"displayName"'
     return getErrorMessage({
       displayName,
@@ -193,7 +193,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the ref is not defined when passed to the component.
     //
     // It appears that "displayName" doesn't handle the ref prop.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Check if your component has a ref prop.
     // 2. For function components, make sure that you are using forwardRef.
     // 3. Check if your component passes ref to an inner component and add targetComponent to isConformant in
@@ -223,7 +223,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the ref doesn't match the DOM node.
     //
     // It appears that "displayName" doesn't apply the ref prop to its root DOM node.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure you're applying the ref to the root element in your component.
     // 2. Check if your component uses an element ref and add elementRefName: 'elementRef' to isConformant in
     //    your test file.
@@ -266,11 +266,9 @@ export const defaultErrorMessages = {
     // After passing a test className "testComponentClassName" to "displayName" it received a className:
     // className='"classNames"'
     //
-    // The className should contain "testComponentClassName"
-    //
     // Partial HTML: ...
     //
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your component accepts a className prop.
     // 2. Make sure that nothing is overwriting the className prop (it should be merged with defaults).
     // 3. Make sure that your component is applying the className to the root.
@@ -281,10 +279,9 @@ export const defaultErrorMessages = {
         `After passing a test className ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
           displayName,
         )} it received:`,
-        `    ${failedError(`className='${formatObject(classNames || ['undefined'])}'`)}`,
+        `    ${failedError(`className="${classNames?.join(' ')}"`)}`,
         '',
-        `The className should contain "${testClassName}"`,
-        ...(debugHTML ? ['', 'Partial HTML:', debugHTML] : []),
+        ...(debugHTML ? ['Partial HTML:', debugHTML] : []),
       ],
       suggestions: [
         `Make sure that your component ${resolveInfo('accepts a className prop')}.`,
@@ -315,7 +312,7 @@ export const defaultErrorMessages = {
     // Since "displayName" has a default className "defaultClassName" it should have been merged with
     // the user-supplied className.
     //
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Check the placement of your className and ensure that it is merged with defaults.
     return getErrorMessage({
       displayName,
@@ -323,10 +320,12 @@ export const defaultErrorMessages = {
       details: [
         `After passing a test classname ${testErrorInfo(`"${testClassName}"`)} to ${testErrorName(
           displayName,
-        )} it received a className:` + `    ${failedError(`className='${classNames?.join(' ')}'`)}`,
+        )} it received a className:`,
+        `    ${failedError(`className='${classNames?.join(' ')}'`)}`,
+        '',
         `Since ${testErrorName(displayName)} has a default className "${testErrorInfo(
           defaultClassName,
-        )}" it should have been with the user-supplied className.`,
+        )}" it should have been merged with the user-supplied className.`,
       ],
       suggestions: [
         `Check the placement of your className and ensure that it is ${resolveInfo('merged')} with defaults.`,
@@ -344,8 +343,8 @@ export const defaultErrorMessages = {
     //
     // It appears that "displayName" doesn't have a matching filename.
     // It received a filename called "filename" instead of "displayName".
-    // To resolve this issue:
-    // 1. Make sure that your component's filename matches the isConformant displayName: "displayName".
+    // Possible solutions:
+    // 1. Make sure that your component's filename matches the displayName "displayName" passed to isConformant.
     return getErrorMessage({
       displayName,
       overview: "doesn't have a matching filename.",
@@ -354,7 +353,9 @@ export const defaultErrorMessages = {
         `(full path: ${componentPath})`,
       ],
       suggestions: [
-        `Make sure that your component's filename matches the isConformant displayName: ${resolveInfo(displayName)}`,
+        `Make sure that your component's filename matches the displayName "${resolveInfo(
+          displayName,
+        )}" passed to isConformant`,
       ],
       error,
     });
@@ -373,7 +374,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the displayName doesn't exist in the index file.
     //
     // It appears that "displayName" doesn't have a top level export in: "indexFile".
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your component's index'.ts file contains "export * from './"displayName"';
     // 2.Check if your component is internal and consider enabling isInternal in your isConformant test.
     return getErrorMessage({
@@ -398,7 +399,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the displayName doesn't match the component's filename.
     //
     // It appears that "displayName" doesn't have a top level file in: "topLevelFile"
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your component's index'.ts file contains "export * from './"displayName"';
     // 2.Check if your component is internal and consider enabling isInternal in your isConformant test.
     return getErrorMessage({
@@ -423,7 +424,7 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the child component is not a static property of the parent..
     //
     // It appears that "displayName" is not a static property of its parent (inferred from the directory name).
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Include the child component: "displayName" as a static property of "dirName".
     // 2.Check to see if "displayName" is a parent component but contained in a directory with a different name.
     return getErrorMessage({
@@ -455,7 +456,11 @@ export const defaultErrorMessages = {
     return getErrorMessage({
       displayName,
       overview: `has aria prop(s) that don't use kebab-casing.`,
-      details: ['They should be renamed as follows:', testErrorName(formatObject(ariaPropsDiff))],
+      suggestions: [
+        'Rename the props as follows as follows:',
+        testErrorName(formatArray(ariaPropsDiff)),
+        "For props that shouldn't be renamed, add them to isConformant `testOptions['",
+      ],
     });
   },
 
@@ -467,18 +472,18 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the second word in a callback ends with 'ed'.
     //
     // It appears that "displayName" uses non-standard callback naming.
-    // These callback(s) need to be renamed: "callbackNames"
-    // To resolve this issue:
-    // 1. Rename "displayName"'s callback props to use present tense (no "ed" ending).
-    // 2. If the name is correct, add the prop to isConformant testOptions['consistent-callback-names'].ignoreProps.
+    // Possible solutions:
+    // 1. Rename these callback props to use present tense (no "ed" ending): "callbackNames"
+    // 2. If the name is correct, add the prop to isConformant `testOptions['consistent-callback-names'].ignoreProps`.
     return getErrorMessage({
       displayName,
       overview: 'uses non-standard callback naming.',
-      details: ['These callback(s) need to be renamed:', testErrorInfo(formatObject(invalidProps))],
       suggestions: [
-        `Rename ${resolveInfo(displayName + `'s`)} callback props to use present tense (no "ed" ending)`,
+        `Rename these callback props to use present tense (no "ed" ending):${EOL}${testErrorInfo(
+          formatArray(invalidProps),
+        )}`,
         `If the name is correct, add the prop to isConformant ${resolveInfo(
-          "testOptions['consistent-callback-names'].ignoreProps",
+          "`testOptions['consistent-callback-names'].ignoreProps`",
         )}.`,
       ],
     });
@@ -492,7 +497,7 @@ export const defaultErrorMessages = {
     // or pass as to the next component.
     //
     // It appears that "displayName" "as" prop doesn't properly handle a function component.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Check if you are missing any requiredProps within the isConformant in your test file.
     // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
     // 3. Make sure that your component's implementation contains a valid return statement.
@@ -518,7 +523,7 @@ export const defaultErrorMessages = {
     // or pass as to the next component.
     //
     // It appears that "displayName" "as" prop doesn't properly handle a class component.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Check if you are missing any requiredProps within the isConformant in your test file.
     // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
     // 3. Make sure that your component's implementation contains a valid return statement.
@@ -544,7 +549,7 @@ export const defaultErrorMessages = {
     // or pass as to the next component.
     //
     // It appears that "displayName" doesn't pass extra props to the component it renders as.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Ensure that you are spreading extra props to the "as" component when rendering.
     // 2. Ensure that there is not a problem rendering the component in isConformant (check previous test results).
     return getErrorMessage({
@@ -566,7 +571,7 @@ export const defaultErrorMessages = {
     // or pass as to the next component.
     //
     // It appears that "displayName" "as" prop doesn't properly handle HTML tags.
-    // To resolve this issue:
+    // Possible solutions:
     // 1. Make sure that your component can correctly render as HTML tags.
     // 2. Check if you are missing any requiredProps within the isConformant in your test file.
     // 3. Make sure that your component's implementation contains a valid return statement.
@@ -618,12 +623,12 @@ function getErrorMessage(params: {
   const { testErrorText, testErrorName, resolveText, sectionBackground, receivedErrorHeader } = errorMessageColors;
   const { displayName, overview, details = [], error, suggestions } = params;
 
-  const messageParts = [testErrorText(`It appears that ${testErrorName(displayName)} ${overview}`), ...details];
+  const messageParts = [testErrorText(`It appears that ${testErrorName(displayName)} ${overview}`), details.join(EOL)];
 
   if (suggestions) {
     messageParts.push(
       sectionBackground('Possible solutions:'),
-      suggestions.map((msg, i) => resolveText(i + 1 + '. ' + msg)).join(EOL),
+      suggestions.map((msg, i) => resolveText(`${i + 1}. ${msg}`)).join(EOL),
     );
   }
 
@@ -638,22 +643,8 @@ function getErrorMessage(params: {
 }
 
 /**
- * Formats a given object to be displayed in the console.
- * @param obj The object to format.
+ * Formats an array of strings to be displayed in the console.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function formatObject(obj: any) {
-  if (obj) {
-    const results = [];
-    if (obj.length > 1) {
-      for (const libName of Object.keys(obj)) {
-        results.push(parseInt(libName, 10) + 1 + `: ${obj[libName]} `);
-      }
-    } else {
-      results.push(`${obj[0]}`);
-    }
-    return results.join(EOL);
-  } else {
-    return 'received undefined';
-  }
+function formatArray(arr: string[] | undefined) {
+  return arr ? arr.map(value => `    ${value}`).join(EOL) : 'received undefined';
 }

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -141,6 +141,10 @@ export const defaultTests: TestObject = {
         act(() => {
           const component = getComponent(el, helperComponents, wrapperComponent);
 
+          // Do an instanceof check first because if `ref` returns a class instance, the toBe check
+          // will print out the very long stringified version in the error (which isn't helpful)
+          expect(rootRef.current).toBeInstanceOf(HTMLElement);
+
           expect(rootRef.current).toBe(component.getDOMNode());
         });
       } catch (e) {

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -19,7 +19,7 @@ export const defaultTests: TestObject = {
     const maxWords = 25;
     const minWords = 5;
 
-    it(`has a docblock with ${minWords} to ${maxWords} words`, () => {
+    it(`has a docblock with ${minWords} to ${maxWords} words (has-docblock)`, () => {
       let description = '(not yet parsed)'; // improves the error message if there's a parsing error
       let wordCount: number | undefined;
       try {
@@ -37,7 +37,7 @@ export const defaultTests: TestObject = {
 
   /** Component file exports a valid React element type  */
   'exports-component': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`exports component from file under correct name`, () => {
+    it(`exports component from file under correct name (exports-component)`, () => {
       const { componentPath, Component, displayName } = testInfo;
       const componentFile = require(componentPath);
 
@@ -55,7 +55,7 @@ export const defaultTests: TestObject = {
 
   /** Component file exports a valid React element and can render it */
   'component-renders': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`renders`, () => {
+    it(`renders (component-renders)`, () => {
       try {
         const { requiredProps, Component, customMount = mount } = testInfo;
         const mountedComponent = customMount(<Component {...requiredProps} />);
@@ -73,7 +73,7 @@ export const defaultTests: TestObject = {
   'component-has-displayname': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     const { Component } = testInfo;
 
-    it(`has a displayName or constructor name`, () => {
+    it(`has a displayName or constructor name (component-has-displayname)`, () => {
       try {
         const constructorName = Component.prototype?.constructor.name;
         const displayName = Component.displayName || constructorName;
@@ -90,7 +90,7 @@ export const defaultTests: TestObject = {
 
   /** Component handles ref */
   'component-handles-ref': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`handles ref`, () => {
+    it(`handles ref (component-handles-ref)`, () => {
       try {
         const { Component, requiredProps, elementRefName = 'ref', targetComponent, customMount = mount } = testInfo;
         const rootRef = React.createRef<HTMLDivElement>();
@@ -116,7 +116,7 @@ export const defaultTests: TestObject = {
 
   /** Component has ref applied to the root component DOM node */
   'component-has-root-ref': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`ref exists on root element`, () => {
+    it(`applies ref to root element (component-has-root-ref)`, () => {
       try {
         const {
           customMount = mount,
@@ -161,7 +161,7 @@ export const defaultTests: TestObject = {
       className: testClassName,
     };
 
-    it(`handles className prop`, () => {
+    it(`handles className prop (component-handles-classname)`, () => {
       const el = customMount(<Component {...mergedProps} />);
       const component = getComponent(el, helperComponents, wrapperComponent);
       const domNode = component.getDOMNode();
@@ -183,7 +183,7 @@ export const defaultTests: TestObject = {
       }
     });
 
-    it(`preserves component's default classNames`, () => {
+    it(`preserves component's default classNames (component-preserves-default-classname)`, () => {
       if (!handledClassName) {
         return; // don't run this test if the main className test failed
       }
@@ -222,7 +222,7 @@ export const defaultTests: TestObject = {
 
   /** Constructor/component name matches filename */
   'name-matches-filename': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`Component/constructor name matches filename`, () => {
+    it(`Component/constructor name matches filename (name-matches-filename)`, () => {
       try {
         const { componentPath, displayName } = testInfo;
         const fileName = path.basename(componentPath, path.extname(componentPath));
@@ -240,7 +240,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`is exported at top-level`, () => {
+    it(`is exported at top-level (exported-top-level)`, () => {
       try {
         const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
         const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
@@ -259,7 +259,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`has corresponding top-level file 'package/src/Component'`, () => {
+    it(`has corresponding top-level file 'package/src/Component' (has-top-level-file)`, () => {
       try {
         const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
         const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
@@ -278,22 +278,24 @@ export const defaultTests: TestObject = {
     const componentFolder = componentPath.replace(path.basename(componentPath) + path.extname(componentPath), '');
     const dirName = path.basename(componentFolder).replace(path.extname(componentFolder), '');
     const isParent = displayName === dirName;
-    if (!isParent) {
-      it(`is a static property of its parent`, () => {
-        try {
-          const parentComponentFile = require(path.join(componentFolder, dirName));
-          const ParentComponent = parentComponentFile.default || parentComponentFile[dirName];
-          expect(ParentComponent[displayName]).toBe(Component);
-        } catch (e) {
-          throw new Error(defaultErrorMessages['is-static-property-of-parent'](testInfo, e));
-        }
-      });
+    if (isParent) {
+      return;
     }
+
+    it(`is a static property of its parent (is-static-property-of-parent)`, () => {
+      try {
+        const parentComponentFile = require(path.join(componentFolder, dirName));
+        const ParentComponent = parentComponentFile.default || parentComponentFile[dirName];
+        expect(ParentComponent[displayName]).toBe(Component);
+      } catch (e) {
+        throw new Error(defaultErrorMessages['is-static-property-of-parent'](testInfo, e));
+      }
+    });
   },
 
   /** Ensures aria attributes are kebab cased */
   'kebab-aria-attributes': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`uses kebab-case for aria attributes`, () => {
+    it(`uses kebab-case for aria attributes (kebab-aria-attributes)`, () => {
       const invalidProps = Object.keys(componentInfo.props).filter(
         prop => prop.startsWith('aria') && !/^aria-[a-z]+$/.test(prop),
       );
@@ -310,7 +312,7 @@ export const defaultTests: TestObject = {
   'consistent-callback-names': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     // Previously this test was broken. Now it's fixed, but enabling it would currently require
     // changes in a lot of files.
-    xit(`has consistent custom callback names`, () => {
+    xit(`has consistent custom callback names (consistent-callback-names)`, () => {
       const { testOptions = {} } = testInfo;
       const propNames = Object.keys(componentInfo.props);
       const ignoreProps = testOptions['consistent-callback-names']?.ignoreProps || [];
@@ -341,7 +343,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`renders as a functional component or passes "as" to the next component`, () => {
+    it(`renders as a functional component or passes "as" to the next  (as-renders-fc)`, () => {
       try {
         const {
           requiredProps,
@@ -379,7 +381,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`renders as a ReactClass or passes "as" to the next component`, () => {
+    it(`renders as a ReactClass or passes "as" to the next component (as-renders-react-class)`, () => {
       try {
         const { requiredProps, Component, customMount = mount, wrapperComponent, helperComponents = [] } = testInfo;
 
@@ -411,7 +413,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`passes extra props to the component it is renders as`, () => {
+    it(`passes extra props to the component it is renders as (as-passes-as-value)`, () => {
       const { customMount = mount, Component, requiredProps, targetComponent, asPropHandlesRef } = testInfo;
 
       let el: ReactWrapper;
@@ -439,7 +441,7 @@ export const defaultTests: TestObject = {
       return;
     }
 
-    it(`renders component as HTML tags or passes "as" to the next component`, () => {
+    it(`renders component as HTML tags or passes "as" to the next component (as-renders-html)`, () => {
       try {
         // silence element nesting warnings
         consoleUtil.disableOnce();

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -2,7 +2,7 @@ import { TestObject, IsConformantOptions } from './types';
 import { defaultErrorMessages } from './defaultErrorMessages';
 import { ComponentDoc } from 'react-docgen-typescript';
 import { getComponent } from './utils/getComponent';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import parseDocblock from './utils/parseDocblock';
 
@@ -13,25 +13,24 @@ import consoleUtil from './utils/consoleUtil';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-const hasAs = (componentInfo: ComponentDoc) =>
-  !!componentInfo.props.as && componentInfo.props.as.parent?.fileName !== 'react/index.d.ts';
-
 export const defaultTests: TestObject = {
   /** Component has a docblock with 5 to 25 words */
   'has-docblock': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     const maxWords = 25;
     const minWords = 5;
 
-    // No need to check if the description is undefined, ComponentDoc.description is a "string".
     it(`has a docblock with ${minWords} to ${maxWords} words`, () => {
+      let description = '(not yet parsed)'; // improves the error message if there's a parsing error
+      let wordCount: number | undefined;
       try {
         const docblock = parseDocblock(componentInfo.description);
+        description = docblock.description;
+        wordCount = _.words(description).length;
 
-        expect(_.words(docblock.description).length).toBeGreaterThanOrEqual(minWords);
-        expect(_.words(docblock.description).length).toBeLessThanOrEqual(maxWords);
+        expect(wordCount).toBeGreaterThanOrEqual(minWords);
+        expect(wordCount).toBeLessThanOrEqual(maxWords);
       } catch (e) {
-        defaultErrorMessages['has-docblock'](componentInfo, testInfo, e);
-        throw new Error();
+        throw new Error(defaultErrorMessages['has-docblock'](testInfo, e, description, wordCount));
       }
     });
   },
@@ -41,10 +40,15 @@ export const defaultTests: TestObject = {
     it(`exports component from file under correct name`, () => {
       const { componentPath, Component, displayName } = testInfo;
       const componentFile = require(componentPath);
-      if (testInfo.useDefaultExport) {
-        expect(componentFile.default).toBe(Component);
-      } else {
-        expect(componentFile[displayName]).toBe(Component);
+
+      try {
+        if (testInfo.useDefaultExport) {
+          expect(componentFile.default).toBe(Component);
+        } else {
+          expect(componentFile[displayName]).toBe(Component);
+        }
+      } catch (e) {
+        throw new Error(defaultErrorMessages['exports-component'](testInfo, e, Object.keys(componentFile)));
       }
     });
   },
@@ -57,8 +61,7 @@ export const defaultTests: TestObject = {
         const mountedComponent = customMount(<Component {...requiredProps} />);
         expect(mountedComponent.exists()).toBeTruthy();
       } catch (e) {
-        defaultErrorMessages['component-renders'](componentInfo, testInfo, e);
-        throw new Error('component-renders');
+        throw new Error(defaultErrorMessages['component-renders'](testInfo, e));
       }
     });
   },
@@ -80,8 +83,7 @@ export const defaultTests: TestObject = {
         // styled() typically have Base in their name, so remove that too.
         expect(displayName).toMatch(new RegExp(`^(Customized|Styled)?${testInfo.displayName}(Base)?$`));
       } catch (e) {
-        defaultErrorMessages['component-has-displayname'](componentInfo, testInfo, e);
-        throw new Error('component-has-displayname');
+        throw new Error(defaultErrorMessages['component-has-displayname'](testInfo, e));
       }
     });
   },
@@ -107,8 +109,7 @@ export const defaultTests: TestObject = {
           expect(rootRef.current?.getAttribute).toBeTruthy();
         });
       } catch (e) {
-        defaultErrorMessages['component-handles-ref'](componentInfo, testInfo, e);
-        throw new Error('component-handles-ref');
+        throw new Error(defaultErrorMessages['component-handles-ref'](testInfo, e));
       }
     });
   },
@@ -143,8 +144,7 @@ export const defaultTests: TestObject = {
           expect(rootRef.current).toBe(component.getDOMNode());
         });
       } catch (e) {
-        defaultErrorMessages['component-has-root-ref'](componentInfo, testInfo, e);
-        throw new Error('component-has-root-ref');
+        throw new Error(defaultErrorMessages['component-has-root-ref'](testInfo, e));
       }
     });
   },
@@ -160,6 +160,7 @@ export const defaultTests: TestObject = {
       ...requiredProps,
       className: testClassName,
     };
+
     it(`handles className prop`, () => {
       const el = customMount(<Component {...mergedProps} />);
       const component = getComponent(el, helperComponents, wrapperComponent);
@@ -170,8 +171,15 @@ export const defaultTests: TestObject = {
         expect(classNames).toContain(testClassName);
         handledClassName = true;
       } catch (e) {
-        defaultErrorMessages['component-handles-classname'](testInfo, e, testClassName, classNames, domNode.outerHTML);
-        throw new Error('component-handles-classname (handles className prop)');
+        throw new Error(
+          defaultErrorMessages['component-handles-classname'](
+            testInfo,
+            e,
+            testClassName,
+            classNames,
+            domNode.outerHTML,
+          ),
+        );
       }
     });
 
@@ -199,14 +207,15 @@ export const defaultTests: TestObject = {
           }
         }
       } catch (e) {
-        defaultErrorMessages['component-preserves-default-classname'](
-          testInfo,
-          e,
-          testClassName,
-          defaultClassName,
-          classNames,
+        throw new Error(
+          defaultErrorMessages['component-preserves-default-classname'](
+            testInfo,
+            e,
+            testClassName,
+            defaultClassName,
+            classNames,
+          ),
         );
-        throw new Error('component-preserves-classname (preserves default classnames)');
       }
     });
   },
@@ -220,46 +229,47 @@ export const defaultTests: TestObject = {
 
         expect(displayName).toMatch(fileName);
       } catch (e) {
-        defaultErrorMessages['name-matches-filename'](componentInfo, testInfo, e);
-        throw new Error('name-matches-filename');
+        throw new Error(defaultErrorMessages['name-matches-filename'](testInfo, e));
       }
     });
   },
 
   /** Ensures component is exported at top level allowing `import { Component } from 'packageName'` */
   'exported-top-level': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!testInfo.isInternal) {
-      it(`is exported at top-level`, () => {
-        try {
-          const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
-          const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-          const indexFile = require(path.join(rootPath, 'src', exportSubdir, 'index'));
-
-          expect(indexFile[displayName]).toBe(Component);
-        } catch (e) {
-          defaultErrorMessages['exported-top-level'](componentInfo, testInfo, e);
-          throw new Error('exported-top-level');
-        }
-      });
+    if (testInfo.isInternal) {
+      return;
     }
+
+    it(`is exported at top-level`, () => {
+      try {
+        const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
+        const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
+        const indexFile = require(path.join(rootPath, 'src', exportSubdir, 'index'));
+
+        expect(indexFile[displayName]).toBe(Component);
+      } catch (e) {
+        throw new Error(defaultErrorMessages['exported-top-level'](testInfo, e));
+      }
+    });
   },
 
   /** Ensures component has top level file in package/src/componentName */
   'has-top-level-file': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!testInfo.isInternal) {
-      it(`has corresponding top-level file 'package/src/Component'`, () => {
-        try {
-          const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
-          const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-          const topLevelFile = require(path.join(rootPath, 'src', exportSubdir, displayName));
-
-          expect(topLevelFile[displayName]).toBe(Component);
-        } catch (e) {
-          defaultErrorMessages['has-top-level-file'](componentInfo, testInfo, e);
-          throw new Error('has-top-level-file');
-        }
-      });
+    if (testInfo.isInternal) {
+      return;
     }
+
+    it(`has corresponding top-level file 'package/src/Component'`, () => {
+      try {
+        const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
+        const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
+        const topLevelFile = require(path.join(rootPath, 'src', exportSubdir, displayName));
+
+        expect(topLevelFile[displayName]).toBe(Component);
+      } catch (e) {
+        throw new Error(defaultErrorMessages['has-top-level-file'](testInfo, e));
+      }
+    });
   },
 
   /** If the component is a subcomponent, ensure its parent has the subcomponent as static property */
@@ -275,8 +285,7 @@ export const defaultTests: TestObject = {
           const ParentComponent = parentComponentFile.default || parentComponentFile[dirName];
           expect(ParentComponent[displayName]).toBe(Component);
         } catch (e) {
-          defaultErrorMessages['is-static-property-of-parent'](componentInfo, testInfo, e);
-          throw new Error('is-static-property-of-parent');
+          throw new Error(defaultErrorMessages['is-static-property-of-parent'](testInfo, e));
         }
       });
     }
@@ -285,17 +294,13 @@ export const defaultTests: TestObject = {
   /** Ensures aria attributes are kebab cased */
   'kebab-aria-attributes': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     it(`uses kebab-case for aria attributes`, () => {
+      const invalidProps = Object.keys(componentInfo.props).filter(
+        prop => prop.startsWith('aria') && !/^aria-[a-z]+$/.test(prop),
+      );
       try {
-        const props = Object.keys(componentInfo.props);
-
-        for (const prop of props) {
-          if (prop.startsWith('aria')) {
-            expect(prop).toMatch(/^aria-[a-z]+$/);
-          }
-        }
+        expect(invalidProps).toEqual([]);
       } catch (e) {
-        defaultErrorMessages['kebab-aria-attributes'](componentInfo, testInfo, e);
-        throw new Error('kebab-aria-attributes');
+        throw new Error(defaultErrorMessages['kebab-aria-attributes'](testInfo, invalidProps));
       }
     });
   },
@@ -303,155 +308,159 @@ export const defaultTests: TestObject = {
   // TODO: Test last word of callback name against list of valid verbs
   /** Ensures that components have consistent custom callback names i.e. on[Part][Event] */
   'consistent-callback-names': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    it(`has consistent custom callback names`, () => {
-      try {
-        const { testOptions = {} } = testInfo;
-        const propNames = Object.keys(componentInfo.props);
-        const ignoreProps = testOptions['consistent-callback-names']?.ignoreProps || [];
+    // Previously this test was broken. Now it's fixed, but enabling it would currently require
+    // changes in a lot of files.
+    xit(`has consistent custom callback names`, () => {
+      const { testOptions = {} } = testInfo;
+      const propNames = Object.keys(componentInfo.props);
+      const ignoreProps = testOptions['consistent-callback-names']?.ignoreProps || [];
 
-        // Object.keys shouldn't be here and is causing this test not to run.
-        // TODO: Remove Object.keys after the package move and disable the test where necessary.
-        for (const propName of Object.keys(propNames)) {
-          if (!ignoreProps.includes(propName) && /^on(?!Render[A-Z])[A-Z]/.test(propName)) {
-            const words = propName.slice(2).match(/[A-Z][a-z]+/g);
-
-            if (words) {
-              // Make sure last word doesn't end with ed
-              const lastWord = words[words.length - 1];
-              expect(lastWord.endsWith('ed')).toBe(false);
-            }
+      const invalidProps = propNames.filter(propName => {
+        if (!ignoreProps.includes(propName) && /^on(?!Render[A-Z])[A-Z]/.test(propName)) {
+          const words = propName.slice(2).match(/[A-Z][a-z]+/g);
+          if (words) {
+            // Make sure last word doesn't end with ed
+            const lastWord = words[words.length - 1];
+            return lastWord.endsWith('ed');
           }
         }
+        return false;
+      });
+
+      try {
+        expect(invalidProps).toEqual([]);
       } catch (e) {
-        defaultErrorMessages['consistent-callback-names'](componentInfo, testInfo, e);
-        throw new Error('consistent-callback-names');
+        throw new Error(defaultErrorMessages['consistent-callback-names'](testInfo, invalidProps));
       }
     });
   },
 
   /** If it has "as" prop: Renders as functional component or passes as to the next component */
   'as-renders-fc': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (hasAs(componentInfo)) {
-      it(`renders as a functional component or passes "as" to the next component`, () => {
-        try {
-          const {
-            requiredProps,
-            Component,
-            customMount = mount,
-            wrapperComponent,
-            helperComponents = [],
-            asPropHandlesRef,
-          } = testInfo;
-          const MyComponent = asPropHandlesRef ? React.forwardRef((props, ref) => null) : () => null;
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const wrapper = customMount(<Component {...requiredProps} {...({ as: MyComponent } as any)} />);
-          const component = getComponent(wrapper, helperComponents, wrapperComponent);
-
-          try {
-            expect(component.type()).toBe(MyComponent);
-          } catch (err) {
-            expect(component.type()).not.toBe(Component);
-            const comp = component
-              .find('[as]')
-              .last()
-              .prop('as');
-            expect(comp).toBe(MyComponent);
-          }
-        } catch (e) {
-          defaultErrorMessages['as-renders-fc'](componentInfo, testInfo, e);
-          throw new Error('as-renders-fc');
-        }
-      });
+    if (!componentInfo.props.as) {
+      return;
     }
+
+    it(`renders as a functional component or passes "as" to the next component`, () => {
+      try {
+        const {
+          requiredProps,
+          Component,
+          customMount = mount,
+          wrapperComponent,
+          helperComponents = [],
+          asPropHandlesRef,
+        } = testInfo;
+        const MyComponent = asPropHandlesRef ? React.forwardRef((props, ref) => null) : () => null;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const wrapper = customMount(<Component {...requiredProps} {...({ as: MyComponent } as any)} />);
+        const component = getComponent(wrapper, helperComponents, wrapperComponent);
+
+        try {
+          expect(component.type()).toBe(MyComponent);
+        } catch (err) {
+          expect(component.type()).not.toBe(Component);
+          const comp = component
+            .find('[as]')
+            .last()
+            .prop('as');
+          expect(comp).toBe(MyComponent);
+        }
+      } catch (e) {
+        throw new Error(defaultErrorMessages['as-renders-fc'](testInfo, e));
+      }
+    });
   },
 
   /** If it has "as" prop: Renders as ReactClass or passes as to the next component */
   'as-renders-react-class': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (hasAs(componentInfo) && !testInfo.asPropHandlesRef) {
-      it(`renders as a ReactClass or passes "as" to the next component`, () => {
-        try {
-          const { requiredProps, Component, customMount = mount, wrapperComponent, helperComponents = [] } = testInfo;
-
-          class MyComponent extends React.Component {
-            public render() {
-              return <div data-my-react-class />;
-            }
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const wrapper = customMount(<Component {...requiredProps} {...({ as: MyComponent } as any)} />);
-          const component = getComponent(wrapper, helperComponents, wrapperComponent);
-
-          try {
-            expect(component.type()).toBe(MyComponent);
-          } catch (err) {
-            expect(component.type()).not.toBe(Component);
-            expect(component.prop('as')).toBe(MyComponent);
-          }
-        } catch (e) {
-          defaultErrorMessages['as-renders-react-class'](componentInfo, testInfo, e);
-          throw new Error('as-renders-react-class');
-        }
-      });
+    if (!componentInfo.props.as || testInfo.asPropHandlesRef) {
+      return;
     }
+
+    it(`renders as a ReactClass or passes "as" to the next component`, () => {
+      try {
+        const { requiredProps, Component, customMount = mount, wrapperComponent, helperComponents = [] } = testInfo;
+
+        class MyComponent extends React.Component {
+          public render() {
+            return <div data-my-react-class />;
+          }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const wrapper = customMount(<Component {...requiredProps} {...({ as: MyComponent } as any)} />);
+        const component = getComponent(wrapper, helperComponents, wrapperComponent);
+
+        try {
+          expect(component.type()).toBe(MyComponent);
+        } catch (err) {
+          expect(component.type()).not.toBe(Component);
+          expect(component.prop('as')).toBe(MyComponent);
+        }
+      } catch (e) {
+        throw new Error(defaultErrorMessages['as-renders-react-class'](testInfo, e));
+      }
+    });
   },
 
   /** If it has "as" prop: Passes extra props to the component it renders as */
   'as-passes-as-value': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    // 2nd check: React.AllHTMLAttributes can also include `as`
-    if (hasAs(componentInfo)) {
-      it(`passes extra props to the component it is renders as`, () => {
-        try {
-          const { customMount = mount, Component, requiredProps, targetComponent, asPropHandlesRef } = testInfo;
-
-          if (targetComponent) {
-            const el = mount(<Component {...requiredProps} data-extra-prop="foo" />).find(targetComponent);
-
-            expect(el.prop('data-extra-prop')).toBe('foo');
-          } else {
-            const MyComponent = asPropHandlesRef ? React.forwardRef((props, ref) => null) : () => null;
-            const el = customMount(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              <Component {...requiredProps} {...({ as: MyComponent } as any)} data-extra-prop="foo" />,
-            ).find(MyComponent);
-            expect(el.prop('data-extra-prop')).toBe('foo');
-          }
-        } catch (e) {
-          defaultErrorMessages['as-passes-as-value'](componentInfo, testInfo, e);
-          throw new Error('as-passes-as-value');
-        }
-      });
+    if (!componentInfo.props.as) {
+      return;
     }
+
+    it(`passes extra props to the component it is renders as`, () => {
+      const { customMount = mount, Component, requiredProps, targetComponent, asPropHandlesRef } = testInfo;
+
+      let el: ReactWrapper;
+      if (targetComponent) {
+        el = mount(<Component {...requiredProps} data-extra-prop="foo" />).find(targetComponent);
+      } else {
+        const MyComponent = asPropHandlesRef ? React.forwardRef((props, ref) => null) : () => null;
+        el = customMount(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          <Component {...requiredProps} {...({ as: MyComponent } as any)} data-extra-prop="foo" />,
+        ).find(MyComponent);
+      }
+
+      try {
+        expect(el.prop('data-extra-prop')).toBe('foo');
+      } catch (e) {
+        throw new Error(defaultErrorMessages['as-passes-as-value'](testInfo, e));
+      }
+    });
   },
 
   /** If it has "as" prop: Renders component as HTML tags */
   'as-renders-html': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (hasAs(componentInfo)) {
-      it(`renders component as HTML tags or passes "as" to the next component`, () => {
-        try {
-          // silence element nesting warnings
-          consoleUtil.disableOnce();
-          const tags = ['a', 'em', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'i', 'p', 'span', 'strong'];
-          const { Component, customMount = mount, requiredProps, wrapperComponent, helperComponents = [] } = testInfo;
-
-          tags.forEach(tag => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const wrapper = customMount(<Component {...requiredProps} {...({ as: tag } as any)} />);
-            const component = getComponent(wrapper, helperComponents, wrapperComponent);
-
-            try {
-              expect(component.is(tag)).toBe(true);
-            } catch (err) {
-              expect(component.type()).not.toBe(Component);
-              expect(component.prop('as')).toBe(tag);
-            }
-          });
-        } catch (e) {
-          defaultErrorMessages['as-renders-html'](componentInfo, testInfo, e);
-          throw new Error('as-renders-html');
-        }
-      });
+    if (!componentInfo.props.as) {
+      return;
     }
+
+    it(`renders component as HTML tags or passes "as" to the next component`, () => {
+      try {
+        // silence element nesting warnings
+        consoleUtil.disableOnce();
+        const tags = ['a', 'em', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'i', 'p', 'span', 'strong'];
+        const { Component, customMount = mount, requiredProps, wrapperComponent, helperComponents = [] } = testInfo;
+
+        tags.forEach(tag => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const wrapper = customMount(<Component {...requiredProps} {...({ as: tag } as any)} />);
+          const component = getComponent(wrapper, helperComponents, wrapperComponent);
+
+          try {
+            expect(component.is(tag)).toBe(true);
+          } catch (err) {
+            expect(component.type()).not.toBe(Component);
+            expect(component.prop('as')).toBe(tag);
+          }
+        });
+      } catch (e) {
+        throw new Error(defaultErrorMessages['as-renders-html'](testInfo, e));
+      }
+    });
   },
 };

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -2,65 +2,45 @@ import * as fs from 'fs';
 
 import { IsConformantOptions } from './types';
 import { defaultTests } from './defaultTests';
-import { defaultErrorMessages } from './defaultErrorMessages';
 import { merge } from './utils/merge';
-import * as os from 'os';
-import chalk from 'chalk';
 import { getComponentDoc } from './utils/getComponentDoc';
 
-export function isConformant(...testInfo: Partial<IsConformantOptions>[]) {
+export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
-  const { componentPath, displayName, disabledTests = [], extraTests, isInternal, exportSubdir = '' } = mergedOptions;
-  if (!fs.existsSync(componentPath)) {
-    throw new Error(`Path ${componentPath} does not exist`);
-  }
+  const { componentPath, displayName, disabledTests = [], extraTests, exportSubdir = '' } = mergedOptions;
 
-  const components = getComponentDoc(componentPath, exportSubdir);
-  const mainComponents = components.filter(comp => comp.displayName === displayName);
-
-  if (mainComponents.length === 1) {
-    const componentInfo = mainComponents[0];
-
-    if (isInternal) {
-      disabledTests.push('exported-top-level');
+  describe('isConformant', () => {
+    if (!fs.existsSync(componentPath)) {
+      throw new Error(`Path ${componentPath} does not exist`);
     }
 
-    describe('isConformant', () => {
-      afterAll(() => {
-        defaultErrorMessages['display-failed-tests'](componentInfo, mergedOptions);
-      });
+    const components = getComponentDoc(componentPath, exportSubdir);
+    const mainComponents = components.filter(comp => comp.displayName === displayName);
+
+    if (mainComponents.length === 1) {
+      const componentInfo = mainComponents[0];
 
       for (const test of Object.keys(defaultTests)) {
         if (!disabledTests.includes(test)) {
           defaultTests[test](componentInfo, mergedOptions);
         }
       }
-    });
 
-    if (extraTests) {
-      describe('isConformant - extraTests', () => {
-        for (const test of Object.keys(extraTests)) {
-          extraTests[test](componentInfo, mergedOptions);
-        }
-      });
+      if (extraTests) {
+        describe('extraTests', () => {
+          for (const test of Object.keys(extraTests)) {
+            extraTests[test](componentInfo, mergedOptions);
+          }
+        });
+      }
+    } else if (components.length === 0) {
+      throw new Error(`No exported components found at path: ${componentPath}`);
+    } else {
+      throw new Error(
+        `No component with name "${displayName}" was found at "${componentPath}".\n` +
+          'These are the exported component names: ' +
+          components.map(component => component.displayName).join(', '),
+      );
     }
-  } else if (components.length === 0) {
-    console.log(
-      chalk.yellow(`No exported components in path: `) + os.EOL.repeat(2) + chalk.green.italic(componentPath),
-    );
-    throw new Error('No exported components in path');
-  } else {
-    console.log(
-      chalk.yellow(`No component with name `) +
-        chalk.hex('#e00000')(displayName) +
-        chalk.yellow(' was found at:') +
-        os.EOL.repeat(2) +
-        chalk.green.italic(componentPath) +
-        os.EOL.repeat(2) +
-        'These are the exported component names:' +
-        os.EOL.repeat(2) +
-        chalk.white.bold.italic.bgHex('#2e2e2e')(components.map(component => component.displayName).join(', ')),
-    );
-    throw new Error(`No component was found that matches the displayName.`);
-  }
+  });
 }

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -37,7 +37,7 @@ export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptio
       throw new Error(`No exported components found at path: ${componentPath}`);
     } else {
       throw new Error(
-        `No component with name "${displayName}" was found at "${componentPath}".\n` +
+        `No component with name "${displayName}" was found at "${componentPath}".\n\n` +
           'These are the exported component names: ' +
           components.map(component => component.displayName).join(', '),
       );

--- a/packages/react-conformance/src/utils/consoleUtil.ts
+++ b/packages/react-conformance/src/utils/consoleUtil.ts
@@ -8,12 +8,16 @@ let isDisabledOnce: boolean;
 /**
  * Enable console logging.
  */
-export const enable = () => Object.assign(console, original);
+export const enable = () => {
+  Object.assign(console, original);
+};
 
 /**
  * Disable console logging.
  */
-export const disable = () => Object.assign(console, disabled);
+export const disable = () => {
+  Object.assign(console, disabled);
+};
 
 /**
  * Silence the console for a single test.  It will be re-enabled after it().

--- a/packages/react-conformance/src/utils/getComponentDoc.ts
+++ b/packages/react-conformance/src/utils/getComponentDoc.ts
@@ -34,9 +34,10 @@ export function getComponentDoc(componentPath: string, exportSubdir: string): Co
     program = ts.createProgram([rootFile], compilerOptions);
 
     parser = withCompilerOptions(compilerOptions, {
-      // Props need to be filtered since react-docgen shows all the props including
-      // inherited native props or React built-in props.
-      propFilter: prop => !/@types[\\/]react[\\/]/.test(prop.parent?.fileName || ''),
+      // Props need to be filtered since react-docgen shows all the props including inherited
+      // native props or React built-in props. (Check for both @types/react and react/index.d.ts
+      // because there may be some variation in which format is used.)
+      propFilter: prop => !/@types[\\/]react[\\/]|\breact[\\/]index\.d\.ts$/.test(prop.parent?.fileName || ''),
     });
   }
 


### PR DESCRIPTION
> **Best viewed with [hide whitespace changes](https://github.com/microsoft/fluentui/pull/17418/files?diff=split&w=1)**

The way conformance test error messages are currently set up can sometimes result in confusing messages or swallowed errors. Also, the error message generation code is not the easiest to read, and some of the individual messages are misleading or incorrect.

This PR addresses these issues mainly in the following ways:
- Add a structured API for generating error messages (instead of using string concatenation)
- Ensure the original error is included in the generated message
- Throw an error with the generated message instead of `console.log`-ing it. This makes the failure show up in Jest's main failure log for each test, which is MUCH more readable.

In addition, I made some smaller improvements including the following:
- Correct inaccuracies or improve wording in various individual error messages or resolution suggestions
- Reduce line spacing to make error messages more compact
- Remove the attempt to list all failed conformance tests at the end (wasn't working correctly, redundant with jest functionality)
- Fix the `consistent-callback-names` test, but globally disable it for now (will re-enable in a separate change, since it will require changes in several packages to disable for individual components that violate the rule)
- Fix the prop filter passed to `react-docgen-typescript` so that it properly removes native props