### PR TITLE
DatePicker: call set selected date if inputted date is out of bounds

### DIFF
--- a/change/@fluentui-react-8fb32156-52cc-473b-bea0-3e1e754e0fc3.json
+++ b/change/@fluentui-react-8fb32156-52cc-473b-bea0-3e1e754e0fc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "call setSelectedDate in DatePicker back to last valid date if the new inputted date is out of bounds. This behavior existed in v7 and was lost in the upgrade to v8. We also already call this if the input can't be parsed",
+  "packageName": "@fluentui/react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -145,6 +145,8 @@ function useErrorMessage(
         } else {
           // Check against optional date boundaries
           if (isDateOutOfBounds(date, minDate, maxDate)) {
+            // reset input field back to previous valid date
+            setSelectedDate(selectedDate);
             setErrorMessage(strings!.isOutOfBoundsErrorMessage || ' ');
           } else {
             setSelectedDate(date);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When DatePicker text box allows for inputting custom strings, if the string is invalid, the control fires the `onSelectDate` callback with the last known valid inputted date.

If a string is inputted that parses to a valid date, but that date is outside the custom min/max boundaries, the control still sets the error state, but does not fire any callback actions or reset the date, it just leaves the invalid string. This is a regression from v7, when the control would reset back to the previous state.

#### Focus areas to test

(optional)
