### PR TITLE
Facepile: overflow number and icons are now properly visible in High Contrast Mode

### DIFF
--- a/change/@fluentui-react-894b5c19-ca92-4378-be08-9ebdcad72fab.json
+++ b/change/@fluentui-react-894b5c19-ca92-4378-be08-9ebdcad72fab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Facepile: overflow number and icons are now properly visible in High Contrast Mode",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Facepile/Facepile.styles.ts
+++ b/packages/react/src/components/Facepile/Facepile.styles.ts
@@ -1,6 +1,6 @@
 import { IFacepileStyleProps, IFacepileStyles } from './Facepile.types';
 
-import { IStyle, hiddenContentStyle, getFocusStyle, getGlobalClassNames } from '../../Styling';
+import { IStyle, hiddenContentStyle, HighContrastSelector, getFocusStyle, getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Facepile',
@@ -127,6 +127,11 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
     overflowInitialsIcon: [
       {
         color: palette.neutralPrimary,
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'WindowText',
+          },
+        },
       },
     ],
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17182 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added high contrast styling to Facepile to properly display the overflow number and icons.
- The overflow button's color is now set to be `WindowText` in High Contrast Mode
**ISSUE:**
![issue](https://user-images.githubusercontent.com/8649804/111551459-8049b100-873d-11eb-93c7-1de16bbea835.JPG)
**FIX:**
![icon-1](https://user-images.githubusercontent.com/8649804/111551195-e5e96d80-873c-11eb-8c36-b426e93ced18.JPG)
![icon-2](https://user-images.githubusercontent.com/8649804/111551200-e97cf480-873c-11eb-9e2c-281870941399.JPG)
![icon-3](https://user-images.githubusercontent.com/8649804/111551204-ebdf4e80-873c-11eb-835a-102f32055991.JPG)



