### PR TITLE
[v7.0] Rating: specifies when a rating's button is selected/not selected to improve a11y experience

### DIFF
--- a/change/@fluentui-react-examples-9686f6f5-374d-49c7-a5c3-592e952916ba.json
+++ b/change/@fluentui-react-examples-9686f6f5-374d-49c7-a5c3-592e952916ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rating: updated examples to reflect addition of ariaLabel prop",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-20edbfb1-eb34-409c-a853-c8761530f1f8.json
+++ b/change/office-ui-fabric-react-20edbfb1-eb34-409c-a853-c8761530f1f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Rating: specifies when a rating's button is selected/not selected to improve a11y experience",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6894,6 +6894,7 @@ export interface IRating {
 // @public
 export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
     allowZeroStars?: boolean;
+    ariaLabel?: string;
     ariaLabelFormat?: string;
     // @deprecated
     ariaLabelId?: string;

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -123,7 +123,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             onClick={this._onFocus.bind(this, i)} // For Safari & Firefox on OSX
             disabled={disabled || readOnly ? true : false}
             role="radio"
-            aria-checked={i === Math.ceil(rating) ? true : false}
+            aria-checked={i === Math.ceil(rating)}
             aria-hidden={readOnly ? 'true' : undefined}
             type="button"
           >

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -69,6 +69,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
 
   public render(): JSX.Element {
     const {
+      ariaLabel,
       disabled,
       getAriaLabel,
       styles,
@@ -121,7 +122,9 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             onFocus={this._onFocus.bind(this, i)}
             onClick={this._onFocus.bind(this, i)} // For Safari & Firefox on OSX
             disabled={disabled || readOnly ? true : false}
-            role="presentation"
+            role="radio"
+            aria-checked={i === Math.ceil(rating) ? true : false}
+            aria-hidden={readOnly ? 'true' : undefined}
             type="button"
           >
             {this._getLabel(i)}
@@ -131,7 +134,8 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       }
     }
 
-    const ariaLabel = getAriaLabel ? getAriaLabel(rating ? rating : 0, max as number) : undefined;
+    const readOnlyAriaLabel = getAriaLabel ? getAriaLabel(rating ? rating : 0, max as number) : undefined;
+    const normalModeAriaLabel = ariaLabel ? ariaLabel : readOnlyAriaLabel;
 
     // When in read-only mode, we allow focus (per ARIA standards) and set up ARIA attributes to indicate element
     // is read-only. https://www.w3.org/TR/wai-aria-1.1/#aria-readonly
@@ -139,9 +143,10 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       ? ({
           allowFocusRoot: true,
           disabled: true,
-          'aria-label': ariaLabel,
+          'aria-label': readOnlyAriaLabel,
           'aria-readonly': true,
           'data-is-focusable': true,
+          role: 'textbox',
           tabIndex: 0,
         } as IFocusZoneProps)
       : undefined;
@@ -152,8 +157,9 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
           [this._classNames.rootIsLarge]: size === RatingSize.Large,
           [this._classNames.rootIsSmall]: size !== RatingSize.Large,
         })}
-        aria-label={!readOnly ? ariaLabel : ''}
+        aria-label={!readOnly ? normalModeAriaLabel : undefined}
         id={id}
+        role={!readOnly ? 'radiogroup' : undefined}
         {...divProps}
       >
         <FocusZone

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -106,7 +106,9 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
   getAriaLabel?: (rating: number, max: number) => string;
 
   /**
-   * Optional aria-label for rating control
+   * Optional aria-label for rating control.
+   * If rating control is readOnly, it is recommended to provide a getAriaLabel prop instead
+   * since otherwise the current rating value will not be read.
    */
   ariaLabel?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -100,9 +100,15 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
   readOnly?: boolean;
 
   /*
-   * Optional callback to set the aria-label for rating control.
+   * Optional callback to set the aria-label for rating control in readOnly mode.
+   * Also used as a fallback aria-label if ariaLabel prop is not provided.
    */
   getAriaLabel?: (rating: number, max: number) => string;
+
+  /**
+   * Optional aria-label for rating control
+   */
+  ariaLabel?: string;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Rating renders correctly. 1`] = `
         height: 32px;
       }
   id="Rating0"
+  role="radiogroup"
 >
   <div
     className=
@@ -60,6 +61,7 @@ exports[`Rating renders correctly. 1`] = `
     onMouseDownCapture={[Function]}
   >
     <button
+      aria-checked={true}
       className=
           ms-Rating-button
           ms-Rating--small
@@ -127,7 +129,7 @@ exports[`Rating renders correctly. 1`] = `
       id="Rating0-star-0"
       onClick={[Function]}
       onFocus={[Function]}
-      role="presentation"
+      role="radio"
       type="button"
     >
       <span
@@ -216,6 +218,7 @@ exports[`Rating renders correctly. 1`] = `
       </div>
     </button>
     <button
+      aria-checked={false}
       className=
           ms-Rating-button
           ms-Rating--small
@@ -282,7 +285,7 @@ exports[`Rating renders correctly. 1`] = `
       id="Rating0-star-1"
       onClick={[Function]}
       onFocus={[Function]}
-      role="presentation"
+      role="radio"
       type="button"
     >
       <span
@@ -371,6 +374,7 @@ exports[`Rating renders correctly. 1`] = `
       </div>
     </button>
     <button
+      aria-checked={false}
       className=
           ms-Rating-button
           ms-Rating--small
@@ -437,7 +441,7 @@ exports[`Rating renders correctly. 1`] = `
       id="Rating0-star-2"
       onClick={[Function]}
       onFocus={[Function]}
-      role="presentation"
+      role="radio"
       type="button"
     >
       <span
@@ -526,6 +530,7 @@ exports[`Rating renders correctly. 1`] = `
       </div>
     </button>
     <button
+      aria-checked={false}
       className=
           ms-Rating-button
           ms-Rating--small
@@ -592,7 +597,7 @@ exports[`Rating renders correctly. 1`] = `
       id="Rating0-star-3"
       onClick={[Function]}
       onFocus={[Function]}
-      role="presentation"
+      role="radio"
       type="button"
     >
       <span
@@ -681,6 +686,7 @@ exports[`Rating renders correctly. 1`] = `
       </div>
     </button>
     <button
+      aria-checked={false}
       className=
           ms-Rating-button
           ms-Rating--small
@@ -747,7 +753,7 @@ exports[`Rating renders correctly. 1`] = `
       id="Rating0-star-4"
       onClick={[Function]}
       onFocus={[Function]}
-      role="presentation"
+      role="radio"
       type="button"
     >
       <span

--- a/packages/react-examples/src/office-ui-fabric-react/Rating/Rating.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Rating/Rating.Basic.Example.tsx
@@ -43,10 +43,10 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         max={5}
         size={RatingSize.Large}
         rating={largeStarRating}
-        getAriaLabel={getRatingComponentAriaLabel}
+        ariaLabel="Large stars"
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onLargeStarChange}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabelFormat={'{0} of {1} stars'}
       />
       Small Stars
       <Rating
@@ -56,8 +56,8 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         rating={smallStarRating}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onSmallStarChange}
-        getAriaLabel={getRatingComponentAriaLabel}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabel="Small stars"
+        ariaLabelFormat={'{0} of {1} stars'}
       />
       10 Small Stars
       <Rating
@@ -66,11 +66,11 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         rating={tenStarRating}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onTenStarChange}
-        getAriaLabel={getRatingComponentAriaLabel}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabel="10 small stars"
+        ariaLabelFormat={'{0} of {1} stars'}
       />
       Disabled:
-      <Rating min={1} max={5} rating={1} disabled={true} ariaLabelFormat={'Select {0} of {1} stars'} />
+      <Rating min={1} max={5} rating={1} disabled={true} ariaLabelFormat={'{0} of {1} stars'} />
       Half star in readOnly mode:
       <Rating
         min={1}
@@ -78,7 +78,7 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         rating={2.5}
         getAriaLabel={getRatingComponentAriaLabel}
         readOnly
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabelFormat={'{0} of {1} stars'}
       />
       Custom icons:
       <Rating
@@ -87,8 +87,8 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         rating={customIconStarRating}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onCustomIconStarChange}
-        getAriaLabel={getRatingComponentAriaLabel}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabel="Custom icons"
+        ariaLabelFormat={'{0} of {1} stars'}
         icon="StarburstSolid"
         unselectedIcon="Starburst"
       />
@@ -99,8 +99,8 @@ export const RatingBasicExample: React.FunctionComponent = () => {
         rating={themedStarRating}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onThemedStarChange}
-        getAriaLabel={getRatingComponentAriaLabel}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabel="Themed star"
+        ariaLabelFormat={'{0} of {1} stars'}
         theme={customTheme}
       />
     </div>

--- a/packages/react-examples/src/office-ui-fabric-react/Rating/Rating.ButtonControlled.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Rating/Rating.ButtonControlled.Example.tsx
@@ -23,7 +23,7 @@ export const RatingButtonControlledExample: React.FunctionComponent = () => {
         allowZeroStars
         // eslint-disable-next-line react/jsx-no-bind
         getAriaLabel={getRatingAriaLabel}
-        ariaLabelFormat={'Select {0} of {1} stars'}
+        ariaLabelFormat={'{0} of {1} stars'}
       />
       <PrimaryButton
         text={'Click to change rating to ' + (5 - currentRating)}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
 <div>
   Large Stars:
   <div
-    aria-label="Rating value is 1 of 5"
+    aria-label="Large stars"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -27,6 +27,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         }
     id="Rating0"
     onChange={[Function]}
+    role="radiogroup"
   >
     <div
       className=
@@ -64,6 +65,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--large
@@ -131,7 +133,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating0-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -154,7 +156,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -220,6 +222,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--large
@@ -286,7 +289,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating0-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -309,7 +312,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -375,6 +378,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--large
@@ -441,7 +445,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating0-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -464,7 +468,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -530,6 +534,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--large
@@ -596,7 +601,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating0-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -619,7 +624,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -685,6 +690,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--large
@@ -751,7 +757,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating0-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -774,7 +780,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=
@@ -843,7 +849,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Small Stars
   <div
-    aria-label="Rating value is 3 of 5"
+    aria-label="Small stars"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -866,6 +872,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         }
     id="small"
     onChange={[Function]}
+    role="radiogroup"
   >
     <div
       className=
@@ -903,6 +910,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -969,7 +977,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating3-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -992,7 +1000,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -1058,6 +1066,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1124,7 +1133,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating3-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1147,7 +1156,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -1213,6 +1222,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1280,7 +1290,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating3-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1303,7 +1313,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -1369,6 +1379,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1435,7 +1446,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating3-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1458,7 +1469,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -1524,6 +1535,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1590,7 +1602,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating3-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1613,7 +1625,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=
@@ -1682,7 +1694,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   10 Small Stars
   <div
-    aria-label="Rating value is 1 of 10"
+    aria-label="10 small stars"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -1705,6 +1717,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         }
     id="Rating6"
     onChange={[Function]}
+    role="radiogroup"
   >
     <div
       className=
@@ -1742,6 +1755,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1809,7 +1823,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1832,7 +1846,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-1"
         >
-          Select 1 of 10 stars
+          1 of 10 stars
         </span>
         <div
           className=
@@ -1898,6 +1912,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -1964,7 +1979,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -1987,7 +2002,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-2"
         >
-          Select 2 of 10 stars
+          2 of 10 stars
         </span>
         <div
           className=
@@ -2053,6 +2068,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2119,7 +2135,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2142,7 +2158,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-3"
         >
-          Select 3 of 10 stars
+          3 of 10 stars
         </span>
         <div
           className=
@@ -2208,6 +2224,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2274,7 +2291,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2297,7 +2314,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-4"
         >
-          Select 4 of 10 stars
+          4 of 10 stars
         </span>
         <div
           className=
@@ -2363,6 +2380,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2429,7 +2447,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2452,7 +2470,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-5"
         >
-          Select 5 of 10 stars
+          5 of 10 stars
         </span>
         <div
           className=
@@ -2518,6 +2536,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2584,7 +2603,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-5"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2607,7 +2626,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-6"
         >
-          Select 6 of 10 stars
+          6 of 10 stars
         </span>
         <div
           className=
@@ -2673,6 +2692,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2739,7 +2759,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-6"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2762,7 +2782,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-7"
         >
-          Select 7 of 10 stars
+          7 of 10 stars
         </span>
         <div
           className=
@@ -2828,6 +2848,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -2894,7 +2915,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-7"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -2917,7 +2938,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-8"
         >
-          Select 8 of 10 stars
+          8 of 10 stars
         </span>
         <div
           className=
@@ -2983,6 +3004,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3049,7 +3071,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-8"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3072,7 +3094,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-9"
         >
-          Select 9 of 10 stars
+          9 of 10 stars
         </span>
         <div
           className=
@@ -3138,6 +3160,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3204,7 +3227,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating6-star-9"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3227,7 +3250,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-10"
         >
-          Select 10 of 10 stars
+          10 of 10 stars
         </span>
         <div
           className=
@@ -3311,6 +3334,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           height: 32px;
         }
     id="Rating9"
+    role="radiogroup"
   >
     <div
       className=
@@ -3348,6 +3372,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3397,7 +3422,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating9-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3420,7 +3445,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -3456,6 +3481,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3504,7 +3530,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating9-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3527,7 +3553,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -3563,6 +3589,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3611,7 +3638,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating9-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3634,7 +3661,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -3670,6 +3697,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3718,7 +3746,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating9-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3741,7 +3769,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -3777,6 +3805,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3825,7 +3854,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating9-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -3848,7 +3877,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=
@@ -3887,7 +3916,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Half star in readOnly mode:
   <div
-    aria-label=""
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -3941,9 +3969,12 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="textbox"
       tabIndex={0}
     >
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -3992,7 +4023,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating12-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4015,7 +4046,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -4081,6 +4112,8 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4129,7 +4162,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating12-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4152,7 +4185,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -4218,6 +4251,8 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={true}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4267,7 +4302,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating12-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4290,7 +4325,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -4356,6 +4391,8 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4404,7 +4441,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating12-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4427,7 +4464,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -4493,6 +4530,8 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4541,7 +4580,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating12-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4564,7 +4603,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=
@@ -4633,7 +4672,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Custom icons:
   <div
-    aria-label="Rating value is 2.5 of 5"
+    aria-label="Custom icons"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -4656,6 +4695,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         }
     id="Rating15"
     onChange={[Function]}
+    role="radiogroup"
   >
     <div
       className=
@@ -4693,6 +4733,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4759,7 +4800,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating15-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4782,7 +4823,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -4848,6 +4889,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -4914,7 +4956,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating15-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -4937,7 +4979,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -5003,6 +5045,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5070,7 +5113,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating15-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5093,7 +5136,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -5159,6 +5202,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5225,7 +5269,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating15-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5248,7 +5292,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -5314,6 +5358,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5380,7 +5425,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating15-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5403,7 +5448,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=
@@ -5472,7 +5517,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Themed star
   <div
-    aria-label="Rating value is 1 of 5"
+    aria-label="Themed star"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -5495,6 +5540,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         }
     id="Rating18"
     onChange={[Function]}
+    role="radiogroup"
   >
     <div
       className=
@@ -5532,6 +5578,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
     >
       <button
+        aria-checked={true}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5599,7 +5646,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating18-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5622,7 +5669,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -5688,6 +5735,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5754,7 +5802,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating18-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5777,7 +5825,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -5843,6 +5891,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -5909,7 +5958,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating18-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -5932,7 +5981,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -5998,6 +6047,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -6064,7 +6114,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating18-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -6087,7 +6137,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -6153,6 +6203,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
+        aria-checked={false}
         className=
             ms-Rating-button
             ms-Rating--small
@@ -6219,7 +6270,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         id="Rating18-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -6242,7 +6293,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -3,7 +3,6 @@
 exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctly 1`] = `
 <div>
   <div
-    aria-label=""
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -57,9 +56,12 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="textbox"
       tabIndex={0}
     >
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -108,7 +110,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         id="Rating0-star-0"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -131,7 +133,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-1"
         >
-          Select 1 of 5 stars
+          1 of 5 stars
         </span>
         <div
           className=
@@ -197,6 +199,8 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -245,7 +249,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         id="Rating0-star-1"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -268,7 +272,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-2"
         >
-          Select 2 of 5 stars
+          2 of 5 stars
         </span>
         <div
           className=
@@ -334,6 +338,8 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -382,7 +388,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         id="Rating0-star-2"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -405,7 +411,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-3"
         >
-          Select 3 of 5 stars
+          3 of 5 stars
         </span>
         <div
           className=
@@ -471,6 +477,8 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
+        aria-checked={false}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -519,7 +527,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         id="Rating0-star-3"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -542,7 +550,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-4"
         >
-          Select 4 of 5 stars
+          4 of 5 stars
         </span>
         <div
           className=
@@ -608,6 +616,8 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
+        aria-checked={true}
+        aria-hidden="true"
         className=
             ms-Rating-button
             ms-Rating--small
@@ -657,7 +667,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         id="Rating0-star-4"
         onClick={[Function]}
         onFocus={[Function]}
-        role="presentation"
+        role="radio"
         type="button"
       >
         <span
@@ -680,7 +690,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-5"
         >
-          Select 5 of 5 stars
+          5 of 5 stars
         </span>
         <div
           className=


### PR DESCRIPTION
cherry-pick of #17267 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16059
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- added `ariaLabel` prop which simplifies naming for the aria-label when not in readOnly mode.
- container and button's are given the role of `radiogroup` and `radio` respectively when not in readOnly mode.
- button's are given an `aria-checked` attribute to specify if they're selected when not in readOnly mode.
- pre-existing `getAriaLabel` function prop is now solely used for readOnly mode
- React-examples were updated to make use of the new `ariaLabel` prop.
- Also removed instances of `getAriaLabel` prop being passed in react-examples when not in readOnly mode.
