### PR TITLE
[ContextualMenu] Fix bug with `useTargetWidth`

### DIFF
--- a/change/@fluentui-react-5755499a-cc3f-4993-99f7-f93f547221f3.json
+++ b/change/@fluentui-react-5755499a-cc3f-4993-99f7-f93f547221f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug with useTargetWidth in ContextualMenu",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -384,9 +384,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
      * When useTargetWidth is true, get the width of the target element and apply it for the context menu container
      */
     let contextMenuStyle: React.CSSProperties;
-    const targetAsHtmlElement = (typeof targetRef.current === 'function'
-      ? targetRef.current()
-      : targetRef.current) as HTMLElement;
+    const targetAsHtmlElement = targetRef.current as HTMLElement;
     if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
       const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
       const targetWidth = targetBoundingRect.width - 2; /* Accounts for 1px border */

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -196,7 +196,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
   const hostElement: React.RefObject<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
 
-  const [targetRef, targetWindow] = useTarget(hostElement);
+  const [targetRef, targetWindow] = useTarget(props.target, hostElement);
   const [expandedMenuItemKey, submenuTarget, expandedByMouseClick, openSubMenu, closeSubMenu] = useSubMenuState(props);
   const [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] = useShouldUpdateFocusOnMouseMove(props);
 
@@ -384,7 +384,9 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
      * When useTargetWidth is true, get the width of the target element and apply it for the context menu container
      */
     let contextMenuStyle: React.CSSProperties;
-    const targetAsHtmlElement = targetRef.current as HTMLElement;
+    const targetAsHtmlElement = (typeof targetRef.current === 'function'
+      ? targetRef.current()
+      : targetRef.current) as HTMLElement;
     if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
       const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
       const targetWidth = targetBoundingRect.width - 2; /* Accounts for 1px border */


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Due to an incorrect usage of `useTargetWidth`, `ContextualMenu` was never correctly calculating its target element, and therefore could not measure its width when `useTargetWidth` was set to `true`.

#### Focus areas to test

(optional)
