### PR TITLE
Dark Theme Default Button Update

### DIFF
--- a/change/@fluentui-azure-themes-4344cfcd-0608-4f7f-9f27-6ffffe578f06.json
+++ b/change/@fluentui-azure-themes-4344cfcd-0608-4f7f-9f27-6ffffe578f06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "dark theme default button update",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -85,6 +85,7 @@ export namespace BaseColors {
   export const GRAY_EDEBE9 = '#EDEBE9';
   export const GRAY_E1DFDD = '#E1DFDD';
   export const GRAY_F3F2F1 = '#F3F2F1';
+  export const GRAY_FAF9F8 = '#FAF9F8';
   export const GRAY_6B849C = '#6B849C';
   export const BLACK = '#000000';
   export const WHITE = '#ffffff';
@@ -215,19 +216,22 @@ export const DarkSemanticColors: IAzureSemanticColors = {
   },
   secondaryButton: {
     rest: {
-      background: BaseColors.GRAY_111111,
-      border: BaseColors.GRAY_979693,
-      text: BaseColors.WHITE,
+      background: BaseColors.GRAY_1B1A19,
+      border: BaseColors.GRAY_8A8886,
+      text: BaseColors.GRAY_F3F2F1,
     },
     hover: {
       background: BaseColors.GRAY_252423,
       border: BaseColors.GRAY_979693,
-      color: BaseColors.WHITE,
+      color: BaseColors.GRAY_FAF9F8,
     },
     pressed: {
-      text: BaseColors.WHITE,
+      text: BaseColors.GRAY_FAF9F8,
       background: BaseColors.GRAY_292827,
       border: BaseColors.GRAY_979693,
+    },
+    focus: {
+      border: BaseColors.GRAY_A19F9D,
     },
   },
   checkBox: {
@@ -410,6 +414,9 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
       background: BaseColors.BLUE_00E8E8,
       border: BaseColors.BLUE_00E8E8,
     },
+    focus: {
+      border: BaseColors.GRAY_A19F9D,
+    },
   },
   checkBox: {
     rest: {
@@ -591,6 +598,9 @@ export const LightSemanticColors: IAzureSemanticColors = {
       background: BaseColors.GRAY_EDEBE9,
       border: BaseColors.GRAY_8A8886,
     },
+    focus: {
+      border: BaseColors.GRAY_605E5C,
+    },
   },
   checkBox: {
     rest: {
@@ -771,6 +781,9 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
       text: BaseColors.WHITE,
       background: BaseColors.PURPLE_660166,
       border: BaseColors.PURPLE_660166,
+    },
+    focus: {
+      border: BaseColors.GRAY_323130,
     },
   },
   checkBox: {

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -17,6 +17,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   buttonBackgroundHovered: DarkSemanticColors.secondaryButton.hover.background,
   buttonBackgroundPressed: DarkSemanticColors.secondaryButton.pressed.background,
   ButtonBorderDisabled: DarkSemanticColors.disabledButton.background,
+  ButtonBorderFocus: DarkSemanticColors.secondaryButton.focus.border,
   buttonText: DarkSemanticColors.secondaryButton.rest.text,
   buttonTextChecked: DarkSemanticColors.secondaryButton.pressed.border,
   buttonTextCheckedHovered: DarkSemanticColors.secondaryButton.hover.border,

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -86,6 +86,9 @@ export interface IAzureSemanticColors {
       background: string;
       border: string;
     };
+    focus: {
+      border: string;
+    };
   };
   checkBox: {
     rest: {

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -13,6 +13,7 @@ export interface IExtendedSemanticColors extends ISemanticColors {
   buttonBackgroundHovered: string;
   buttonBackgroundPressed: string;
   ButtonBorderDisabled: string;
+  ButtonBorderFocus: string;
   buttonText: string;
   buttonTextChecked: string;
   buttonTextCheckedHovered: string;

--- a/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
@@ -58,19 +58,22 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
     rootFocused: {
+      selectors: {
+        '::after': {
+          outlineColor: `${extendedSemanticColors.ButtonBorderFocus} !important`,
+        },
+      },
       backgroundColor: semanticColors.buttonBackground,
       color: semanticColors.buttonText,
       fill: semanticColors.buttonTextHovered,
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
     },
     rootHovered: {
-      border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorderHovered}`,
       backgroundColor: semanticColors.buttonBackgroundHovered,
       color: semanticColors.buttonTextHovered,
     },
     rootPressed: {
       backgroundColor: semanticColors.buttonBackgroundPressed,
-      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.inputBorderPressed}`,
       color: semanticColors.buttonTextHovered,
     },
     rootChecked: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Cherry picked #17254, as PR isn't working. 
- IAzureSemanticColors.ts 
  - Added focus.border to secondaryButton 
- IExtendedSemanticColors.ts 
  -  Added ButtonBorderFocus 
- AzureColors.ts 
  - Added GRAY_FAF9F8 
  - Dark 
    - SecondaryButton 
      - Rest 
        - Background: GRAY_111111 -> GRAY_1B1A19 
        - Border: GRAY_979693-> GRAY_8A8886 
        - Text: WHITE -> GRAY_F3F2F1 
      - Hover 
        - Color: WHITE -> GRAY_FAF9F8 
      - Pressed 
        -Text: WHITE -> GRAY_FAF9F8 
      - Added focus 
  - Light 
    - SecondaryButton 
      - Added focus 
    - High Contrast Dark 
      - SecondaryButton 
        - Added focus 
    - High Contrast Light 
      - Secondary Button 
        - Added focus 
- AzureThemeDark.ts 
  - Added ButtonBorderFocus 
- DefaultButton.styles.ts 
  - RootFocusted 
    - Added inner border on focus 
  - RootHovered 
    - Took border away 
      - This fixed both light and dark mode 
  - RootPressed 
    - Took border away 
      - This fixed dark mode 

#### Dark Default Rest
Changed background, border color, and text color
Before:
<img width="135" alt="DefaultButton_Dark_Rest_Prior" src="https://user-images.githubusercontent.com/35254365/109535868-e6fa7980-7a71-11eb-8286-b928cf5f8deb.PNG">
After:
<img width="135" alt="DefaultButton_Dark_Rest_Fix" src="https://user-images.githubusercontent.com/35254365/109535890-ecf05a80-7a71-11eb-942c-b6231dbf1636.PNG">

#### Dark Default Hover
Changed text color
Before:
<img width="134" alt="DefaultButton_Dark_Hover_Prior" src="https://user-images.githubusercontent.com/35254365/109536050-17daae80-7a72-11eb-9c44-45597eed0a77.PNG">
After:
<img width="133" alt="DefaultButton_Dark_Hover_Fix" src="https://user-images.githubusercontent.com/35254365/109536057-1b6e3580-7a72-11eb-88cf-115149934060.PNG">

#### Dark Default Pressed
Changed text color
Before:
<img width="135" alt="DefaultButton_Dark_Pressed_Prior" src="https://user-images.githubusercontent.com/35254365/109536125-317bf600-7a72-11eb-89be-1774e3c45c24.PNG">
After:
<img width="136" alt="DefaultButton_Dark_Pressed_Fix" src="https://user-images.githubusercontent.com/35254365/109536132-3640aa00-7a72-11eb-8b0d-fe791f7563d0.PNG">

#### Dark Default Focus:
Changed focus border color
Before:
<img width="133" alt="DefaultButton_Dark_Focus_Prior" src="https://user-images.githubusercontent.com/35254365/109536177-45275c80-7a72-11eb-8252-4a842e283bd6.PNG">
After:
<img width="139" alt="DefaultButton_Dark_Focus_Fix" src="https://user-images.githubusercontent.com/35254365/109536186-48bae380-7a72-11eb-926d-fc66433d7fdc.PNG">

#### Light Default Hover:
Changed border color
Before:
<img width="135" alt="DefaultButton_Light_Hover_Border_Prior" src="https://user-images.githubusercontent.com/35254365/109536242-5a9c8680-7a72-11eb-9fa0-8f9f74809959.PNG">
After:
<img width="136" alt="DefaultButton_Light_Hover_Border_Fix" src="https://user-images.githubusercontent.com/35254365/109536248-5e300d80-7a72-11eb-9864-294d41e59ce0.PNG">

(give an overview)

#### Focus areas to test

(optional)
