### PR TITLE
[v7.0] Pickers SuggestionsItems: remove button now visible after receiving keyboard focus

### DIFF
--- a/change/office-ui-fabric-react-23813214-1175-4a35-ae27-acb36e16dc3a.json
+++ b/change/office-ui-fabric-react-23813214-1175-4a35-ae27-acb36e16dc3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pickers SuggestionsItems: remove button now visible after receiving keyboard focus",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -1,5 +1,6 @@
 import { getGlobalClassNames, HighContrastSelector, getHighContrastNoAdjustStyle } from '../../../Styling';
 import { ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
+import { IsFocusVisibleClassName } from '../../../Utilities';
 
 export const SuggestionsItemGlobalClassNames = {
   root: 'ms-Suggestions-item',
@@ -35,6 +36,14 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
       },
       suggested && {
         selectors: {
+          [`.${IsFocusVisibleClassName} &`]: {
+            selectors: {
+              [`.${classNames.closeButton}`]: {
+                display: 'block',
+                background: semanticColors.menuItemBackgroundPressed,
+              },
+            },
+          },
           ':after': {
             pointerEvents: 'none',
             content: '""',
@@ -113,6 +122,13 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
         },
       },
       suggested && {
+        [`.${IsFocusVisibleClassName} &`]: {
+          selectors: {
+            ':hover, :active': {
+              background: palette.neutralTertiary,
+            },
+          },
+        },
         selectors: {
           ':hover, :active': {
             background: palette.neutralTertiary,

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -30,6 +30,10 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            .ms-Fabric--isFocusVisible & .ms-Suggestions-closeButton {
+              background: #edebe9;
+              display: block;
+            }
             &:after {
               border: 1px solid #605e5c;
               bottom: 0px;
@@ -2052,6 +2056,10 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f3f2f1;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            .ms-Fabric--isFocusVisible & .ms-Suggestions-closeButton {
+              background: #edebe9;
               display: block;
             }
             &:after {
@@ -5121,6 +5129,10 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f3f2f1;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            .ms-Fabric--isFocusVisible & .ms-Suggestions-closeButton {
+              background: #edebe9;
               display: block;
             }
             &:after {


### PR DESCRIPTION
cherry-pick of #17315 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [10292](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10292)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added css styling to display remove button when focus is visible

**Keyboard focus:**
![remove-button-visible](https://user-images.githubusercontent.com/8649804/110364009-1f610100-7ff8-11eb-962c-3acbbe48a1d7.JPG)
**Keyboard focus with mouse hover on remove button**
![remove-button-on-hover-while-focused](https://user-images.githubusercontent.com/8649804/110364230-5f27e880-7ff8-11eb-8e33-86a475870f6a.jpeg)
