### PR TITLE
fix(useContextSelectors): bug in calculating new context causes infinite rerender

### DIFF
--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -582,7 +582,7 @@ const ComponentExampleWithTheme = props => {
 
   // Only error string is displayed, so setError only needs to be called when error string is different.
   // Prevent rerender on new error object with the same error message as previous error object.
-  const stable_setError = React.useCallback(error => {
+  const handleError = React.useCallback(error => {
     setError(prevError => {
       if (prevError?.toString() === error?.toString()) {
         return prevError;

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -580,9 +580,22 @@ const ComponentExampleWithTheme = props => {
   // React handles setState() in hooks and classes differently: it performs strict equal check in hooks
   const [error, setError] = React.useState<Error | null>(null);
 
+  // Only error string is displayed, so setError only needs to be called when error string is different.
+  // Prevent rerender on new error object with the same error message as previous error object.
+  const stable_setError = React.useCallback(error => {
+    setError(prevError => {
+      if (prevError?.toString() === error?.toString()) {
+        return prevError;
+      }
+      return error;
+    });
+  }, []);
+
   return (
     <ComponentSourceManager examplePath={props.examplePath}>
-      {codeProps => <ComponentExample {...props} {...exampleProps} {...codeProps} onError={setError} error={error} />}
+      {codeProps => (
+        <ComponentExample {...props} {...exampleProps} {...codeProps} onError={stable_setError} error={error} />
+      )}
     </ComponentSourceManager>
   );
 };

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -594,7 +594,7 @@ const ComponentExampleWithTheme = props => {
   return (
     <ComponentSourceManager examplePath={props.examplePath}>
       {codeProps => (
-        <ComponentExample {...props} {...exampleProps} {...codeProps} onError={stable_setError} error={error} />
+        <ComponentExample {...props} {...exampleProps} {...codeProps} onError={handleError} error={error} />
       )}
     </ComponentSourceManager>
   );

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -31,7 +31,10 @@ export const useContextSelectors = <
 
   const [state, dispatch] = React.useReducer(
     (
-      prevState: readonly [Record<Properties, Value> /* contextValue */, SelectedValue /* selector(value) */],
+      prevState: readonly [
+        Value /* contextValue */,
+        Record<Properties, SelectedValue> /* { [key]: selector(value) } */,
+      ],
       payload:
         | undefined // undefined from render below
         | readonly [ContextVersion, Value], // from provider effect

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -8,7 +8,7 @@ import { useIsomorphicLayoutEffect } from './utils';
  * It will trigger re-render if only the selected value is referencially changed.
  */
 export const useContextSelectors = <
-  Value,
+  Value extends Record<string, any>,
   Properties extends string,
   Selectors extends Record<Properties, ContextSelector<Value, SelectedValue>>,
   SelectedValue extends any
@@ -70,10 +70,10 @@ export const useContextSelectors = <
         });
 
         const selectedHasNotChanged = Object.keys(selectors).every((key: Properties) => {
-          return Object.is(prevState[1][key] as SelectedValue, nextSelected[key]);
+          return Object.is(prevState[1][key] /* previous { [key]: selector(value) } */, nextSelected[key]);
         });
 
-        if (selecteddHasNotChanged) {
+        if (selectedHasNotChanged) {
           return prevState;
         }
 

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -69,7 +69,7 @@ export const useContextSelectors = <
           nextSelected[key] = selectors[key](payload[1]);
         });
 
-        const selecteddHasNotChanged = Object.keys(selectors).every((key: Properties) => {
+        const selectedHasNotChanged = Object.keys(selectors).every((key: Properties) => {
           return Object.is(prevState[1][key] as SelectedValue, nextSelected[key]);
         });
 

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -31,10 +31,10 @@ export const useContextSelectors = <
 
   const [state, dispatch] = React.useReducer(
     (
-      prevState: readonly [Record<Properties, SelectedValue> /* contextValue */, SelectedValue /* selector(value) */],
+      prevState: readonly [Record<Properties, Value> /* contextValue */, SelectedValue /* selector(value) */],
       payload:
         | undefined // undefined from render below
-        | readonly [ContextVersion, Record<Properties, Value>], // from provider effect
+        | readonly [ContextVersion, Value], // from provider effect
     ) => {
       if (!payload) {
         return [value, selected] as const;
@@ -54,7 +54,7 @@ export const useContextSelectors = <
 
       try {
         const statePayloadHasChanged = Object.keys(prevState[0]).some((key: Properties) => {
-          return !Object.is(prevState[0][key] as SelectedValue, payload[1][key]);
+          return !Object.is(prevState[0][key], (payload[1] as Record<string, any>)[key]);
         });
 
         if (!statePayloadHasChanged) {
@@ -63,7 +63,7 @@ export const useContextSelectors = <
 
         const nextSelected = {} as Record<Properties, SelectedValue>;
         Object.keys(selectors).forEach((key: Properties) => {
-          nextSelected[key] = selectors[key](payload[1][key]);
+          nextSelected[key] = selectors[key](payload[1]);
         });
 
         const selecteddHasNotChanged = Object.keys(selectors).every((key: Properties) => {

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -88,10 +88,10 @@ export const useContextSelectors = <
   );
 
   // schedule re-render when selected context is updated
-  const updatedSelectedContext = Object.keys(selectors).find(
+  const hasSelectedValuesUpdates = Object.keys(selectors).find(
     (key: Properties) => !Object.is(state[1] /* previous { [key]: selector(value) } */[key], selected[key]),
   );
-  if (updatedSelectedContext !== undefined) {
+  if (hasSelectedValuesUpdates !== undefined) {
     dispatch(undefined);
   }
 

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -57,7 +57,7 @@ export const useContextSelectors = <
 
       try {
         const statePayloadHasChanged = Object.keys(prevState[0]).some((key: Properties) => {
-          return !Object.is(prevState[0][key], (payload[1] as Record<string, any>)[key]);
+          return !Object.is(prevState[0] /* previous contextValue */[key], payload[1] /* current contextValue */[key]);
         });
 
         if (!statePayloadHasChanged) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The real change is in one line L66, and everything else is just fix typing:

```ts
nextSelected[key] = selectors[key](payload[1][key]);
``` 
changed to 
```ts
nextSelected[key] = selectors[key](payload[1]);
```

`selectors[key]` is a function, that takes context as argument, and return one selected context. 
For example, for the `useContexSelectors` in `MenuItem`, `selector['active']` is `v => v.activeIndex === inputProps.index`

`payload[1]` is context. 
For example, for the `useContexSelectors` in `MenuItem`, `payload[1]` is `MenuContext`'s current value

For `useContexSelectors` in `MenuItem`, the original code will try to look for `menuContext['active'].activeIndex`, while it suppose to look for `menuContext.activeIndex`. And because `menuContext['active']` is undefined, the try block in `useContexSelectors` will throw and be caught in the dummy catch block. And the useContextSelectors will always schedule an update. 

In docsite, we use menu to render toolbar for code editor. That's why docsite crashes during editing. 
To reproduce it, go to https://fluentsite.z22.web.core.windows.net/0.53.0/components/button/definition?showCode=true&showRtl=false&showTransparent=false&showVariables=false#types-button and change `export default ButtonExample` to `export default ButtonExample1`.
However, it bothers me that, this reproduction only crashes for production build, but not for development build.
Nevertheless I'm pretty confident this fix is needed, so I'm putting out a PR.

#### Focus areas to test

(optional)
