### PR TITLE
Change Azure PR deploy storage

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -20,3 +20,15 @@ steps:
   - script: |
       echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace"
     displayName: Force exit on error (bash)
+
+  # Log all the environment variables since it can be useful for debugging.
+  # (This happens automatically for the built-in agents, but not for custom agents.)
+  - script: |
+      printenv | sort
+      echo "SHELLOPTS $SHELLOPTS"
+      echo 'deployBasePath "$(deployBasePath)"'
+      echo 'deployUrl "$(deployUrl)"'
+      echo 'isPR "$(isPR)"'
+      echo 'targetBranch "$(targetBranch)"'
+    displayName: Log environment variables (Linux)
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/.devops/templates/variables.yml
+++ b/.devops/templates/variables.yml
@@ -1,11 +1,8 @@
 parameters:
+  # For customizing the deployment path in non-PR builds
   - name: deployBasePath
     type: string
     default: ''
-
-  - name: azureSubscription
-    type: string
-    default: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
 
   # Skip the component governance detection step (injected by a pipeline decorator from an
   # internal extension) by default because we run it separately. Since all our pipelines
@@ -16,17 +13,26 @@ parameters:
     default: true
 
 variables:
-  deployBasePath: ${{ coalesce(parameters.deployBasePath, 'pr-deploy-site/$(Build.SourceBranch)') }}
+  # Also accessed as process.env.DEPLOYHOST
+  deployHost: 'fluentuipr.z22.web.core.windows.net'
 
-  deployHost: 'fabricweb.z5.web.core.windows.net'
+  # Also accessed as process.env.DEPLOYURL
+  deployUrl: 'https://$(deployHost)/$(deployBasePath)'
 
-  azureSubscription: ${{ parameters.azureSubscription }}
+  # This service principal ("subscription" is a misleading name) only has access to the fluentuipr storage account
+  azureSubscription: Azure PR deploy
+  azureStorage: fluentuipr
 
-  ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+  ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/')) }}:
     isPR: true
     targetBranch: 'origin/$(System.PullRequest.TargetBranch)'
-  ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+    # Deploy PRs under "pull/####" unless otherwise requested
+    # (this is also accessed as process.env.DEPLOYBASEPATH)
+    deployBasePath: ${{ coalesce(parameters.deployBasePath, 'pull/$(System.PullRequest.PullRequestNumber)') }}
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
     isPR: false
     targetBranch: ''
+    # Deploy master under "heads/branchname" unless otherwise requested
+    deployBasePath: ${{ coalesce(parameters.deployBasePath, replace(variables['Build.SourceBranch'], 'refs/', '')) }}
 
   skipComponentGovernanceDetection: ${{ parameters.skipComponentGovernanceDetection }}

--- a/apps/perf-test/tasks/fluentPerfRegressions.ts
+++ b/apps/perf-test/tasks/fluentPerfRegressions.ts
@@ -27,8 +27,8 @@ export function getFluentPerfRegressions() {
 }
 
 function linkToFlamegraph(value: string, filename: string) {
-  const urlForDeployPath = process.env.BUILD_SOURCEBRANCH
-    ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test-northstar`
+  const urlForDeployPath = process.env.DEPLOYURL
+    ? `${process.env.DEPLOYURL}/perf-test-northstar`
     : 'file://' + config.paths.packageDist('perf-test');
 
   return `[${value}](${urlForDeployPath}/${path.basename(filename)})`;

--- a/apps/pr-deploy-site/.eslintrc.json
+++ b/apps/pr-deploy-site/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["plugin:@fluentui/eslint-plugin/node"],
+  "root": true,
+  "overrides": [
+    {
+      // pr-deploy-site.js is run without transpiling in all browsers, which means it must use
+      // IE 11-compatible syntax as long as we still support IE 11.
+      "files": ["pr-deploy-site.js"],
+      "plugins": ["es5"],
+      "extends": ["plugin:es5/no-es2015"],
+      "rules": {
+        // turn off conflicting or unwanted rules from normal set
+        "curly": "off",
+        "no-var": "off",
+        "vars-on-top": "off",
+        "prefer-arrow-callback": "off"
+      }
+    }
+  ]
+}

--- a/apps/pr-deploy-site/README.md
+++ b/apps/pr-deploy-site/README.md
@@ -1,8 +1,8 @@
 # PR deployed demo site
 
-This is the site that gets deployed for each PR at `https://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/#####/merge/` or `https://fluentuipr.z22.web.core.windows.net/pr-deploy-site/refs/pull/#####/merge/` (where `#####` is the real PR number).
+This is the site that gets deployed for each PR at `https://fluentuipr.z22.web.core.windows.net/pull/#####/` (where `#####` is the real PR number).
 
-It's also deployed during CI builds for [`master`](https://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/), [`7.0`](https://fluentuipr.z22.web.core.windows.net/pr-deploy-site/refs/heads/7.0/), and [`6.0`](https://fluentuipr.z22.web.core.windows.net/pr-deploy-site/refs/heads/7.0/).
+It's also deployed during CI builds for [`master`](https://fluentuipr.z22.web.core.windows.net/heads/master/), [`7.0`](https://fluentuipr.z22.web.core.windows.net/heads/7.0/), and [`6.0`](https://fluentuipr.z22.web.core.windows.net/heads/6.0/).
 
 ## How to add a new package to the site
 

--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -46,6 +46,7 @@
     </script>
 
     <script>
+      // Function is defined in pr-deploy-site.js and replacement is done in just.config.ts
       renderSiteLinks(/* insert packages here */);
     </script>
   </body>

--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -22,32 +22,5 @@
     </ul>
 
     <script src="./pr-deploy-site.js"></script>
-
-    <script>
-      // @ts-check
-      // NOTE: use var and string concatenation (not templates) here to ensure compat
-      var hrefMatch = window.location.href.match(/refs\/(pull|heads)\/([^/]+)/);
-      var repoUrl = 'https://github.com/microsoft/fluentui';
-      if (hrefMatch) {
-        var link = /** @type {HTMLAnchorElement} */ (document.getElementById('prLink'));
-        if (hrefMatch[1] === 'heads') {
-          // master or other branch CI
-          link.innerHTML = hrefMatch[2];
-          link.href = repoUrl + '/tree/' + hrefMatch[2];
-          // remove the PR-specific explanation
-          var prExplanation = document.getElementById('prExplanation');
-          prExplanation.parentElement.removeChild(prExplanation);
-        } else {
-          // PR
-          link.innerHTML = 'PR #' + hrefMatch[2];
-          link.href = repoUrl + '/pull/' + hrefMatch[2];
-        }
-      }
-    </script>
-
-    <script>
-      // Function is defined in pr-deploy-site.js and replacement is done in just.config.ts
-      renderSiteLinks(/* insert packages here */);
-    </script>
   </body>
 </html>

--- a/apps/pr-deploy-site/just.config.ts
+++ b/apps/pr-deploy-site/just.config.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import { preset, series, task, copyInstructionsTask, copyInstructions } from '@fluentui/scripts';
+import { series, task, copyInstructionsTask, copyInstructions } from '@fluentui/scripts';
 import { findGitRoot, getAllPackageInfo } from '@fluentui/scripts/monorepo/index';
 
 const gitRoot = findGitRoot();
-let instructions = copyInstructions.copyFilesToDestinationDirectory(
-  ['pr-deploy-site.js', 'pr-deploy-site.css', 'chiclet-test.html'],
+const instructions = copyInstructions.copyFilesToDestinationDirectory(
+  ['pr-deploy-site.css', 'chiclet-test.html', 'index.html'],
   'dist',
 );
 
@@ -32,40 +32,44 @@ const allPackages = getAllPackageInfo();
 const repoDeps = dependencies.map(dep => allPackages[dep]);
 const deployedPackages = new Set<string>();
 repoDeps.forEach(dep => {
-  const distPath = path.join(gitRoot, dep.packagePath, 'dist');
+  const packageDist = path.join(gitRoot, dep.packagePath, 'dist');
 
-  if (fs.existsSync(distPath)) {
-    let sourcePath = distPath;
-
+  if (fs.existsSync(packageDist)) {
     if (dep.packageJson.name === '@fluentui/docs') {
-      instructions.push(...copyInstructions.copyFilesInDirectory(sourcePath, path.join('dist', 'react-northstar')));
+      instructions.push(...copyInstructions.copyFilesInDirectory(packageDist, path.join('dist', 'react-northstar')));
       deployedPackages.add(dep.packageJson.name);
     } else if (dep.packageJson.name === '@fluentui/perf-test') {
-      instructions.push(...copyInstructions.copyFilesInDirectory(sourcePath, path.join('dist', 'perf-test-northstar')));
+      instructions.push(
+        ...copyInstructions.copyFilesInDirectory(packageDist, path.join('dist', 'perf-test-northstar')),
+      );
       deployedPackages.add(dep.packageJson.name);
     } else {
       instructions.push(
-        ...copyInstructions.copyFilesInDirectory(sourcePath, path.join('dist', path.basename(dep.packagePath))),
+        ...copyInstructions.copyFilesInDirectory(packageDist, path.join('dist', path.basename(dep.packagePath))),
       );
       deployedPackages.add(dep.packageJson.name);
     }
   }
 });
 
-preset();
-
 /**
- * Renders a site with tiles that are potentially from a partial set of deployed packages
+ * Sets the list of tiles to render based on which packages were actually built
  */
-task('generate:index', () => {
-  const indexContent = fs.readFileSync(path.join(__dirname, './index.html'), 'utf-8');
+task('generate:js', () => {
+  const jsContent = fs.readFileSync(path.join(__dirname, './pr-deploy-site.js'), 'utf-8');
+
+  if (!jsContent.includes('var packages;')) {
+    console.error('pr-deploy-site.js must contain a line "var packages;" to replace with the actual packages');
+    process.exit(1);
+  }
+
   fs.writeFileSync(
-    path.join('dist', 'index.html'),
-    indexContent.replace('/* insert packages here */', JSON.stringify([...deployedPackages])),
+    path.join('dist', 'pr-deploy-site.js'),
+    jsContent.replace('var packages;', `var packages = ${JSON.stringify([...deployedPackages])};`),
   );
 });
 
 /**
- * Copies all the built (potentially partially) dist files and then generates a index HTML for it
+ * Copies all the built dist files and updates the JS to load the ones that were actually built
  */
-task('generate:site', series(copyInstructionsTask({ copyInstructions: instructions }), 'generate:index'));
+task('generate:site', series(copyInstructionsTask({ copyInstructions: instructions }), 'generate:js'));

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -6,10 +6,11 @@
   "private": true,
   "scripts": {
     "generate:site": "just-scripts generate:site",
-    "just": "just-scripts"
+    "lint": "eslint --ext .js,.ts ."
   },
   "license": "MIT",
   "devDependencies": {
+    "@fluentui/eslint-plugin": "^1.0.1",
     "@fluentui/scripts": "^1.0.0"
   }
 }

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -1,7 +1,10 @@
+// @ts-check
 // If you are adding a new tile into this site, place make sure it is also being copied from `just.config.ts`
 
-// Syntax here MUST BE IE11-COMPATIBLE because this file is run without transpiling, and needs to
-// work in all browsers including IE 11 as long as we still support it.
+// A build step will replace this with the list of actual built packages
+/** @type {string[]} */
+var packages;
+
 var siteInfo = [
   {
     package: '@fluentui/public-docsite-resources',
@@ -59,25 +62,40 @@ var siteInfo = [
   },
 ];
 
+var hrefMatch = window.location.href.match(/refs\/(pull|heads)\/([^/]+)/);
+var repoUrl = 'https://github.com/microsoft/fluentui';
+if (hrefMatch) {
+  var link = /** @type {HTMLAnchorElement} */ (document.getElementById('prLink'));
+  if (hrefMatch[1] === 'heads') {
+    // master or other branch CI
+    link.innerHTML = hrefMatch[2];
+    link.href = repoUrl + '/tree/' + hrefMatch[2];
+    // remove the PR-specific explanation
+    var prExplanation = document.getElementById('prExplanation');
+    prExplanation.parentElement.removeChild(prExplanation);
+  } else {
+    // PR
+    link.innerHTML = 'PR #' + hrefMatch[2];
+    link.href = repoUrl + '/pull/' + hrefMatch[2];
+  }
+}
+
 var siteLink = document.getElementById('site-list');
 
-window.renderSiteLinks = function(packages) {
-  siteInfo.forEach(function(info) {
-    if (packages.indexOf(info.package) > -1) {
-      var li = document.createElement('LI');
-      li.className = 'Tile';
-      // Syntax here MUST BE IE11-COMPATIBLE (no backticks)
-      li.innerHTML =
-        '<a href="' +
-        info.link +
-        '" class="Tile-link">' +
-        '<i class="ms-Icon ms-Icon--' +
-        info.icon +
-        '"></i>' +
-        info.title +
-        '</a>';
+siteInfo.forEach(function(info) {
+  if (packages.indexOf(info.package) > -1) {
+    var li = document.createElement('LI');
+    li.className = 'Tile';
+    li.innerHTML =
+      '<a href="' +
+      info.link +
+      '" class="Tile-link">' +
+      '<i class="ms-Icon ms-Icon--' +
+      info.icon +
+      '"></i>' +
+      info.title +
+      '</a>';
 
-      siteLink.appendChild(li);
-    }
-  });
-};
+    siteLink.appendChild(li);
+  }
+});

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -1,6 +1,8 @@
 // If you are adding a new tile into this site, place make sure it is also being copied from `just.config.ts`
 
-const siteInfo = [
+// Syntax here MUST BE IE11-COMPATIBLE because this file is run without transpiling, and needs to
+// work in all browsers including IE 11 as long as we still support it.
+var siteInfo = [
   {
     package: '@fluentui/public-docsite-resources',
     link: './public-docsite-resources/demo/index.html',
@@ -64,9 +66,16 @@ window.renderSiteLinks = function(packages) {
     if (packages.indexOf(info.package) > -1) {
       var li = document.createElement('LI');
       li.className = 'Tile';
-      li.innerHTML = `<a href="${info.link}" class="Tile-link">
-        <i class="ms-Icon ms-Icon--${info.icon}"></i>${info.title}
-      </a>`;
+      // Syntax here MUST BE IE11-COMPATIBLE (no backticks)
+      li.innerHTML =
+        '<a href="' +
+        info.link +
+        '" class="Tile-link">' +
+        '<i class="ms-Icon ms-Icon--' +
+        info.icon +
+        '"></i>' +
+        info.title +
+        '</a>';
 
       siteLink.appendChild(li);
     }

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -52,18 +52,18 @@ steps:
     inputs:
       SourcePath: 'packages/fluentui/perf-test/dist'
       azureSubscription: $(azureSubscription)
-      storage: fabricweb
+      storage: $(azureStorage)
       ContainerName: '$web'
-      BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test-northstar'
+      BlobPrefix: '$(deployBasePath)/perf-test-northstar'
 
   - task: AzureUpload@2
     displayName: Upload Perf Test Result to PR deploy site
     inputs:
       SourcePath: 'apps/perf-test/dist'
       azureSubscription: $(azureSubscription)
-      storage: fabricweb
+      storage: $(azureStorage)
       ContainerName: '$web'
-      BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test'
+      BlobPrefix: '$(deployBasePath)/perf-test'
 
   - task: GithubPRComment@0
     displayName: 'Post Perf Results to Github Pull Request'

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -9,7 +9,6 @@ variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
     parameters:
-      azureSubscription: 'UI Fabric (private)'
       skipComponentGovernanceDetection: false
 
 pool: 'Self Host Ubuntu'
@@ -35,17 +34,6 @@ steps:
       git config user.email "fluentui-internal@service.microsoft.com"
       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
-
-  # This step has no dependencies, so do it early in the build in case other steps fail
-  - task: AzureUpload@2
-    displayName: Upload demo images
-    inputs:
-      azureSubscription: $(azureSubscription)
-      BlobPrefix: 'assets'
-      CacheControl: 'public, max-age=600000'
-      ContainerName: 'fabric-website' # this container has a CDN
-      SourcePath: 'packages/fluentui/docs/src/public'
-      storage: fabricweb
 
   - task: Bash@3
     inputs:
@@ -96,6 +84,13 @@ steps:
     displayName: yarn bundle
 
   - script: |
+      npm run publish:beachball -- -b origin/master -n $(npmToken) --access public -y
+      git reset --hard origin/master
+    env:
+      GITHUB_PAT: $(githubPAT)
+    displayName: Publish changes and bump versions
+
+  - script: |
       echo Making $(Build.ArtifactStagingDirectory)/api
       mkdir -p $(Build.ArtifactStagingDirectory)/api
       cp packages/*/dist/*.api.json $(Build.ArtifactStagingDirectory)/api
@@ -106,86 +101,85 @@ steps:
       pathtoPublish: $(Build.ArtifactStagingDirectory)/api
       artifactName: 'api-json'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: api.json'
+    displayName: 'Publish artifact: api-json'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: apps/public-docsite/dist
       artifactName: 'fabric-website'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: Fabric Website'
+    displayName: 'Publish artifact: fabric-website (public-docsite)'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: apps/public-docsite/index.html
       artifactName: 'fabric-website-index'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: Fabric Website index.html'
+    displayName: 'Publish artifact: fabric-website-index (public-docsite index.html)'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: packages/react/dist
       artifactName: 'fabric'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: Fabric'
-
-  - script: |
-      npm run publish:beachball -- -b origin/master -n $(npmToken) --access public -y
-      git reset --hard origin/master
-    env:
-      GITHUB_PAT: $(githubPAT)
-    displayName: 'Publish Change Requests and Bump Versions'
-
-  - script: |
-      node -r ./scripts/ts-node-register ./scripts/updateReleaseNotes/index.ts --token=$(githubPAT) --apply --debug
-    displayName: 'Update github release notes'
+    displayName: 'Publish artifact: fabric (packages/react/dist)'
 
   - script: |
       oufrVersion=$(node -p -e "require('./packages/react/package.json').version")
       echo "OUFR Version: $oufrVersion"
       echo $oufrVersion > oufr-version.txt
       echo "##vso[task.setvariable variable=oufrVersion;]$oufrVersion"
-    displayName: 'Set OUFR Version Task Variable'
+    displayName: 'Set oufrVersion variable'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: ./oufr-version.txt
       artifactName: 'oufr-version'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: oufr-version.txt'
+    displayName: 'Publish artifact: oufr-version'
 
   - script: |
       npm run create-public-flight-config -- --baseCDNUrl https://fabricweb.azureedge.net/fabric-website/$(Build.BuildNumber)/
     workingDirectory: apps/public-docsite
-    displayName: 'Generate Fabric Website Flight Manifest Files'
+    displayName: 'Generate website manifests'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: apps/public-docsite/flights
       artifactName: 'fabric-website-manifests'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: Website manifests'
+    displayName: 'Publish artifact: fabric-website-manifests'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: apps/public-docsite-resources/dist/demo
       artifactName: 'fabric-website-resources'
       publishLocation: 'Container'
-    displayName: 'Publish Artifact: Fabric Website Resources'
+    displayName: 'Publish artifact: fabric-website-resources (public-docsite-resources)'
 
   - script: |
       node ./scripts/generate-package-manifest
-    displayName: 'Generates a package manifest'
+    displayName: 'Generate package manifest'
 
-  - task: AzureUpload@2
-    displayName: Upload Package Manifest
+  - task: PublishBuildArtifacts@1
     inputs:
-      SourcePath: 'package-manifest'
-      azureSubscription: $(azureSubscription)
-      storage: fabricweb
-      ContainerName: 'fabric'
-      BlobPrefix: 'package-manifest'
-      Gzip: false
+      pathtoPublish: package-manifest
+      artifactName: 'package-manifest'
+      publishLocation: 'Container'
+    displayName: 'Publish artifact: package-manifest'
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: packages/fluentui/docs/src/public
+      artifactName: 'demo-images'
+      publishLocation: 'Container'
+    displayName: 'Publish artifact: demo-images'
+
+  # Run this near the end because it's more likely to fail than the artifact upload tasks, and its
+  # failure doesn't need to block anything else
+  - script: |
+      node -r ./scripts/ts-node-register ./scripts/updateReleaseNotes/index.ts --token=$(githubPAT) --apply --debug
+    displayName: 'Update github release notes'
 
   # This would usually be run automatically (via a pipeline decorator from an extension), but the
   # thorough cleanup step prevents it from working. So run it manually here.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pr:
 trigger: none
 
 variables:
-  - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/')) }}:
       - name: sinceArg
         value: --since $(targetBranch)
 
@@ -58,8 +58,6 @@ jobs:
         displayName: build, test, lint
 
       - template: .devops/templates/cleanup.yml
-        parameters:
-          checkForChangedFiles: false
 
   - job: Deploy
     workspace:
@@ -82,9 +80,6 @@ jobs:
           yarn workspace @fluentui/pr-deploy-site generate:site
         displayName: generate PR Deploy Site
 
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: Build-PR-$(Build.BuildNumber)
-
       - task: AzureUpload@2
         displayName: Upload PR deploy site
         inputs:
@@ -92,7 +87,7 @@ jobs:
           BlobPrefix: $(deployBasePath)
           ContainerName: '$web'
           SourcePath: 'apps/pr-deploy-site/dist'
-          storage: fabricweb
+          storage: $(azureStorage)
 
       - task: GithubPRStatus@0
         displayName: 'Update PR deploy site github status'
@@ -101,7 +96,8 @@ jobs:
           githubRepo: fluentui
           githubContext: 'Pull request demo site'
           githubDescription: 'Click "Details" to go to the deployed demo site for this pull request'
-          githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
+          # This MUST have a trailing slash, or the links to PR deploy site assets won't work
+          githubTargetLink: $(deployUrl)/
 
       - template: .devops/templates/cleanup.yml
 
@@ -116,7 +112,8 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: yarn workspace @fluentui/docs vr:build
+      - script: |
+          yarn workspace @fluentui/docs vr:build
         displayName: build FUI N* VR Test
         env:
           SCREENER_BUILD: 1
@@ -129,7 +126,7 @@ jobs:
           CacheControl: 'public, max-age=600000'
           ContainerName: '$web'
           SourcePath: 'packages/fluentui/docs/dist'
-          storage: fabricweb
+          storage: $(azureStorage)
 
       - script: yarn workspace @fluentui/docs vr:test
         displayName: start FUI N* VR Test

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "beachball": "1.53.1",
     "cross-env": "^5.1.4",
     "css-loader": "5.0.1",
+    "eslint-plugin-es5": "1.5.0",
     "danger": "^6.0.5",
     "file-loader": "6.2.0",
     "gulp": "^4.0.2",

--- a/packages/fluentui/perf-test/tasks/perf-test.ts
+++ b/packages/fluentui/perf-test/tasks/perf-test.ts
@@ -27,14 +27,7 @@ type ExtendedCookResults = Record<string, ExtendedCookResult>;
 
 // TODO: We can't do CI, measure baseline or do regression analysis until master & PR files are deployed and publicly accessible.
 // TODO: Fluent reporting is outside of this script so this code will probably be moved entirely on perf-test consolidation.
-// const urlForDeployPath = process.env.BUILD_SOURCEBRANCH
-//   ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test`
-//   : `file://${path.resolve(__dirname, '../dist/')}`;
 const urlForDeployPath = `file://${path.resolve(__dirname, '../dist/')}`;
-
-// const urlForMaster = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
-//   ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test/index.html`
-//   : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/index.html';
 
 const urlForDeploy = `${urlForDeployPath}/index.html`;
 const defaultIterations = 1;
@@ -45,13 +38,16 @@ const tempDir = path.join(__dirname, '../logfiles');
 console.log(`__dirname: ${__dirname}`);
 
 export default async function getPerfRegressions(baselineOnly: boolean = false) {
-  let urlForMaster;
+  let urlForMaster: string | undefined;
 
   if (!baselineOnly) {
-    urlForMaster = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
-      ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test-northstar/index.html`
-      : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test-northstar/index.html';
+    const targetPath = `heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH || 'master'}`;
+    urlForMaster = `https://${process.env.DEPLOYHOST}/${targetPath}/perf-test-northstar/index.html`;
   }
+
+  // For debugging, in case the environment variables used to generate these have unexpected values
+  console.log(`urlForDeployPath: "${urlForDeployPath}"`);
+  console.log(`urlForMaster: "${urlForMaster}"`);
 
   // TODO: support iteration/kind/story via commandline as in other perf-test script
   // TODO: can do this now that we have story information

--- a/scripts/screener/screener.states.ts
+++ b/scripts/screener/screener.states.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import getScreenerSteps from './screener.steps';
 
-const baseUrl = `https://${process.env.DEPLOYHOST}/${process.env.DEPLOYBASEPATH}/react-northstar-screener`;
+const baseUrl = `${process.env.DEPLOYURL}/react-northstar-screener`;
 const examplePaths = glob.sync('packages/fluentui/docs/src/examples/**/*.tsx', {
   ignore: ['**/index.tsx', '**/*.knobs.tsx', '**/BestPractices/*.tsx', '**/Playground.tsx'],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11862,6 +11862,11 @@ eslint-plugin-deprecation@^1.1.0:
     tslib "^1.10.0"
     tsutils "^3.0.0"
 
+eslint-plugin-es5@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
+  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
+
 eslint-plugin-import@^2.20.1, eslint-plugin-import@^2.21.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"


### PR DESCRIPTION
(New version of #16304) 

Switch PR deploys and perf results to use the `fluentuipr` Azure storage account (and an Azure connection which only has access to that storage account), and simplify the URLs. 
```
For PR:
  Old:  http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/#####/merge/
  New:  https://fluentuipr.z22.web.core.windows.net/pull/#####/

For CI:
  Old:  http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/branchname/
  New:  https://fluentuipr.z22.web.core.windows.net/heads/branchname/
```

To get rid of the remaining `fabricweb` blob storage access from pipelines, switch the release build to only upload artifacts, and use a separate internal release pipeline to upload those artifacts to storage.

I also removed some ES6 syntax from the PR deploy site (it needs to use ES5 for IE 11 compat) and added linting to ensure it stays that way, as well as consolidating all the JS code for the site into pr-deploy-site.js (better for linting and overall).