### PR TITLE
Add option to use FocusTrapZone in ContextualMenus

### DIFF
--- a/change/@fluentui-react-0d361218-f801-4654-a443-00a12a3e88ff.json
+++ b/change/@fluentui-react-0d361218-f801-4654-a443-00a12a3e88ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add option to use FocusTrapZone in ContextualMenu",
+  "packageName": "@fluentui/react",
+  "email": "anhw@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3361,6 +3361,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
     doNotLayer?: boolean;
+    focusTrapZoneProps?: IFocusTrapZoneProps;
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // @deprecated

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3361,7 +3361,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
     doNotLayer?: boolean;
-    focusTrapZoneProps?: IFocusTrapZoneProps;
+    focusZoneAs?: React.ComponentClass<IFocusZoneProps> | React.FunctionComponent<IFocusZoneProps>;
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // @deprecated

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -10,7 +10,8 @@ import {
   IContextualMenuItemRenderProps,
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
+import { FocusTrapZone } from '../../FocusTrapZone';
 import { IMenuItemClassNames, IContextualMenuClassNames } from './ContextualMenu.classNames';
 import {
   divProperties,
@@ -452,27 +453,22 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                 onFocusCapture={onMenuFocusCapture}
               >
                 {title && <div className={this._classNames.title}> {title} </div>}
-                {items && items.length ? (
-                  <FocusZone
-                    className={this._classNames.root}
-                    isCircularNavigation={true}
-                    handleTabKey={FocusZoneTabbableElements.all}
-                    {...this._adjustedFocusZoneProps}
-                  >
-                    {onRenderMenuList(
-                      {
-                        ariaLabel,
-                        items,
-                        totalItemCount,
-                        hasCheckmarks,
-                        hasIcons,
-                        defaultMenuItemRenderer: this._defaultMenuItemRenderer,
-                        labelElementId,
-                      },
-                      this._onRenderMenuList,
-                    )}
-                  </FocusZone>
-                ) : null}
+                {items && items.length
+                  ? this._renderFocusZone(
+                      onRenderMenuList(
+                        {
+                          ariaLabel,
+                          items,
+                          totalItemCount,
+                          hasCheckmarks,
+                          hasIcons,
+                          defaultMenuItemRenderer: this._defaultMenuItemRenderer,
+                          labelElementId,
+                        },
+                        this._onRenderMenuList,
+                      ),
+                    )
+                  : null}
                 {submenuProps && onRenderSubMenu(submenuProps, this._onRenderSubMenu)}
               </div>
             </Callout>
@@ -542,6 +538,18 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       </ul>
     );
   };
+
+  private _renderFocusZone(children: JSX.Element | null): JSX.Element {
+    const { focusZoneProps, focusTrapZoneProps } = this.props;
+    const FocusComponent = !!focusTrapZoneProps ? FocusTrapZone : FocusZone;
+    const focusComponentProps = !!focusTrapZoneProps ? focusTrapZoneProps : focusZoneProps;
+
+    return (
+      <FocusComponent isClickableOutsideFocusTrap={true} {...focusComponentProps}>
+        {children}
+      </FocusComponent>
+    );
+  }
 
   /**
    * !!!IMPORTANT!!! Avoid mutating `item: IContextualMenuItem` argument. It will

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -542,7 +542,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
     const { focusZoneProps, focusTrapZoneProps } = this.props;
 
-    if (!!focusTrapZoneProps) {
+    if (focusTrapZoneProps) {
       return (
         <FocusTrapZone className={this._classNames.root} isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
           {children}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -11,7 +11,6 @@ import {
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
-import { FocusTrapZone } from '../../FocusTrapZone';
 import { IMenuItemClassNames, IContextualMenuClassNames } from './ContextualMenu.classNames';
 import {
   divProperties,
@@ -375,7 +374,13 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       return false;
     }
 
-    this._adjustedFocusZoneProps = { ...focusZoneProps, direction: this._getFocusZoneDirection() };
+    this._adjustedFocusZoneProps = {
+      ...focusZoneProps,
+      className: this._classNames.root,
+      isCircularNavigation: true,
+      handleTabKey: FocusZoneTabbableElements.all,
+      direction: this._getFocusZoneDirection(),
+    };
 
     const hasCheckmarks = canAnyMenuItemsCheck(items);
     const submenuProps = expandedMenuItemKey && this.props.hidden !== true ? this._getSubmenuProps() : null;
@@ -540,26 +545,8 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   };
 
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
-    const { focusZoneProps, focusTrapZoneProps } = this.props;
-
-    if (focusTrapZoneProps) {
-      return (
-        <FocusTrapZone className={this._classNames.root} isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
-          {children}
-        </FocusTrapZone>
-      );
-    }
-
-    return (
-      <FocusZone
-        className={this._classNames.root}
-        isCircularNavigation={true}
-        handleTabKey={FocusZoneTabbableElements.all}
-        {...focusZoneProps}
-      >
-        {children}
-      </FocusZone>
-    );
+    const { focusZoneAs: ChildrenRenderer = FocusZone } = this.props;
+    return <ChildrenRenderer {...this._adjustedFocusZoneProps}>{children}</ChildrenRenderer>;
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -541,12 +541,20 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
     const { focusZoneProps, focusTrapZoneProps } = this.props;
-    const FocusComponent = !!focusTrapZoneProps ? FocusTrapZone : FocusZone;
-    const focusComponentProps = !!focusTrapZoneProps
-      ? { ...focusTrapZoneProps, isClickableOutsideFocusTrap: true }
-      : { ...focusZoneProps, isCircularNavigation: true, handleTabkey: FocusZoneTabbableElements.all };
 
-    return <FocusComponent {...focusComponentProps}>{children}</FocusComponent>;
+    if (!!focusTrapZoneProps) {
+      return (
+        <FocusTrapZone isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
+          {children}
+        </FocusTrapZone>
+      );
+    }
+
+    return (
+      <FocusZone isCircularNavigation={true} handleTabKey={FocusZoneTabbableElements.all} {...focusZoneProps}>
+        {children}
+      </FocusZone>
+    );
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -10,7 +10,7 @@ import {
   IContextualMenuItemRenderProps,
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
 import { FocusTrapZone } from '../../FocusTrapZone';
 import { IMenuItemClassNames, IContextualMenuClassNames } from './ContextualMenu.classNames';
 import {
@@ -542,13 +542,11 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
     const { focusZoneProps, focusTrapZoneProps } = this.props;
     const FocusComponent = !!focusTrapZoneProps ? FocusTrapZone : FocusZone;
-    const focusComponentProps = !!focusTrapZoneProps ? focusTrapZoneProps : focusZoneProps;
+    const focusComponentProps = !!focusTrapZoneProps
+      ? { ...focusTrapZoneProps, isClickableOutsideFocusTrap: true }
+      : { ...focusZoneProps, isCircularNavigation: true, handleTabkey: FocusZoneTabbableElements.all };
 
-    return (
-      <FocusComponent isClickableOutsideFocusTrap={true} {...focusComponentProps}>
-        {children}
-      </FocusComponent>
-    );
+    return <FocusComponent {...focusComponentProps}>{children}</FocusComponent>;
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -544,14 +544,19 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
     if (!!focusTrapZoneProps) {
       return (
-        <FocusTrapZone isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
+        <FocusTrapZone className={this._classNames.root} isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
           {children}
         </FocusTrapZone>
       );
     }
 
     return (
-      <FocusZone isCircularNavigation={true} handleTabKey={FocusZoneTabbableElements.all} {...focusZoneProps}>
+      <FocusZone
+        className={this._classNames.root}
+        isCircularNavigation={true}
+        handleTabKey={FocusZoneTabbableElements.all}
+        {...focusZoneProps}
+      >
         {children}
       </FocusZone>
     );

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -257,7 +257,7 @@ export interface IContextualMenuProps
   /**
    * Props to pass down to the FocusTrapZone.
    * NOTE: passing these props will override the default usage of FocusZone and replace it with a FocusTrapZone.
-   * @defaultvalue \{ isClickableOutsideFocusTrap: true }
+   * @defaultvalue \{ isClickableOutsideFocusTrap: true \}
    */
   focusTrapZoneProps?: IFocusTrapZoneProps;
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { IFocusZoneProps } from '../../FocusZone';
+import { IFocusTrapZoneProps } from '../../FocusTrapZone';
 import { IIconProps } from '../../Icon';
 import { ICalloutProps, ICalloutContentStyleProps } from '../../Callout';
 import { ITheme, IStyle } from '../../Styling';
@@ -18,6 +19,7 @@ import {
 import { IKeytipProps } from '../../Keytip';
 import { Target } from '@fluentui/react-hooks';
 import { IPopupRestoreFocusParams } from '../../Popup';
+import { IFocusTrapZoneProps } from '../FocusTrapZone/index';
 
 export { DirectionalHint } from '../../common/DirectionalHint';
 
@@ -252,6 +254,12 @@ export interface IContextualMenuProps
    * @defaultvalue \{ direction: FocusZoneDirection.vertical \}
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * Props to pass down to the FocusTrapZone.
+   * NOTE: passing these props will override the default usage of FocusZone and replace it with a FocusTrapZone.
+   */
+  focusTrapZoneProps?: IFocusTrapZoneProps;
 
   /**
    * If true, renders the ContextualMenu in a hidden state.

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -255,7 +255,7 @@ export interface IContextualMenuProps
 
   /**
    * Custom component to use for rendering the focus zone (the root).
-   * @defaultValue: FocusZone
+   * @defaultValue FocusZone
    */
   focusZoneAs?: React.ComponentClass<IFocusZoneProps> | React.FunctionComponent<IFocusZoneProps>;
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -19,7 +19,6 @@ import {
 import { IKeytipProps } from '../../Keytip';
 import { Target } from '@fluentui/react-hooks';
 import { IPopupRestoreFocusParams } from '../../Popup';
-import { IFocusTrapZoneProps } from '../FocusTrapZone/index';
 
 export { DirectionalHint } from '../../common/DirectionalHint';
 
@@ -258,6 +257,7 @@ export interface IContextualMenuProps
   /**
    * Props to pass down to the FocusTrapZone.
    * NOTE: passing these props will override the default usage of FocusZone and replace it with a FocusTrapZone.
+   * @defaultvalue \{ isClickableOutsideFocusTrap: true }
    */
   focusTrapZoneProps?: IFocusTrapZoneProps;
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { IFocusZoneProps } from '../../FocusZone';
-import { IFocusTrapZoneProps } from '../../FocusTrapZone';
 import { IIconProps } from '../../Icon';
 import { ICalloutProps, ICalloutContentStyleProps } from '../../Callout';
 import { ITheme, IStyle } from '../../Styling';
@@ -255,11 +254,10 @@ export interface IContextualMenuProps
   focusZoneProps?: IFocusZoneProps;
 
   /**
-   * Props to pass down to the FocusTrapZone.
-   * NOTE: passing these props will override the default usage of FocusZone and replace it with a FocusTrapZone.
-   * @defaultvalue \{ isClickableOutsideFocusTrap: true \}
+   * Custom component to use for rendering the focus zone (the root).
+   * @defaultValue: FocusZone
    */
-  focusTrapZoneProps?: IFocusTrapZoneProps;
+  focusZoneAs?: React.ComponentClass<IFocusZoneProps> | React.FunctionComponent<IFocusZoneProps>;
 
   /**
    * If true, renders the ContextualMenu in a hidden state.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15635
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Exposes a prop for Contextual Menu to optionally use a FocusTrapZone instead of a FocusZone. This can be used for scenarios where components inside the Contextual Menu use another FocusZone, such as a calendar, without disrupting the expected keyboard focus behavior.

#### Focus areas to test

Normal Contextual Menu behaviors.
