### PR TITLE
Fix buttonSize dependency

### DIFF
--- a/change/@fluentui-react-experiments-e21f6614-3a47-445a-9789-a36fc66cedff.json
+++ b/change/@fluentui-react-experiments-e21f6614-3a47-445a-9789-a36fc66cedff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix dependency on buttonSize",
+  "packageName": "@fluentui/react-experiments",
+  "email": "jaredi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
@@ -147,7 +147,7 @@ const SelectedPersonaInner = React.memo(
         }),
       // TODO: evaluate whether to add deps on `item` and `styles`
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [selected, isValid, theme],
+      [selected, isValid, theme, buttonSize],
     );
 
     return (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add buttonSize to the list of dependencies for instance of useMemo that uses buttonSize

Unsure if we want to add deps for `item` and `styles` so leaving that alone for now

#### Focus areas to test

(optional)
