### PR TITLE
fix(react-docsite-components): add accessible names to docsite implementation tables

### DIFF
--- a/change/@fluentui-react-docsite-components-8a950f38-23e4-4933-9329-e47a5b63fee9.json
+++ b/change/@fluentui-react-docsite-components-8a950f38-23e4-4933-9329-e47a5b63fee9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add readable docs table names for screen readers",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -31,6 +31,7 @@ export type IApiReferencesTableState = {};
 
 /** @internal */
 type IApiDetailsListProps = (IApiEnumDetailsListProps | IApiPropertyDetailsListProps | IApiMethodDetailsListProps) & {
+  ariaLabel?: string;
   tokenResolver: IApiReferencesTableProps['tokenResolver'];
 };
 /** Do not use directly */
@@ -127,7 +128,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
   }
 
   private _renderTables(): JSX.Element | undefined {
-    const { properties, methods, tokenResolver } = this.props;
+    const { properties, methods, tokenResolver, title } = this.props;
 
     if (this._isClass) {
       // Render class members and methods tables
@@ -137,6 +138,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
             <Stack tokens={gapTokens.small}>
               <h4>Members</h4>
               <ApiDetailsList
+                ariaLabel={`${title} Members`}
                 itemKind="property"
                 items={properties as IApiInterfaceProperty[]}
                 tokenResolver={tokenResolver}
@@ -146,7 +148,12 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
           {methods && methods.length > 0 && (
             <Stack tokens={gapTokens.small}>
               <h4>Methods</h4>
-              <ApiDetailsList itemKind="method" items={methods!} tokenResolver={tokenResolver} />
+              <ApiDetailsList
+                ariaLabel={`${title} Methods`}
+                itemKind="method"
+                items={methods!}
+                tokenResolver={tokenResolver}
+              />
             </Stack>
           )}
         </Stack>
@@ -156,9 +163,19 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
     // Render enum or interface property tables
     // (the calling method already verified that at least one property is defined)
     return this._isEnum ? (
-      <ApiDetailsList itemKind="enum" items={properties as IApiEnumProperty[]} tokenResolver={tokenResolver} />
+      <ApiDetailsList
+        ariaLabel={title}
+        itemKind="enum"
+        items={properties as IApiEnumProperty[]}
+        tokenResolver={tokenResolver}
+      />
     ) : (
-      <ApiDetailsList itemKind="property" items={properties as IApiInterfaceProperty[]} tokenResolver={tokenResolver} />
+      <ApiDetailsList
+        ariaLabel={title}
+        itemKind="property"
+        items={properties as IApiInterfaceProperty[]}
+        tokenResolver={tokenResolver}
+      />
     );
   }
 
@@ -181,7 +198,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
  */
 const ApiDetailsList: React.FunctionComponent<IApiDetailsListProps> = React.memo(props => {
   // Alphabetize the items and add a key to each one.
-  const { itemKind, items } = props;
+  const { itemKind, items, ariaLabel } = props;
   const processedItems: IApiEnumProperty[] | IApiInterfaceProperty[] | IMethod[] = useConst(() => {
     if (itemKind === 'enum') {
       return (items as IApiEnumProperty[])
@@ -208,6 +225,7 @@ const ApiDetailsList: React.FunctionComponent<IApiDetailsListProps> = React.memo
   return (
     <DetailsList
       items={processedItems}
+      ariaLabelForGrid={ariaLabel}
       columns={columns}
       selectionMode={SelectionMode.none}
       layoutMode={DetailsListLayoutMode.justified}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [8803](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/8803)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Modifies ApiReferenceTable to use the existing `title` to also name the API table.
