### PR TITLE
fix: fix performance test for ButtonNext

### DIFF
--- a/apps/perf-test/src/scenarios/ButtonNext.tsx
+++ b/apps/perf-test/src/scenarios/ButtonNext.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
+import { FluentProvider } from '@fluentui/react-provider';
+import { webLightTheme } from '@fluentui/react-theme';
 
 const Scenario = () => <Button>I am a button</Button>;
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
 
 export default Scenario;


### PR DESCRIPTION
#### Description of changes

Currently it fails because there is no `Provider`:

![TypeError: Cannot read property 'neutral' of undefined](https://user-images.githubusercontent.com/14183168/112489963-400eb200-8d7f-11eb-87f7-16f55df83502.png)
