### PR TITLE
Pivot: Fix selectedKey={null} to render no item

### DIFF
--- a/change/@fluentui-react-8d9e5832-73ec-48dd-a10f-9498ae5d37ee.json
+++ b/change/@fluentui-react-8d9e5832-73ec-48dd-a10f-9498ae5d37ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pivot: Fix setting selectedKey={null} to not render any PivotItem",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -189,7 +189,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
     };
 
     const isKeyValid = (itemKey: string | null | undefined): boolean => {
-      return itemKey !== undefined && itemKey !== null && linkCollection.keyToIndexMapping[itemKey] !== undefined;
+      return itemKey === null || (itemKey !== undefined && linkCollection.keyToIndexMapping[itemKey] !== undefined);
     };
 
     const getSelectedKey = () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17241
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When Pivot was converted to a function component, the logic to allow setting `selectedKey={null}` to render no active tab was broken. This restores the behavior from v7.