### PR TITLE
[web-components] fix number field outline color

### DIFF
--- a/change/@fluentui-web-components-4d049dd9-298f-4ff2-a526-906f0d233cb2.json
+++ b/change/@fluentui-web-components-4d049dd9-298f-4ff2-a526-906f0d233cb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "correct outline color for number field to ensure alignment w/ other inputs",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -2,9 +2,6 @@ import { css } from '@microsoft/fast-element';
 import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
-  accentFillActiveBehavior,
-  accentFillHoverBehavior,
-  accentFillRestBehavior,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -12,6 +9,8 @@ import {
   neutralFillRestBehavior,
   neutralFocusBehavior,
   neutralForegroundRestBehavior,
+  neutralOutlineActiveBehavior,
+  neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
 } from '../styles/index';
 import { appearanceBehavior } from '../utilities/behaviors';
@@ -60,7 +59,7 @@ export const NumberFieldStyles = css`
         color: ${neutralForegroundRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
         border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
         height: calc(${heightNumber} * 1px);
     }
 
@@ -152,12 +151,12 @@ export const NumberFieldStyles = css`
 
     :host(:hover:not([disabled])) .root {
         background: ${neutralFillInputHoverBehavior.var};
-        border-color: ${accentFillHoverBehavior.var};
+        border-color: ${neutralOutlineHoverBehavior.var};
     }
 
     :host(:active:not([disabled])) .root {
         background: ${neutralFillInputHoverBehavior.var};
-        border-color: ${accentFillActiveBehavior.var};
+        border-color: ${neutralOutlineActiveBehavior.var};
     }
 
     :host(:focus-within:not([disabled])) .root {
@@ -186,15 +185,14 @@ export const NumberFieldStyles = css`
     }
 `.withBehaviors(
   appearanceBehavior('filled', NumberFieldFilledStyles),
-  accentFillActiveBehavior,
-  accentFillHoverBehavior,
-  accentFillRestBehavior,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
   neutralFillInputRestBehavior,
   neutralFillRestBehavior,
   neutralFocusBehavior,
   neutralForegroundRestBehavior,
+  neutralOutlineActiveBehavior,
+  neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
   forcedColorsStylesheetBehavior(
     css`


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fixes an issue where the incorrect color recipe was used for the number field component. This aligns number field with text field.

#### Focus areas to test

(optional)
