### PR TITLE
Converged component state

### DIFF
--- a/change/@fluentui-react-accordion-1a4cd9a8-a499-4494-a9f1-3d18d305e250.json
+++ b/change/@fluentui-react-accordion-1a4cd9a8-a499-4494-a9f1-3d18d305e250.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-accordion",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-bacb438c-065f-45bf-9072-42d728144ae9.json
+++ b/change/@fluentui-react-avatar-bacb438c-065f-45bf-9072-42d728144ae9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Avatar to use ComponentState",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-39f75d44-7653-49e2-a276-05d0264bb6e7.json
+++ b/change/@fluentui-react-badge-39f75d44-7653-49e2-a276-05d0264bb6e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-badge",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-25e929e5-0d3c-4ddc-a1ea-3cd11d8ab280.json
+++ b/change/@fluentui-react-button-25e929e5-0d3c-4ddc-a1ea-3cd11d8ab280.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-button",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-cards-b1de5ff2-3f2d-4638-84fb-ec1fea4291d9.json
+++ b/change/@fluentui-react-cards-b1de5ff2-3f2d-4638-84fb-ec1fea4291d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-cards",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-ddecb98f-b6ec-4d31-b2af-71111a3cf8c1.json
+++ b/change/@fluentui-react-divider-ddecb98f-b6ec-4d31-b2af-71111a3cf8c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-divider",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-flex-1f8d4398-a55e-480b-a5a3-6b6a42f2ee63.json
+++ b/change/@fluentui-react-flex-1f8d4398-a55e-480b-a5a3-6b6a42f2ee63.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-flex",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-management-0343f16f-9a78-43ba-922a-035efea9a6b0.json
+++ b/change/@fluentui-react-focus-management-0343f16f-9a78-43ba-922a-035efea9a6b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-focus-management",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-4368616d-3b4a-408a-9479-94513f00ebc2.json
+++ b/change/@fluentui-react-image-4368616d-3b4a-408a-9479-94513f00ebc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-image",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-65e2dc87-30f0-4bae-a15f-069dccde353d.json
+++ b/change/@fluentui-react-link-65e2dc87-30f0-4bae-a15f-069dccde353d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-link",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-094453b6-7b95-40f7-b4d1-dff4dc0894e8.json
+++ b/change/@fluentui-react-menu-094453b6-7b95-40f7-b4d1-dff4dc0894e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-menu",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-2c9a0b5d-7479-4ccd-ad7e-f3eeda421ea6.json
+++ b/change/@fluentui-react-provider-2c9a0b5d-7479-4ccd-ad7e-f3eeda421ea6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-provider",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-d0f77a43-359c-49d0-82c4-1a77492f3851.json
+++ b/change/@fluentui-react-text-d0f77a43-359c-49d0-82c4-1a77492f3851.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix type errors caught by makeMergeProps improvements",
+  "packageName": "@fluentui/react-text",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-provider-9e2fbc1e-5e22-4322-b47f-a7ee9b396a23.json
+++ b/change/@fluentui-react-theme-provider-9e2fbc1e-5e22-4322-b47f-a7ee9b396a23.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mergeProps was updated to improve type checking; use compat layer until type errors can be fixed",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-38633d81-8384-4735-9eb9-5c3a9c2623d3.json
+++ b/change/@fluentui-react-utilities-38633d81-8384-4735-9eb9-5c3a9c2623d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ComponentState helper type; improve type checking for makeMergeProps",
+  "packageName": "@fluentui/react-utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -50,7 +50,7 @@ export interface AccordionHeaderProps extends ComponentProps, React.HTMLAttribut
 }
 
 // @public
-export const accordionHeaderShorthandProps: string[];
+export const accordionHeaderShorthandProps: readonly ["expandIcon", "button", "children"];
 
 // @public (undocumented)
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { AccordionProps, AccordionState } from './Accordion.types';
 import { useCreateAccordionContext } from './useAccordionContext';
 import { useArrowNavigationGroup } from '@fluentui/react-focus-management';
@@ -9,7 +9,8 @@ import { useArrowNavigationGroup } from '@fluentui/react-focus-management';
  */
 export const accordionShorthandProps = [];
 
-const mergeProps = makeMergeProps<AccordionState>({ deepMerge: accordionShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<AccordionState>({ deepMerge: accordionShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import {
   AccordionHeaderExpandIconPosition,
   AccordionHeaderProps,
@@ -14,9 +14,10 @@ import { useContextSelector } from '@fluentui/react-context-selector';
 /**
  * Consts listing which props are shorthand props.
  */
-export const accordionHeaderShorthandProps = ['expandIcon', 'button', 'children'];
+export const accordionHeaderShorthandProps = ['expandIcon', 'button', 'children'] as const;
 
-const mergeProps = makeMergeProps<AccordionHeaderState>({ deepMerge: accordionHeaderShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<AccordionHeaderState>({ deepMerge: accordionHeaderShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { AccordionItemProps, AccordionItemState } from './AccordionItem.types';
 import { useCreateAccordionItemContext } from './useAccordionItemContext';
 
@@ -8,7 +8,8 @@ import { useCreateAccordionItemContext } from './useAccordionItemContext';
  */
 export const accordionItemShorthandProps = [];
 
-const mergeProps = makeMergeProps<AccordionItemState>({ deepMerge: accordionItemShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<AccordionItemState>({ deepMerge: accordionItemShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { AccordionPanelProps, AccordionPanelState } from './AccordionPanel.types';
 import { useAccordionItemContext } from '../AccordionItem/index';
 
@@ -8,7 +8,8 @@ import { useAccordionItemContext } from '../AccordionItem/index';
  */
 export const accordionPanelShorthandProps = [];
 
-const mergeProps = makeMergeProps<AccordionPanelState>({ deepMerge: accordionPanelShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<AccordionPanelState>({ deepMerge: accordionPanelShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, ShorthandProps } from '@fluentui/react-utilities';
 
 import { BadgeProps } from '../Badge/index';
 import { ImageProps } from '../Image/index';
@@ -121,20 +121,10 @@ export type AvatarNamedColor =
   | 'platinum'
   | 'anchor';
 
-/**
- * Convert from a Props type to a State type.
- * Replace all given shorthand props from ShorthandProps<P> to ObjectShorthandProps<P>
- */
-type PropsToState<T, ShorthandPropNames extends keyof T> = Omit<T, ShorthandPropNames> &
-  {
-    [U in ShorthandPropNames]: T[U] extends ShorthandProps<infer P> ? ObjectShorthandProps<P> : T[U];
-  };
+export const avatarShorthandProps = ['label', 'image', 'badge'] as const;
 
-/**
- * Avatar props that will never be undefined in AvatarState
- */
-export type AvatarDefaults = { ref: React.RefObject<HTMLElement> } & Required<
-  Pick<AvatarProps, 'as' | 'size' | 'getInitials' | 'label' | 'image' | 'badge'>
+export type AvatarState = ComponentState<
+  AvatarProps,
+  /* ShorthandProps: */ typeof avatarShorthandProps[number],
+  /* DefaultedProps: */ 'as' | 'size' | 'getInitials' | 'label' | 'image' | 'badge'
 >;
-
-export type AvatarState = PropsToState<AvatarProps & AvatarDefaults, 'label' | 'image' | 'badge'>;

--- a/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { AvatarState } from './Avatar.types';
-import { avatarShorthandProps } from './useAvatar';
+import { avatarShorthandProps, AvatarState } from './Avatar.types';
 
 export const renderAvatar = (state: AvatarState) => {
   const { slots, slotProps } = getSlots(state, avatarShorthandProps);

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { makeMergeProps, nullRender, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergeProps, nullRender, resolveShorthandProps } from '@fluentui/react-utilities';
 import { getInitials as defaultGetInitials } from '../../utils/index';
 import { Image } from '../Image/index';
-import { AvatarDefaults, AvatarProps, AvatarState, AvatarNamedColor } from './Avatar.types';
+import { AvatarProps, AvatarState, AvatarNamedColor, avatarShorthandProps } from './Avatar.types';
 import { DefaultAvatarIcon } from './DefaultAvatarIcon';
-
-export const avatarShorthandProps: (keyof AvatarProps)[] = ['label', 'image', 'badge'];
 
 const mergeProps = makeMergeProps<AvatarState>({ deepMerge: avatarShorthandProps });
 
@@ -18,8 +16,8 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>, defau
       badge: { as: nullRender },
       size: 32,
       getInitials: defaultGetInitials,
-      ref: useMergedRefs(ref, React.useRef(null)),
-    } as AvatarDefaults,
+      ref,
+    },
     defaultProps,
     resolveShorthandProps(props, avatarShorthandProps),
   );

--- a/packages/react-avatar/src/components/Badge/Badge.types.tsx
+++ b/packages/react-avatar/src/components/Badge/Badge.types.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, ShorthandProps } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { SizeValue } from '../utils/commonTypes';
@@ -43,6 +43,10 @@ export type BadgeTokenSet = {
   iconColor?: string;
 };
 
-export type BadgeState = BadgeProps & {
-  icon: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
-};
+export const badgeShorthandProps = ['icon'] as const;
+
+export type BadgeState = ComponentState<
+  BadgeProps,
+  /* ShorthandProps: */ typeof badgeShorthandProps[number],
+  /* DefaultedProps: */ 'icon'
+>;

--- a/packages/react-avatar/src/components/Badge/renderBadge.tsx
+++ b/packages/react-avatar/src/components/Badge/renderBadge.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { BadgeState } from './Badge.types';
+import { badgeShorthandProps, BadgeState } from './Badge.types';
 import { getSlots } from '@fluentui/react-utilities';
-import { badgeShorthandProps } from './useBadge';
 
 export const renderBadge = (state: BadgeState) => {
   const { slots, slotProps } = getSlots(state, badgeShorthandProps);

--- a/packages/react-avatar/src/components/Badge/useBadge.tsx
+++ b/packages/react-avatar/src/components/Badge/useBadge.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { BadgeProps, BadgeState } from './Badge.types';
-import { resolveShorthandProps, makeMergeProps, useMergedRefs } from '@fluentui/react-utilities';
-
-export const badgeShorthandProps: (keyof BadgeProps)[] = ['icon'];
+import { BadgeProps, badgeShorthandProps, BadgeState } from './Badge.types';
+import { resolveShorthandProps, makeMergeProps } from '@fluentui/react-utilities';
 
 const mergeProps = makeMergeProps<BadgeState>({ deepMerge: badgeShorthandProps });
 
@@ -10,7 +8,7 @@ export const useBadge = (props: BadgeProps, ref: React.Ref<HTMLElement>, default
   const state = mergeProps(
     {
       as: 'span',
-      ref: useMergedRefs(ref, React.useRef<HTMLElement>(null)),
+      ref,
       icon: { as: 'span' },
     },
     defaultProps,

--- a/packages/react-avatar/src/components/Image/Image.types.tsx
+++ b/packages/react-avatar/src/components/Image/Image.types.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 export interface ImageProps extends ComponentProps, React.ImgHTMLAttributes<HTMLImageElement> {}
 
-export type ImageState = ImageProps;
+export type ImageState = ComponentState<ImageProps>;

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -36,7 +36,7 @@ export type BadgeSize = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 
 // @public (undocumented)
 export interface BadgeState extends BadgeProps {
     icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
-    ref: React.MutableRefObject<HTMLElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public
@@ -57,7 +57,7 @@ export interface CounterBadgeProps extends Omit<BadgeProps, 'appearance' | 'shap
 }
 
 // @public
-export const counterBadgeShorthandProps: string[];
+export const counterBadgeShorthandProps: readonly ["icon"];
 
 // @public (undocumented)
 export interface CounterBadgeState extends BadgeState {

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -57,7 +57,7 @@ export interface BadgeState extends BadgeProps {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement>;
   /**
    * Icon slot when processed by internal state
    */

--- a/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
+++ b/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { makeMergeProps } from '@fluentui/react-utilities';
+import { makeMergePropsCompat } from '@fluentui/react-utilities';
 import { CounterBadgeProps, CounterBadgeState } from './CounterBadge.types';
 import { useBadge, BadgeProps } from '../Badge/index';
 
 /**
  * Consts listing which props are shorthand props.
  */
-export const counterBadgeShorthandProps: string[] = ['icon'];
+export const counterBadgeShorthandProps = ['icon'] as const;
 
-const mergeProps = makeMergeProps<CounterBadgeState>({ deepMerge: counterBadgeShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<CounterBadgeState>({ deepMerge: counterBadgeShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps } from '@fluentui/react-utilities';
+import { makeMergePropsCompat } from '@fluentui/react-utilities';
 import { PresenceBadgeProps, PresenceBadgeState, PresenceBadgeStatus } from './PresenceBadge.types';
 import { useBadge, BadgeProps } from '../Badge/index';
 import {
@@ -15,7 +15,8 @@ import {
  */
 export const presenceBadgeShorthandProps: (keyof PresenceBadgeProps)[] = ['icon'];
 
-const mergeProps = makeMergeProps<PresenceBadgeState>({ deepMerge: presenceBadgeShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<PresenceBadgeState>({ deepMerge: presenceBadgeShorthandProps });
 
 const iconMap: (outOfOffice: boolean) => Record<PresenceBadgeStatus, JSX.Element | null> = outOfOffice => ({
   busy: <SkypeMinusIcon />,

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -30,7 +30,7 @@ export type ButtonProps = ComponentProps & React.ButtonHTMLAttributes<HTMLElemen
 };
 
 // @public
-export const buttonShorthandProps: string[];
+export const buttonShorthandProps: readonly ["icon", "children"];
 
 // @public (undocumented)
 export interface ButtonState extends ButtonProps {
@@ -39,7 +39,7 @@ export interface ButtonState extends ButtonProps {
     // (undocumented)
     icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
     // (undocumented)
-    ref: React.RefObject<HTMLButtonElement>;
+    ref: React.Ref<HTMLElement>;
 }
 
 // @public (undocumented)

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -57,7 +57,7 @@ export type ButtonProps = ComponentProps &
  * {@docCategory Button}
  */
 export interface ButtonState extends ButtonProps {
-  ref: React.RefObject<HTMLButtonElement>;
+  ref: React.Ref<HTMLElement>;
 
   icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
   children?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps } from '@fluentui/react-utilities';
 import { ButtonProps, ButtonState } from './Button.types';
 import { useButtonState } from './useButtonState';
 
 /**
  * Consts listing which props are shorthand props.
  */
-export const buttonShorthandProps = ['icon', 'children'];
+export const buttonShorthandProps = ['icon', 'children'] as const;
 
-const mergeProps = makeMergeProps<ButtonState>({ deepMerge: buttonShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<ButtonState>({ deepMerge: buttonShorthandProps });
 
 /**
  * Given user props, returns state and render function for a Button.
@@ -17,7 +18,7 @@ export const useButton = (props: ButtonProps, ref: React.Ref<HTMLElement>, defau
   // Ensure that the `ref` prop can be used by other things (like useFocusRects) to refer to the root.
   // NOTE: We are assuming refs should not mutate to undefined. Either they are passed or not.
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const resolvedRef = ref || React.useRef();
+  const resolvedRef = ref || React.useRef<HTMLElement>(null);
   const state = mergeProps(
     {
       ref: resolvedRef,

--- a/packages/react-cards/etc/react-cards.api.md
+++ b/packages/react-cards/etc/react-cards.api.md
@@ -69,7 +69,7 @@ export interface CardSectionState extends CardSectionProps {
 // @public (undocumented)
 export interface CardState extends CardProps {
     // (undocumented)
-    ref: React.RefObject<HTMLDivElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public (undocumented)

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -46,5 +46,5 @@ export type CardProps = ComponentProps &
  * {@docCategory Card}
  */
 export interface CardState extends CardProps {
-  ref: React.RefObject<HTMLDivElement>;
+  ref: React.RefObject<HTMLElement>;
 }

--- a/packages/react-cards/src/components/Card/useCard.ts
+++ b/packages/react-cards/src/components/Card/useCard.ts
@@ -12,7 +12,7 @@ const mergeProps = makeMergeProps<CardState>({ deepMerge: [] });
 export const useCard = (props: CardProps, ref: React.Ref<HTMLElement>, defaultProps?: CardProps) => {
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef()),
+      ref: useMergedRefs(ref, React.useRef<HTMLElement>(null)),
       as: 'div',
     },
     defaultProps,

--- a/packages/react-divider/etc/react-divider.api.md
+++ b/packages/react-divider/etc/react-divider.api.md
@@ -45,12 +45,12 @@ export interface DividerProps extends ComponentProps, React.HTMLAttributes<HTMLE
 }
 
 // @public
-export const dividerShorthandProps: string[];
+export const dividerShorthandProps: readonly ["wrapper", "children"];
 
 // @public (undocumented)
 export interface DividerState extends DividerProps {
     labelledById?: string;
-    ref: React.MutableRefObject<HTMLElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -76,7 +76,7 @@ export interface DividerState extends DividerProps {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement>;
 
   /**
    * The Id created to expose accessability for readers

--- a/packages/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-divider/src/components/Divider/useDivider.ts
@@ -5,7 +5,7 @@ import { DividerProps, DividerState } from './Divider.types';
 /**
  * Consts listing which props are shorthand props.
  */
-export const dividerShorthandProps = ['wrapper', 'children'];
+export const dividerShorthandProps = ['wrapper', 'children'] as const;
 
 const mergeProps = makeMergeProps<DividerState>({ deepMerge: dividerShorthandProps });
 

--- a/packages/react-flex/etc/react-flex.api.md
+++ b/packages/react-flex/etc/react-flex.api.md
@@ -19,7 +19,7 @@ export const flexShorthandProps: (keyof FlexProps)[];
 
 // @public (undocumented)
 export interface FlexState extends FlexProps {
-    ref: React.MutableRefObject<HTMLElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public

--- a/packages/react-flex/src/components/Flex/Flex.types.ts
+++ b/packages/react-flex/src/components/Flex/Flex.types.ts
@@ -15,5 +15,5 @@ export interface FlexState extends FlexProps {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement>;
 }

--- a/packages/react-focus-management/src/FocusManagementProvider.tsx
+++ b/packages/react-focus-management/src/FocusManagementProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, useMergedRefs } from '@fluentui/react-utilities';
 import { getCurrentAbilityHelpers, createAbilityHelpers, Types as AHTypes } from 'ability-helpers';
 import { internal__FocusManagementContext, FocusManagementContextValue } from './focusManagementContext';
 
@@ -24,7 +24,8 @@ export interface FocusManagementProviderState extends FocusManagementProvideProp
   contextValue: FocusManagementContextValue;
 }
 
-const mergeProps = makeMergeProps<FocusManagementProviderState>();
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<FocusManagementProviderState>();
 
 export const useFocusManagementProvider = (
   props: FocusManagementProvideProps,

--- a/packages/react-image/etc/react-image.api.md
+++ b/packages/react-image/etc/react-image.api.md
@@ -24,7 +24,7 @@ export interface ImageProps extends ComponentProps, React.ImgHTMLAttributes<HTML
 // @public (undocumented)
 export interface ImageState extends ImageProps {
     // (undocumented)
-    ref: React.RefObject<HTMLImageElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public

--- a/packages/react-image/src/components/Image/Image.types.ts
+++ b/packages/react-image/src/components/Image/Image.types.ts
@@ -39,5 +39,5 @@ export interface ImageProps extends ComponentProps, React.ImgHTMLAttributes<HTML
 }
 
 export interface ImageState extends ImageProps {
-  ref: React.RefObject<HTMLImageElement>;
+  ref: React.RefObject<HTMLElement>;
 }

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -38,6 +38,8 @@ export const linkShorthandProps: never[];
 
 // @public (undocumented)
 export interface LinkState extends LinkProps {
+    // (undocumented)
+    ref: React.Ref<HTMLElement>;
 }
 
 // @public

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -70,7 +70,9 @@ export type LinkProps = ComponentProps &
 /**
  * {@docCategory Link}
  */
-export interface LinkState extends LinkProps {}
+export interface LinkState extends LinkProps {
+  ref: React.Ref<HTMLElement>;
+}
 
 // /**
 //  * {@docCategory Link}

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -65,7 +65,7 @@ export interface MenuItemCheckboxProps extends ComponentProps, React.HTMLAttribu
 }
 
 // @public
-export const menuItemCheckboxShorthandProps: string[];
+export const menuItemCheckboxShorthandProps: readonly ["icon", "checkmark"];
 
 // @public (undocumented)
 export interface MenuItemCheckboxState extends MenuItemCheckboxProps, MenuItemState, MenuItemSelectableState {
@@ -92,7 +92,7 @@ export interface MenuItemRadioProps extends ComponentProps, React.HTMLAttributes
 }
 
 // @public
-export const menuItemRadioShorthandProps: string[];
+export const menuItemRadioShorthandProps: readonly ["icon", "checkmark"];
 
 // @public (undocumented)
 export interface MenuItemRadioState extends MenuItemRadioProps, MenuItemSelectableState {
@@ -116,7 +116,7 @@ export interface MenuItemSelectableState extends MenuItemSelectableProps {
 }
 
 // @public
-export const menuItemShorthandProps: string[];
+export const menuItemShorthandProps: readonly ["icon"];
 
 // @public (undocumented)
 export interface MenuItemState extends MenuItemProps {

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  makeMergeProps,
+  makeMergePropsCompat,
   resolveShorthandProps,
   useMergedRefs,
   useControllableValue,
@@ -14,7 +14,8 @@ import { getCode, keyboardKey } from '@fluentui/keyboard-key';
 
 export const menuShorthandProps: (keyof MenuProps)[] = ['menuPopup'];
 
-const mergeProps = makeMergeProps<MenuState>({ deepMerge: menuShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuState>({ deepMerge: menuShorthandProps });
 
 /**
  * Create the state required to render Menu.

--- a/packages/react-menu/src/components/MenuDivider/useMenuDivider.ts
+++ b/packages/react-menu/src/components/MenuDivider/useMenuDivider.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuDividerProps, MenuDividerState } from './MenuDivider.types';
 
-const mergeProps = makeMergeProps<MenuDividerState>({});
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuDividerState>({});
 
 /**
  * Given user props, returns state and render function for a MenuDivider.

--- a/packages/react-menu/src/components/MenuGroup/useMenuGroup.ts
+++ b/packages/react-menu/src/components/MenuGroup/useMenuGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs, useId } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs, useId } from '@fluentui/react-utilities';
 import { MenuGroupProps, MenuGroupState } from './MenuGroup.types';
 
 /**
@@ -7,7 +7,8 @@ import { MenuGroupProps, MenuGroupState } from './MenuGroup.types';
  */
 export const menuGroupShorthandProps = ['loader', 'content'];
 
-const mergeProps = makeMergeProps<MenuGroupState>({ deepMerge: menuGroupShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuGroupState>({ deepMerge: menuGroupShorthandProps });
 
 /**
  * Given user props, returns state and render function for a MenuGroup.

--- a/packages/react-menu/src/components/MenuGroupHeader/useMenuGroupHeader.ts
+++ b/packages/react-menu/src/components/MenuGroupHeader/useMenuGroupHeader.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuGroupHeaderProps, MenuGroupHeaderState } from './MenuGroupHeader.types';
 import { useMenuGroupContext } from '../../menuGroupContext';
 
-const mergeProps = makeMergeProps<MenuGroupHeaderState>({});
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuGroupHeaderState>({});
 
 /**
  * Given user props, returns state and render function for a MenuGroupHeader.

--- a/packages/react-menu/src/components/MenuItem/useMenuItem.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItem.ts
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuItemProps, MenuItemState } from './MenuItem.types';
 import { useCharacterSearch } from '../../utils/useCharacterSearch';
 
 /**
  * Consts listing which props are shorthand props.
  */
-export const menuItemShorthandProps = ['icon'];
+export const menuItemShorthandProps = ['icon'] as const;
 
-const mergeProps = makeMergeProps<MenuItemState>({ deepMerge: menuItemShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuItemState>({ deepMerge: menuItemShorthandProps });
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
 import { useMenuItemSelectable } from '../../selectable/index';
 import { useCharacterSearch } from '../../utils/useCharacterSearch';
@@ -8,9 +8,10 @@ import { useMenuListContext } from '../../menuListContext';
 /**
  * Consts listing which props are shorthand props.
  */
-export const menuItemCheckboxShorthandProps = ['icon', 'checkmark'];
+export const menuItemCheckboxShorthandProps = ['icon', 'checkmark'] as const;
 
-const mergeProps = makeMergeProps<MenuItemCheckboxState>({ deepMerge: menuItemCheckboxShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuItemCheckboxState>({ deepMerge: menuItemCheckboxShorthandProps });
 
 /** Returns the props and state required to render the component */
 export const useMenuItemCheckbox = (

--- a/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadio.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio.types';
 import { useMenuItemSelectable } from '../../selectable/index';
 import { useCharacterSearch } from '../../utils/useCharacterSearch';
@@ -8,9 +8,10 @@ import { useMenuListContext } from '../../menuListContext';
 /**
  * Consts listing which props are shorthand props.
  */
-export const menuItemRadioShorthandProps = ['icon', 'checkmark'];
+export const menuItemRadioShorthandProps = ['icon', 'checkmark'] as const;
 
-const mergeProps = makeMergeProps<MenuItemRadioState>({ deepMerge: menuItemRadioShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuItemRadioState>({ deepMerge: menuItemRadioShorthandProps });
 
 /**
  * Given user props, returns state and render function for a MenuItemRadio.

--- a/packages/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuList.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  makeMergeProps,
+  makeMergePropsCompat,
   resolveShorthandProps,
   useMergedRefs,
   useEventCallback,
@@ -10,7 +10,8 @@ import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-focus-
 import { MenuListProps, MenuListState } from './MenuList.types';
 import { useMenuContext } from '../../menuContext';
 
-const mergeProps = makeMergeProps<MenuListState>();
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuListState>();
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
+import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
 import { useTriggerElement } from './useTriggerElement';
 
 export const menuTriggerShorthandProps: (keyof MenuTriggerProps)[] = [];
 
-const mergeProps = makeMergeProps<MenuTriggerState>({ deepMerge: menuTriggerShorthandProps });
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<MenuTriggerState>({ deepMerge: menuTriggerShorthandProps });
 
 /**
  * Create the state required to render MenuTrigger.

--- a/packages/react-provider/src/FluentProvider.tsx
+++ b/packages/react-provider/src/FluentProvider.tsx
@@ -1,7 +1,7 @@
 import { PartialTheme, Theme } from '@fluentui/react-theme';
 import { internal__ThemeContext, ThemeProviderState, useThemeProviderState } from '@fluentui/react-theme-provider';
 import { FocusManagementProvider } from '@fluentui/react-focus-management';
-import { getSlots, makeMergeProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getSlots, makeMergePropsCompat, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { internal__FluentProviderContext, useFluent } from './context';
@@ -21,7 +21,8 @@ export interface ProviderState {
   theme: Theme;
 }
 
-const mergeProps = makeMergeProps<ProviderState>();
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<ProviderState>();
 
 export function useFluentProviderState(draftState: ProviderState) {
   const parentContext = useFluent();

--- a/packages/react-text/etc/react-text.api.md
+++ b/packages/react-text/etc/react-text.api.md
@@ -21,7 +21,7 @@ export interface TextProps extends ComponentProps, React.HTMLAttributes<HTMLSpan
 // @public (undocumented)
 export interface TextState extends TextProps {
     // (undocumented)
-    ref: React.MutableRefObject<HTMLElement>;
+    ref: React.RefObject<HTMLElement>;
 }
 
 // @public

--- a/packages/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-text/src/components/Text/Text.types.ts
@@ -7,5 +7,5 @@ export interface TextProps extends ComponentProps, React.HTMLAttributes<HTMLSpan
 }
 
 export interface TextState extends TextProps {
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement>;
 }

--- a/packages/react-text/src/components/Text/useText.tsx
+++ b/packages/react-text/src/components/Text/useText.tsx
@@ -11,7 +11,7 @@ const mergeProps = makeMergeProps<TextState>();
 export const useText = (props: TextProps, ref: React.Ref<HTMLElement>, defaultProps?: TextProps): TextState => {
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef()),
+      ref: useMergedRefs(ref, React.useRef(null)),
       as: 'span',
     },
     defaultProps,

--- a/packages/react-theme-provider/src/ThemeProvider.tsx
+++ b/packages/react-theme-provider/src/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { mergeThemes, themeToCSSVariables, PartialTheme, Theme } from '@fluentui/react-theme';
-import { getSlots, makeMergeProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getSlots, makeMergePropsCompat, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { internal__ThemeContext, useTheme } from './context';
@@ -11,7 +11,8 @@ export interface ThemeProviderState extends React.HTMLAttributes<HTMLElement> {
   theme: Theme;
 }
 
-const mergeProps = makeMergeProps<ThemeProviderState>();
+// eslint-disable-next-line deprecation/deprecation
+const mergeProps = makeMergePropsCompat<ThemeProviderState>();
 
 export function useThemeProviderState(draftState: ThemeProviderState) {
   const parentTheme = useTheme();

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -120,7 +120,7 @@ export type MergePropsOptions<TState> = {
 export const nullRender: () => null;
 
 // @public (undocumented)
-export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & {
+export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & ComponentProps & {
     children?: TProps['children'] | ShorthandRenderFunction<TProps>;
 };
 

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -50,6 +50,12 @@ export interface ComponentProps {
 }
 
 // @public
+export type ComponentState<Props, ShorthandProps extends keyof Props = never, DefaultedProps extends keyof ResolvedShorthandProps<Props, ShorthandProps> = never, RefType = React.Ref<HTMLElement>> = RequiredProps<ResolvedShorthandProps<Props, ShorthandProps>, DefaultedProps> & {
+    as?: React.ElementType;
+    ref: RefType;
+};
+
+// @public
 export const divProperties: Record<string, number>;
 
 // @public
@@ -65,7 +71,7 @@ export function getNativeElementProps<TAttributes extends React.HTMLAttributes<a
 export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
 
 // @public
-export const getSlots: (state: Record<string, any>, slotNames?: string[] | undefined) => {
+export const getSlots: (state: Record<string, any>, slotNames?: readonly string[] | undefined) => {
     slots: Record<string, any>;
     slotProps: Record<string, any>;
 };
@@ -92,11 +98,22 @@ export const labelProperties: Record<string, number>;
 export const liProperties: Record<string, number>;
 
 // @public
-export const makeMergeProps: <TState = Record<string, any>>(options?: MergePropsOptions) => (target: Record<string, any>, ...propSets: (Record<string, any> | undefined)[]) => TState;
+export const makeMergeProps: <TState = Record<string, any>, TProps = Record<string, any>>(options?: MergePropsOptions<TState>) => MergePropsFunction<TState, TProps>;
+
+// @public
+export const makeMergePropsCompat: <TState = Record<string, any>>(options?: MergePropsCompatOptions) => (target: Record<string, any>, ...propSets: (Record<string, any> | undefined)[]) => TState;
 
 // @public (undocumented)
-export type MergePropsOptions = {
-    deepMerge?: string[];
+export type MergePropsCompatOptions = {
+    deepMerge?: readonly string[];
+};
+
+// @public
+export type MergePropsFunction<TState, TProps> = (target: TState, ...propSets: (Partial<TState | TProps> | undefined)[]) => TState;
+
+// @public (undocumented)
+export type MergePropsOptions<TState> = {
+    deepMerge?: readonly (keyof TState)[];
 };
 
 // @public
@@ -120,7 +137,17 @@ export const optionProperties: Record<string, number>;
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 // @public
-export const resolveShorthandProps: <TProps>(props: TProps, shorthandPropNames: string[]) => TProps;
+export type RequiredProps<T, K extends keyof T> = Omit<T, K> & {
+    [P in K]-?: T[P];
+};
+
+// @public
+export type ResolvedShorthandProps<T, K extends keyof T> = Omit<T, K> & {
+    [P in K]: T[P] extends ShorthandProps<infer U> ? ObjectShorthandProps<U> : T[P];
+};
+
+// @public
+export const resolveShorthandProps: <TProps, TShorthandPropNames extends keyof TProps>(props: TProps, shorthandPropNames: readonly TShorthandPropNames[]) => ResolvedShorthandProps<TProps, TShorthandPropNames>;
 
 // @public
 export const selectProperties: Record<string, number>;

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -100,13 +100,8 @@ export const liProperties: Record<string, number>;
 // @public
 export const makeMergeProps: <TState = Record<string, any>, TProps = Record<string, any>>(options?: MergePropsOptions<TState>) => MergePropsFunction<TState, TProps>;
 
-// @public
-export const makeMergePropsCompat: <TState = Record<string, any>>(options?: MergePropsCompatOptions) => (target: Record<string, any>, ...propSets: (Record<string, any> | undefined)[]) => TState;
-
-// @public (undocumented)
-export type MergePropsCompatOptions = {
-    deepMerge?: readonly string[];
-};
+// @public @deprecated
+export const makeMergePropsCompat: <TState = Record<string, any>>(options?: MergePropsOptions<Record<string, any>>) => (target: Record<string, any>, ...propSets: (Record<string, any> | undefined)[]) => TState;
 
 // @public
 export type MergePropsFunction<TState, TProps> = (target: TState, ...propSets: (Partial<TState | TProps> | undefined)[]) => TState;
@@ -120,7 +115,7 @@ export type MergePropsOptions<TState> = {
 export const nullRender: () => null;
 
 // @public (undocumented)
-export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & ComponentProps & {
+export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & Omit<ComponentProps, 'children'> & {
     children?: TProps['children'] | ShorthandRenderFunction<TProps>;
 };
 

--- a/packages/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-utilities/src/compose/getSlots.ts
@@ -20,7 +20,7 @@ import { nullRender } from './nullRender';
  * @param slotNames - Name of which props are slots
  * @returns An object containing the `slots` map and `slotProps` map.
  */
-export const getSlots = (state: GenericDictionary, slotNames?: string[] | undefined) => {
+export const getSlots = (state: GenericDictionary, slotNames?: readonly string[]) => {
   const slots: GenericDictionary = {
     root: state.as || 'div',
   };

--- a/packages/react-utilities/src/compose/index.ts
+++ b/packages/react-utilities/src/compose/index.ts
@@ -1,5 +1,6 @@
 export * from './getSlots';
 export * from './makeMergeProps';
+export * from './makeMergePropsCompat';
 export * from './nullRender';
 export * from './resolveShorthandProps';
 export * from './types';

--- a/packages/react-utilities/src/compose/makeMergeProps.test.tsx
+++ b/packages/react-utilities/src/compose/makeMergeProps.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { makeMergeProps } from './makeMergeProps';
+import { GenericDictionary } from './types';
 
 describe('mergeProps', () => {
-  const basicMergeProps = makeMergeProps({ deepMerge: ['a', 'b', 'c', 'd', 'e', 'f'] });
+  const basicMergeProps = makeMergeProps<GenericDictionary>({ deepMerge: ['a', 'b', 'c', 'd', 'e', 'f'] });
 
   it('can merge objects', () => {
     expect(basicMergeProps({ a: 1, b: 1 }, { b: 2, c: 2 }, { c: 3, d: 3 })).toEqual({ a: 1, b: 2, c: 3, d: 3 });

--- a/packages/react-utilities/src/compose/makeMergePropsCompat.ts
+++ b/packages/react-utilities/src/compose/makeMergePropsCompat.ts
@@ -1,125 +1,16 @@
-import * as React from 'react';
-
+import { makeMergeProps, MergePropsOptions } from './makeMergeProps';
 import { GenericDictionary } from './types';
 
-// TODO
-// css() function is temporary there, ax() should be used instead, but it's not possible now due possible
-// circular dependencies
-
 /**
- * Dictionary of booleans.
+ * Backwards-compatible version of makeMergeProps that has less restrictive type checking
  *
- * @internal
+ * @deprecated Use makeMergeProps instead
  */
-interface Dictionary {
-  [className: string]: boolean;
-}
-
-/**
- * Serializable object.
- *
- * @internal
- */
-interface SerializableObject {
-  toString?: () => string;
-}
-
-/**
- * css input type.
- *
- * @internal
- */
-type CssInput = string | SerializableObject | Dictionary | null | undefined | boolean;
-
-/**
- * Concatination helper, which can merge class names together. Skips over falsey values.
- *
- * @public
- */
-function css(...args: CssInput[]): string {
-  const classes = [];
-
-  for (const arg of args) {
-    if (arg) {
-      if (typeof arg === 'string') {
-        classes.push(arg);
-      } else if (arg.hasOwnProperty('toString') && typeof arg.toString === 'function') {
-        classes.push(arg.toString());
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        for (const key in arg as any) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if ((arg as any)[key]) {
-            classes.push(key);
-          }
-        }
-      }
-    }
-  }
-
-  return classes.join(' ');
-}
-
-export type MergePropsCompatOptions = {
-  /**
-   * A list of props to deep merge. By default, `style` will
-   * always be deep merged so it's not required to be provided.
-   */
-  deepMerge?: readonly string[];
-};
-
-/**
- * Helper which deep clones props, but respectively assigns JSX, object refs, and class names
- * appropriately.
- *
- * @param target - the target object to merge onto.
- * @param propSets - one or more prop sets to deep merge onto the target.
- */
-export const makeMergePropsCompat = <TState = GenericDictionary>(options: MergePropsCompatOptions = {}) => {
-  const deepMerge = [...(options.deepMerge || []), 'style'];
-
-  const mergeProps = (target: GenericDictionary, ...propSets: (GenericDictionary | undefined)[]): TState => {
-    for (const props of propSets) {
-      if (props) {
-        for (const propName of Object.keys(props)) {
-          const propValue = props[propName];
-          const propValueType = typeof propValue;
-
-          if (propValue !== undefined) {
-            if (propValue && propValueType === 'object') {
-              if (Array.isArray(propValue)) {
-                // for arrays, replace.
-                target[propName] = propValue;
-              } else {
-                target[propName] = target[propName] || {};
-
-                if (
-                  typeof target[propName] !== 'object' ||
-                  React.isValidElement(propValue) ||
-                  (propValue && typeof propValue === 'object' && propValue.hasOwnProperty('current')) ||
-                  deepMerge.indexOf(propName) === -1
-                ) {
-                  // if target is not an object, or value is JSX,  or a ref object, replace
-                  target[propName] = propValue;
-                } else {
-                  // else deep merge.
-                  mergeProps(target[propName], propValue);
-                }
-              }
-            } else if (propName === 'className') {
-              if (propValue) {
-                // for classnames, append
-                target[propName] = css(target[propName], propValue);
-              }
-            } else {
-              target[propName] = propValue;
-            }
-          }
-        }
-      }
-    }
-    return target as TState;
-  };
-
-  return mergeProps;
+export const makeMergePropsCompat = <TState = GenericDictionary>(
+  options: MergePropsOptions<GenericDictionary> = {},
+) => {
+  return makeMergeProps(options) as (
+    target: GenericDictionary,
+    ...propSets: (GenericDictionary | undefined)[]
+  ) => TState;
 };

--- a/packages/react-utilities/src/compose/makeMergePropsCompat.ts
+++ b/packages/react-utilities/src/compose/makeMergePropsCompat.ts
@@ -60,21 +60,13 @@ function css(...args: CssInput[]): string {
   return classes.join(' ');
 }
 
-export type MergePropsOptions<TState> = {
+export type MergePropsCompatOptions = {
   /**
    * A list of props to deep merge. By default, `style` will
    * always be deep merged so it's not required to be provided.
    */
-  deepMerge?: readonly (keyof TState)[];
+  deepMerge?: readonly string[];
 };
-
-/**
- * The return type from makeMergeProps
- */
-export type MergePropsFunction<TState, TProps> = (
-  target: TState,
-  ...propSets: (Partial<TState | TProps> | undefined)[]
-) => TState;
 
 /**
  * Helper which deep clones props, but respectively assigns JSX, object refs, and class names
@@ -83,9 +75,7 @@ export type MergePropsFunction<TState, TProps> = (
  * @param target - the target object to merge onto.
  * @param propSets - one or more prop sets to deep merge onto the target.
  */
-export const makeMergeProps = <TState = GenericDictionary, TProps = GenericDictionary>(
-  options: MergePropsOptions<TState> = {},
-): MergePropsFunction<TState, TProps> => {
+export const makeMergePropsCompat = <TState = GenericDictionary>(options: MergePropsCompatOptions = {}) => {
   const deepMerge = [...(options.deepMerge || []), 'style'];
 
   const mergeProps = (target: GenericDictionary, ...propSets: (GenericDictionary | undefined)[]): TState => {

--- a/packages/react-utilities/src/compose/resolveShorthandProps.tsx
+++ b/packages/react-utilities/src/compose/resolveShorthandProps.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ObjectShorthandProps, ResolvedShorthandProps } from './types';
 
 /**
  * Ensures that the given slots are represented using object syntax. This ensures that
@@ -6,7 +7,10 @@ import * as React from 'react';
  * @param props - The incoming props
  * @param shorthandPropNames - An array of prop names to apply simplification to
  */
-export const resolveShorthandProps = <TProps,>(props: TProps, shorthandPropNames: string[]) => {
+export const resolveShorthandProps = <TProps, TShorthandPropNames extends keyof TProps>(
+  props: TProps,
+  shorthandPropNames: readonly TShorthandPropNames[],
+): ResolvedShorthandProps<TProps, TShorthandPropNames> => {
   let newProps = props;
 
   if (shorthandPropNames && shorthandPropNames.length) {
@@ -14,17 +18,13 @@ export const resolveShorthandProps = <TProps,>(props: TProps, shorthandPropNames
       ...props,
     };
     for (const propName of shorthandPropNames) {
-      // TODO find clean way of guaranteeing only shorthand props are typechecked
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const propValue = props[propName];
 
       if (propValue !== undefined && (typeof propValue !== 'object' || React.isValidElement(propValue))) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (newProps as any)[propName] = { children: propValue };
+        (newProps[propName] as ObjectShorthandProps) = { children: propValue };
       }
     }
   }
 
-  return newProps as TProps;
+  return (newProps as unknown) as ResolvedShorthandProps<TProps, TShorthandPropNames>;
 };

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -35,7 +35,7 @@ export type ShorthandProps<TProps extends ComponentProps = {}> =
       });
 
 export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps &
-  ComponentProps & {
+  Omit<ComponentProps, 'children'> & {
     children?: TProps['children'] | ShorthandRenderFunction<TProps>;
   };
 

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -48,3 +48,31 @@ export type SlotProps<TSlots extends BaseSlots, TProps, TRootProps extends React
 } & {
   root: TRootProps;
 };
+
+/**
+ * Helper type to convert the given props of type ShorthandProps into ObjectShorthandProps
+ */
+export type ResolvedShorthandProps<T, K extends keyof T> = Omit<T, K> &
+  { [P in K]: T[P] extends ShorthandProps<infer U> ? ObjectShorthandProps<U> : T[P] };
+
+/**
+ * Helper type to mark the given props as required.
+ * Similar to Required<T> except it only requires a subset of the props.
+ */
+export type RequiredProps<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: T[P] };
+
+/**
+ * Converts a components Props type to a State type:
+ * * Adds the 'ref' and 'as' props
+ * * Ensures the specified ShorthandProps are of type ObjectShorthandProps<T>
+ * * Marks the given DefaultedProps as required (-?)
+ */
+export type ComponentState<
+  Props,
+  ShorthandProps extends keyof Props = never,
+  DefaultedProps extends keyof ResolvedShorthandProps<Props, ShorthandProps> = never,
+  RefType = React.Ref<HTMLElement>
+> = RequiredProps<ResolvedShorthandProps<Props, ShorthandProps>, DefaultedProps> & {
+  as?: React.ElementType;
+  ref: RefType;
+};

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -34,9 +34,10 @@ export type ShorthandProps<TProps extends ComponentProps = {}> =
         children?: TProps['children'] | ShorthandRenderFunction<TProps>;
       });
 
-export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & {
-  children?: TProps['children'] | ShorthandRenderFunction<TProps>;
-};
+export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps &
+  ComponentProps & {
+    children?: TProps['children'] | ShorthandRenderFunction<TProps>;
+  };
 
 export interface BaseSlots {
   root: React.ElementType;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses changes discussed in RFC #17232
- [x] Include a change request file using `$ yarn change`

#### Description of changes

* Add `ComponentState` helper type that defines the State type from the Props type, for converged components
* Improve type checking for `mergeProps`:
  * The first parameter must be a valid State object, and must provide values for every prop that should have a default
  * All other parameters must be partial State objects
* Make minor type fixes to some components, caught by the updated type checking
* Add `makeMergePropsCompat` function that maintains the more permissive type checking for components that require more involved fixes