### PR TITLE
Fix: SearchBox onChange handler called twice

### DIFF
--- a/change/@fluentui-react-a300a599-b0c9-4873-b895-f0926c9e5e92.json
+++ b/change/@fluentui-react-a300a599-b0c9-4873-b895-f0926c9e5e92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: SearchBox onChange handler called twice",
+  "packageName": "@fluentui/react",
+  "email": "feodor@appveyor.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -128,15 +128,15 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
   let _lastChangeValue: string | undefined;
 
   const onInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    const value = ev.target.value;
+    const val = ev.target.value;
 
-    if (value === _lastChangeValue) {
+    if (val === _lastChangeValue) {
       _lastChangeValue = undefined;
       return;
     }
-    _lastChangeValue = value;
+    _lastChangeValue = val;
 
-    setValue(value);
+    setValue(val);
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -125,8 +125,18 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     [customOnBlur],
   );
 
+  let _lastChangeValue: string | undefined;
+
   const onInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(ev.target.value);
+    const value = ev.target.value;
+
+    if (value === _lastChangeValue) {
+      _lastChangeValue = undefined;
+      return;
+    }
+    _lastChangeValue = value;
+
+    setValue(value);
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17587
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In Fluent UI v7.0 there is a trick preventing double call of `onChange` handler: https://github.com/microsoft/fluentui/blob/7.0/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx#L238-L248

PR applies the same technique to SearchBox v8.
