### PR TITLE
Ensure multiline inline scripts exit with error if any command fails

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -16,7 +16,7 @@ steps:
   # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
   # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
   # The options below include ADO defaults (braceexpand:hashall:interactive-comments) plus
-  # errexit:errtrace:nounset:xtrace for better logging and error behavior.
+  # errexit:errtrace:nounset for better error behavior.
   - script: |
-      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace:nounset:xtrace"
+      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace:nounset"
     displayName: Force exit on error (bash)

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -16,7 +16,7 @@ steps:
   # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
   # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
   # The options below include ADO defaults (braceexpand:hashall:interactive-comments) plus
-  # errexit:errtrace:nounset for better error behavior.
+  # errexit:errtrace for better error behavior.
   - script: |
-      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace:nounset"
+      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace"
     displayName: Force exit on error (bash)

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -11,3 +11,12 @@ steps:
       versionSpec: 1.22.x
       checkLatest: false
       includePrerelease: false
+
+  # For multiline scripts, we want the whole task to fail if any line of the script fails.
+  # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
+  # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+  # The options below include ADO defaults (braceexpand:hashall:interactive-comments) plus
+  # errexit:errtrace:nounset:xtrace for better logging and error behavior.
+  - script: |
+      echo "##vso[task.setvariable variable=shellopts]braceexpand:hashall:interactive-comments:errexit:errtrace:nounset:xtrace"
+    displayName: Force exit on error (bash)

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -74,8 +74,8 @@ steps:
     displayName: yarn bundle
 
   - script: |
-      echo Making $(Build.ArtifactStagingDirectory)/api &&
-      mkdir -p $(Build.ArtifactStagingDirectory)/api &&
+      echo Making $(Build.ArtifactStagingDirectory)/api
+      mkdir -p $(Build.ArtifactStagingDirectory)/api
       cp packages/*/dist/*.api.json $(Build.ArtifactStagingDirectory)/api
     displayName: Copy api.json files to artifact staging directory
 
@@ -108,7 +108,7 @@ steps:
     displayName: 'Publish Artifact: Fabric'
 
   - script: |
-      npm run publish:beachball -- -b origin/master -n $(npmToken) --access public -y &&
+      npm run publish:beachball -- -b origin/master -n $(npmToken) --access public -y
       git reset --hard origin/master
     env:
       GITHUB_PAT: $(githubPAT)
@@ -119,9 +119,9 @@ steps:
     displayName: 'Update github release notes'
 
   - script: |
-      oufrVersion=$(node -p -e "require('./packages/react/package.json').version") &&
-      echo "OUFR Version: $oufrVersion" &&
-      echo $oufrVersion > oufr-version.txt &&
+      oufrVersion=$(node -p -e "require('./packages/react/package.json').version")
+      echo "OUFR Version: $oufrVersion"
+      echo $oufrVersion > oufr-version.txt
       echo "##vso[task.setvariable variable=oufrVersion;]$oufrVersion"
     displayName: 'Set OUFR Version Task Variable'
 


### PR DESCRIPTION
For multiline scripts, we want the whole task to fail if any line of the script fails. ADO [intentionally doesn't configure bash this way](https://github.com/microsoft/azure-pipelines-agent/issues/1803) 😡  , so we've been using `&&` to join the lines, but it's easy to forget to do that.

I did some searching and it turns out you can change the settings for the whole run by overriding the [SHELLOPTS built-in variable](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html). So I added that to the `tools.yml` template which runs before all of our builds. (The size auditor build which uses Windows also runs that template, but setting the variable should just do nothing there.)

(I verified this by temporarily making a multi-line command fail, then reverting that change.)