### PR TITLE
TeachingBubble: Keyboard focus now properly visible on buttons

### DIFF
--- a/change/@fluentui-react-01a3dbfd-deea-432c-bbf8-e15140ba8573.json
+++ b/change/@fluentui-react-01a3dbfd-deea-432c-bbf8-e15140ba8573.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "TeachingBubble: Keyboard focus now properly visible on buttons",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -112,6 +112,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
   const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
   const hideDefaultFocusRing = getFocusStyle(theme, {
+    inset: -1,
     outlineColor: 'transparent',
     borderColor: 'transparent',
   });

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -111,7 +111,10 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
   const hasLargeHeadline: boolean = !hasCondensedHeadline && !hasSmallHeadline;
   const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
-  const hideDefaultFocusRing = getFocusStyle(theme, { outlineColor: 'none', borderColor: 'none' });
+  const hideDefaultFocusRing = getFocusStyle(theme, {
+    outlineColor: 'transparent',
+    borderColor: 'transparent',
+  });
   return {
     root: [classNames.root, fonts.medium, calloutProps.className],
     body: [

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -112,7 +112,6 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
   const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
   const hideDefaultFocusRing = getFocusStyle(theme, {
-    inset: -1,
     outlineColor: 'transparent',
     borderColor: 'transparent',
   });

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -3,6 +3,7 @@ import { ICalloutContentStyleProps } from '../../Callout';
 import {
   AnimationVariables,
   FontWeights,
+  getFocusStyle,
   getGlobalClassNames,
   GlobalClassNames,
   IStyle,
@@ -110,7 +111,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
   const hasLargeHeadline: boolean = !hasCondensedHeadline && !hasSmallHeadline;
   const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
-
+  const hideDefaultFocusRing = getFocusStyle(theme, { outlineColor: 'none', borderColor: 'none' });
   return {
     root: [classNames.root, fonts.medium, calloutProps.className],
     body: [
@@ -213,6 +214,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     primaryButton: [
       classNames.primaryButton,
       primaryButtonClassName,
+      hideDefaultFocusRing,
       {
         backgroundColor: palette.white,
         borderColor: palette.white,
@@ -223,12 +225,16 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
           [`.${classNames.buttonLabel}`]: fonts.medium,
           ':hover': {
             backgroundColor: palette.themeLighter,
-            borderColor: palette.themeLighter,
             color: palette.themePrimary,
+            border: `2px solid ${palette.black}`,
+            outline: `1px solid ${palette.white}`,
+            outlineOffset: '-3px',
           },
           ':focus': {
             backgroundColor: palette.themeLighter,
-            borderColor: palette.white,
+            border: `2px solid ${palette.black}`,
+            outline: `1px solid ${palette.white}`,
+            outlineOffset: '-3px',
           },
           ':active': {
             backgroundColor: palette.white,
@@ -241,6 +247,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     secondaryButton: [
       classNames.secondaryButton,
       secondaryButtonClassName,
+      hideDefaultFocusRing,
       {
         backgroundColor: palette.themePrimary,
         borderColor: palette.white,
@@ -254,8 +261,10 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
             },
           ],
           '&:hover, &:focus': {
-            backgroundColor: palette.themeDarkAlt,
-            borderColor: palette.white,
+            backgroundColor: palette.themeDark,
+            border: `2px solid ${palette.black}`,
+            outline: `1px solid ${palette.white}`,
+            outlineOffset: '-3px',
           },
           ':active': {
             backgroundColor: palette.themePrimary,

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -228,16 +228,14 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
           [`.${classNames.buttonLabel}`]: fonts.medium,
           ':hover': {
             backgroundColor: palette.themeLighter,
+            borderColor: palette.themeLighter,
             color: palette.themePrimary,
-            border: `2px solid ${palette.black}`,
-            outline: `1px solid ${palette.white}`,
-            outlineOffset: '-3px',
           },
           ':focus': {
             backgroundColor: palette.themeLighter,
-            border: `2px solid ${palette.black}`,
+            border: `1px solid ${palette.black}`,
             outline: `1px solid ${palette.white}`,
-            outlineOffset: '-3px',
+            outlineOffset: '-2px',
           },
           ':active': {
             backgroundColor: palette.white,
@@ -263,11 +261,15 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
               color: palette.white,
             },
           ],
-          '&:hover, &:focus': {
+          ':hover': {
+            backgroundColor: palette.themeDarkAlt,
+            borderColor: palette.white,
+          },
+          ':focus': {
             backgroundColor: palette.themeDark,
-            border: `2px solid ${palette.black}`,
+            border: `1px solid ${palette.black}`,
             outline: `1px solid ${palette.white}`,
-            outlineOffset: '-3px',
+            outlineOffset: '-2px',
           },
           ':active': {
             backgroundColor: palette.themePrimary,

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -193,13 +193,13 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 2px;
+                  bottom: 0px;
                   content: "";
-                  left: 2px;
-                  outline: 1px solid #605e5c;
+                  left: 0px;
+                  outline: 1px solid transparent;
                   position: absolute;
-                  right: 2px;
-                  top: 2px;
+                  right: 0px;
+                  top: 0px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -215,17 +215,21 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   top: 0px;
                 }
                 &:hover {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
+                  background-color: #005a9e;
+                  border: 2px solid #000000;
                   color: #201f1e;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
                 &:focus {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
+                  background-color: #005a9e;
+                  border: 2px solid #000000;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 &:active {
                   background-color: #0078d4;
@@ -325,15 +329,15 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   border: 0;
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: 2px;
+                  border: 1px solid transparent;
+                  bottom: 0px;
                   content: "";
-                  left: 2px;
+                  left: 0px;
                   outline-color: #ffffff;
-                  outline: 1px solid #605e5c;
+                  outline: 1px solid transparent;
                   position: absolute;
-                  right: 2px;
-                  top: 2px;
+                  right: 0px;
+                  top: 0px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -357,9 +361,10 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 &:hover {
                   background-color: #deecf9;
-                  border-color: #deecf9;
-                  border: 1px solid #106ebe;
+                  border: 2px solid #000000;
                   color: #0078d4;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -368,7 +373,9 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 &:focus {
                   background-color: #deecf9;
-                  border-color: #ffffff;
+                  border: 2px solid #000000;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 &:active {
                   background-color: #ffffff;

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -215,11 +215,9 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   top: 0px;
                 }
                 &:hover {
-                  background-color: #005a9e;
-                  border: 2px solid #000000;
+                  background-color: #106ebe;
+                  border-color: #ffffff;
                   color: #201f1e;
-                  outline-offset: -3px;
-                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   border-color: Highlight;
@@ -227,8 +225,8 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 &:focus {
                   background-color: #005a9e;
-                  border: 2px solid #000000;
-                  outline-offset: -3px;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }
                 &:active {
@@ -361,10 +359,9 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 &:hover {
                   background-color: #deecf9;
-                  border: 2px solid #000000;
+                  border-color: #deecf9;
+                  border: 1px solid #106ebe;
                   color: #0078d4;
-                  outline-offset: -3px;
-                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -373,8 +370,8 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 &:focus {
                   background-color: #deecf9;
-                  border: 2px solid #000000;
-                  outline-offset: -3px;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }
                 &:active {

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -193,13 +193,13 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 0px;
+                  bottom: 1px;
                   content: "";
-                  left: 0px;
+                  left: 1px;
                   outline: 1px solid transparent;
                   position: absolute;
-                  right: 0px;
-                  top: 0px;
+                  right: 1px;
+                  top: 1px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -330,14 +330,14 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 0px;
+                  bottom: 1px;
                   content: "";
-                  left: 0px;
+                  left: 1px;
                   outline-color: #ffffff;
                   outline: 1px solid transparent;
                   position: absolute;
-                  right: 0px;
-                  top: 0px;
+                  right: 1px;
+                  top: 1px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -482,11 +482,9 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   top: 0px;
                 }
                 &:hover {
-                  background-color: #005a9e;
-                  border: 2px solid #000000;
+                  background-color: #106ebe;
+                  border-color: #ffffff;
                   color: #201f1e;
-                  outline-offset: -3px;
-                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   border-color: Highlight;
@@ -494,8 +492,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 &:focus {
                   background-color: #005a9e;
-                  border: 2px solid #000000;
-                  outline-offset: -3px;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }
                 &:active {
@@ -628,10 +626,9 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 &:hover {
                   background-color: #deecf9;
-                  border: 2px solid #000000;
+                  border-color: #deecf9;
+                  border: 1px solid #106ebe;
                   color: #0078d4;
-                  outline-offset: -3px;
-                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -640,8 +637,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 &:focus {
                   background-color: #deecf9;
-                  border: 2px solid #000000;
-                  outline-offset: -3px;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }
                 &:active {

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -460,13 +460,13 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 2px;
+                  bottom: 0px;
                   content: "";
-                  left: 2px;
-                  outline: 1px solid #605e5c;
+                  left: 0px;
+                  outline: 1px solid transparent;
                   position: absolute;
-                  right: 2px;
-                  top: 2px;
+                  right: 0px;
+                  top: 0px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -482,17 +482,21 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   top: 0px;
                 }
                 &:hover {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
+                  background-color: #005a9e;
+                  border: 2px solid #000000;
                   color: #201f1e;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
                 &:focus {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
+                  background-color: #005a9e;
+                  border: 2px solid #000000;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 &:active {
                   background-color: #0078d4;
@@ -592,15 +596,15 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   border: 0;
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: 2px;
+                  border: 1px solid transparent;
+                  bottom: 0px;
                   content: "";
-                  left: 2px;
+                  left: 0px;
                   outline-color: #ffffff;
-                  outline: 1px solid #605e5c;
+                  outline: 1px solid transparent;
                   position: absolute;
-                  right: 2px;
-                  top: 2px;
+                  right: 0px;
+                  top: 0px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -624,9 +628,10 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 &:hover {
                   background-color: #deecf9;
-                  border-color: #deecf9;
-                  border: 1px solid #106ebe;
+                  border: 2px solid #000000;
                   color: #0078d4;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -635,7 +640,9 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 &:focus {
                   background-color: #deecf9;
-                  border-color: #ffffff;
+                  border: 2px solid #000000;
+                  outline-offset: -3px;
+                  outline: 1px solid #ffffff;
                 }
                 &:active {
                   background-color: #ffffff;

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -460,13 +460,13 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 0px;
+                  bottom: 1px;
                   content: "";
-                  left: 0px;
+                  left: 1px;
                   outline: 1px solid transparent;
                   position: absolute;
-                  right: 0px;
-                  top: 0px;
+                  right: 1px;
+                  top: 1px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -597,14 +597,14 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid transparent;
-                  bottom: 0px;
+                  bottom: 1px;
                   content: "";
-                  left: 0px;
+                  left: 1px;
                   outline-color: #ffffff;
                   outline: 1px solid transparent;
                   position: absolute;
-                  right: 0px;
-                  top: 0px;
+                  right: 1px;
+                  top: 1px;
                   z-index: 1;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [10549](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10549)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Adds double black/white stroke outline when button is focused
- Changed secondary button ("Maybe Later") background color from `themeDarkAlt` to `themeDark` when focused.


**Fix:** 
![fix-1](https://user-images.githubusercontent.com/8649804/113438813-2b917180-939e-11eb-8825-c5a8ad557287.JPG)


