### PR TITLE
ContextualMenu: Focus now returns to contextual menu trigger when closed

### DIFF
--- a/change/@fluentui-react-f20d4fc3-d28d-40f3-8c53-ad550c017ce2.json
+++ b/change/@fluentui-react-f20d4fc3-d28d-40f3-8c53-ad550c017ce2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Focus now returns to contextual menu trigger when closed",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -36,6 +36,7 @@ import {
   initializeComponentRef,
   memoizeFunction,
   getPropsWithDefaults,
+  getDocument,
 } from '../../Utilities';
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { Callout, ICalloutContentStyleProps, ICalloutContentStyles } from '../../Callout';
@@ -296,8 +297,31 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     return !shallowCompare(this.props, newProps) || !shallowCompare(this.state, newState);
   }
 
+  public getSnapshotBeforeUpdate(prevProps: IContextualMenuInternalProps): null {
+    const { hoisted } = this.props;
+
+    if (this._isHidden(prevProps) !== this._isHidden(this.props)) {
+      if (this._isHidden(this.props)) {
+        this._onMenuClosed();
+      } else {
+        this._previousActiveElement = hoisted.targetWindow
+          ? (hoisted.targetWindow.document.activeElement as HTMLElement)
+          : undefined;
+      }
+    }
+    return null;
+  }
+
   // Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
   public componentDidMount(): void {
+    const { hidden, hoisted } = this.props;
+
+    if (!hidden) {
+      this._previousActiveElement = hoisted.targetWindow
+        ? (hoisted.targetWindow.document.activeElement as HTMLElement)
+        : undefined;
+    }
+
     this._mounted = true;
   }
 
@@ -485,15 +509,30 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   }
 
   private _tryFocusPreviousActiveElement = (options: IPopupRestoreFocusParams) => {
-    if (options && options.containsFocus && this._previousActiveElement) {
+    if (options && options.documentContainsFocus && this._previousActiveElement) {
       // Make sure that the focus method actually exists
       // In some cases the object might exist but not be a real element.
       // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.
-      if (this._previousActiveElement.focus) {
-        this._previousActiveElement.focus();
-      }
+      this._previousActiveElement.focus?.();
     }
   };
+
+  private _onMenuClosed() {
+    this._tryFocusPreviousActiveElement?.({
+      originalElement: this._previousActiveElement,
+      containsFocus: true,
+      documentContainsFocus: getDocument()?.hasFocus() || false,
+    });
+  }
+
+  /**
+   * Return whether the contextual menu is hidden.
+   * Undefined value for hidden is equivalent to hidden being false.
+   * @param props - Props for the component
+   */
+  private _isHidden(props: IContextualMenuProps) {
+    return !!props.hidden;
+  }
 
   /**
    * Gets the focusZoneDirection by using the arrowDirection if specified,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17283
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Changes follow the same pattern that v7 uses to implement this ability with modifications to better fit how this component is implemented in v8.
   1) used getSnapshotBeforeUpdate lifecycle as opposed to legacy componentWillUpdate used in v7.
   2) used componentDidMount lifecycle to initialize `_previousActiveElement` as opposed to legacy componentWillMount used in v7.
- Initializes `_previousActiveElement` in componentDidMount when menu has opened (originally, `_previousActiveElement` remained undefined the whole time) 
- When prop variable `hidden `is changed, update `_previousActiveElement` appropriately

**Focus being returned to trigger (menu and submenu)**

1) 
![FocusReturn1](https://user-images.githubusercontent.com/8649804/111232389-43988100-85a8-11eb-8a0f-821981007b37.JPG)

2)
 ![FocusReturn2](https://user-images.githubusercontent.com/8649804/111232397-47c49e80-85a8-11eb-91b0-8ba21a3c18e3.JPG)

3) 
![FocusReturn3](https://user-images.githubusercontent.com/8649804/111232407-4b582580-85a8-11eb-91cc-55a9944d879f.JPG)
