### PR TITLE
Fix GroupSpacer collapsing flexbox issue

### DIFF
--- a/change/@fluentui-react-b1b7a228-ecce-4e5d-99fd-6bf9aae684ab.json
+++ b/change/@fluentui-react-b1b7a228-ecce-4e5d-99fd-6bf9aae684ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix GroupSpacer flex shrinking styles",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-68704046-e262-40c7-93fb-550f61b47843.json
+++ b/change/@fluentui-react-examples-68704046-e262-40c7-93fb-550f61b47843.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "snapshot updates to DetailsList GroupSpacer",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -79,6 +79,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
         }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone1"
     data-is-focusable={true}
@@ -772,6 +776,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
+        }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
         }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone8"
@@ -1467,6 +1475,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
         }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone15"
     data-is-focusable={true}
@@ -2160,6 +2172,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
+        }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
         }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone22"
@@ -2855,6 +2871,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
         }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone29"
     data-is-focusable={true}
@@ -3548,6 +3568,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
+        }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
         }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone36"
@@ -4243,6 +4267,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
         }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone43"
     data-is-focusable={true}
@@ -4936,6 +4964,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
+        }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
         }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone50"
@@ -5631,6 +5663,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
         }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone57"
     data-is-focusable={true}
@@ -6324,6 +6360,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
           opacity: 1;
+        }
+        & .ms-GroupSpacer {
+          flex-grow: 0;
+          flex-shrink: 0;
         }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone64"

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -812,6 +812,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone6"
                         data-is-focusable={true}
@@ -1215,6 +1219,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone7"
@@ -1620,6 +1628,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone8"
                         data-is-focusable={true}
@@ -2023,6 +2035,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone9"
@@ -2428,6 +2444,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone10"
                         data-is-focusable={true}
@@ -2831,6 +2851,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone11"
@@ -3236,6 +3260,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
@@ -3639,6 +3667,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone13"
@@ -4044,6 +4076,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone14"
                         data-is-focusable={true}
@@ -4447,6 +4483,10 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone15"

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -608,6 +608,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
@@ -1146,6 +1150,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone9"
@@ -1686,6 +1694,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone13"
                       data-is-focusable={true}
@@ -2224,6 +2236,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone17"
@@ -2764,6 +2780,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone21"
                       data-is-focusable={true}
@@ -3302,6 +3322,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone25"
@@ -3842,6 +3866,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone29"
                       data-is-focusable={true}
@@ -4380,6 +4408,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone33"
@@ -4920,6 +4952,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone37"
                       data-is-focusable={true}
@@ -5458,6 +5494,10 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone41"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1576,6 +1576,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone16"
                         data-is-focusable={true}
@@ -1979,6 +1983,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone17"
@@ -2384,6 +2392,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone18"
                         data-is-focusable={true}
@@ -2787,6 +2799,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone19"
@@ -3192,6 +3208,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone20"
                         data-is-focusable={true}
@@ -3595,6 +3615,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone21"
@@ -4000,6 +4024,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone22"
                         data-is-focusable={true}
@@ -4403,6 +4431,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone23"
@@ -4808,6 +4840,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone24"
                         data-is-focusable={true}
@@ -5211,6 +5247,10 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone25"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -875,6 +875,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone3"
                         data-is-focusable={true}
@@ -1335,6 +1339,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone4"
@@ -1797,6 +1805,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone5"
                         data-is-focusable={true}
@@ -2257,6 +2269,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone6"
@@ -2719,6 +2735,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone7"
                         data-is-focusable={true}
@@ -3179,6 +3199,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone8"
@@ -3641,6 +3665,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone9"
                         data-is-focusable={true}
@@ -4101,6 +4129,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone10"
@@ -4563,6 +4595,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone11"
                         data-is-focusable={true}
@@ -5023,6 +5059,10 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone12"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1102,6 +1102,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone6"
                           data-is-focusable={true}
@@ -1562,6 +1566,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone7"
@@ -2024,6 +2032,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone8"
                           data-is-focusable={true}
@@ -2484,6 +2496,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone9"
@@ -2946,6 +2962,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
@@ -3406,6 +3426,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone11"
@@ -3868,6 +3892,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
@@ -4328,6 +4356,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone13"
@@ -4790,6 +4822,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
@@ -5250,6 +5286,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone15"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1087,6 +1087,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone6"
                           data-is-focusable={true}
@@ -1548,6 +1552,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone7"
@@ -2011,6 +2019,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone8"
                           data-is-focusable={true}
@@ -2472,6 +2484,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone9"
@@ -2935,6 +2951,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
@@ -3396,6 +3416,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone11"
@@ -3859,6 +3883,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
@@ -4320,6 +4348,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone13"
@@ -4783,6 +4815,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
@@ -5244,6 +5280,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone15"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -632,6 +632,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone3"
                       data-is-focusable={true}
@@ -1072,6 +1076,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
@@ -1514,6 +1522,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
@@ -1954,6 +1966,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone6"
@@ -2396,6 +2412,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
@@ -2836,6 +2856,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone8"
@@ -3278,6 +3302,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
@@ -3718,6 +3746,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone10"
@@ -4160,6 +4192,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
@@ -4600,6 +4636,10 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone12"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -853,6 +853,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
@@ -1313,6 +1317,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
@@ -1775,6 +1783,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
@@ -2235,6 +2247,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone7"
@@ -2697,6 +2713,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
@@ -3154,6 +3174,10 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             }
             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
               opacity: 1;
+            }
+            & .ms-GroupSpacer {
+              flex-grow: 0;
+              flex-shrink: 0;
             }
         data-automationid="DetailsRow"
         data-focuszone-id="FocusZone3"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -991,6 +991,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone4"
                                 data-is-focusable={true}
@@ -1404,6 +1408,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone5"
@@ -1819,6 +1827,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone6"
                                 data-is-focusable={true}
@@ -2232,6 +2244,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone7"
@@ -2647,6 +2663,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone8"
                                 data-is-focusable={true}
@@ -3060,6 +3080,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone9"
@@ -3475,6 +3499,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone10"
                                 data-is-focusable={true}
@@ -3888,6 +3916,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone11"
@@ -4303,6 +4335,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone12"
                                 data-is-focusable={true}
@@ -4716,6 +4752,10 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone13"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -639,6 +639,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone3"
                       data-is-focusable={true}
@@ -1042,6 +1046,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
@@ -1448,6 +1456,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
@@ -1851,6 +1863,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone6"
@@ -2257,6 +2273,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
@@ -2660,6 +2680,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone8"
@@ -3066,6 +3090,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
@@ -3469,6 +3497,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone10"
@@ -3875,6 +3907,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
@@ -4278,6 +4314,10 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone12"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1441,6 +1441,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone8"
                         data-is-focusable={true}
@@ -1773,6 +1777,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone10"
@@ -2107,6 +2115,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
@@ -2439,6 +2451,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone14"
@@ -2773,6 +2789,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone16"
                         data-is-focusable={true}
@@ -3105,6 +3125,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone18"
@@ -3439,6 +3463,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone20"
                         data-is-focusable={true}
@@ -3771,6 +3799,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone22"
@@ -4105,6 +4137,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
                             }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
+                            }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone24"
                         data-is-focusable={true}
@@ -4437,6 +4473,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                               opacity: 1;
+                            }
+                            & .ms-GroupSpacer {
+                              flex-grow: 0;
+                              flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
                         data-focuszone-id="FocusZone26"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1298,6 +1298,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone10"
                           data-is-draggable={true}
@@ -1703,6 +1707,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone11"
@@ -2110,6 +2118,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone12"
                           data-is-draggable={true}
@@ -2515,6 +2527,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone13"
@@ -2922,6 +2938,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone14"
                           data-is-draggable={true}
@@ -3327,6 +3347,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone15"
@@ -3734,6 +3758,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone16"
                           data-is-draggable={true}
@@ -4139,6 +4167,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone17"
@@ -4546,6 +4578,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
                               }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
+                              }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone18"
                           data-is-draggable={true}
@@ -4951,6 +4987,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               }
                               .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                 opacity: 1;
+                              }
+                              & .ms-GroupSpacer {
+                                flex-grow: 0;
+                                flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
                           data-focuszone-id="FocusZone19"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1716,6 +1716,10 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
+                                      & .ms-GroupSpacer {
+                                        flex-grow: 0;
+                                        flex-shrink: 0;
+                                      }
                                   data-automationid="DetailsRow"
                                   data-focuszone-id="FocusZone14"
                                   data-is-focusable={true}
@@ -2194,6 +2198,10 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       }
                                       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                         opacity: 1;
+                                      }
+                                      & .ms-GroupSpacer {
+                                        flex-grow: 0;
+                                        flex-shrink: 0;
                                       }
                                   data-automationid="DetailsRow"
                                   data-focuszone-id="FocusZone15"
@@ -3522,6 +3530,10 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
+                                      & .ms-GroupSpacer {
+                                        flex-grow: 0;
+                                        flex-shrink: 0;
+                                      }
                                   data-automationid="DetailsRow"
                                   data-focuszone-id="FocusZone16"
                                   data-is-focusable={true}
@@ -4001,6 +4013,10 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
+                                      & .ms-GroupSpacer {
+                                        flex-grow: 0;
+                                        flex-shrink: 0;
+                                      }
                                   data-automationid="DetailsRow"
                                   data-focuszone-id="FocusZone17"
                                   data-is-focusable={true}
@@ -4479,6 +4495,10 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       }
                                       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                         opacity: 1;
+                                      }
+                                      & .ms-GroupSpacer {
+                                        flex-grow: 0;
+                                        flex-shrink: 0;
                                       }
                                   data-automationid="DetailsRow"
                                   data-focuszone-id="FocusZone18"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1371,6 +1371,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone5"
                                 data-is-focusable={true}
@@ -1841,6 +1845,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone6"
@@ -2313,6 +2321,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone7"
                                 data-is-focusable={true}
@@ -2783,6 +2795,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone8"
@@ -3255,6 +3271,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone9"
                                 data-is-focusable={true}
@@ -3725,6 +3745,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone10"
@@ -4197,6 +4221,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone11"
                                 data-is-focusable={true}
@@ -4667,6 +4695,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone12"
@@ -5139,6 +5171,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone13"
                                 data-is-focusable={true}
@@ -5609,6 +5645,10 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone14"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -741,6 +741,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone3"
                       data-is-focusable={true}
@@ -1275,6 +1279,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
@@ -1811,6 +1819,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
@@ -2345,6 +2357,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone6"
@@ -2881,6 +2897,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
@@ -3415,6 +3435,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone8"
@@ -3951,6 +3975,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
@@ -4486,6 +4514,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
@@ -5020,6 +5052,10 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone11"

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -530,6 +530,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone11"
                             data-is-focusable={true}
@@ -1057,6 +1061,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone12"
                             data-is-focusable={true}
@@ -1583,6 +1591,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
+                                }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
                                 }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone13"
@@ -2513,6 +2525,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone14"
                             data-is-focusable={true}
@@ -3040,6 +3056,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone15"
                             data-is-focusable={true}
@@ -3566,6 +3586,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
+                                }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
                                 }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone16"
@@ -4496,6 +4520,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone17"
                             data-is-focusable={true}
@@ -5023,6 +5051,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
+                                }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone18"
                             data-is-focusable={true}
@@ -5549,6 +5581,10 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                   opacity: 1;
+                                }
+                                & .ms-GroupSpacer {
+                                  flex-grow: 0;
+                                  flex-shrink: 0;
                                 }
                             data-automationid="DetailsRow"
                             data-focuszone-id="FocusZone19"

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -587,6 +587,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone3"
                       data-is-focusable={true}
@@ -834,6 +838,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
@@ -1083,6 +1091,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
@@ -1330,6 +1342,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone6"
@@ -1579,6 +1595,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
@@ -1826,6 +1846,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone8"
@@ -2075,6 +2099,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
@@ -2322,6 +2350,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone10"
@@ -2571,6 +2603,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
@@ -2818,6 +2854,10 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone12"

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -587,6 +587,10 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone3"
                       data-is-focusable={true}
@@ -837,6 +841,10 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
                           }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                          }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
@@ -1086,6 +1094,10 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           }
                           .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                             opacity: 1;
+                          }
+                          & .ms-GroupSpacer {
+                            flex-grow: 0;
+                            flex-shrink: 0;
                           }
                       data-automationid="DetailsRow"
                       data-focuszone-id="FocusZone5"

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -318,6 +318,11 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
           [`.${IsFocusVisibleClassName} &:focus .${classNames.check}`]: {
             opacity: 1,
           },
+
+          '.ms-GroupSpacer': {
+            flexShrink: 0,
+            flexGrow: 0,
+          },
         },
       },
       isSelected && selectedStyles,

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -7196,6 +7196,10 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone22"
                                 data-is-focusable={true}
@@ -7381,6 +7385,10 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone23"
@@ -7820,6 +7828,10 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone24"
                                 data-is-focusable={true}
@@ -8006,6 +8018,10 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
+                                    }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone25"
                                 data-is-focusable={true}
@@ -8191,6 +8207,10 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     }
                                     .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
                                       opacity: 1;
+                                    }
+                                    & .ms-GroupSpacer {
+                                      flex-grow: 0;
+                                      flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
                                 data-focuszone-id="FocusZone26"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1739,6 +1739,10 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
         opacity: 1;
       }
+      & .ms-GroupSpacer {
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
   data-automationid="DetailsRow"
   data-focuszone-id="FocusZone12"
   data-is-focusable={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17477
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Since the parent of `GroupSpacer` is a flex container, GroupSpacer's width can end up shrinking to 0 in the right conditions (e.g. when the siblings' width is greater than the parent width, as described in the related issue). We need GroupSpacer to have `flex-shrink: 0`, or have its width defined with `flex: 0 0 36px` instead of `width: 36px`.

The flex issue depends entirely on GroupSpacer existing within a flex container, and those styles are defined in `DetailsRow`, which is why I added the styles to the `DetailsRow.styles.ts` file. Plus, GroupSpacer uses a hard-coded classname, and doesn't have its own styles file 😄.
