### PR TITLE
fix(Popup): prevent to dismiss popup on scroll inside popup

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update the `OpenOutsideIcon` icon @notandrew ([#17361](https://github.com/microsoft/fluentui/pull/17361))
 - Fix `Popup` to make sure `updatePosition` is always defined in `renderContent` @yuanboxue-amber ([#17377](https://github.com/microsoft/fluentui/pull/17377))
 - Updating the colors for the Carousel's paddles @notandrew ([#17323](https://github.com/microsoft/fluentui/pull/17323))
+- Prevent Popup to be dismissed when scroll happens inside @yuanboxue-amber ([#17419](https://github.com/microsoft/fluentui/pull/17419))
 
 ## Features
 - For `Tree`, add keyboard navigation based on the first letter of the text content of tree items @yuanboxue-amber ([#16994](https://github.com/microsoft/fluentui/pull/16994))

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -457,7 +457,10 @@ export const Popup: React.FC<PopupProps> &
   };
 
   const dismissOnScroll = (e: TouchEvent | WheelEvent) => {
-    trySetOpen(false, e);
+    // we only need to dismiss if the scroll happens outside the popup
+    if (!popupContentRef.current.contains(e.target as Node)) {
+      trySetOpen(false, e);
+    }
   };
 
   const trySetOpen = (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Same as #17294 but for popup. 
Prevent Popup to be dismissed when scroll happens inside.

before fix
![before](https://user-images.githubusercontent.com/28751745/111196692-dd1e5d80-85bd-11eb-9b1d-f0e9e9de551f.gif)
after fix
![after](https://user-images.githubusercontent.com/28751745/111196715-e27ba800-85bd-11eb-943a-e7aa739e6eaf.gif)


#### Focus areas to test

(optional)
