### PR TITLE
DetailsList: selected row border now clearly visible when focused in High Contrast Mode

### DIFF
--- a/change/@fluentui-react-5cb2cbc0-9672-4427-ad4d-34aaf07805a7.json
+++ b/change/@fluentui-react-5cb2cbc0-9672-4427-ad4d-34aaf07805a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: row border now visible when focused in High Contrast Mode",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -105,9 +105,21 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
     focusHoverBackground: neutralQuaternaryAlt,
   };
 
+  const rowHighContrastFocus = {
+    top: 2,
+    right: 2,
+    bottom: 2,
+    left: 2,
+  };
+
   // Selected row styles
   const selectedStyles: IStyle = [
-    getFocusStyle(theme, { inset: -1, borderColor: focusBorder, outlineColor: white }),
+    getFocusStyle(theme, {
+      inset: -1,
+      borderColor: focusBorder,
+      outlineColor: white,
+      highContrastStyle: rowHighContrastFocus,
+    }),
     classNames.isSelected,
     {
       color: colors.selectedMetaText,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [10795](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10795)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Offsetted white border of selected row when focused in High Contrast Mode in order to improve visibility and  ensure users are aware of which row is in focus.

**Issue:** 
![issue](https://user-images.githubusercontent.com/8649804/111844413-3e954380-88c0-11eb-872f-7f5304f12969.JPG)
**Fix:**
![fix](https://user-images.githubusercontent.com/8649804/111844427-43f28e00-88c0-11eb-82c2-f89157a0f550.JPG)



