### PR TITLE
VirtualizedComboBox: ARIA attributes now have valid values after passing id and arialabelledby attributes to List component

### DIFF
--- a/change/@fluentui-react-3c30c36c-2122-4ed1-9bde-838730a0dcbf.json
+++ b/change/@fluentui-react-3c30c36c-2122-4ed1-9bde-838730a0dcbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "VirtualizedComboBox: Now passes id and arialabelledby attributes to List component to ensure ARIA attributes have valid values",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1217,6 +1217,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     } = props;
 
     const { isOpen } = this.state;
+    const id = this._id;
 
     const comboBoxMenuWidth =
       useComboBoxAsMenuWidth && this._comboBoxWrapper.current
@@ -1249,7 +1250,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       >
         {onRenderUpperContent(this.props, this._onRenderUpperContent)}
         <div className={this._classNames.optionsContainerWrapper} ref={this._comboBoxMenu}>
-          {onRenderList?.({ ...props }, this._onRenderList)}
+          {onRenderList?.({ ...props, id }, this._onRenderList)}
         </div>
         {onRenderLowerContent(this.props, this._onRenderLowerContent)}
       </Callout>

--- a/packages/react/src/components/ComboBox/VirtualizedComboBox.tsx
+++ b/packages/react/src/components/ComboBox/VirtualizedComboBox.tsx
@@ -54,13 +54,15 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
   }
 
   protected _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem } = props;
+    const { id, onRenderItem } = props;
 
     // Render virtualized list
     return (
       <List
         componentRef={this._list}
         role="listbox"
+        id={`${id}-list`}
+        aria-labelledby={`${id}-label`}
         items={props.options}
         // eslint-disable-next-line react/jsx-no-bind
         onRenderCell={onRenderItem ? (item: ISelectableOption) => onRenderItem(item) : () => null}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [10688](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10688)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- `VirtualizedComboBox` uses the `List` component to render the ComboBox options and the container div of `List` was missing the `id` and `aria-labelledby` attributes.
- Those attributes have now been added to `List` via prop passing.

Errors Resolved: 
![Combobox](https://user-images.githubusercontent.com/8649804/111370999-1acec500-8656-11eb-8367-eeac56a12f54.JPG)

