### PR TITLE
Update API Extractor config detection, exclude local config

### DIFF
--- a/scripts/tasks/api-extractor.ts
+++ b/scripts/tasks/api-extractor.ts
@@ -4,7 +4,8 @@ import { apiExtractorVerifyTask, task, series } from 'just-scripts';
 
 const apiExtractorConfigs = glob
   .sync(path.join(process.cwd(), 'config/api-extractor*.json'))
-  .map(configPath => [configPath, configPath.replace(/.*\bapi-extractor(?:-(.*))?\.json$/, '$1') || 'default']);
+  .map(configPath => [configPath, configPath.replace(/.*\bapi-extractor(?:\.(.*))?\.json$/, '$1') || 'default'])
+  .filter(([, configName]) => configName !== 'local');
 
 // Whether to update automatically on build
 const localBuild = !process.env.TF_BUILD;


### PR DESCRIPTION
Update the API Extractor task to properly determine the config name assuming a file name format of `api-extractor.configName.json`, and exclude `api-extractor.local.json` if it exists.