### PR TITLE
UnifiedPicker: Fix bug where focus is lost in input after the first item is selected

### DIFF
--- a/change/@fluentui-react-experiments-9ea720a9-f05a-41b1-91e6-7b887bf5e4a3.json
+++ b/change/@fluentui-react-experiments-9ea720a9-f05a-41b1-91e6-7b887bf5e4a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker: Fix bug where focus is lost in input after the first item is selected",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -584,6 +584,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onRemoveSuggestion: _onFloatingSuggestionRemoved,
     });
 
+  React.useEffect(() => {
+    // We add the selected items list in the UI once we have items, which causes us
+    // to lose focus in the picker, so call focus again here in that case
+    if (selectedItems.length === 1) {
+      input.current?.focus();
+    }
+  }, [selectedItems.length]);
+
   const renderPickerInput = () => {
     return (
       <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We add the selected items list in the UI once we have items, which causes us to lose focus in the picker. So adding an effect to call focus again in that case. I will investigate a better solution to this, but want to get this in so that users don't have bugs on the v8 upgrade.
