### PR TITLE
Wrap Tooltip content in <div> for non string content type

### DIFF
--- a/change/@fluentui-react-4c61963a-f0bd-47ee-bcfb-3ca4307ac376.json
+++ b/change/@fluentui-react-4c61963a-f0bd-47ee-bcfb-3ca4307ac376.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Wrap Tooltip content in div when type is not string",
+  "packageName": "@fluentui/react",
+  "email": "zhigzhen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.base.tsx
@@ -68,6 +68,10 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
   }
 
   private _onRenderContent = (props: ITooltipProps): JSX.Element => {
-    return <p className={this._classNames.subText}>{props.content}</p>;
+    if (typeof props.content === "string") {
+      return <p className={this._classNames.subText}>{props.content}</p>;
+    } else {
+      return <div>{props.content}</div>;
+    }
   };
 }

--- a/packages/react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.base.tsx
@@ -68,7 +68,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
   }
 
   private _onRenderContent = (props: ITooltipProps): JSX.Element => {
-    if (typeof props.content === "string") {
+    if (typeof props.content === 'string') {
       return <p className={this._classNames.subText}>{props.content}</p>;
     } else {
       return <div>{props.content}</div>;

--- a/packages/react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.base.tsx
@@ -71,7 +71,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     if (typeof props.content === 'string') {
       return <p className={this._classNames.subText}>{props.content}</p>;
     } else {
-      return <div>{props.content}</div>;
+      return <div className={this._classNames.subText}>{props.content}</div>;
     }
   };
 }

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
           <div
             role="tooltip"
           >
-            <p />
+            <div />
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17344
- [x] Include a change request file using $ yarn change

#### Description of changes

See the issue thread for more context. 

If a JSX object with a `<div>` other than a string is passed into the content field of a `TooltipHost` / `Tooltip`, the browser will complain with the following error:

> Warning: validateDOMnesting(...): `<div>` cannot appear as a descendant of `<p>`...

To deal with this error, we should only wrap the object in `<p>` if it is type string, otherwise we can wrap it in a `<div>`