### PR TITLE
chore: switch vmImage for size-auditor

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -11,7 +11,7 @@ jobs:
   - job: build_react
     timeoutInMinutes: 75
     pool:
-      vmImage: 'ubuntu-20.04'
+      pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 
@@ -46,7 +46,7 @@ jobs:
   - job: build_converged
     timeoutInMinutes: 75
     pool:
-      vmImage: 'ubuntu-20.04'
+      pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 
@@ -81,7 +81,7 @@ jobs:
   - job: build_northstar
     timeoutInMinutes: 75
     pool:
-      vmImage: 'ubuntu-20.04'
+      pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -10,8 +10,7 @@ variables:
 jobs:
   - job: build_react
     timeoutInMinutes: 75
-    pool:
-      pool: 'Self Host Ubuntu'
+    pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 
@@ -45,8 +44,7 @@ jobs:
 
   - job: build_converged
     timeoutInMinutes: 75
-    pool:
-      pool: 'Self Host Ubuntu'
+    pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 
@@ -80,8 +78,7 @@ jobs:
 
   - job: build_northstar
     timeoutInMinutes: 75
-    pool:
-      pool: 'Self Host Ubuntu'
+    pool: 'Self Host Ubuntu'
     steps:
       - template: .devops/templates/tools.yml
 

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -46,7 +46,7 @@ jobs:
   - job: build_converged
     timeoutInMinutes: 75
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'ubuntu-20.04'
     steps:
       - template: .devops/templates/tools.yml
 

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - task: Bash@3
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: yarn build --to @fluentui/react @fluentui/react-button @fluentui/react-compose @fluentui/keyboard-key --no-cache
@@ -48,7 +50,9 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - task: Bash@3
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: yarn build --to @fluentui/react-components --no-cache
@@ -81,7 +85,9 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: npx midgard-yarn install
+      - task: Bash@3
+        inputs:
+          filePath: yarn-ci.sh
         displayName: yarn
 
       - script: yarn build --to @fluentui/react-northstar --no-cache

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -11,7 +11,7 @@ jobs:
   - job: build_react
     timeoutInMinutes: 75
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'ubuntu-20.04'
     steps:
       - template: .devops/templates/tools.yml
 
@@ -44,7 +44,7 @@ jobs:
   - job: build_northstar
     timeoutInMinutes: 75
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'ubuntu-20.04'
     steps:
       - template: .devops/templates/tools.yml
 


### PR DESCRIPTION
## Description of changes

This PR switches build jobs in `azure-pipelines.bundlesize.yml` from Windows to Ubuntu to speed up builds 🚀

#### Before

![Before](https://user-images.githubusercontent.com/14183168/112625678-8ae80280-8e2f-11eb-9141-252235a5a298.png)

#### After

![After](https://user-images.githubusercontent.com/14183168/112626067-03e75a00-8e30-11eb-934b-166e6a616719.png)

