### PR TITLE
Update packages to call isConformant consistently (and use generic for props)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,7 @@
         "NODE_ENV": "test"
       },
       "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/packages/fluentui/*/dist/**/*.js"],
       "outputCapture": "std",
       "console": "integratedTerminal"
     },

--- a/change/@fluentui-react-accordion-304da6f2-a816-453d-a1d8-204b7c02e721.json
+++ b/change/@fluentui-react-accordion-304da6f2-a816-453d-a1d8-204b7c02e721.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-accordion",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-5c1e99d7-1540-45ae-855c-e6863f248cf3.json
+++ b/change/@fluentui-react-avatar-5c1e99d7-1540-45ae-855c-e6863f248cf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-dc0bcf1a-8b25-40c9-8306-8d731bf72960.json
+++ b/change/@fluentui-react-badge-dc0bcf1a-8b25-40c9-8306-8d731bf72960.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-bd32c42a-9c7d-4d0a-bb02-3382aeb72260.json
+++ b/change/@fluentui-react-bd32c42a-9c7d-4d0a-bb02-3382aeb72260.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-41b3ce38-0523-473b-ae4c-398a8fe310f9.json
+++ b/change/@fluentui-react-button-41b3ce38-0523-473b-ae4c-398a8fe310f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-bcc56bd3-391a-47d0-82fa-136a713b6c35.json
+++ b/change/@fluentui-react-checkbox-bcc56bd3-391a-47d0-82fa-136a713b6c35.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-38f8f079-da8c-4a2d-b111-ed8662932665.json
+++ b/change/@fluentui-react-conformance-38f8f079-da8c-4a2d-b111-ed8662932665.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option for disabling all as prop tests (instead of inferring from props) and remove exportSubdir option",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-0006d265-60ac-4455-9c9d-71514b47489b.json
+++ b/change/@fluentui-react-divider-0006d265-60ac-4455-9c9d-71514b47489b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-divider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-ab029814-facb-4be6-839b-e65afc6a5994.json
+++ b/change/@fluentui-react-focus-ab029814-facb-4be6-839b-e65afc6a5994.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-management-5ad2864c-97cb-4496-b1ed-f3d7872a658c.json
+++ b/change/@fluentui-react-focus-management-5ad2864c-97cb-4496-b1ed-f3d7872a658c.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Upgrade to ts 4.0",
-  "packageName": "@fluentui/react-focus-management",
-  "email": "joschect@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-image-856896d3-d18b-4b7d-b638-81389bc4449e.json
+++ b/change/@fluentui-react-image-856896d3-d18b-4b7d-b638-81389bc4449e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-df4d79b2-af10-4d19-81b9-264e6d30716a.json
+++ b/change/@fluentui-react-label-df4d79b2-af10-4d19-81b9-264e6d30716a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-label",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-b54197c2-d57a-4416-8e92-829f2996c180.json
+++ b/change/@fluentui-react-link-b54197c2-d57a-4416-8e92-829f2996c180.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-6fa2b44e-f08b-4848-814d-fa69f57b6c8b.json
+++ b/change/@fluentui-react-menu-6fa2b44e-f08b-4848-814d-fa69f57b6c8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-88b20d94-ac18-4503-8d35-e989d4caed63.json
+++ b/change/@fluentui-react-portal-88b20d94-ac18-4503-8d35-e989d4caed63.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-portal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-426bc085-d9cd-4492-b7dc-431cade1c113.json
+++ b/change/@fluentui-react-slider-426bc085-d9cd-4492-b7dc-431cade1c113.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-slider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-bf2394f4-d6d1-4315-b81c-07dd00ee73ce.json
+++ b/change/@fluentui-react-tabs-bf2394f4-d6d1-4315-b81c-07dd00ee73ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-3b3e5b2b-483d-41da-ae23-5586aeac421a.json
+++ b/change/@fluentui-react-text-3b3e5b2b-483d-41da-ae23-5586aeac421a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toggle-f3ca794e-5ebd-474f-b4c2-a82a0297ac40.json
+++ b/change/@fluentui-react-toggle-f3ca794e-5ebd-474f-b4c2-a82a0297ac40.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-toggle",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-2aef8e08-2013-42be-a538-37d3e83c28a4.json
+++ b/change/@fluentui-react-tooltip-2aef8e08-2013-42be-a538-37d3e83c28a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update conformance tests in all packages to use a package-level isConformant wrapper with  appropriate generics for props",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -15,7 +15,8 @@ import { getDisplayName, mountWithProvider as mount, syntheticEvent, mountWithPr
 import * as FluentUI from 'src/index';
 import { getEventTargetComponent, EVENT_TARGET_ATTRIBUTE } from './eventTarget';
 
-export interface Conformant<TProps = {}> extends Pick<IsConformantOptions<TProps>, 'disabledTests' | 'testOptions'> {
+export interface Conformant<TProps = {}>
+  extends Pick<IsConformantOptions<TProps>, 'disabledTests' | 'skipAsPropTests' | 'testOptions'> {
   /** Path to the test file. */
   testPath: string;
   constructorName?: string;
@@ -82,9 +83,7 @@ export function isConformant(
     ? (Component as ComposedComponent).fluentComposeConfig?.handledProps
     : Component.handledProps;
 
-  const helperComponentNames = [...[Ref, RefFindNode], ...(wrapperComponent ? [wrapperComponent] : [])].map(
-    getDisplayName,
-  );
+  const helperComponentNames = [Ref, RefFindNode, ...(wrapperComponent ? [wrapperComponent] : [])].map(getDisplayName);
 
   const toNextNonTrivialChild = (from: ReactWrapper) => {
     const current = from.childAt(0);

--- a/packages/fluentui/react-northstar/test/specs/components/Animation/Animation-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Animation/Animation-test.tsx
@@ -9,8 +9,9 @@ describe('Animation', () => {
     testPath: __filename,
     constructorName: 'Animation',
     hasAccessibilityProp: false,
-    disabledTests: ['as-renders-fc', 'as-passes-as-value', 'as-renders-html', 'as-renders-react-class'],
+    skipAsPropTests: true,
     requiredProps: { children: <div /> },
+    testOptions: { 'consistent-callback-names': { ignoreProps: ['onEntered', 'onExited'] } },
   });
 
   test('does not throw if children is not passed', () => {

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/DropdownSearchInput-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/DropdownSearchInput-test.tsx
@@ -6,7 +6,7 @@ describe('DropdownSearchInput', () => {
     testPath: __filename,
     constructorName: 'DropdownSearchInput',
     hasAccessibilityProp: false,
-    disabledTests: ['as-renders-fc', 'as-passes-as-value', 'as-renders-html', 'as-renders-react-class'],
+    skipAsPropTests: true,
     eventTargets: {
       onKeyUp: `.${dropdownSearchInputSlotClassNames.input}`,
       onFocus: `.${dropdownSearchInputSlotClassNames.input}`,

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
@@ -18,6 +18,7 @@ describe('MenuItem', () => {
     constructorName: 'MenuItem',
     wrapperComponent: MenuItemWrapper,
     autoControlledProps: ['menuOpen'],
+    testOptions: { 'consistent-callback-names': { ignoreProps: ['onActiveChanged'] } },
   });
 
   implementsShorthandProp(MenuItem)('menu', Menu, {

--- a/packages/react-accordion/src/common/isConformant.ts
+++ b/packages/react-accordion/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.test.tsx
+++ b/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.test.tsx
@@ -3,10 +3,12 @@ import { AccordionPanel } from './AccordionPanel';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
+import { AccordionPanelProps } from './AccordionPanel.types';
 
 describe('AccordionPanel', () => {
   isConformant({
-    requiredProps: { open: true },
+    // hack: this is usually provided through context
+    requiredProps: { open: true } as AccordionPanelProps,
     Component: AccordionPanel,
     displayName: 'AccordionPanel',
   });

--- a/packages/react-avatar/src/common/isConformant.ts
+++ b/packages/react-avatar/src/common/isConformant.ts
@@ -1,0 +1,13 @@
+import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    asPropHandlesRef: true,
+    componentPath: module!.parent!.filename.replace('.test', ''),
+    disabledTests: ['has-docblock'],
+  };
+
+  baseIsConformant(defaultOptions, testInfo);
+}

--- a/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import * as path from 'path';
-import { isConformant } from '@fluentui/react-conformance';
+import { isConformant } from '../../common/isConformant';
 import { Avatar } from './Avatar';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
@@ -16,11 +15,8 @@ describe('Avatar', () => {
   });
 
   isConformant({
-    asPropHandlesRef: true,
-    componentPath: path.join(__dirname, 'Avatar.tsx'),
     Component: Avatar,
     displayName: 'Avatar',
-    disabledTests: ['has-docblock'],
   });
 
   /**

--- a/packages/react-badge/src/common/isConformant.ts
+++ b/packages/react-badge/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-button/src/common/isConformant.ts
+++ b/packages/react-button/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],

--- a/packages/react-checkbox/src/common/isConformant.ts
+++ b/packages/react-checkbox/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -1,10 +1,10 @@
 import { IsConformantOptions } from './types';
 
-import chalk from 'chalk';
 import { EOL } from 'os';
-
 import * as _ from 'lodash';
 import * as path from 'path';
+
+import { errorMessageColors, formatArray, getErrorMessage } from './utils/errorMessages';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -280,8 +280,7 @@ export const defaultErrorMessages = {
           displayName,
         )} it received:`,
         `    ${failedError(`className="${classNames?.join(' ')}"`)}`,
-        '',
-        ...(debugHTML ? ['Partial HTML:', debugHTML] : []),
+        ...(debugHTML ? ['', 'Partial HTML:', debugHTML] : []),
       ],
       suggestions: [
         `Make sure that your component ${resolveInfo('accepts a className prop')}.`,
@@ -472,18 +471,18 @@ export const defaultErrorMessages = {
     // Message Description: Handles scenario where the second word in a callback ends with 'ed'.
     //
     // It appears that "displayName" uses non-standard callback naming.
+    // These callback(s) need to be renamed: "callbackNames"
     // Possible solutions:
-    // 1. Rename these callback props to use present tense (no "ed" ending): "callbackNames"
-    // 2. If the name is correct, add the prop to isConformant `testOptions['consistent-callback-names'].ignoreProps`.
+    // 1. Rename "displayName"'s callback props to use present tense (no "ed" ending).
+    // 2. If the name is correct, add the prop to isConformant testOptions['consistent-callback-names'].ignoreProps.
     return getErrorMessage({
       displayName,
       overview: 'uses non-standard callback naming.',
+      details: ['These callback(s) need to be renamed:', testErrorInfo(formatArray(invalidProps))],
       suggestions: [
-        `Rename these callback props to use present tense (no "ed" ending):${EOL}${testErrorInfo(
-          formatArray(invalidProps),
-        )}`,
+        `Rename ${resolveInfo(displayName + `'s`)} callback props to use present tense (no "ed" ending)`,
         `If the name is correct, add the prop to isConformant ${resolveInfo(
-          "`testOptions['consistent-callback-names'].ignoreProps`",
+          "testOptions['consistent-callback-names'].ignoreProps",
         )}.`,
       ],
     });
@@ -498,16 +497,18 @@ export const defaultErrorMessages = {
     //
     // It appears that "displayName" "as" prop doesn't properly handle a function component.
     // Possible solutions:
-    // 1. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
-    // 3. Make sure that your component's implementation contains a valid return statement.
-    // 4. Check to see if your component works as expected with Enzyme's mount().
+    // - If your component doesn't have an "as" prop, enable isConformant's skipAsPropTests option.
+    // - If your component uses forwardRef, enable isConformant's asPropHandlesRef option.
+    // - Check if you are missing any requiredProps within the isConformant in your test file.
+    // - Make sure that your component's implementation contains a valid return statement.
+    // - Check to see if your component works as expected with Enzyme's mount().
     return getErrorMessage({
       displayName,
       overview: `"as" prop doesn't properly handle a function component.`,
       suggestions: [
+        `If your component doesn't have an "as" prop, enable isConformant's ${resolveInfo('skipAsPropTests')} option.`,
+        `If your component uses forwardRef, enable isConformant's ${resolveInfo('asPropHandlesRef')} option.`,
         `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
-        `If your component uses forwardRef you will need to enable isConformant's ${resolveInfo('asPropHandlesRef')}.`,
         `Make sure that your component code contains a valid return statement.`,
         `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
       ],
@@ -524,16 +525,18 @@ export const defaultErrorMessages = {
     //
     // It appears that "displayName" "as" prop doesn't properly handle a class component.
     // Possible solutions:
-    // 1. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 2. If your component uses forwardRef you will need to enable isConformant's asPropHandlesRef.
-    // 3. Make sure that your component's implementation contains a valid return statement.
-    // 4. Check to see if your component works as expected with Enzyme's mount().
+    // - If your component doesn't have an "as" prop, enable isConformant's skipAsPropTests option.
+    // - If your component uses forwardRef, enable isConformant's asPropHandlesRef option.
+    // - Check if you are missing any requiredProps within the isConformant in your test file.
+    // - Make sure that your component's implementation contains a valid return statement.
+    // - Check to see if your component works as expected with Enzyme's mount().
     return getErrorMessage({
       displayName,
       overview: `"as" prop doesn't properly handle a class component.`,
       suggestions: [
+        `If your component doesn't have an "as" prop, enable isConformant's ${resolveInfo('skipAsPropTests')} option.`,
+        `If your component uses forwardRef, enable isConformant's ${resolveInfo('asPropHandlesRef')} option.`,
         `Check if you are missing any ${resolveInfo('requiredProps')} within the test's isConformant.`,
-        `If your component uses forwardRef you will need to enable isConformant's ${resolveInfo('asPropHandlesRef')}.`,
         `Make sure that your component's implementation contains a valid return statement.`,
         `Check to see if your component works as expected with Enzyme's ${resolveInfo('mount()')}.`,
       ],
@@ -550,12 +553,14 @@ export const defaultErrorMessages = {
     //
     // It appears that "displayName" doesn't pass extra props to the component it renders as.
     // Possible solutions:
-    // 1. Ensure that you are spreading extra props to the "as" component when rendering.
-    // 2. Ensure that there is not a problem rendering the component in isConformant (check previous test results).
+    // - If your component doesn't have an "as" prop, enable isConformant's skipAsPropTests option.
+    // - Ensure that you are spreading extra props to the "as" component when rendering.
+    // - Ensure that there is not a problem rendering the component in isConformant (check previous test results).
     return getErrorMessage({
       displayName,
       overview: `doesn't pass extra props to the component it renders as.`,
       suggestions: [
+        `If your component doesn't have an "as" prop, enable isConformant's ${resolveInfo('skipAsPropTests')} option.`,
         `Ensure that you are ${resolveInfo('spreading extra props')} to the "as" component when rendering.`,
         `Ensure that there is not a problem rendering the component (check previous test results).`,
       ],
@@ -572,14 +577,16 @@ export const defaultErrorMessages = {
     //
     // It appears that "displayName" "as" prop doesn't properly handle HTML tags.
     // Possible solutions:
-    // 1. Make sure that your component can correctly render as HTML tags.
-    // 2. Check if you are missing any requiredProps within the isConformant in your test file.
-    // 3. Make sure that your component's implementation contains a valid return statement.
-    // 4. Check to see if your component works as expected with Enzyme's mount().
+    // - If your component doesn't have an "as" prop, enable isConformant's skipAsPropTests option.
+    // - Make sure that your component can correctly render as HTML tags.
+    // - Check if you are missing any requiredProps within the isConformant in your test file.
+    // - Make sure that your component's implementation contains a valid return statement.
+    // - Check to see if your component works as expected with Enzyme's mount().
     return getErrorMessage({
       displayName,
       overview: `"as" prop doesn't properly handle HTML tags.`,
       suggestions: [
+        `If your component doesn't have an "as" prop, enable isConformant's ${resolveInfo('skipAsPropTests')} option.`,
         `Make sure that your component can correctly render as ${resolveInfo('HTML tags')}.`,
         `Check if you are missing any ${resolveInfo('requiredProps')} within the isConformant in your test file.`,
         `Make sure that your component's implementation contains a valid return statement.`,
@@ -589,62 +596,3 @@ export const defaultErrorMessages = {
     });
   },
 };
-
-/** Console message colors used in the test. */
-const errorMessageColors = {
-  // Colors for the defaultErrorMessage section.
-  testErrorText: chalk.yellow,
-  testErrorName: chalk.white,
-  testErrorInfo: chalk.green,
-  testErrorPath: chalk.green.italic,
-  // Colors for the resolveErrorMessages section.
-  resolveText: chalk.cyan,
-  resolveInfo: chalk.hex('#e00000'),
-  // Colors for the receivedErrorMessage section.
-  receivedErrorHeader: chalk.white.bold.bgRed,
-  // Other colors.
-  failedError: chalk.red,
-  // Color for section headers.
-  sectionBackground: chalk.white.bold.italic.bgHex('#2e2e2e'),
-};
-
-function getErrorMessage(params: {
-  /** Component display name */
-  displayName: string;
-  /** Overall error description */
-  overview: string;
-  /** More details about the error (single line spacing, so include empty strings for blank lines) */
-  details?: string[];
-  /** Suggestions for fixing the error */
-  suggestions?: string[];
-  /** Original error */
-  error?: Error;
-}) {
-  const { testErrorText, testErrorName, resolveText, sectionBackground, receivedErrorHeader } = errorMessageColors;
-  const { displayName, overview, details = [], error, suggestions } = params;
-
-  const messageParts = [testErrorText(`It appears that ${testErrorName(displayName)} ${overview}`), details.join(EOL)];
-
-  if (suggestions) {
-    messageParts.push(
-      sectionBackground('Possible solutions:'),
-      suggestions.map((msg, i) => resolveText(`${i + 1}. ${msg}`)).join(EOL),
-    );
-  }
-
-  if (error) {
-    messageParts.push(
-      `Also check the ${receivedErrorHeader('original error message')} in case there's some other issue:`,
-      error.stack || error.message || String(error),
-    );
-  }
-
-  return messageParts.join(EOL + EOL);
-}
-
-/**
- * Formats an array of strings to be displayed in the console.
- */
-function formatArray(arr: string[] | undefined) {
-  return arr ? arr.map(value => `    ${value}`).join(EOL) : 'received undefined';
-}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -246,9 +246,9 @@ export const defaultTests: TestObject = {
 
     it(`is exported at top-level (exported-top-level)`, () => {
       try {
-        const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
+        const { displayName, componentPath, Component } = testInfo;
         const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-        const indexFile = require(path.join(rootPath, 'src', exportSubdir, 'index'));
+        const indexFile = require(path.join(rootPath, 'src', 'index'));
 
         expect(indexFile[displayName]).toBe(Component);
       } catch (e) {
@@ -265,9 +265,9 @@ export const defaultTests: TestObject = {
 
     it(`has corresponding top-level file 'package/src/Component' (has-top-level-file)`, () => {
       try {
-        const { displayName, componentPath, exportSubdir = '', Component } = testInfo;
+        const { displayName, componentPath, Component } = testInfo;
         const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-        const topLevelFile = require(path.join(rootPath, 'src', exportSubdir, displayName));
+        const topLevelFile = require(path.join(rootPath, 'src', displayName));
 
         expect(topLevelFile[displayName]).toBe(Component);
       } catch (e) {
@@ -314,9 +314,7 @@ export const defaultTests: TestObject = {
   // TODO: Test last word of callback name against list of valid verbs
   /** Ensures that components have consistent custom callback names i.e. on[Part][Event] */
   'consistent-callback-names': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    // Previously this test was broken. Now it's fixed, but enabling it would currently require
-    // changes in a lot of files.
-    xit(`has consistent custom callback names (consistent-callback-names)`, () => {
+    it(`has consistent custom callback names (consistent-callback-names)`, () => {
       const { testOptions = {} } = testInfo;
       const propNames = Object.keys(componentInfo.props);
       const ignoreProps = testOptions['consistent-callback-names']?.ignoreProps || [];
@@ -343,7 +341,7 @@ export const defaultTests: TestObject = {
 
   /** If it has "as" prop: Renders as functional component or passes as to the next component */
   'as-renders-fc': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!componentInfo.props.as) {
+    if (testInfo.skipAsPropTests) {
       return;
     }
 
@@ -381,7 +379,7 @@ export const defaultTests: TestObject = {
 
   /** If it has "as" prop: Renders as ReactClass or passes as to the next component */
   'as-renders-react-class': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!componentInfo.props.as || testInfo.asPropHandlesRef) {
+    if (testInfo.skipAsPropTests || testInfo.asPropHandlesRef) {
       return;
     }
 
@@ -413,7 +411,7 @@ export const defaultTests: TestObject = {
 
   /** If it has "as" prop: Passes extra props to the component it renders as */
   'as-passes-as-value': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!componentInfo.props.as) {
+    if (testInfo.skipAsPropTests) {
       return;
     }
 
@@ -441,7 +439,7 @@ export const defaultTests: TestObject = {
 
   /** If it has "as" prop: Renders component as HTML tags */
   'as-renders-html': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    if (!componentInfo.props.as) {
+    if (testInfo.skipAsPropTests) {
       return;
     }
 

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -7,14 +7,14 @@ import { getComponentDoc } from './utils/getComponentDoc';
 
 export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
-  const { componentPath, displayName, disabledTests = [], extraTests, exportSubdir = '' } = mergedOptions;
+  const { componentPath, displayName, disabledTests = [], extraTests } = mergedOptions;
 
   describe('isConformant', () => {
     if (!fs.existsSync(componentPath)) {
       throw new Error(`Path ${componentPath} does not exist`);
     }
 
-    const components = getComponentDoc(componentPath, exportSubdir);
+    const components = getComponentDoc(componentPath);
     const mainComponents = components.filter(comp => comp.displayName === displayName);
 
     if (mainComponents.length === 1) {

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -66,6 +66,10 @@ export interface IsConformantOptions<TProps = {}> {
    */
   helperComponents?: React.ElementType[];
   /**
+   * Whether to skip all tests for the `as` prop.
+   */
+  skipAsPropTests?: boolean;
+  /**
    * If the component's 'as' property requires a ref, this will attach a forwardRef to the test component passed to 'as'
    * and disable the as-renders-react-class test.
    */
@@ -80,11 +84,6 @@ export interface IsConformantOptions<TProps = {}> {
    * Child component that will receive unhandledProps.
    */
   targetComponent?: ComponentType<TProps>;
-  /**
-   * The subdirectory that this component is exported from, if not the root of the package folder.
-   * Currently this is only used for "next" and "compat" versions of a component.
-   */
-  exportSubdir?: 'next' | 'compat';
 }
 
 export type ConformanceTest<TProps = {}> = (componentInfo: ComponentDoc, testInfo: IsConformantOptions<TProps>) => void;

--- a/packages/react-conformance/src/utils/errorMessages.ts
+++ b/packages/react-conformance/src/utils/errorMessages.ts
@@ -1,0 +1,64 @@
+import chalk from 'chalk';
+import { EOL } from 'os';
+
+/** Console message colors used in the test. */
+export const errorMessageColors = {
+  // Colors for the defaultErrorMessage section.
+  testErrorText: chalk.yellow,
+  testErrorName: chalk.white,
+  testErrorInfo: chalk.green,
+  testErrorPath: chalk.green.italic,
+  // Colors for the resolveErrorMessages section.
+  resolveText: chalk.cyan,
+  resolveInfo: chalk.hex('#e00000'),
+  // Colors for the receivedErrorMessage section.
+  receivedErrorHeader: chalk.white.bold.bgRed,
+  // Other colors.
+  failedError: chalk.red,
+  // Color for section headers.
+  sectionBackground: chalk.white.bold.italic.bgHex('#2e2e2e'),
+};
+
+export function getErrorMessage(params: {
+  /** Component display name */
+  displayName: string;
+  /** Overall error description */
+  overview: string;
+  /** More details about the error (single line spacing, so include empty strings for blank lines) */
+  details?: string[];
+  /** Suggestions for fixing the error */
+  suggestions?: string[];
+  /** Original error */
+  error?: Error;
+}) {
+  const { testErrorText, testErrorName, resolveText, sectionBackground, receivedErrorHeader } = errorMessageColors;
+  const { displayName, overview, details = [], error, suggestions } = params;
+
+  const messageParts = [testErrorText(`It appears that ${testErrorName(displayName)} ${overview}`)];
+  if (details) {
+    messageParts.push(details.join(EOL));
+  }
+
+  if (suggestions) {
+    messageParts.push(
+      sectionBackground('Possible solutions:'),
+      suggestions.map((msg, i) => resolveText(`${i + 1}. ${msg}`)).join(EOL),
+    );
+  }
+
+  if (error) {
+    messageParts.push(
+      `Also check the ${receivedErrorHeader('original error message')} in case there's some other issue:`,
+      error.stack || error.message || String(error),
+    );
+  }
+
+  return messageParts.join(EOL + EOL);
+}
+
+/**
+ * Formats an array of strings to be displayed in the console.
+ */
+export function formatArray(arr: string[] | undefined) {
+  return arr ? arr.map(value => `    ${value}`).join(EOL) : 'received undefined';
+}

--- a/packages/react-conformance/src/utils/getComponentDoc.ts
+++ b/packages/react-conformance/src/utils/getComponentDoc.ts
@@ -10,7 +10,7 @@ let parser: FileParser;
 /**
  * Run `react-docgen-typescript` on a component file to get info about its props.
  */
-export function getComponentDoc(componentPath: string, exportSubdir: string): ComponentDoc[] {
+export function getComponentDoc(componentPath: string): ComponentDoc[] {
   if (!program) {
     // Calling parse() from react-docgen-typescript would create a new ts.Program for every component,
     // which can take multiple seconds in a large project. For better performance, we create a single
@@ -26,7 +26,7 @@ export function getComponentDoc(componentPath: string, exportSubdir: string): Co
     // To reduce the number of files parsed, only list the index file as the entry point.
     // This should work okay because it would be strange if a component being conformance tested
     // was not also referenced from some file eventually imported by the index file.
-    const rootFile = path.join(path.dirname(tsconfigPath), 'src', exportSubdir, 'index.ts');
+    const rootFile = path.join(path.dirname(tsconfigPath), 'src', 'index.ts');
     if (!fs.existsSync(rootFile)) {
       throw new Error(`Index file does not exist at expected path ${rootFile}`);
     }

--- a/packages/react-divider/src/common/isConformant.ts
+++ b/packages/react-divider/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-focus/src/common/isConformant.ts
+++ b/packages/react-focus/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'> & { componentPath?: string }) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
@@ -89,6 +89,9 @@ describe('FocusZone', () => {
     ],
     asPropHandlesRef: true,
     elementRefName: 'elementRef',
+    testOptions: {
+      'consistent-callback-names': { ignoreProps: ['onActiveElementChanged'] },
+    },
   });
 
   it('can use arrows vertically', () => {

--- a/packages/react-image/src/common/isConformant.ts
+++ b/packages/react-image/src/common/isConformant.ts
@@ -1,0 +1,13 @@
+import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    asPropHandlesRef: true,
+    componentPath: module!.parent!.filename.replace('.test', ''),
+    disabledTests: ['has-docblock'],
+  };
+
+  baseIsConformant(defaultOptions, testInfo);
+}

--- a/packages/react-image/src/components/Image/Image.test.tsx
+++ b/packages/react-image/src/components/Image/Image.test.tsx
@@ -1,14 +1,10 @@
-import { isConformant } from '@fluentui/react-conformance';
-import * as path from 'path';
+import { isConformant } from '../../common/isConformant';
 
 import { Image } from './Image';
 
 describe('Image', () => {
   isConformant({
-    asPropHandlesRef: true,
-    componentPath: path.join(__dirname, 'Image.tsx'),
     Component: Image,
     displayName: 'Image',
-    disabledTests: ['has-docblock'],
   });
 });

--- a/packages/react-label/src/common/isConformant.ts
+++ b/packages/react-label/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-link/src/common/isConformant.ts
+++ b/packages/react-link/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
     disabledTests: [`has-docblock`],

--- a/packages/react-menu/src/common/isConformant.ts
+++ b/packages/react-menu/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -14,14 +14,8 @@ import { MenuItemRadio } from '../MenuItemRadio/index';
 
 describe('Menu', () => {
   isConformant({
-    disabledTests: [
-      'as-renders-html',
-      'as-renders-fc',
-      'component-handles-ref',
-      'component-has-root-ref',
-      'component-handles-classname',
-      'as-passes-as-value',
-    ],
+    skipAsPropTests: true,
+    disabledTests: ['component-handles-ref', 'component-has-root-ref', 'component-handles-classname'],
     Component: Menu,
     displayName: 'Menu',
     requiredProps: {

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
@@ -9,10 +9,6 @@ import { MenuListContextValue, MenuListProvider } from '../../contexts/menuListC
 
 describe('MenuItemCheckbox conformance', () => {
   isConformant({
-    asPropHandlesRef: true,
-    // TODO fix generics in conformance
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     Component: MenuItemCheckbox,
     requiredProps: {
       name: 'checkbox',

--- a/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
@@ -9,10 +9,6 @@ import { MenuListProvider, MenuListContextValue } from '../../contexts/menuListC
 
 describe('MenuItemRadio', () => {
   isConformant({
-    asPropHandlesRef: true,
-    // TODO fix generics in conformance
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     Component: MenuItemRadio,
     requiredProps: {
       name: 'radio',

--- a/packages/react-menu/src/components/MenuList/MenuList.test.tsx
+++ b/packages/react-menu/src/components/MenuList/MenuList.test.tsx
@@ -7,7 +7,6 @@ import { MenuListProvider } from '../../contexts/menuListContext';
 
 describe('MenuList', () => {
   isConformant({
-    asPropHandlesRef: true,
     Component: MenuList,
     displayName: 'MenuList',
     helperComponents: [MenuListProvider],

--- a/packages/react-popover/src/common/isConformant.ts
+++ b/packages/react-popover/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-popover/src/components/PopoverContent/PopoverContent.test.tsx
+++ b/packages/react-popover/src/components/PopoverContent/PopoverContent.test.tsx
@@ -5,6 +5,7 @@ import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
 import { Portal } from '@fluentui/react-portal';
 import { mockPopoverContext } from '../../common/mockUsePopoverContext';
+import { PopoverContentProps } from './PopoverContent.types';
 
 jest.mock('../../popoverContext');
 
@@ -14,7 +15,7 @@ describe('PopoverContent', () => {
     disabledTests: ['as-renders-html'],
     Component: PopoverContent,
     displayName: 'PopoverContent',
-    requiredProps: { open: true },
+    requiredProps: { open: true } as PopoverContentProps,
     helperComponents: [Portal, 'span'],
   });
 

--- a/packages/react-portal/src/common/isConformant.ts
+++ b/packages/react-portal/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-slider/src/common/isConformant.ts
+++ b/packages/react-slider/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-tabs/src/common/isConformant.ts
+++ b/packages/react-tabs/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react-tabs/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react-tabs/src/components/Tabs/Tabs.test.tsx
@@ -24,6 +24,7 @@ describe('Tabs', () => {
   isConformant({
     Component: Tabs,
     displayName: 'Tabs',
+    skipAsPropTests: true,
   });
 
   it('can be focused', () => {

--- a/packages/react-text/src/common/isConformant.ts
+++ b/packages/react-text/src/common/isConformant.ts
@@ -1,0 +1,13 @@
+import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    asPropHandlesRef: true,
+    componentPath: module!.parent!.filename.replace('.test', ''),
+    disabledTests: ['has-docblock'],
+  };
+
+  baseIsConformant(defaultOptions, testInfo);
+}

--- a/packages/react-text/src/components/Text/Text.test.tsx
+++ b/packages/react-text/src/components/Text/Text.test.tsx
@@ -1,14 +1,12 @@
-import { isConformant } from '@fluentui/react-conformance';
+import { isConformant } from '../../common/isConformant';
 import * as path from 'path';
 
 import { Text } from './Text';
 
 describe('Text', () => {
   isConformant({
-    asPropHandlesRef: true,
     componentPath: path.join(__dirname, 'Text.ts'),
     Component: Text,
     displayName: 'Text',
-    disabledTests: ['has-docblock'],
   });
 });

--- a/packages/react-toggle/src/common/isConformant.ts
+++ b/packages/react-toggle/src/common/isConformant.ts
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     disabledTests: ['has-docblock', 'kebab-aria-attributes'],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };

--- a/packages/react/src/common/isConformant.ts
+++ b/packages/react/src/common/isConformant.ts
@@ -1,8 +1,17 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'> & { componentPath?: string }) {
-  const defaultOptions = {
-    disabledTests: ['has-docblock', 'kebab-aria-attributes', 'is-static-property-of-parent'],
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    disabledTests: [
+      'has-docblock',
+      'kebab-aria-attributes',
+      'is-static-property-of-parent',
+      // Will enable with appropriate overrides separately
+      'consistent-callback-names',
+    ],
+    skipAsPropTests: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };
 

--- a/packages/react/src/components/Announced/Announced.test.tsx
+++ b/packages/react/src/components/Announced/Announced.test.tsx
@@ -40,6 +40,7 @@ describe('Announced', () => {
     Component: Announced,
     displayName: 'Announced',
     componentPath: path.join(__dirname, 'Announced.ts'),
+    skipAsPropTests: false,
     // Problem: Ref isn't passed.
     // Solution: Ref should be added and passed onto the root.
     disabledTests: ['component-handles-ref', 'component-has-root-ref'],

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -105,7 +105,7 @@ describe('Breadcrumb', () => {
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
-      'as-passes-value',
+      'as-passes-as-value',
     ],
   });
 

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -98,9 +98,15 @@ describe('Breadcrumb', () => {
   isConformant({
     Component: Breadcrumb,
     displayName: 'Breadcrumb',
+    skipAsPropTests: false,
     // Problem: Doesn’t handle ref.
     // Solution: Add a ref to the root element.
-    disabledTests: ['component-handles-ref', 'component-has-root-ref', 'component-handles-classname'],
+    disabledTests: [
+      'component-handles-ref',
+      'component-has-root-ref',
+      'component-handles-classname',
+      'as-passes-value',
+    ],
   });
 
   it('renders items with expected element type', () => {

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
@@ -1,16 +1,9 @@
 import { CalendarDayGrid } from './CalendarDayGrid';
 import { defaultCalendarStrings } from '../Calendar/index';
-import { DateRangeType, DayOfWeek, FirstWeekOfYear, ICalendarStrings } from '@fluentui/date-time-utilities';
+import { DateRangeType, DayOfWeek, FirstWeekOfYear } from '@fluentui/date-time-utilities';
 import { isConformant } from '../../common/isConformant';
 
 describe('CalendarDayGrid', () => {
-  const timeFormatter = {
-    formatMonthDayYear: (date: Date, strings?: ICalendarStrings) => 'm/d/y',
-    formatMonthYear: (date: Date, strings?: ICalendarStrings) => 'm/y',
-    formatDay: (date: Date) => 'd',
-    formatYear: (date: Date) => 'y',
-  };
-
   isConformant({
     Component: CalendarDayGrid,
     displayName: 'CalendarDayGrid',
@@ -18,11 +11,16 @@ describe('CalendarDayGrid', () => {
       strings: defaultCalendarStrings,
       selectedDate: new Date('2020-09-18T21:06:52.856Z'),
       navigatedDate: new Date('2020-09-18T21:06:52.856Z'),
-      navigatedMonthDate: new Date('2020-09-18T21:06:52.856Z'),
       dateRangeType: DateRangeType.Day,
       firstDayOfWeek: DayOfWeek.Sunday,
       firstWeekOfYear: FirstWeekOfYear.FirstFullWeek,
-      dateTimeFormatter: timeFormatter,
+      dateTimeFormatter: {
+        formatMonthDayYear: () => 'm/d/y',
+        formatMonthYear: () => 'm/y',
+        formatDay: () => 'd',
+        formatMonth: () => 'm',
+        formatYear: () => 'y',
+      },
     },
     disabledTests: [
       'component-handles-classname',

--- a/packages/react/src/components/ComponentConformance.test.tsx
+++ b/packages/react/src/components/ComponentConformance.test.tsx
@@ -35,17 +35,6 @@ describe('Top Level Component File Conformance', () => {
     jest.resetModules();
   });
 
-  // Top Level Compoennt File Compliance -
-  // make sure that there is a corresponding top level component file for each component in the directory
-  components.forEach(componentName => {
-    it(`${componentName} has a corresponding top level component file`, () => {
-      expect(
-        fs.existsSync(path.resolve(__dirname, `../${componentName}.ts`)) ||
-          fs.existsSync(path.resolve(__dirname, `../${componentName}.tsx`)),
-      ).toBeTruthy();
-    });
-  });
-
   // make sure that there is a version import in each corresponding top level component file
   topLevelComponentFiles.forEach(file => {
     const componentName = path.basename(file).split('.')[0];

--- a/packages/react/src/components/HoverCard/HoverCard.test.tsx
+++ b/packages/react/src/components/HoverCard/HoverCard.test.tsx
@@ -9,7 +9,7 @@ import { ExpandingCardBase } from './ExpandingCard.base';
 import { IExpandingCardProps } from './ExpandingCard.types';
 import { HoverCard } from './HoverCard';
 import { HoverCardBase } from './HoverCard.base';
-import { HoverCardType } from './HoverCard.types';
+import { HoverCardType, IHoverCardProps } from './HoverCard.types';
 import { KeyCodes } from '../../Utilities';
 import * as path from 'path';
 import { isConformant } from '../../common/isConformant';
@@ -75,11 +75,12 @@ describe('HoverCard', () => {
     ReactDOM.createPortal = createPortal;
   });
 
-  isConformant({
+  isConformant<IHoverCardProps>({
     Component: HoverCard,
     displayName: 'HoverCard',
     componentPath: path.join(__dirname, 'HoverCard.ts'),
-    targetComponent: ExpandingCardBase,
+    // cast due to slight mismatch in style props
+    targetComponent: ExpandingCardBase as React.ComponentType<IHoverCardProps>,
     // Problem: Ref doesn't match DOM node and returns outermost wrapper div.
     // Solution: Ensure ref is passed correctly to the root element.
     disabledTests: ['component-has-root-ref', 'component-handles-ref'],

--- a/packages/react/src/components/Label/Label.test.tsx
+++ b/packages/react/src/components/Label/Label.test.tsx
@@ -19,6 +19,7 @@ describe('Label', () => {
   isConformant({
     Component: Label,
     displayName: 'Label',
+    skipAsPropTests: false,
     // Problem: Ref is not supported
     // Solution: Convert to FunctionComponent and support using forwardRef
     disabledTests: ['component-handles-ref', 'component-has-root-ref'],

--- a/packages/react/src/components/Link/Link.test.tsx
+++ b/packages/react/src/components/Link/Link.test.tsx
@@ -101,7 +101,7 @@ describe('Link', () => {
           // eslint-disable-next-line deprecation/deprecation
           <Customizer settings={{ theme: NoClassNamesTheme }}>
             <Link href="helloworld.html">My Link</Link>
-          </Customizer>, // eslint-disable-line deprecation/deprecation
+          </Customizer>,
         ),
       ),
     ).toBe(false);

--- a/packages/react/src/components/Link/Link.test.tsx
+++ b/packages/react/src/components/Link/Link.test.tsx
@@ -72,6 +72,7 @@ describe('Link', () => {
   isConformant({
     Component: Link,
     displayName: 'Link',
+    skipAsPropTests: false,
     asPropHandlesRef: true,
   });
 

--- a/packages/react/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/react/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -54,9 +54,7 @@ describe('ResizeGroup', () => {
     displayName: 'ResizeGroup',
     requiredProps: {
       data: { content: 5 },
-      onRenderData: () => {
-        return;
-      },
+      onRenderData: () => <div />,
       onReduceData: onReduceScalingData,
     },
   });

--- a/packages/react/src/components/Stack/Stack.test.tsx
+++ b/packages/react/src/components/Stack/Stack.test.tsx
@@ -15,6 +15,7 @@ describe('Stack', () => {
     Component: Stack,
     displayName: 'Stack',
     useDefaultExport: true,
+    skipAsPropTests: false,
     // Problem: Ref is not supported
     // Solution: Convert to FunctionComponent and support using forwardRef
     disabledTests: ['component-handles-ref', 'component-has-root-ref'],

--- a/packages/react/src/components/Stack/Stack.test.tsx
+++ b/packages/react/src/components/Stack/Stack.test.tsx
@@ -207,7 +207,7 @@ describe('Stack', () => {
           <Stack.Item>Item 1</Stack.Item>
           <Stack.Item>Item 2</Stack.Item>
         </Stack>
-      </Fabric>, // eslint-disable-line deprecation/deprecation
+      </Fabric>,
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react/src/components/Text/Text.test.tsx
+++ b/packages/react/src/components/Text/Text.test.tsx
@@ -23,9 +23,10 @@ describe('Text', () => {
     displayName: 'Text',
     requiredProps: { children: 'content' },
     componentPath: path.join(__dirname, 'Text.ts'),
+    skipAsPropTests: false,
+    asPropHandlesRef: true,
     // Problem: Ref is not supported
     // Solution: Convert to FunctionComponent and support using forwardRef
-    asPropHandlesRef: true,
     disabledTests: ['component-has-root-ref', 'component-handles-ref'],
   });
 });

--- a/packages/react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/react/src/components/Toggle/Toggle.test.tsx
@@ -54,6 +54,7 @@ describe('Toggle', () => {
     Component: Toggle,
     displayName: 'Toggle',
     targetComponent: Toggle,
+    skipAsPropTests: false,
   });
 
   it('renders aria-label', () => {

--- a/packages/react/src/utilities/ButtonGrid/ButtonGrid.test.tsx
+++ b/packages/react/src/utilities/ButtonGrid/ButtonGrid.test.tsx
@@ -23,9 +23,7 @@ describe('ButtonGrid', () => {
       items: DEFAULT_ITEMS,
       columnCount: 4,
       styles: getStyles,
-      onRenderItem: () => {
-        return;
-      },
+      onRenderItem: () => <div />,
     },
     disabledTests: ['has-top-level-file', 'component-handles-classname'],
   });

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
@@ -77,7 +77,7 @@ describe('makeStyles', () => {
       // eslint-disable-next-line deprecation/deprecation
       <Customizer settings={{ theme: customTheme }}>
         <ThemeStyledComponent />
-      </Customizer>, // eslint-disable-line deprecation/deprecation
+      </Customizer>,
     );
     expect(stylesheet.getRules()).toEqual('.root-0{background:purple;}');
   });

--- a/scripts/create-component/plop-templates-component/src/common/isConformant.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/common/isConformant.ts.hbs
@@ -1,7 +1,9 @@
 import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
 
-export function isConformant(testInfo: Omit<IsConformantOptions, 'componentPath'>) {
-  const defaultOptions = {
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The main goal of this change is "conformance test conformance": making all the converged packages call `isConformant` via a wrapper like this:
```ts
import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';

export function isConformant<TProps = {}>(
  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
) {
  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
    componentPath: module!.parent!.filename.replace('.test', ''),
    // other defaults here
  };

  baseIsConformant(defaultOptions, testInfo);
}
```

I also made some smaller conformance test-related changes, mainly in preparation for splitting out the tests that use `react-docgen-typescript` (so those can be run separately instead of slowing down every component's tests):
- Add an option `skipAsPropTests` to disable all tests for the `as` prop, instead of determining whether to run them based on whether `ComponentDoc.props` (generated by `react-docgen-typescript`) contains `as`.
- Move test error message utilities to a separate file
- Remove `exportSubdir` option which is unused
- Enable the `consistent-callback-names` test everywhere except `@fluentui/react` (will do that separately since it requires a lot of overrides)