### PR TITLE
Adding ability to pass a Rectangle as a target and account for it in positioning logic

### DIFF
--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -154,4 +154,64 @@ storiesOf('Callout', module)
     <Callout {...defaultProps} calloutWidth={undefined}>
       {calloutContent}
     </Callout>
-  ));
+  ))
+  .addStory('Rendering callout attached to an element inside of an iframe', () => {
+    const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+    const [target, setTarget] = React.useState({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    });
+
+    React.useEffect(() => {
+      if (iframeRef.current) {
+        const iframe = iframeRef.current;
+        const iframeWindow = iframe.contentWindow;
+        if (iframeWindow) {
+          iframeWindow.onload = () => {
+            const iframeDocument = iframeWindow.document;
+            const button = iframeDocument.getElementById('button1');
+            if (button) {
+              button!.style.border = '1px solid red';
+
+              const iframeRect = iframe.getBoundingClientRect();
+              const buttonRect = button!.getBoundingClientRect();
+              setTarget({
+                left: iframeRect.x + buttonRect.x,
+                top: iframeRect.y + buttonRect.y,
+                right: iframeRect.x + buttonRect.x + buttonRect.width,
+                bottom: iframeRect.y + buttonRect.y + buttonRect.height,
+              });
+            }
+          };
+        }
+      }
+    });
+
+    return (
+      <>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <iframe
+          ref={iframeRef}
+          id="iframe"
+          srcDoc="<br /><br /><br /><br /><br /><br /><button id='button1'>HELLO</button>"
+        ></iframe>
+        <br />
+        <Callout {...defaultProps} target={target}>
+          {calloutContent}
+        </Callout>
+      </>
+    );
+  });

--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -1,4 +1,5 @@
 // NOTE: filename is prefixed with z_ to make callout tests run last to avoid instability
+/* eslint-disable react/self-closing-comp, jsx-a11y/iframe-has-title */
 
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
@@ -206,9 +207,8 @@ storiesOf('Callout', module)
         <iframe
           ref={iframeRef}
           id="iframe"
-          title="iframe"
           srcDoc="<br /><br /><br /><br /><br /><br /><button id='button1'>HELLO</button>"
-        />
+        ></iframe>
         <br />
         <Callout {...defaultProps} target={target}>
           {calloutContent}

--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -206,8 +206,9 @@ storiesOf('Callout', module)
         <iframe
           ref={iframeRef}
           id="iframe"
+          title="iframe"
           srcDoc="<br /><br /><br /><br /><br /><br /><button id='button1'>HELLO</button>"
-        ></iframe>
+        />
         <br />
         <Callout {...defaultProps} target={target}>
           {calloutContent}

--- a/change/@fluentui-react-d8d53715-4dd5-4a3c-b8d4-71ed81878747.json
+++ b/change/@fluentui-react-d8d53715-4dd5-4a3c-b8d4-71ed81878747.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding ability to pass a Rectangle as a target and account for it in positioning logic.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-580a8ecc-760b-4415-88fa-82a6f99399ba.json
+++ b/change/@fluentui-react-hooks-580a8ecc-760b-4415-88fa-82a6f99399ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding ability to pass a Rectangle as a target and account for it in positioning logic.",
+  "packageName": "@fluentui/react-hooks",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -9,6 +9,7 @@ import { ISettingsMap } from '@fluentui/utilities/lib/warn';
 import { IWarnControlledUsageParams } from '@fluentui/utilities/lib/warn';
 import { Point } from '@fluentui/utilities';
 import * as React from 'react';
+import { Rectangle } from '@fluentui/utilities';
 
 // @public (undocumented)
 export type ChangeCallback<TElement extends HTMLElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (ev: TEvent, newValue: TValue | undefined) => void;
@@ -42,7 +43,7 @@ export type RefCallback<T> = ((value: T | null) => void) & React.RefObject<T>;
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 // @public (undocumented)
-export type Target = Element | string | MouseEvent | Point | null | React.RefObject<Element>;
+export type Target = Element | string | MouseEvent | Point | Rectangle | null | React.RefObject<Element>;
 
 // @public
 export function useAsync(): Async;
@@ -105,7 +106,7 @@ export type UseSetTimeoutReturnType = {
 };
 
 // @public
-export function useTarget<TElement extends HTMLElement = HTMLElement>(target: Target | undefined, hostElement?: React.RefObject<TElement | null>): Readonly<[React.RefObject<Element | MouseEvent | Point | null>, Window | undefined]>;
+export function useTarget<TElement extends HTMLElement = HTMLElement>(target: Target | undefined, hostElement?: React.RefObject<TElement | null>): Readonly<[React.RefObject<Element | MouseEvent | Point | Rectangle | null>, Window | undefined]>;
 
 // @public
 export const useUnmount: (callback: () => void) => void;

--- a/packages/react-hooks/src/useTarget.ts
+++ b/packages/react-hooks/src/useTarget.ts
@@ -1,8 +1,8 @@
-import { Point, getDocument } from '@fluentui/utilities';
+import { getDocument, Point, Rectangle } from '@fluentui/utilities';
 import * as React from 'react';
 import { useWindow } from '@fluentui/react-window-provider';
 
-export type Target = Element | string | MouseEvent | Point | null | React.RefObject<Element>;
+export type Target = Element | string | MouseEvent | Point | Rectangle | null | React.RefObject<Element>;
 
 /**
  * Hook to calculate and cache the target element specified by the given target attribute,
@@ -14,12 +14,12 @@ export type Target = Element | string | MouseEvent | Point | null | React.RefObj
 export function useTarget<TElement extends HTMLElement = HTMLElement>(
   target: Target | undefined,
   hostElement?: React.RefObject<TElement | null>,
-): Readonly<[React.RefObject<Element | MouseEvent | Point | null>, Window | undefined]> {
+): Readonly<[React.RefObject<Element | MouseEvent | Point | Rectangle | null>, Window | undefined]> {
   const previousTargetProp = React.useRef<
-    Element | string | MouseEvent | Point | React.RefObject<Element> | null | undefined
+    Element | string | MouseEvent | Point | Rectangle | React.RefObject<Element> | null | undefined
   >();
 
-  const targetRef = React.useRef<Element | MouseEvent | Point | null>(null);
+  const targetRef = React.useRef<Element | MouseEvent | Point | Rectangle | null>(null);
   /**
    * Stores an instance of Window, used to check
    * for server side rendering and if focus was lost.

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1152,7 +1152,7 @@ export function getAriaDescribedBy(keySequences: string[]): string;
 export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public (undocumented)
-export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | null, targetWindow: IWindowWithSegments): IRectangle;
+export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | Rectangle | null, targetWindow: IWindowWithSegments): IRectangle;
 
 // @public
 export function getColorFromHSV(hsv: IHSV, a?: number): IColor;
@@ -1182,7 +1182,7 @@ export const getIconContent: (iconName?: string | undefined) => IIconContent | n
 export function getInitialResponsiveMode(): ResponsiveMode;
 
 // @public
-export function getMaxHeight(target: Element | MouseEvent | Point, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
+export function getMaxHeight(target: Element | MouseEvent | Point | Rectangle, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
 // @public
 export const getMeasurementCache: () => {

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -635,7 +635,7 @@ function _getRectangleFromIRect(rect: IRectangle): Rectangle {
   return new Rectangle(rect.left, rect.right, rect.top, rect.bottom);
 }
 
-function _getTargetRect(bounds: Rectangle, target: Element | MouseEvent | Point | undefined): Rectangle {
+function _getTargetRect(bounds: Rectangle, target: Element | MouseEvent | Point | Rectangle | undefined): Rectangle {
   let targetRectangle: Rectangle;
   if (target) {
     // eslint-disable-next-line no-extra-boolean-cast
@@ -647,12 +647,14 @@ function _getTargetRect(bounds: Rectangle, target: Element | MouseEvent | Point 
       targetRectangle = _getRectangleFromElement(target as Element);
       // HTMLImgElements can have x and y values. The check for it being a point must go last.
     } else {
-      const point: Point = target as Point;
+      const rectOrPoint: Rectangle & Point = target as Rectangle & Point;
       // eslint-disable-next-line deprecation/deprecation
-      const left = point.left || point.x;
+      const left = rectOrPoint.left || rectOrPoint.x;
       // eslint-disable-next-line deprecation/deprecation
-      const top = point.top || point.y;
-      targetRectangle = new Rectangle(left, left, top, top);
+      const top = rectOrPoint.top || rectOrPoint.y;
+      const right = rectOrPoint.right || rectOrPoint.left;
+      const bottom = rectOrPoint.bottom || rectOrPoint.top;
+      targetRectangle = new Rectangle(left, right, top, bottom);
     }
 
     if (!_isRectangleWithinBounds(targetRectangle, bounds)) {
@@ -859,7 +861,7 @@ export function positionCard(
  * If no bounds are provided then the window is treated as the bounds.
  */
 export function getMaxHeight(
-  target: Element | MouseEvent | Point,
+  target: Element | MouseEvent | Point | Rectangle,
   targetEdge: DirectionalHint,
   gapSpace: number = 0,
   bounds?: IRectangle,
@@ -867,22 +869,24 @@ export function getMaxHeight(
 ): number {
   const mouseTarget: MouseEvent = target as MouseEvent;
   const elementTarget: Element = target as Element;
-  const pointTarget: Point = target as Point;
+  const rectOrPointTarget: Point & Rectangle = target as Point & Rectangle;
   let targetRect: Rectangle;
   const boundingRectangle = bounds
     ? _getRectangleFromIRect(bounds)
     : new Rectangle(0, window.innerWidth - getScrollbarWidth(), 0, window.innerHeight);
 
   // eslint-disable-next-line deprecation/deprecation
-  const left = pointTarget.left || pointTarget.x;
+  const left = rectOrPointTarget.left || rectOrPointTarget.x;
   // eslint-disable-next-line deprecation/deprecation
-  const top = pointTarget.top || pointTarget.y;
+  const top = rectOrPointTarget.top || rectOrPointTarget.y;
+  const right = rectOrPointTarget.right || rectOrPointTarget.left;
+  const bottom = rectOrPointTarget.bottom || rectOrPointTarget.top;
 
   // eslint-disable-next-line no-extra-boolean-cast -- may not actually be a MouseEvent
   if (!!mouseTarget.stopPropagation) {
     targetRect = new Rectangle(mouseTarget.clientX, mouseTarget.clientX, mouseTarget.clientY, mouseTarget.clientY);
   } else if (left !== undefined && top !== undefined) {
-    targetRect = new Rectangle(left, left, top, top);
+    targetRect = new Rectangle(left, right, top, bottom);
   } else {
     targetRect = _getRectangleFromElement(elementTarget);
   }
@@ -898,7 +902,7 @@ export function getOppositeEdge(edge: RectangleEdge): RectangleEdge {
 }
 
 function _getBoundsFromTargetWindow(
-  target: Element | MouseEvent | Point | null,
+  target: Element | MouseEvent | Point | Rectangle | null,
   targetWindow: IWindowWithSegments,
 ): IRectangle {
   let segments = undefined;
@@ -956,7 +960,7 @@ function _getBoundsFromTargetWindow(
 }
 
 export function getBoundsFromTargetWindow(
-  target: Element | MouseEvent | Point | null,
+  target: Element | MouseEvent | Point | Rectangle | null,
   targetWindow: IWindowWithSegments,
 ): IRectangle {
   return _getBoundsFromTargetWindow(target, targetWindow);

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -647,13 +647,13 @@ function _getTargetRect(bounds: Rectangle, target: Element | MouseEvent | Point 
       targetRectangle = _getRectangleFromElement(target as Element);
       // HTMLImgElements can have x and y values. The check for it being a point must go last.
     } else {
-      const rectOrPoint: Rectangle & Point = target as Rectangle & Point;
+      const rectOrPoint: Point & Rectangle = target as Point & Rectangle;
       // eslint-disable-next-line deprecation/deprecation
       const left = rectOrPoint.left || rectOrPoint.x;
       // eslint-disable-next-line deprecation/deprecation
       const top = rectOrPoint.top || rectOrPoint.y;
-      const right = rectOrPoint.right || rectOrPoint.left;
-      const bottom = rectOrPoint.bottom || rectOrPoint.top;
+      const right = rectOrPoint.right || left;
+      const bottom = rectOrPoint.bottom || top;
       targetRectangle = new Rectangle(left, right, top, bottom);
     }
 
@@ -879,8 +879,8 @@ export function getMaxHeight(
   const left = rectOrPointTarget.left || rectOrPointTarget.x;
   // eslint-disable-next-line deprecation/deprecation
   const top = rectOrPointTarget.top || rectOrPointTarget.y;
-  const right = rectOrPointTarget.right || rectOrPointTarget.left;
-  const bottom = rectOrPointTarget.bottom || rectOrPointTarget.top;
+  const right = rectOrPointTarget.right || left;
+  const bottom = rectOrPointTarget.bottom || top;
 
   // eslint-disable-next-line no-extra-boolean-cast -- may not actually be a MouseEvent
   if (!!mouseTarget.stopPropagation) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the ability to pass a `Rectangle` as one of the possible `targets` of a popup element (i.e. `Callout`, `TeachingBubble`, etc.). This is done by accounting for the fact that `Rectangles` and `Points` have a similar shape so we check for the existence of `top` and `bottom` to determine if the `target` is a `Rectangle` and, if not, we default to treating the `target` as a `Point`.