### PR TITLE
chore: run lint on ./config directory in packages

### DIFF
--- a/apps/a11y-tests/jest.config.js
+++ b/apps/a11y-tests/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/change/@fluentui-dom-utilities-83892dfc-e414-4130-be5b-defbb58579ff.json
+++ b/change/@fluentui-dom-utilities-83892dfc-e414-4130-be5b-defbb58579ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-0a26b367-68f0-44ae-ad83-2ba8a299eb22.json
+++ b/change/@fluentui-eslint-plugin-0a26b367-68f0-44ae-ad83-2ba8a299eb22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(eslint-plugin): make ./config files override work",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-3c51c1a5-e1d5-41d3-a16e-1e06dfff6e11.json
+++ b/change/@fluentui-foundation-legacy-3c51c1a5-e1d5-41d3-a16e-1e06dfff6e11.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-c3193295-dd86-470e-bab8-c4b92bd7ff57.json
+++ b/change/@fluentui-keyboard-key-c3193295-dd86-470e-bab8-c4b92bd7ff57.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(keyboard-key): fix lint errors",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-c70ce388-6c47-46ed-a30d-fa83fd75a4ed.json
+++ b/change/@fluentui-merge-styles-c70ce388-6c47-46ed-a30d-fa83fd75a4ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-e7bb782f-c102-4bd2-bc70-d6f1df6b25e9.json
+++ b/change/@fluentui-react-cards-e7bb782f-c102-4bd2-bc70-d6f1df6b25e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-df419180-2171-4760-9c72-9af69dd7bf86.json
+++ b/change/@fluentui-react-charting-df419180-2171-4760-9c72-9af69dd7bf86.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-19f87cdd-850d-45a9-9240-478afef5d339.json
+++ b/change/@fluentui-react-checkbox-19f87cdd-850d-45a9-9240-478afef5d339.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-compose-e95c9c59-7dcf-4f5b-9d90-f519b869531e.json
+++ b/change/@fluentui-react-compose-e95c9c59-7dcf-4f5b-9d90-f519b869531e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-compose",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-8f09e53d-2adc-4ce0-9749-f97698432aec.json
+++ b/change/@fluentui-react-context-selector-8f09e53d-2adc-4ce0-9749-f97698432aec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-3099731c-e2ef-4a86-beee-48163df795c1.json
+++ b/change/@fluentui-react-date-time-3099731c-e2ef-4a86-beee-48163df795c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-8f097fa8-880f-4b3a-b752-dddd5ea66f3f.json
+++ b/change/@fluentui-react-experiments-8f097fa8-880f-4b3a-b752-dddd5ea66f3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-6c937bc8-a505-4d54-8265-dfc406d6cd02.json
+++ b/change/@fluentui-react-file-type-icons-6c937bc8-a505-4d54-8265-dfc406d6cd02.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-7fde98f3-843c-4532-8f63-7d613cd9a61e.json
+++ b/change/@fluentui-react-focus-7fde98f3-843c-4532-8f63-7d613cd9a61e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-39b69218-d961-481f-a905-4a234df7dc01.json
+++ b/change/@fluentui-react-hooks-39b69218-d961-481f-a905-4a234df7dc01.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-f7dadb33-eca9-4587-ba9f-a5fe79340b6d.json
+++ b/change/@fluentui-react-icon-provider-f7dadb33-eca9-4587-ba9f-a5fe79340b6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-24ae7112-575c-4cea-8ca3-6936c695c475.json
+++ b/change/@fluentui-react-icons-mdl2-24ae7112-575c-4cea-8ca3-6936c695c475.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-31a7fef0-acbf-4480-9fb2-75997fbb0b85.json
+++ b/change/@fluentui-react-link-31a7fef0-acbf-4480-9fb2-75997fbb0b85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-a91ae7e0-ad08-4fde-a076-a5c08d1ef125.json
+++ b/change/@fluentui-react-shared-contexts-a91ae7e0-ad08-4fde-a076-a5c08d1ef125.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-334cad1c-4233-4205-9c48-2ac4952a5cf4.json
+++ b/change/@fluentui-react-slider-334cad1c-4233-4205-9c48-2ac4952a5cf4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-7f61f6f6-58a3-4a65-bf42-e4bdadc8cf4a.json
+++ b/change/@fluentui-react-tabs-7f61f6f6-58a3-4a65-bf42-e4bdadc8cf4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-a127812b-198e-413b-8f2d-1041116df603.json
+++ b/change/@fluentui-react-theme-a127812b-198e-413b-8f2d-1041116df603.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-provider-09444cb6-e8cb-4b4b-94fd-a36afd09244c.json
+++ b/change/@fluentui-react-theme-provider-09444cb6-e8cb-4b4b-94fd-a36afd09244c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toggle-00784eef-b9f9-4478-8591-84b432053182.json
+++ b/change/@fluentui-react-toggle-00784eef-b9f9-4478-8591-84b432053182.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-toggle",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-b2dfb730-730e-47b2-b471-b22e509993c5.json
+++ b/change/@fluentui-react-utilities-b2dfb730-730e-47b2-b471-b22e509993c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-122d68d2-27a0-4541-8893-1344328dc7a3.json
+++ b/change/@fluentui-style-utilities-122d68d2-27a0-4541-8893-1344328dc7a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/style-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-74d61b16-db62-4d2c-8727-798d6dbfbd70.json
+++ b/change/@fluentui-test-utilities-74d61b16-db62-4d2c-8727-798d6dbfbd70.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(test-utilities): fix lint errors",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-3699979b-fa33-4144-9808-b39c9d66a073.json
+++ b/change/@fluentui-theme-3699979b-fa33-4144-9808-b39c9d66a073.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-06f61e5d-f23c-4c4e-b465-5fcc9791a49c.json
+++ b/change/@fluentui-utilities-06f61e5d-f23c-4c4e-b465-5fcc9791a49c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix lint errors in config files",
+  "packageName": "@fluentui/utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/dom-utilities/jest.config.js
+++ b/packages/dom-utilities/jest.config.js
@@ -1,2 +1,2 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({});

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -14,7 +14,7 @@ const testFiles = [
 
 const docsFiles = ['**/*Page.tsx', '**/{docs,demo}/**', '**/*.doc.{ts,tsx}'];
 
-const configFiles = ['./just.config.ts', './gulpfile.ts', './*.js', './.*.js', './config', './scripts', './tasks'];
+const configFiles = ['./just.config.ts', './gulpfile.ts', './*.js', './.*.js', './config/**', './scripts', './tasks'];
 
 /**
  * Whether linting is running in context of lint-staged (which should disable rules requiring

--- a/packages/foundation-legacy/jest.config.js
+++ b/packages/foundation-legacy/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/keyboard-key/jest.config.js
+++ b/packages/keyboard-key/jest.config.js
@@ -1,4 +1,4 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 const config = createConfig({
   collectCoverage: true,

--- a/packages/merge-styles/jest.config.js
+++ b/packages/merge-styles/jest.config.js
@@ -1,3 +1,3 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 module.exports = createConfig();

--- a/packages/react-cards/jest.config.js
+++ b/packages/react-cards/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-charting/jest.config.js
+++ b/packages/react-charting/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-checkbox/jest.config.js
+++ b/packages/react-checkbox/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-compose/jest.config.js
+++ b/packages/react-compose/jest.config.js
@@ -1,5 +1,5 @@
-let path = require('path');
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });

--- a/packages/react-context-selector/jest.config.js
+++ b/packages/react-context-selector/jest.config.js
@@ -1,4 +1,4 @@
-const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({

--- a/packages/react-date-time/jest.config.js
+++ b/packages/react-date-time/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-experiments/jest.config.js
+++ b/packages/react-experiments/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-file-type-icons/jest.config.js
+++ b/packages/react-file-type-icons/jest.config.js
@@ -1,3 +1,3 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 module.exports = createConfig();

--- a/packages/react-focus/jest.config.js
+++ b/packages/react-focus/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-hooks/jest.config.js
+++ b/packages/react-hooks/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-icon-provider/jest.config.js
+++ b/packages/react-icon-provider/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-icons-mdl2/jest.config.js
+++ b/packages/react-icons-mdl2/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-link/jest.config.js
+++ b/packages/react-link/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-shared-contexts/jest.config.js
+++ b/packages/react-shared-contexts/jest.config.js
@@ -1,5 +1,5 @@
-let path = require('path');
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });

--- a/packages/react-slider/jest.config.js
+++ b/packages/react-slider/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-tabs/jest.config.js
+++ b/packages/react-tabs/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-theme-provider/jest.config.js
+++ b/packages/react-theme-provider/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-theme/jest.config.js
+++ b/packages/react-theme/jest.config.js
@@ -1,4 +1,4 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 const config = createConfig();
 

--- a/packages/react-toggle/jest.config.js
+++ b/packages/react-toggle/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/react-utilities/jest.config.js
+++ b/packages/react-utilities/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/style-utilities/jest.config.js
+++ b/packages/style-utilities/jest.config.js
@@ -1,3 +1,3 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 module.exports = createConfig();

--- a/packages/test-utilities/jest.config.js
+++ b/packages/test-utilities/jest.config.js
@@ -1,2 +1,2 @@
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({});

--- a/packages/theme/jest.config.js
+++ b/packages/theme/jest.config.js
@@ -1,5 +1,5 @@
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
-let path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],

--- a/packages/utilities/jest.config.js
+++ b/packages/utilities/jest.config.js
@@ -1,5 +1,5 @@
-let path = require('path');
-let { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const path = require('path');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: [resolveMergeStylesSerializer()],

--- a/scripts/tasks/eslint.ts
+++ b/scripts/tasks/eslint.ts
@@ -1,10 +1,7 @@
 import { eslintTask } from 'just-scripts';
 import * as configHelpers from '@fluentui/eslint-plugin/src/utils/configHelpers';
-import * as path from 'path';
 
 export const eslint = eslintTask({
-  // TODO: also lint config files?
-  files: [path.join(process.cwd(), 'src')],
   extensions: configHelpers.extensions.join(','),
   cache: true, // only lint files changed since last lint
   fix: process.argv.includes('--fix'),


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

 - fixed all configs that violated rules. Wish we did lint all of this since the begging. now we do! yay

**Before:**
- `./config` folders are not linted
- `overrides` lint config doesn't catch files within `./config`

**After:**
- `./config` folders are linted  and overrides work as expected

#### Focus areas to test

(optional)
