### PR TITLE
Charting: Callout dismiss on ESC issue solved in all bar charts

### DIFF
--- a/change/@fluentui-react-charting-8ece3e6e-0dea-4be6-a2cb-ed3252ad7b56.json
+++ b/change/@fluentui-react-charting-8ece3e6e-0dea-4be6-a2cb-ed3252ad7b56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "callout dismiss on escape issue resolved",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-8ece3e6e-0dea-4be6-a2cb-ed3252ad7b56.json
+++ b/change/@fluentui-react-charting-8ece3e6e-0dea-4be6-a2cb-ed3252ad7b56.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "callout dismiss on escape issue resolved",
   "packageName": "@fluentui/react-charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -133,6 +133,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       gapSpace: 15,
       isBeakVisible: false,
       setInitialFocus: true,
+      onDismiss: this._closeCallout,
       ...this.props.calloutProps,
     };
     return (
@@ -613,5 +614,11 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     } else {
       return 0;
     }
+  };
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
   };
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -119,6 +119,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
       Legend: this.state.titleForHoverCard,
       XValue: this.state.xCalloutValue,
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
+      onDismiss: this._closeCallout,
       ...this.props.calloutProps,
     };
     const tickParams = {
@@ -370,6 +371,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
       .domain(this._keys)
       .range(this._isRtl ? [xScale0.bandwidth(), 0] : [0, xScale0.bandwidth()])
       .padding(0.05);
+  };
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
   };
 
   private _onLegendClick(customMessage: string): void {

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -174,6 +174,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
       target: this.state.target,
       styles: this._classNames.subComponentStyles.calloutStyles,
       directionalHint: DirectionalHint.bottomLeftEdge,
+      onDismiss: this._closeCallout,
     };
     const chartHoverProps: IModifiedCartesianChartProps['chartHoverProps'] = {
       ...(this.state.ratio && {
@@ -652,5 +653,11 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
   private _getFormattedLabelForYAxisDataPoint = (point: string): string => {
     const { yAxisStringFormatter } = this.props;
     return yAxisStringFormatter ? yAxisStringFormatter(point) : point;
+  };
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
   };
 }

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -115,6 +115,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
             hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
             directionalHint={DirectionalHint.rightTopEdge}
             id={this._calloutId}
+            onDismiss={this._closeCallout}
             {...this.props.calloutProps!}
           >
             {this.props.onRenderCalloutPerHorizontalBar ? (
@@ -277,4 +278,10 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     });
     return bars;
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
+  };
 }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -97,6 +97,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           hidden={!(!this.props.hideTooltip && isCalloutVisible)}
           directionalHint={DirectionalHint.topRightEdge}
           id={this._calloutId}
+          onDismiss={this._closeCallout}
           {...this.props.calloutProps!}
         >
           {this.props.onRenderCalloutPerDataPoint ? (
@@ -397,4 +398,10 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
   private _redirectToUrl(href: string | undefined): void {
     href ? (window.location.href = href) : '';
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
+  };
 }

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -142,6 +142,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
                 hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
                 directionalHint={DirectionalHint.topRightEdge}
                 id={this._calloutId}
+                onDismiss={this._closeCallout}
                 {...this.props.calloutProps}
               >
                 {this.props.onRenderCalloutPerDataPoint ? (
@@ -405,4 +406,10 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
   private _redirectToUrl(href: string | undefined): void {
     href ? (window.location.href = href) : '';
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
+  };
 }

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -115,6 +115,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       legend: this.state.selectedLegendTitle,
       XValue: this.state.xCalloutValue,
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
+      onDismiss: this._closeCallout,
       ...this.props.calloutProps,
     };
     const tickParams = {
@@ -553,6 +554,12 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     }
     return bars;
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
+  };
 
   private _onLegendClick(customMessage: string): void {
     if (this.state.isLegendSelected) {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -142,6 +142,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
       YValueHover: this.state.YValueHover,
       hoverXValue: this.state.hoverXValue,
+      onDismiss: this._closeCallout,
       ...this.props.calloutProps,
     };
     const tickParams = {
@@ -850,5 +851,11 @@ export class VerticalStackedBarChartBase extends React.Component<
       this._xAxisType === XAxisTypes.NumericAxis
         ? this._createNumericBars(containerHeight, containerWidth, xElement!)
         : this._createStringBars(containerHeight, containerWidth, xElement!));
+  };
+
+  private _closeCallout = () => {
+    this.setState({
+      isCalloutVisible: false,
+    });
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/17551
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added onDismiss prop to callout props which enables callout dismiss on ESC click

#### Focus areas to test

All Charts
