### PR TITLE
Autofill: Inherit font-family to prevent defaulting to Arial

### DIFF
--- a/change/@fluentui-react-examples-2151236c-fd6b-4527-8944-7a11fce9088e.json
+++ b/change/@fluentui-react-examples-2151236c-fd6b-4527-8944-7a11fce9088e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Autofill: Inherit font-family to prevent defaulting to Arial.",
+  "packageName": "@fluentui/react-examples",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-99ea7ebe-27e3-46a8-8413-3cb05e0b94ce.json
+++ b/change/@fluentui-react-experiments-99ea7ebe-27e3-46a8-8413-3cb05e0b94ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-f7171097-ecc1-47fe-868e-08023aba68f3.json
+++ b/change/@fluentui-react-f7171097-ecc1-47fe-868e-08023aba68f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Autofill: Inherit font-family to prevent defaulting to Arial.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -132,6 +132,11 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -184,6 +184,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -743,6 +744,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -184,7 +184,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -239,6 +238,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Option C"
       />
@@ -744,7 +748,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -799,6 +802,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Option C"
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -204,6 +204,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -204,7 +204,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -259,6 +258,11 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Option C"
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
@@ -225,7 +225,6 @@ exports[`Component Examples renders ComboBox.ControlledMulti.Example.tsx correct
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -280,6 +279,11 @@ exports[`Component Examples renders ComboBox.ControlledMulti.Example.tsx correct
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Option C, Option D"
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.ControlledMulti.Example.tsx.shot
@@ -225,6 +225,7 @@ exports[`Component Examples renders ComboBox.ControlledMulti.Example.tsx correct
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -204,7 +204,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -259,6 +258,11 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Calibri"
       />
@@ -606,7 +610,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -661,6 +664,11 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Calibri"
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -204,6 +204,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -605,6 +606,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
@@ -140,7 +140,6 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -195,6 +194,11 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="Option B"
       />
@@ -552,7 +556,6 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -607,6 +610,11 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value=""
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.ErrorHandling.Example.tsx.shot
@@ -140,6 +140,7 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -551,6 +552,7 @@ exports[`Component Examples renders ComboBox.ErrorHandling.Example.tsx correctly
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -204,7 +204,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -259,6 +258,11 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value=""
       />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -204,6 +204,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -183,7 +183,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             border-style: none;
             box-sizing: border-box;
             color: #323130;
-            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -238,6 +237,11 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
       onTouchStart={[Function]}
       role="combobox"
       spellCheck={false}
+      style={
+        Object {
+          "fontFamily": "inherit",
+        }
+      }
       type="text"
       value="Option 547"
     />

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -183,6 +183,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             border-style: none;
             box-sizing: border-box;
             color: #323130;
+            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;

--- a/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -60,11 +60,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  font-family: inherit;
-                }
+            className="ms-BasePicker-input"
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -77,6 +73,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             onKeyDown={[Function]}
             onPaste={[Function]}
             role="combobox"
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>
@@ -282,11 +283,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  font-family: inherit;
-                }
+            className="ms-BasePicker-input"
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -299,6 +296,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             onKeyDown={[Function]}
             onPaste={[Function]}
             role="combobox"
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -60,7 +60,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  font-family: inherit;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -278,7 +282,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  font-family: inherit;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
@@ -60,11 +60,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  font-family: inherit;
-                }
+            className="ms-BasePicker-input"
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -77,6 +73,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             onKeyDown={[Function]}
             onPaste={[Function]}
             role="combobox"
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>
@@ -282,11 +283,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  font-family: inherit;
-                }
+            className="ms-BasePicker-input"
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -299,6 +296,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             onKeyDown={[Function]}
             onPaste={[Function]}
             role="combobox"
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
@@ -60,7 +60,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  font-family: inherit;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}
@@ -278,7 +282,11 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  font-family: inherit;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -96,6 +96,11 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -96,6 +96,11 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               onKeyDown={[Function]}
               role="textbox"
               spellCheck={false}
+              style={
+                Object {
+                  "fontFamily": "inherit",
+                }
+              }
               value=""
             />
           </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -96,6 +96,11 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -72,6 +72,11 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
           onInput={[Function]}
           onKeyDown={[Function]}
           role="textbox"
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -96,6 +96,11 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1447,6 +1447,11 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -96,6 +96,11 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -235,6 +235,11 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>
@@ -337,6 +342,11 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onKeyDown={[Function]}
             role="textbox"
             spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1507,7 +1507,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
-              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;
@@ -1562,6 +1561,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
         onTouchStart={[Function]}
         role="combobox"
         spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
         type="text"
         value="1"
       />

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1507,6 +1507,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               border-style: none;
               box-sizing: border-box;
               color: #323130;
+              font-family: inherit;
               font: inherit;
               height: 100%;
               outline: none;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -112,6 +112,11 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
             onInput={[Function]}
             onKeyDown={[Function]}
             onPaste={[Function]}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>
@@ -879,6 +884,11 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
               onInput={[Function]}
               onKeyDown={[Function]}
               onPaste={[Function]}
+              style={
+                Object {
+                  "fontFamily": "inherit",
+                }
+              }
               value=""
             />
           </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -112,6 +112,11 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
             onInput={[Function]}
             onKeyDown={[Function]}
             onPaste={[Function]}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
             value=""
           />
         </div>
@@ -263,6 +268,11 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
               onInput={[Function]}
               onKeyDown={[Function]}
               onPaste={[Function]}
+              style={
+                Object {
+                  "fontFamily": "inherit",
+                }
+              }
               value=""
             />
           </div>

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { mergeStyles } from '../../Styling';
 import { Async, getNativeProps, initializeComponentRef, inputProperties, isIE11, KeyCodes } from '../../Utilities';
 import { IAutofill, IAutofillProps } from './Autofill.types';
 
@@ -126,12 +127,14 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
 
   public render(): JSX.Element {
     const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
+    const className = mergeStyles({ fontFamily: 'inherit' }, this.props.className);
     return (
       <input
         autoCapitalize="off"
         autoComplete="off"
         aria-autocomplete={'both'}
         {...nativeProps}
+        className={className}
         ref={this._inputElement}
         value={this._getDisplayValue()}
         onCompositionStart={this._onCompositionStart}

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { mergeStyles } from '../../Styling';
 import { Async, getNativeProps, initializeComponentRef, inputProperties, isIE11, KeyCodes } from '../../Utilities';
 import { IAutofill, IAutofillProps } from './Autofill.types';
 
@@ -127,14 +126,14 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
 
   public render(): JSX.Element {
     const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
-    const className = mergeStyles({ fontFamily: 'inherit' }, this.props.className);
+    const style = { ...this.props.style, fontFamily: 'inherit' };
     return (
       <input
         autoCapitalize="off"
         autoComplete="off"
         aria-autocomplete={'both'}
         {...nativeProps}
-        className={className}
+        style={style}
         ref={this._inputElement}
         value={this._getDisplayValue()}
         onCompositionStart={this._onCompositionStart}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -153,7 +153,6 @@ exports[`ComboBox Renders correctly 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
-            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -208,6 +207,11 @@ exports[`ComboBox Renders correctly 1`] = `
       onTouchStart={[Function]}
       role="combobox"
       spellCheck={false}
+      style={
+        Object {
+          "fontFamily": "inherit",
+        }
+      }
       type="text"
       value="testValue"
     />
@@ -512,7 +516,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
-            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -556,6 +559,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
       id="ComboBox0-input"
       role="combobox"
       spellcheck="false"
+      style="font-family: inherit;"
       type="text"
       value="Option 2"
     />
@@ -1281,7 +1285,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
-            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -1326,6 +1329,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
       placeholder="Option 2"
       role="combobox"
       spellcheck="false"
+      style="font-family: inherit;"
       type="text"
       value=""
     />
@@ -2178,7 +2182,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
-            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -2222,6 +2225,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
       id="ComboBox0-input"
       role="combobox"
       spellcheck="false"
+      style="font-family: inherit;"
       type="text"
       value=""
     />

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`ComboBox Renders correctly 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
+            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -511,6 +512,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
+            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -1279,6 +1281,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
+            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;
@@ -2175,6 +2178,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             border-style: none;
             box-sizing: border-box;
             color: #323130;
+            font-family: inherit;
             font: inherit;
             height: 100%;
             outline: none;

--- a/packages/react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
+++ b/packages/react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
@@ -39,11 +39,7 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                font-family: inherit;
-              }
+          className="ms-BasePicker-input"
           data-lpignore={true}
           onChange={[Function]}
           onClick={[Function]}
@@ -55,6 +51,11 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1
           onKeyDown={[Function]}
           onPaste={[Function]}
           role="combobox"
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>
@@ -113,11 +114,7 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected a
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                font-family: inherit;
-              }
+          className="ms-BasePicker-input"
           data-lpignore={true}
           onChange={[Function]}
           onClick={[Function]}
@@ -129,6 +126,11 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected a
           onKeyDown={[Function]}
           onPaste={[Function]}
           role="combobox"
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>

--- a/packages/react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
+++ b/packages/react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
@@ -39,7 +39,11 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className="ms-BasePicker-input"
+          className=
+              ms-BasePicker-input
+              {
+                font-family: inherit;
+              }
           data-lpignore={true}
           onChange={[Function]}
           onClick={[Function]}
@@ -109,7 +113,11 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected a
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className="ms-BasePicker-input"
+          className=
+              ms-BasePicker-input
+              {
+                font-family: inherit;
+              }
           data-lpignore={true}
           onChange={[Function]}
           onClick={[Function]}

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -93,6 +93,11 @@ exports[`PeoplePicker renders correctly 1`] = `
           onKeyDown={[Function]}
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>
@@ -653,6 +658,11 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
           onKeyDown={[Function]}
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -301,6 +301,11 @@ exports[`TagPicker renders correctly 1`] = `
           onKeyDown={[Function]}
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>
@@ -610,6 +615,11 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
           onKeyDown={[Function]}
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -42,7 +42,11 @@ exports[`BasePicker renders correctly 1`] = `
           aria-controls=" "
           autoCapitalize="off"
           autoComplete="off"
-          className="ms-BasePicker-input"
+          className=
+              ms-BasePicker-input
+              {
+                font-family: inherit;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}
@@ -105,7 +109,12 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
           aria-controls=" "
           autoCapitalize="off"
           autoComplete="off"
-          className="ms-BasePicker-input testclass "
+          className=
+              ms-BasePicker-input
+              testclass
+              {
+                font-family: inherit;
+              }
           data-lpignore={true}
           id="pckSelectedUser"
           onBlur={[Function]}

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -42,11 +42,7 @@ exports[`BasePicker renders correctly 1`] = `
           aria-controls=" "
           autoCapitalize="off"
           autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                font-family: inherit;
-              }
+          className="ms-BasePicker-input"
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}
@@ -59,6 +55,11 @@ exports[`BasePicker renders correctly 1`] = `
           onKeyDown={[Function]}
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>
@@ -109,12 +110,7 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
           aria-controls=" "
           autoCapitalize="off"
           autoComplete="off"
-          className=
-              ms-BasePicker-input
-              testclass
-              {
-                font-family: inherit;
-              }
+          className="ms-BasePicker-input testclass "
           data-lpignore={true}
           id="pckSelectedUser"
           onBlur={[Function]}
@@ -129,6 +125,11 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
           placeholder="Bitte einen Benutzer angeben..."
           role="textbox"
           spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
           value=""
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`Autofill` was not inheriting the `font-family` so there were cases were it defaulted back to `Arial`. This PR fixes the issue by adding that styling to `Autofill`, which in turn fixes the issue for `Combobox` and `Pickers` as well.
