### PR TITLE
Adding ability to pass a Rectangle as a target and account for it in positioning logic

### DIFF
--- a/apps/vr-tests/src/stories/Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/Callout.stories.tsx
@@ -146,4 +146,64 @@ storiesOf('Callout', module)
     <Callout {...defaultProps} calloutWidth={undefined}>
       {calloutContent}
     </Callout>
-  ));
+  ))
+  .addStory('Rendering callout attached to an element inside of an iframe', () => {
+    const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+    const [target, setTarget] = React.useState({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    });
+
+    React.useEffect(() => {
+      if (iframeRef.current) {
+        const iframe = iframeRef.current;
+        const iframeWindow = iframe.contentWindow;
+        if (iframeWindow) {
+          iframeWindow.onload = () => {
+            const iframeDocument = iframeWindow.document;
+            const button = iframeDocument.getElementById('button1');
+            if (button) {
+              button!.style.border = '1px solid red';
+
+              const iframeRect = iframe.getBoundingClientRect();
+              const buttonRect = button!.getBoundingClientRect();
+              setTarget({
+                left: iframeRect.x + buttonRect.x,
+                top: iframeRect.y + buttonRect.y,
+                right: iframeRect.x + buttonRect.x + buttonRect.width,
+                bottom: iframeRect.y + buttonRect.y + buttonRect.height,
+              });
+            }
+          };
+        }
+      }
+    });
+
+    return (
+      <>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <iframe
+          ref={iframeRef}
+          id="iframe"
+          srcDoc="<br /><br /><br /><br /><br /><br /><button id='button1'>HELLO</button>"
+        ></iframe>
+        <br />
+        <Callout {...defaultProps} target={target}>
+          {calloutContent}
+        </Callout>
+      </>
+    );
+  });

--- a/change/@uifabric-react-hooks-0e2ae2d1-1283-4d59-bca6-d5e34e8fe7d5.json
+++ b/change/@uifabric-react-hooks-0e2ae2d1-1283-4d59-bca6-d5e34e8fe7d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding ability to pass a Rectangle as a target and account for it in positioning logic.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-ca8dd9d3-36cc-411c-9136-75d0067c4d82.json
+++ b/change/office-ui-fabric-react-ca8dd9d3-36cc-411c-9136-75d0067c4d82.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding ability to pass a Rectangle as a target and account for it in positioning logic.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1329,7 +1329,7 @@ export function getAriaDescribedBy(keySequences: string[]): string;
 export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public (undocumented)
-export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | null, targetWindow: IWindowWithSegments): IRectangle;
+export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | Rectangle | null, targetWindow: IWindowWithSegments): IRectangle;
 
 // @public
 export function getColorFromHSV(hsv: IHSV, a?: number): IColor;
@@ -1356,7 +1356,7 @@ export function getFullColorString(color: IColor): string;
 export const getIconContent: (iconName?: string | undefined) => IIconContent | null;
 
 // @public
-export function getMaxHeight(target: Element | MouseEvent | Point, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
+export function getMaxHeight(target: Element | MouseEvent | Point | Rectangle, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
 // @public
 export const getMeasurementCache: () => {

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -9,6 +9,7 @@ import { ISettingsMap } from '@uifabric/utilities/lib/warn';
 import { IWarnControlledUsageParams } from '@uifabric/utilities/lib/warn';
 import { Point } from '@uifabric/utilities';
 import * as React from 'react';
+import { Rectangle } from '@uifabric/utilities';
 
 // @public (undocumented)
 export type ChangeCallback<TElement extends HTMLElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (ev: TEvent, newValue: TValue | undefined) => void;
@@ -42,7 +43,7 @@ export type RefCallback<T> = ((value: T | null) => void) & React.RefObject<T>;
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 // @public (undocumented)
-export type Target = Element | string | MouseEvent | Point | null | React.RefObject<Element>;
+export type Target = Element | string | MouseEvent | Point | Rectangle | null | React.RefObject<Element>;
 
 // @public
 export function useAsync(): Async;
@@ -99,7 +100,7 @@ export type UseSetTimeoutReturnType = {
 };
 
 // @public
-export function useTarget<TElement extends HTMLElement = HTMLElement>(target: Target | undefined, hostElement?: React.RefObject<TElement | null>): Readonly<[React.RefObject<Element | MouseEvent | Point | null>, Window | undefined]>;
+export function useTarget<TElement extends HTMLElement = HTMLElement>(target: Target | undefined, hostElement?: React.RefObject<TElement | null>): Readonly<[React.RefObject<Element | MouseEvent | Point | Rectangle | null>, Window | undefined]>;
 
 // @public
 export function useWarnings<P>(options: IWarningOptions<P>): void;

--- a/packages/react-hooks/src/useTarget.ts
+++ b/packages/react-hooks/src/useTarget.ts
@@ -1,8 +1,8 @@
-import { Point, getDocument } from '@uifabric/utilities';
+import { getDocument, Point, Rectangle } from '@uifabric/utilities';
 import * as React from 'react';
 import { useWindow } from '@fluentui/react-window-provider';
 
-export type Target = Element | string | MouseEvent | Point | null | React.RefObject<Element>;
+export type Target = Element | string | MouseEvent | Point | Rectangle | null | React.RefObject<Element>;
 
 /**
  * Hook to calculate and cache the target element specified by the given target attribute,
@@ -14,12 +14,12 @@ export type Target = Element | string | MouseEvent | Point | null | React.RefObj
 export function useTarget<TElement extends HTMLElement = HTMLElement>(
   target: Target | undefined,
   hostElement?: React.RefObject<TElement | null>,
-): Readonly<[React.RefObject<Element | MouseEvent | Point | null>, Window | undefined]> {
+): Readonly<[React.RefObject<Element | MouseEvent | Point | Rectangle | null>, Window | undefined]> {
   const previousTargetProp = React.useRef<
-    Element | string | MouseEvent | Point | React.RefObject<Element> | null | undefined
+    Element | string | MouseEvent | Point | Rectangle | React.RefObject<Element> | null | undefined
   >();
 
-  const targetRef = React.useRef<Element | MouseEvent | Point | null>(null);
+  const targetRef = React.useRef<Element | MouseEvent | Point | Rectangle | null>(null);
   /**
    * Stores an instance of Window, used to check
    * for server side rendering and if focus was lost.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherrypick of #17467_

This PR adds the ability to pass a `Rectangle` as one of the possible `targets` of a popup element (i.e. `Callout`, `TeachingBubble`, etc.). This is done by accounting for the fact that `Rectangles` and `Points` have a similar shape so we check for the existence of `top` and `bottom` to determine if the `target` is a `Rectangle` and, if not, we default to treating the `target` as a `Point`.
