### PR TITLE
fix(react): DetailsList aria-rowindex off-by-one fix

### DIFF
--- a/change/@fluentui-react-d6fc3aa0-1a27-46bf-8ab1-184cc11dabf7.json
+++ b/change/@fluentui-react-d6fc3aa0-1a27-46bf-8ab1-184cc11dabf7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix DetailsList off-by-one aria-rowindex values when headers are visible\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-b52d6dfc-cf4d-4036-aa7e-8ea6475a75b3.json
+++ b/change/@fluentui-react-examples-b52d6dfc-cf4d-4036-aa7e-8ea6475a75b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "DetailsList snapshot updates",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -14,7 +14,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
   role="grid"
 >
   <div
-    aria-rowindex={1}
+    aria-rowindex={2}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -708,7 +708,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={2}
+    aria-rowindex={3}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -1402,7 +1402,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={3}
+    aria-rowindex={4}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -2096,7 +2096,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={4}
+    aria-rowindex={5}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -2790,7 +2790,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={5}
+    aria-rowindex={6}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -3484,7 +3484,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={6}
+    aria-rowindex={7}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -4178,7 +4178,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={7}
+    aria-rowindex={8}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -4872,7 +4872,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={8}
+    aria-rowindex={9}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -5566,7 +5566,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={9}
+    aria-rowindex={10}
     className=
         ms-FocusZone
         ms-DetailsRow
@@ -6260,7 +6260,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     />
   </div>
   <div
-    aria-rowindex={10}
+    aria-rowindex={11}
     className=
         ms-FocusZone
         ms-DetailsRow

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -744,7 +744,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={1}
+                        aria-rowindex={2}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1148,7 +1148,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={2}
+                        aria-rowindex={3}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1552,7 +1552,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={3}
+                        aria-rowindex={4}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1956,7 +1956,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={4}
+                        aria-rowindex={5}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2360,7 +2360,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={5}
+                        aria-rowindex={6}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2764,7 +2764,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={6}
+                        aria-rowindex={7}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3168,7 +3168,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={7}
+                        aria-rowindex={8}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3572,7 +3572,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={8}
+                        aria-rowindex={9}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3976,7 +3976,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={9}
+                        aria-rowindex={10}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4380,7 +4380,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={10}
+                        aria-rowindex={11}
                         aria-selected={false}
                         className=
                             ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -540,7 +540,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1079,7 +1079,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1618,7 +1618,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2157,7 +2157,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2696,7 +2696,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3235,7 +3235,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={7}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3774,7 +3774,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={7}
+                      aria-rowindex={8}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4313,7 +4313,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={8}
+                      aria-rowindex={9}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4852,7 +4852,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={9}
+                      aria-rowindex={10}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -5391,7 +5391,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={10}
+                      aria-rowindex={11}
                       aria-selected={false}
                       className=
                           ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1508,7 +1508,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={1}
+                        aria-rowindex={2}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1912,7 +1912,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={2}
+                        aria-rowindex={3}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2316,7 +2316,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={3}
+                        aria-rowindex={4}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2720,7 +2720,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={4}
+                        aria-rowindex={5}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3124,7 +3124,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={5}
+                        aria-rowindex={6}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3528,7 +3528,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={6}
+                        aria-rowindex={7}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3932,7 +3932,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={7}
+                        aria-rowindex={8}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4336,7 +4336,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={8}
+                        aria-rowindex={9}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4740,7 +4740,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={9}
+                        aria-rowindex={10}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -5144,7 +5144,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={10}
+                        aria-rowindex={11}
                         aria-selected={false}
                         className=
                             ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -807,7 +807,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={1}
+                        aria-rowindex={2}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1268,7 +1268,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={2}
+                        aria-rowindex={3}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -1729,7 +1729,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={3}
+                        aria-rowindex={4}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2190,7 +2190,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={4}
+                        aria-rowindex={5}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -2651,7 +2651,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={5}
+                        aria-rowindex={6}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3112,7 +3112,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={6}
+                        aria-rowindex={7}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -3573,7 +3573,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={7}
+                        aria-rowindex={8}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4034,7 +4034,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={8}
+                        aria-rowindex={9}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4495,7 +4495,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={9}
+                        aria-rowindex={10}
                         aria-selected={false}
                         className=
                             ms-FocusZone
@@ -4956,7 +4956,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={10}
+                        aria-rowindex={11}
                         aria-selected={false}
                         className=
                             ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1034,7 +1034,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={1}
+                          aria-rowindex={2}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -1495,7 +1495,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={2}
+                          aria-rowindex={3}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -1956,7 +1956,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={3}
+                          aria-rowindex={4}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2417,7 +2417,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={4}
+                          aria-rowindex={5}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2878,7 +2878,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={5}
+                          aria-rowindex={6}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3339,7 +3339,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={6}
+                          aria-rowindex={7}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3800,7 +3800,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={7}
+                          aria-rowindex={8}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4261,7 +4261,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={8}
+                          aria-rowindex={9}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4722,7 +4722,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={9}
+                          aria-rowindex={10}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -5183,7 +5183,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={10}
+                          aria-rowindex={11}
                           aria-selected={false}
                           className=
                               ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1018,7 +1018,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={1}
+                          aria-rowindex={2}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -1480,7 +1480,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={2}
+                          aria-rowindex={3}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -1942,7 +1942,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={3}
+                          aria-rowindex={4}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2404,7 +2404,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={4}
+                          aria-rowindex={5}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2866,7 +2866,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={5}
+                          aria-rowindex={6}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3328,7 +3328,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={6}
+                          aria-rowindex={7}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3790,7 +3790,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={7}
+                          aria-rowindex={8}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4252,7 +4252,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={8}
+                          aria-rowindex={9}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4714,7 +4714,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={9}
+                          aria-rowindex={10}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -5176,7 +5176,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={10}
+                          aria-rowindex={11}
                           aria-selected={false}
                           className=
                               ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -564,7 +564,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1005,7 +1005,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1446,7 +1446,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1887,7 +1887,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2328,7 +2328,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2769,7 +2769,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={7}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3210,7 +3210,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={7}
+                      aria-rowindex={8}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3651,7 +3651,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={8}
+                      aria-rowindex={9}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4092,7 +4092,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={9}
+                      aria-rowindex={10}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4533,7 +4533,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={10}
+                      aria-rowindex={11}
                       aria-selected={false}
                       className=
                           ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -785,7 +785,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1246,7 +1246,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1707,7 +1707,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2168,7 +2168,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2629,7 +2629,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3090,7 +3090,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         </div>
       </div>
       <div
-        aria-rowindex={0}
+        aria-rowindex={1}
         aria-selected={false}
         className=
             ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -570,7 +570,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -975,7 +975,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1379,7 +1379,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1784,7 +1784,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2188,7 +2188,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2593,7 +2593,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={7}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2997,7 +2997,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={7}
+                      aria-rowindex={8}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3402,7 +3402,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={8}
+                      aria-rowindex={9}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3806,7 +3806,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={9}
+                      aria-rowindex={10}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4211,7 +4211,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={10}
+                      aria-rowindex={11}
                       aria-selected={false}
                       className=
                           ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1377,7 +1377,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={1}
+                        aria-rowindex={2}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -1710,7 +1710,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={2}
+                        aria-rowindex={3}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -2043,7 +2043,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={3}
+                        aria-rowindex={4}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -2376,7 +2376,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={4}
+                        aria-rowindex={5}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -2709,7 +2709,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={5}
+                        aria-rowindex={6}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -3042,7 +3042,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={6}
+                        aria-rowindex={7}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -3375,7 +3375,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={7}
+                        aria-rowindex={8}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -3708,7 +3708,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={8}
+                        aria-rowindex={9}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -4041,7 +4041,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={9}
+                        aria-rowindex={10}
                         className=
                             ms-FocusZone
                             ms-DetailsRow
@@ -4374,7 +4374,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                       role="presentation"
                     >
                       <div
-                        aria-rowindex={10}
+                        aria-rowindex={11}
                         className=
                             ms-FocusZone
                             ms-DetailsRow

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1230,7 +1230,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={1}
+                          aria-rowindex={2}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -1636,7 +1636,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={2}
+                          aria-rowindex={3}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2042,7 +2042,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={3}
+                          aria-rowindex={4}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2448,7 +2448,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={4}
+                          aria-rowindex={5}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -2854,7 +2854,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={5}
+                          aria-rowindex={6}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3260,7 +3260,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={6}
+                          aria-rowindex={7}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -3666,7 +3666,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={7}
+                          aria-rowindex={8}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4072,7 +4072,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={8}
+                          aria-rowindex={9}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4478,7 +4478,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={9}
+                          aria-rowindex={10}
                           aria-selected={false}
                           className=
                               ms-FocusZone
@@ -4884,7 +4884,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         role="presentation"
                       >
                         <div
-                          aria-rowindex={10}
+                          aria-rowindex={11}
                           aria-selected={false}
                           className=
                               ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -673,7 +673,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1208,7 +1208,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -1743,7 +1743,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2278,7 +2278,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -2813,7 +2813,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3348,7 +3348,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={7}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -3883,7 +3883,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={7}
+                      aria-rowindex={8}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4418,7 +4418,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={8}
+                      aria-rowindex={9}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -4953,7 +4953,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={9}
+                      aria-rowindex={10}
                       aria-selected={false}
                       className=
                           ms-FocusZone

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -523,7 +523,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -771,7 +771,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -1019,7 +1019,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -1267,7 +1267,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={5}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -1515,7 +1515,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={6}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -1763,7 +1763,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={7}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -2011,7 +2011,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={7}
+                      aria-rowindex={8}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -2259,7 +2259,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={8}
+                      aria-rowindex={9}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -2507,7 +2507,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={9}
+                      aria-rowindex={10}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -2755,7 +2755,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={10}
+                      aria-rowindex={11}
                       className=
                           ms-FocusZone
                           ms-DetailsRow

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -523,7 +523,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={1}
+                      aria-rowindex={2}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -773,7 +773,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       className=
                           ms-FocusZone
                           ms-DetailsRow
@@ -1023,7 +1023,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       className=
                           ms-FocusZone
                           ms-DetailsRow

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3894,6 +3894,7 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
         eventName: string;
         callback: (item?: any, index?: number, event?: any) => void;
     }[];
+    flatIndexOffset?: number;
     getRowAriaDescribedBy?: (item: any) => string;
     getRowAriaLabel?: (item: any) => string;
     item: any;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -491,6 +491,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       collapseAllVisibility,
       getRowAriaLabel,
       getRowAriaDescribedBy,
+      isHeaderVisible,
       checkButtonAriaLabel,
       checkboxCellClassName,
       useReducedRowRenderer,

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -435,6 +435,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       const rowProps: IDetailsRowProps = {
         item: item,
         itemIndex: index,
+        flatIndexOffset: isHeaderVisible ? 2 : 1,
         compact,
         columns: adjustedColumns,
         groupNestingDepth: nestingDepth,

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -178,6 +178,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       dragDropEvents,
       item,
       itemIndex,
+      flatIndexOffset = 2,
       onRenderCheck = this._onRenderCheck,
       onRenderDetailsCheckbox,
       onRenderItemColumn,
@@ -282,7 +283,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         data-selection-index={itemIndex}
         data-selection-touch-invoke={true}
         data-item-index={itemIndex}
-        aria-rowindex={groupNestingDepth ? undefined : itemIndex + 1}
+        aria-rowindex={groupNestingDepth ? undefined : itemIndex + flatIndexOffset}
         aria-level={(groupNestingDepth && groupNestingDepth + 1) || undefined}
         data-automationid="DetailsRow"
         style={{ minWidth: rowWidth }}

--- a/packages/react/src/components/DetailsList/DetailsRow.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.test.tsx
@@ -85,6 +85,26 @@ describe('DetailsRow', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders details list row with correct row index by default', () => {
+    const component = renderer.create(<DetailsList {...mockProps} onRenderRow={undefined} />);
+
+    const rows = component.root.findAllByType(DetailsRow);
+
+    expect(rows[0].props.flatIndexOffset).toBe(2);
+    expect(rows[0].findByProps({ role: 'row' }).props['aria-rowindex']).toBe(2);
+    expect(rows[4].findByProps({ role: 'row' }).props['aria-rowindex']).toBe(6);
+  });
+
+  it('renders details list row with correct row index with no headers', () => {
+    const component = renderer.create(<DetailsList {...mockProps} onRenderRow={undefined} isHeaderVisible={false} />);
+
+    const rows = component.root.findAllByType(DetailsRow);
+
+    expect(rows[0].props.flatIndexOffset).toBe(1);
+    expect(rows[0].findByProps({ role: 'row' }).props['aria-rowindex']).toBe(1);
+    expect(rows[4].findByProps({ role: 'row' }).props['aria-rowindex']).toBe(5);
+  });
+
   it('renders details list row with checkbox visible always correctly', () => {
     const component = renderer.create(
       <DetailsRow

--- a/packages/react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.types.ts
@@ -102,6 +102,12 @@ export interface IDetailsRowBaseProps
   itemIndex: number;
 
   /**
+   * Offset used to calculate the aria-rowindex value based on itemIndex
+   * @defaultvalue 2
+   */
+  flatIndexOffset?: number;
+
+  /**
    * Whether to render in compact mode
    */
   compact?: boolean;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1674,7 +1674,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
 
 exports[`DetailsRow renders details list row with checkbox visible always correctly 1`] = `
 <div
-  aria-rowindex={1}
+  aria-rowindex={2}
   aria-selected={false}
   className=
       ms-FocusZone
@@ -1740,7 +1740,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         opacity: 1;
       }
   data-automationid="DetailsRow"
-  data-focuszone-id="FocusZone12"
+  data-focuszone-id="FocusZone26"
   data-is-focusable={true}
   data-item-index={0}
   data-selection-index={0}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10558](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10558)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

JAWS skips the first row of a DetailsList with visible headers, since the `aria-rowindex` property incorrectly starts at 1 within the table body, instead of at 2 when column headers are visible.

This PR adds a `flatIndexOffset` property on DetailsRow, so DetailsList can control the relation between `itemIndex` and `aria-rowindex` based on whether headers are visible.
