### PR TITLE
Use separate deployment URL for northstar screener

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,13 +76,14 @@ jobs:
           yarn bundle --no-cache $(sinceArg)
         displayName: bundle
 
+      - script: |
+          yarn workspace @fluentui/docs build
+        displayName: build FUI N* docs
+
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |
           yarn workspace @fluentui/pr-deploy-site generate:site
         displayName: generate PR Deploy Site
-
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: Build-PR-$(Build.BuildNumber)
 
       - task: AzureUpload@2
         displayName: Upload PR deploy site
@@ -117,12 +118,14 @@ jobs:
 
       - script: yarn workspace @fluentui/docs vr:build
         displayName: build FUI N* VR Test
+        env:
+          SCREENER_BUILD: 1
 
       - task: AzureUpload@2
-        displayName: Upload N* doc site
+        displayName: Upload N* VR test site
         inputs:
           azureSubscription: $(azureSubscription)
-          BlobPrefix: '$(deployBasePath)/react-northstar'
+          BlobPrefix: $(deployBasePath)/react-northstar-screener
           CacheControl: 'public, max-age=600000'
           ContainerName: '$web'
           SourcePath: 'packages/fluentui/docs/dist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,18 +72,18 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
+      # this also builds FUI N* docs if appropriate
       - script: |
           yarn bundle --no-cache $(sinceArg)
         displayName: bundle
-
-      - script: |
-          yarn workspace @fluentui/docs build
-        displayName: build FUI N* docs
 
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |
           yarn workspace @fluentui/pr-deploy-site generate:site
         displayName: generate PR Deploy Site
+
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: Build-PR-$(Build.BuildNumber)
 
       - task: AzureUpload@2
         displayName: Upload PR deploy site

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -10,8 +10,9 @@ const __DEV__ = env === 'development';
 const __PERF__ = !!process.env.PERF;
 const __PROD__ = env === 'production';
 let __BASENAME__ = process.env.DEPLOYBASEPATH
-  ? // This needs a trailing slash or images won't work
-    `/${process.env.DEPLOYBASEPATH}/react-northstar/`
+  ? // This needs a trailing slash or images won't work.
+    // The path is different for standard PR deploy and screener deploy.
+    `/${process.env.DEPLOYBASEPATH}/${process.env.SCREENER_BUILD ? 'react-northstar-screener' : 'react-northstar'}/`
   : '/';
 
 if (process.env.OFFICIALRELEASE) {

--- a/scripts/screener/screener.states.ts
+++ b/scripts/screener/screener.states.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import getScreenerSteps from './screener.steps';
 
-const baseUrl = `https://${process.env.DEPLOYHOST}/${process.env.DEPLOYBASEPATH}/react-northstar`;
+const baseUrl = `https://${process.env.DEPLOYHOST}/${process.env.DEPLOYBASEPATH}/react-northstar-screener`;
 const examplePaths = glob.sync('packages/fluentui/docs/src/examples/**/*.tsx', {
   ignore: ['**/index.tsx', '**/*.knobs.tsx', '**/BestPractices/*.tsx', '**/Playground.tsx'],
 });


### PR DESCRIPTION
The PR deploy site and screener site for northstar (which have some slightly different settings) were getting uploaded to the same place. Depending on which one was uploaded when, it could change whether an accessibility warning was displayed on screener states and cause intermittent failures in ~220 states. Fix is to upload the screener site to a separate URL.