### PR TITLE
Website: Add version switcher in v6 site

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,7 +45,7 @@
   "tslint.rulesDirectory": "./common/temp/node_modules/tslint-microsoft-contrib",
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
-  "editor.formatOnSave": false, // to prevent formatting conflicts with newer prettier
+  "editor.formatOnSave": true,
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
   "tslint.autoFixOnSave": false,
   "files.associations": {

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { ISiteDefinition, LoadingComponent } from '@uifabric/example-app-base/lib/index2';
 import { FluentCustomizations } from '@uifabric/fluent-theme';
+import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { ControlsPages, ResourcesPages, StylesPages, GetStartedPages } from './SiteDefinition.pages/index';
 import { Platforms } from '../interfaces/Platforms';
 import { platforms } from './SiteDefinition.platforms';
+
+const currentVersionData = require<any>('office-ui-fabric-react/package.json');
+
+const currentVersion = 'Fabric React 6';
+const versions = ['Fluent UI React 7', 'Fabric React 6', 'Fabric React 5'];
 
 export const SiteDefinition: ISiteDefinition<Platforms> = {
   siteTitle: 'Office UI Fabric',
@@ -57,21 +63,19 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     { from: '#/controls/web/fluent-theme', to: '#/styles/web/fluent-theme' },
     { from: '#/examples', to: '#/controls/web' }
   ],
-  messageBars: [
-    {
-      path: '#/controls/web',
-      exclude: 'fluent-theme',
-      text: 'You can now implement the new Fluent styles in Fabric Web controls.',
-      linkText: 'Learn more',
-      linkUrl: '#/styles/web/fluent-theme',
-      sessionStoragePrefix: 'WebFluentUpdates'
+  versionSwitcherDefinition: {
+    currentVersion,
+    currentVersionNumber: currentVersionData.version,
+    onVersionMenuClick: (event, item) => {
+      const restOfPathIndex = location.href.indexOf('#');
+      const restOfPath = restOfPathIndex !== -1 ? location.href.substr(restOfPathIndex) : '';
+      if (item.key !== currentVersion) {
+        // Reload the page to switch versions
+        location.href = `${location.protocol}//${location.host}${location.pathname}?fabricVer=${
+          item.key[item.key.length - 1]
+        }${restOfPath}`;
+      }
     },
-    {
-      path: new RegExp(/^#?\/?$/),
-      text: 'Microsoft employees can sign in to see additional documentation.',
-      linkText: 'Sign in',
-      linkUrl: 'https://aka.ms/hig',
-      sessionStoragePrefix: 'SignIn'
-    }
-  ]
+    versions
+  }
 };

--- a/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
@@ -3,6 +3,7 @@ import { Page, IPageProps, PlatformContext } from '@uifabric/example-app-base/li
 import { getSubTitle } from '../../utilities/index';
 import { Platforms } from '../../interfaces/Platforms';
 import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
+import { SiteDefinition } from '../../SiteDefinition/SiteDefinition';
 
 export interface IControlsPageProps extends IPageProps<Platforms> {}
 
@@ -19,7 +20,14 @@ const ControlsAreaPageBase: React.StatelessComponent<IControlsPageProps> = props
       }
     }
   }
-  return <Page subTitle={getSubTitle(props.platform)} jsonDocs={jsonDocs} {...props} />;
+  return (
+    <Page
+      subTitle={getSubTitle(props.platform)}
+      jsonDocs={jsonDocs}
+      {...props}
+      versionSwitcherDefinition={props.platform === Platforms.web ? SiteDefinition.versionSwitcherDefinition : undefined}
+    />
+  );
 };
 
 export const ControlsAreaPage: React.StatelessComponent<IPageProps<Platforms>> = (props: IPageProps<Platforms>) => (

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -12,15 +12,16 @@ import {
   DirectionalHint,
   ActionButton,
   Stack,
+  IStackProps,
   IRawStyle,
   css
 } from 'office-ui-fabric-react';
 import { trackEvent, EventNames, getSiteArea, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { platforms } from '../../SiteDefinition/SiteDefinition.platforms';
 import { AndroidLogo, AppleLogo, WebLogo } from '../../utilities/index';
+import { SiteDefinition } from '../../SiteDefinition/SiteDefinition';
 import { IHomePageProps, IHomePageStyles, IHomePageStyleProps } from './HomePage.types';
 import { monoFont } from './HomePage.styles';
-const reactPackageData = require<any>('office-ui-fabric-react/package.json');
 
 const getClassNames = classNamesFunction<IHomePageStyleProps, IHomePageStyles>();
 
@@ -153,6 +154,13 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
       isInverted: true
     });
 
+    const { currentVersionNumber, versions, onVersionMenuClick } = SiteDefinition.versionSwitcherDefinition;
+
+    const versionOptions: IContextualMenuItem[] = versions.map(version => ({
+      key: version,
+      text: version
+    }));
+
     const versionSwitcherColor: IRawStyle = { color: theme.palette.black };
     const versionSwitcherActiveColor: IRawStyle = { color: theme.palette.neutralPrimary };
 
@@ -169,10 +177,10 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
                 allowDisabledFocus={true}
                 className={classNames.versionSwitcher}
                 styles={{
-                  root: versionSwitcherColor,
+                  root: { ...versionSwitcherColor, padding: '12px 0' },
                   flexContainer: { fontFamily: monoFont },
                   menuIcon: versionSwitcherColor,
-                  rootHovered: versionSwitcherActiveColor,
+                  rootHovered: { ...versionSwitcherActiveColor, borderBottom: '1px solid white' },
                   rootPressed: versionSwitcherActiveColor,
                   rootExpanded: versionSwitcherActiveColor
                 }}
@@ -181,15 +189,15 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
                   beakWidth: 8,
                   isBeakVisible: true,
                   shouldFocusOnMount: true,
-                  items: fabricVersionOptions,
+                  items: versionOptions,
                   directionalHint: DirectionalHint.bottomCenter,
-                  onItemClick: this._onVersionMenuClick,
+                  onItemClick: onVersionMenuClick,
                   styles: {
                     root: { minWidth: 100 }
                   }
                 }}
               >
-                Fabric React {reactPackageData.version}
+                Fabric React {currentVersionNumber}
               </ActionButton>
             </Stack>
             <ul className={classNames.cardList}>
@@ -333,12 +341,5 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
       nextPage: url,
       currentPage: window.location.hash
     });
-  };
-
-  private _onVersionMenuClick = (event: any, item: IContextualMenuItem): void => {
-    if (item.key !== CURRENT_VERSION) {
-      // Reload the page to switch versions
-      location.href = `${location.protocol}//${location.host}${location.pathname}?fabricVer=${item.key}`;
-    }
   };
 }

--- a/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
@@ -17,6 +17,7 @@ const ControlsPageBase: React.StatelessComponent<IPageProps<Platforms>> = props 
       subTitle={getSubTitle(platform)}
       otherSections={_otherSections(platform)}
       showSideRail={false}
+      versionSwitcherDefinition={platform === Platforms.web ? SiteDefinition.versionSwitcherDefinition : undefined}
       {...ControlsPageProps[platform]}
     />
   );

--- a/change/@uifabric-example-app-base-2021-03-16-11-59-25-version-switcher-6.json
+++ b/change/@uifabric-example-app-base-2021-03-16-11-59-25-version-switcher-6.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add version switcher to website",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "8c01d13159534b4282140e71331cf42dbea41c57",
+  "date": "2021-03-16T18:59:13.943Z"
+}

--- a/change/@uifabric-fabric-website-2021-03-16-11-59-25-version-switcher-6.json
+++ b/change/@uifabric-fabric-website-2021-03-16-11-59-25-version-switcher-6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add version switcher to website",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "8c01d13159534b4282140e71331cf42dbea41c57",
+  "date": "2021-03-16T18:59:10.039Z"
+}

--- a/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.tsx
+++ b/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.tsx
@@ -75,25 +75,23 @@ const generateParagraphs = (): JSX.Element => {
   return <>{paragraphs}</>;
 };
 
-const shimmerSections = memoizeFunction(
-  (): IPageSectionProps[] => {
-    const sections: IPageSectionProps[] = [];
+const shimmerSections = memoizeFunction((): IPageSectionProps[] => {
+  const sections: IPageSectionProps[] = [];
 
-    for (let i = 0; i <= 1; i++) {
-      sections.push({
-        className: shimmerSectionClass,
-        content: (
-          <>
-            <Shimmer width="25%" shimmerElements={[{ type: ElementType.line, height: 28 }]} style={{ marginBottom: 24 }} />
-            {generateParagraphs()}
-          </>
-        )
-      });
-    }
-
-    return sections;
+  for (let i = 0; i <= 1; i++) {
+    sections.push({
+      className: shimmerSectionClass,
+      content: (
+        <>
+          <Shimmer width="25%" shimmerElements={[{ type: ElementType.line, height: 28 }]} style={{ marginBottom: 24 }} />
+          {generateParagraphs()}
+        </>
+      )
+    });
   }
-);
+
+  return sections;
+});
 
 export interface ILoadingComponentState {
   pastDelay: boolean;
@@ -136,7 +134,7 @@ export class LoadingComponent extends React.PureComponent<ILoadingComponentProps
 
   public render(): JSX.Element {
     const { pastDelay, pastOffset } = this.state;
-    const { title } = this.props;
+    const { title, versionSwitcherDefinition } = this.props;
 
     return (
       <Page
@@ -145,6 +143,7 @@ export class LoadingComponent extends React.PureComponent<ILoadingComponentProps
         sectionWrapperClassName={css(pastDelay && pastDelayClass, pastOffset && pastOffsetClass)}
         showSideRail={false}
         className={rootClass}
+        versionSwitcherDefinition={versionSwitcherDefinition}
       />
     );
   }

--- a/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.types.ts
+++ b/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.types.ts
@@ -1,4 +1,7 @@
+import { IVersionSwitcherDefinition } from '../../utilities/SiteDefinition.types';
+
 export interface ILoadingComponentProps {
   title?: string;
   shimmer?: boolean;
+  versionSwitcherDefinition?: IVersionSwitcherDefinition;
 }

--- a/packages/example-app-base/src/components/Page/Page.tsx
+++ b/packages/example-app-base/src/components/Page/Page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Async, css } from 'office-ui-fabric-react';
+import { Async, css, mergeStyles } from 'office-ui-fabric-react';
 import { slugify } from '../../utilities/index2';
 import { PageHeader } from '../PageHeader/index';
 import { Markdown } from '../Markdown/index';
@@ -19,6 +19,7 @@ import {
 } from './sections/index';
 import { IPageProps, IPageSectionProps } from './Page.types';
 import * as styles from './Page.module.scss';
+import { sideRailWidth } from '../../styles/constants';
 
 const SECTION_STAGGER_INTERVAL = 0.05;
 /** Section key/id prefix for sections which don't have a title */
@@ -79,18 +80,20 @@ export class Page extends React.Component<IPageProps, IPageState> {
           sectionWrapperClassName
         )}
       >
-        {// Map over array of section objects in order to add increasing transitionDelay to stagger load animation.
-        sections.map((section: IPageSectionProps, sectionIndex: number) => {
-          const { renderAs: SectionType = OtherPageSection, className, style, ...rest } = section;
-          return (
-            <SectionType
-              key={section.id || sectionIndex}
-              {...rest}
-              className={css(className, styles.section)}
-              style={{ transitionDelay: `${sectionIndex * SECTION_STAGGER_INTERVAL}s` }}
-            />
-          );
-        })}
+        {
+          // Map over array of section objects in order to add increasing transitionDelay to stagger load animation.
+          sections.map((section: IPageSectionProps, sectionIndex: number) => {
+            const { renderAs: SectionType = OtherPageSection, className, style, ...rest } = section;
+            return (
+              <SectionType
+                key={section.id || sectionIndex}
+                {...rest}
+                className={css(className, styles.section)}
+                style={{ transitionDelay: `${sectionIndex * SECTION_STAGGER_INTERVAL}s` }}
+              />
+            );
+          })
+        }
       </div>
     );
   };
@@ -211,8 +214,25 @@ export class Page extends React.Component<IPageProps, IPageState> {
   };
 
   private _getPageHeader = (): JSX.Element | null => {
-    const { title, subTitle } = this.props;
-    return title ? <PageHeader pageTitle={title} pageSubTitle={subTitle} /> : null;
+    const { showSideRail, title, subTitle, versionSwitcherDefinition } = this.props;
+    return title ? (
+      <PageHeader
+        pageTitle={title}
+        pageSubTitle={subTitle}
+        versionSwitcherDefinition={versionSwitcherDefinition}
+        className={mergeStyles(
+          showSideRail
+            ? {
+                selectors: {
+                  '@media only screen and (min-width: 1360px)': {
+                    width: `calc(100% - ${sideRailWidth}px)`
+                  }
+                }
+              }
+            : { width: '100%' }
+        )}
+      />
+    ) : null;
   };
 
   private _getSideRail = (sections: IPageSectionProps[]): JSX.Element | undefined => {

--- a/packages/example-app-base/src/components/Page/Page.types.ts
+++ b/packages/example-app-base/src/components/Page/Page.types.ts
@@ -3,6 +3,7 @@ import { IComponentAs, Omit } from 'office-ui-fabric-react';
 import { IExampleCardProps } from '../ExampleCard/index';
 import { ISideRailLink } from '../SideRail/index';
 import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
+import { IVersionSwitcherDefinition } from '../../utilities/SiteDefinition.types';
 
 /**
  * Props for the page.
@@ -107,6 +108,11 @@ export interface IPageProps<TPlatforms extends string = string> {
 
   /** Currently selected platform. */
   platform?: TPlatforms;
+
+  /**
+   * Defines the necessary information to populate the version switcher.
+   */
+  versionSwitcherDefinition?: IVersionSwitcherDefinition;
 }
 
 export interface IExample extends IExampleCardProps {

--- a/packages/example-app-base/src/components/PageHeader/PageHeader.tsx
+++ b/packages/example-app-base/src/components/PageHeader/PageHeader.tsx
@@ -1,23 +1,52 @@
 import * as React from 'react';
 import { IPageHeaderProps, IPageHeaderStyleProps, IPageHeaderStyles } from './PageHeader.types';
-import { css, ScreenWidthMinUhfMobile, FontWeights, IStyleFunction, classNamesFunction, styled } from 'office-ui-fabric-react';
+import {
+  classNamesFunction,
+  FontWeights,
+  styled,
+  DirectionalHint,
+  IStyleFunction,
+  ScreenWidthMinUhfMobile,
+  IContextualMenuItem,
+  ActionButton,
+  ScreenWidthMaxMedium,
+  ScreenWidthMaxLarge
+} from 'office-ui-fabric-react';
 import { FontSizes } from '@uifabric/fluent-theme';
-import { appPaddingSm, appPaddingLg, pageHeaderFullHeight } from '../../styles/constants';
+import { appPaddingSm, appPaddingLg, contentWidth, pageHeaderFullHeight } from '../../styles/constants';
+import { IVersionSwitcherDefinition } from '../../utilities/SiteDefinition.types';
+
+// Local copy of this function for use in version 6 since it's old and we should minimize API changes
+function getScreenSelector(min: number | undefined, max: number | undefined): string {
+  const minSelector = typeof min === 'number' ? ` and (min-width: ${min}px)` : '';
+  const maxSelector = typeof max === 'number' ? ` and (max-width: ${max}px)` : '';
+  return `@media only screen${minSelector}${maxSelector}`;
+}
 
 const getStyles: IStyleFunction<IPageHeaderStyleProps, IPageHeaderStyles> = props => {
-  const palette = props.theme!.palette;
+  const { className, pageTitle, theme } = props;
+  const palette = theme!.palette;
+  const isLongTitle = pageTitle.length > 20;
   return {
-    root: {
-      position: 'relative',
-      marginBottom: appPaddingSm,
-      selectors: {
-        [`@media screen and (min-width: ${ScreenWidthMinUhfMobile}px)`]: {
+    root: [
+      {
+        alignItems: 'baseline',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginBottom: appPaddingSm,
+        position: 'relative',
+        [getScreenSelector(ScreenWidthMinUhfMobile, undefined)]: {
           marginBottom: 0,
           padding: `${appPaddingLg}px 0`,
           minHeight: pageHeaderFullHeight
+        },
+        [getScreenSelector(1360, undefined)]: {
+          maxWidth: contentWidth + appPaddingSm * 2
         }
-      }
-    },
+      },
+      className
+    ],
     title: {
       alignItems: 'baseline',
       color: palette.neutralPrimary,
@@ -32,6 +61,20 @@ const getStyles: IStyleFunction<IPageHeaderStyleProps, IPageHeaderStyles> = prop
       fontSize: FontSizes.size14,
       fontWeight: FontWeights.regular,
       color: palette.neutralSecondary
+    },
+    versionSelector: {
+      color: palette.neutralSecondary,
+      height: '1em',
+      marginBottom: -4,
+      padding: '12px 0',
+      // Hide the version selector at certain widths where it's likely to not work well
+      // (these are rough estimates based on the length of the title)
+      [getScreenSelector(undefined, isLongTitle ? ScreenWidthMaxLarge : ScreenWidthMaxMedium)]: {
+        display: 'none'
+      },
+      [getScreenSelector(ScreenWidthMinUhfMobile, isLongTitle ? ScreenWidthMaxLarge : 850)]: {
+        display: 'none'
+      }
     }
   };
 };
@@ -39,15 +82,47 @@ const getStyles: IStyleFunction<IPageHeaderStyleProps, IPageHeaderStyles> = prop
 const getClassNames = classNamesFunction<IPageHeaderStyleProps, IPageHeaderStyles>();
 
 const PageHeaderBase: React.StatelessComponent<IPageHeaderProps> = props => {
-  const { pageTitle = 'Page title', pageSubTitle, theme } = props;
-  const styles = getClassNames(getStyles, { theme });
+  const {
+    className,
+    pageTitle = 'Page title',
+    pageSubTitle,
+    theme,
+    versionSwitcherDefinition: { versions, onVersionMenuClick, currentVersionNumber } = {} as IVersionSwitcherDefinition
+  } = props;
+  const styles = getClassNames(getStyles, { className, pageTitle, theme });
+
+  const versionOptions: IContextualMenuItem[] | undefined =
+    versions &&
+    versions.map(version => ({
+      key: version,
+      text: version
+    }));
 
   return (
-    <header className={css(styles.root, props.className)}>
+    <header className={styles.root}>
       <h1 className={styles.title}>
         {pageTitle}
         {pageSubTitle && <span className={styles.subTitle}>{pageSubTitle}</span>}
       </h1>
+      {versionOptions && (
+        <ActionButton
+          className={styles.versionSelector}
+          menuProps={{
+            gapSpace: 3,
+            beakWidth: 8,
+            isBeakVisible: true,
+            shouldFocusOnMount: true,
+            items: versionOptions,
+            directionalHint: DirectionalHint.bottomCenter,
+            onItemClick: onVersionMenuClick,
+            styles: {
+              root: { minWidth: 100 }
+            }
+          }}
+        >
+          Fluent UI React {currentVersionNumber}
+        </ActionButton>
+      )}
     </header>
   );
 };

--- a/packages/example-app-base/src/components/PageHeader/PageHeader.tsx
+++ b/packages/example-app-base/src/components/PageHeader/PageHeader.tsx
@@ -120,7 +120,7 @@ const PageHeaderBase: React.StatelessComponent<IPageHeaderProps> = props => {
             }
           }}
         >
-          Fluent UI React {currentVersionNumber}
+          Fabric React {currentVersionNumber}
         </ActionButton>
       )}
     </header>

--- a/packages/example-app-base/src/components/PageHeader/PageHeader.types.ts
+++ b/packages/example-app-base/src/components/PageHeader/PageHeader.types.ts
@@ -1,4 +1,5 @@
 import { ITheme, IStyle, IStyleFunctionOrObject } from 'office-ui-fabric-react';
+import { IVersionSwitcherDefinition } from '../../utilities/SiteDefinition.types';
 
 export interface IPageHeaderProps {
   /** The title of the current page. */
@@ -15,12 +16,18 @@ export interface IPageHeaderProps {
 
   /** Theme provided by higher-order component. */
   theme?: ITheme;
+
+  /**
+   * Defines the necessary information to populate the version switcher.
+   */
+  versionSwitcherDefinition?: IVersionSwitcherDefinition;
 }
 
-export type IPageHeaderStyleProps = Pick<IPageHeaderProps, 'theme'>;
+export type IPageHeaderStyleProps = Pick<IPageHeaderProps, 'className' | 'pageTitle' | 'theme'>;
 
 export interface IPageHeaderStyles {
   root: IStyle;
   title: IStyle;
   subTitle: IStyle;
+  versionSelector: IStyle;
 }

--- a/packages/example-app-base/src/styles/constants.ts
+++ b/packages/example-app-base/src/styles/constants.ts
@@ -1,4 +1,8 @@
 export const appPaddingSm = 28;
+export const appPaddingMd = 40;
 export const appPaddingLg = 52;
+export const contentWidth = 1024;
 export const pageHeaderFullHeight = 136;
 export const uhfScreenMaxLg = 1083;
+export const sideRailPaddingLeft = appPaddingMd - 8;
+export const sideRailWidth = 182 + sideRailPaddingLeft;

--- a/packages/example-app-base/src/utilities/SiteDefinition.types.ts
+++ b/packages/example-app-base/src/utilities/SiteDefinition.types.ts
@@ -1,7 +1,33 @@
-import { ICustomizations } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { ICustomizations, IContextualMenuItem } from 'office-ui-fabric-react';
 import { INavPage } from '../components/Nav/index';
 import { IPlatform } from '../components/PlatformPicker/index';
 import { ISiteMessageBarProps } from '../components/SiteMessageBar/index';
+
+/**
+ * Interface defining the necessary information to populate the version switcher.
+ */
+export interface IVersionSwitcherDefinition {
+  /**
+   * The list of available versions whose documentation is presented on the website.
+   */
+  versions?: string[];
+
+  /**
+   * Callback that determines what happens when a version is chosen from the version dropdown.
+   */
+  onVersionMenuClick?: (event: React.MouseEvent<HTMLElement>, item: IContextualMenuItem) => void;
+
+  /**
+   * The current version of the library including the name, such as "Fluent UI React 8"
+   */
+  currentVersion?: string;
+
+  /**
+   * The current version number of the library, as specified in package.json.
+   */
+  currentVersionNumber?: string;
+}
 
 /**
  * Site definition.
@@ -37,6 +63,11 @@ export interface ISiteDefinition<TPlatforms extends string = string> {
    * that need to show that message bar. You can define exclusions too.
    */
   messageBars?: ISiteMessageBarConfig[];
+
+  /**
+   * Defines the necessary information to populate the version switcher.
+   */
+  versionSwitcherDefinition?: IVersionSwitcherDefinition;
 }
 
 export interface ISiteMessageBarConfig extends ISiteMessageBarProps {

--- a/packages/prettier-rules/package.json
+++ b/packages/prettier-rules/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uifabric/prettier-rules",
   "version": "1.0.2",
+  "private": true,
   "description": "Shared Prettier rules for UI Fabric projects",
   "main": "prettier.config.js",
   "scripts": {

--- a/packages/prettier-rules/prettier.config.js
+++ b/packages/prettier-rules/prettier.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   printWidth: 140,
   tabWidth: 2,
-  singleQuote: true
+  singleQuote: true,
+  // Set these for compatibility with prettier 2 in case it's used by format on save
+  trailingComma: 'none',
+  arrowParens: 'avoid'
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #15917: add a version switcher to the v6 website. (v7: #17431)

A couple additional things:
- Remove message bars from site that are no longer relevant
- Change prettier settings to allow auto-format on save while reducing formatting conflicts caused by an extension's newer prettier version (there will unfortunately still be some inconsistent prettier changes, as seen a couple places in this PR, but it's a lot less than there would be without the new options)
- Stop publishing `@uifabric/prettier-rules` (it's not important to publish)