### PR TITLE
chore: update the appearance filled styles on text-field, text-area and number-field components

### DIFF
--- a/change/@fluentui-web-components-107a678a-6dd4-4802-bfd2-a6b9947442c3.json
+++ b/change/@fluentui-web-components-107a678a-6dd4-4802-bfd2-a6b9947442c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update filled style on textfield textarea and numberfield",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -423,6 +423,11 @@ export const DividerStyles: import("@microsoft/fast-element").ElementStyles;
 // @public
 export const elevation: string;
 
+// Warning: (ae-internal-missing-underscore) The name "FillStateStyles" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const FillStateStyles: ElementStyles;
+
 // @public
 export const FlipperStyles: import("@microsoft/fast-element").ElementStyles;
 

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -3,6 +3,7 @@ import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior }
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   accentFillRestBehavior,
+  FillStateStyles,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -13,7 +14,6 @@ import {
   neutralOutlineActiveBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
-  FillStateStyles,
 } from '../styles/index';
 import { appearanceBehavior } from '../utilities/behaviors';
 

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -2,6 +2,7 @@ import { css } from '@microsoft/fast-element';
 import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
+  accentFillRestBehavior,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -23,9 +24,36 @@ export const NumberFieldFilledStyles = css`
   :host([appearance='filled']:hover:not([disabled])) .root {
     background: ${neutralFillHoverBehavior.var};
   }
+
+  :host([appearance='filled']:not([disabled]):active) .root {
+    border-color: ${neutralOutlineRestBehavior.var};
+    box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${neutralOutlineRestBehavior.var} inset;
+  }
+
+  :host([appearance='filled']:not([disabled]):active) .root::after {
+    content: '';
+    position: absolute;
+    top: -1px;
+    bottom: -1px;
+    border-top: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
+    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
+  }
+
+  :host([appearance='filled']:not([disabled]):active) .root::after {
+    left: 50%;
+    width: 40%;
+    transform: translateX(-50%);
+  }
+
+  :host([appearance='filled']:not([disabled]):focus-within:not(:active)) .root {
+    border-color: ${accentFillRestBehavior.var};
+    box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${accentFillRestBehavior.var} inset;
+  }
 `.withBehaviors(
+  accentFillRestBehavior,
   neutralFillHoverBehavior,
   neutralFillRestBehavior,
+  neutralOutlineRestBehavior,
   forcedColorsStylesheetBehavior(
     css`
       :host([appearance='filled']) .root {
@@ -34,7 +62,19 @@ export const NumberFieldFilledStyles = css`
       }
       :host([appearance='filled']:hover:not([disabled])) .root {
         background: ${SystemColors.Field};
+        border-color: ${SystemColors.FieldText};
+      }
+      :host([appearance='filled']:not([disabled]):active) .root {
+        border-color: ${SystemColors.FieldText};
+        box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${SystemColors.FieldText} inset;
+      }
+      :host([appearance='filled']:not([disabled]):active) .root::after {
+        border-top-color: ${SystemColors.Highlight};
+        border-bottom-color: ${SystemColors.Highlight};
+      }
+      :host([appearance='filled']:not([disabled]):focus-within:not(:active)) .root {
         border-color: ${SystemColors.Highlight};
+        box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${SystemColors.Highlight} inset;
       }
       :host([appearance='filled'][disabled]) .root {
         border-color: ${SystemColors.GrayText};
@@ -49,6 +89,7 @@ export const NumberFieldStyles = css`
         font-family: var(--body-font);
         outline: none;
         user-select: none;
+        position: relative;
     }
 
     .root {

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -273,7 +273,8 @@ export const NumberFieldStyles = css`
         background: ${SystemColors.Field};
       }
       :host([disabled]) ::placeholder,
-      :host([disabled]) ::-webkit-input-placeholder {
+      :host([disabled]) ::-webkit-input-placeholder,
+      :host([disabled]) .label {
         color: ${SystemColors.GrayText};
       }
     `,

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -13,42 +13,26 @@ import {
   neutralOutlineActiveBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
+  FillStateStyles,
 } from '../styles/index';
 import { appearanceBehavior } from '../utilities/behaviors';
 
 export const NumberFieldFilledStyles = css`
   :host([appearance='filled']) .root {
     background: ${neutralFillRestBehavior.var};
+    border-color: transparent;
   }
 
   :host([appearance='filled']:hover:not([disabled])) .root {
     background: ${neutralFillHoverBehavior.var};
+    border-color: transparent;
   }
 
-  :host([appearance='filled']:not([disabled]):active) .root {
-    border-color: ${neutralOutlineRestBehavior.var};
-    box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${neutralOutlineRestBehavior.var} inset;
+  :host([appearance='filled']:focus-within:not([disabled])) .root {
+    border-color: transparent;
+    box-shadow: none;
   }
-
-  :host([appearance='filled']:not([disabled]):active) .root::after {
-    content: '';
-    position: absolute;
-    top: -1px;
-    bottom: -1px;
-    border-top: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
-    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
-  }
-
-  :host([appearance='filled']:not([disabled]):active) .root::after {
-    left: 50%;
-    width: 40%;
-    transform: translateX(-50%);
-  }
-
-  :host([appearance='filled']:not([disabled]):focus-within:not(:active)) .root {
-    border-color: ${accentFillRestBehavior.var};
-    box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${accentFillRestBehavior.var} inset;
-  }
+  ${FillStateStyles}
 `.withBehaviors(
   accentFillRestBehavior,
   neutralFillHoverBehavior,
@@ -56,25 +40,23 @@ export const NumberFieldFilledStyles = css`
   neutralOutlineRestBehavior,
   forcedColorsStylesheetBehavior(
     css`
-      :host([appearance='filled']) .root {
-        background: ${SystemColors.Field};
-        border-color: ${SystemColors.FieldText};
-      }
+      :host([appearance='filled']) .root,
       :host([appearance='filled']:hover:not([disabled])) .root {
         background: ${SystemColors.Field};
         border-color: ${SystemColors.FieldText};
       }
-      :host([appearance='filled']:not([disabled]):active) .root {
+      :host([appearance='filled']:active:not([disabled])) .root,
+      :host([appearance='filled']:focus-within:not([disabled])) .root {
+        background: ${SystemColors.Field};
         border-color: ${SystemColors.FieldText};
-        box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${SystemColors.FieldText} inset;
       }
-      :host([appearance='filled']:not([disabled]):active) .root::after {
-        border-top-color: ${SystemColors.Highlight};
+      :host([appearance='filled']:not([disabled]):active)::after,
+      :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
         border-bottom-color: ${SystemColors.Highlight};
       }
-      :host([appearance='filled']:not([disabled]):focus-within:not(:active)) .root {
-        border-color: ${SystemColors.Highlight};
-        box-shadow: 0 0 0 calc(var(--outline-width) * 1px) ${SystemColors.Highlight} inset;
+      :host([appearance='filled'][disabled]) .root {
+        border-color: ${SystemColors.GrayText};
+        background: ${SystemColors.Field};
       }
       :host([appearance='filled'][disabled]) .root {
         border-color: ${SystemColors.GrayText};

--- a/packages/web-components/src/styles/patterns/index.ts
+++ b/packages/web-components/src/styles/patterns/index.ts
@@ -1,1 +1,2 @@
 export * from './button';
+export * from './input';

--- a/packages/web-components/src/styles/patterns/input.ts
+++ b/packages/web-components/src/styles/patterns/input.ts
@@ -1,6 +1,9 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import { accentFillRestBehavior } from '../behaviors';
 
+/**
+ * @internal
+ */
 export const FillStateStyles: ElementStyles = css`
   :host([appearance='filled']:not(.disabled):active)::after,
   :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {

--- a/packages/web-components/src/styles/patterns/input.ts
+++ b/packages/web-components/src/styles/patterns/input.ts
@@ -1,0 +1,28 @@
+import { css, ElementStyles } from '@microsoft/fast-element';
+import { accentFillRestBehavior } from '../behaviors';
+
+export const FillStateStyles: ElementStyles = css`
+  :host([appearance='filled']:not(.disabled):active)::after,
+  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
+    border-bottom-left-radius: calc(var(--corner-radius) * 1px);
+    border-bottom-right-radius: calc(var(--corner-radius) * 1px);
+    z-index: 2;
+  }
+
+  :host([appearance='filled']:not(.disabled):active)::after {
+    left: 50%;
+    width: 40%;
+    transform: translateX(-50%);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
+    left: 0;
+    width: 100%;
+  }
+`;

--- a/packages/web-components/src/styles/patterns/input.ts
+++ b/packages/web-components/src/styles/patterns/input.ts
@@ -14,6 +14,7 @@ export const FillStateStyles: ElementStyles = css`
     border-bottom-left-radius: calc(var(--corner-radius) * 1px);
     border-bottom-right-radius: calc(var(--corner-radius) * 1px);
     z-index: 2;
+    transition: all 300ms cubic-bezier(0.1, 0.9, 0.2, 1);
   }
 
   :host([appearance='filled']:not(.disabled):active)::after {

--- a/packages/web-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/src/text-area/text-area.styles.ts
@@ -1,6 +1,8 @@
 import { css } from '@microsoft/fast-element';
 import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
+import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
+  accentFillRestBehavior,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -23,13 +25,62 @@ export const TextAreaFilledStyles = css`
     background: ${neutralFillHoverBehavior.var};
     border-color: transparent;
   }
-`.withBehaviors(neutralFillHoverBehavior, neutralFillRestBehavior);
+
+  :host([appearance='filled']:focus-within:not([disabled])) .control {
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  :host([appearance='filled']:not([disabled]):active)::after,
+  :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
+    border-bottom-left-radius: calc(var(--corner-radius) * 1px);
+    border-bottom-right-radius: calc(var(--corner-radius) * 1px);
+    z-index: 2;
+  }
+
+  :host([appearance='filled']:not([disabled]):active)::after {
+    left: 50%;
+    width: 40%;
+    transform: translateX(-50%);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
+    left: 0;
+    width: 100%;
+  }
+`.withBehaviors(
+  accentFillRestBehavior,
+  neutralFillHoverBehavior,
+  neutralFillRestBehavior,
+  forcedColorsStylesheetBehavior(
+    css`
+      :host([appearance='filled']:hover:not([disabled])) .control,
+      :host([appearance='filled']:focus-within:not([disabled])) .control {
+        background: ${SystemColors.Field};
+        border-color: ${SystemColors.FieldText};
+      }
+      :host([appearance='filled']:not([disabled]):active)::after,
+      :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
+        border-bottom-color: ${SystemColors.Highlight};
+      }
+    `,
+  ),
+);
 
 export const TextAreaStyles = css`
-    ${display('inline-block')} :host {
+    ${display('inline-flex')} :host {
         font-family: var(--body-font);
         outline: none;
         user-select: none;
+        position: relative;
+        flex-direction: column;
+        vertical-align: bottom;
     }
 
     .control {

--- a/packages/web-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/src/text-area/text-area.styles.ts
@@ -3,6 +3,7 @@ import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior }
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   accentFillRestBehavior,
+  FillStateStyles,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -12,7 +13,6 @@ import {
   neutralForegroundRestBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
-  FillStateStyles,
 } from '../styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 

--- a/packages/web-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/src/text-area/text-area.styles.ts
@@ -164,6 +164,15 @@ export const TextAreaStyles = css`
       :host([disabled]) {
         opacity: 1;
       }
+      ::placeholder,
+      ::-webkit-input-placeholder {
+        color: ${SystemColors.FieldText};
+      }
+      :host([disabled]) ::placeholder,
+      :host([disabled]) ::-webkit-input-placeholder,
+      :host([disabled]) .label {
+        color: ${SystemColors.GrayText};
+      }
     `,
   ),
 );

--- a/packages/web-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/src/text-area/text-area.styles.ts
@@ -12,6 +12,7 @@ import {
   neutralForegroundRestBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
+  FillStateStyles,
 } from '../styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 
@@ -30,30 +31,7 @@ export const TextAreaFilledStyles = css`
     border-color: transparent;
     box-shadow: none;
   }
-
-  :host([appearance='filled']:not([disabled]):active)::after,
-  :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
-    border-bottom-left-radius: calc(var(--corner-radius) * 1px);
-    border-bottom-right-radius: calc(var(--corner-radius) * 1px);
-    z-index: 2;
-  }
-
-  :host([appearance='filled']:not([disabled]):active)::after {
-    left: 50%;
-    width: 40%;
-    transform: translateX(-50%);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
-    left: 0;
-    width: 100%;
-  }
+  ${FillStateStyles}
 `.withBehaviors(
   accentFillRestBehavior,
   neutralFillHoverBehavior,

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -3,6 +3,7 @@ import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior }
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   accentFillRestBehavior,
+  FillStateStyles,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -12,7 +13,6 @@ import {
   neutralForegroundRestBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
-  FillStateStyles,
 } from '../styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -12,6 +12,7 @@ import {
   neutralForegroundRestBehavior,
   neutralOutlineHoverBehavior,
   neutralOutlineRestBehavior,
+  FillStateStyles,
 } from '../styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 
@@ -30,30 +31,7 @@ export const TextFieldFilledStyles = css`
     border-color: transparent;
     box-shadow: none;
   }
-
-  :host([appearance='filled']:not(.disabled):active)::after,
-  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
-    border-bottom-left-radius: calc(var(--corner-radius) * 1px);
-    border-bottom-right-radius: calc(var(--corner-radius) * 1px);
-    z-index: 2;
-  }
-
-  :host([appearance='filled']:not(.disabled):active)::after {
-    left: 50%;
-    width: 40%;
-    transform: translateX(-50%);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
-    left: 0;
-    width: 100%;
-  }
+  ${FillStateStyles}
 `.withBehaviors(
   accentFillRestBehavior,
   neutralFillHoverBehavior,

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -2,6 +2,7 @@ import { css } from '@microsoft/fast-element';
 import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
+  accentFillRestBehavior,
   heightNumber,
   neutralFillHoverBehavior,
   neutralFillInputHoverBehavior,
@@ -24,7 +25,37 @@ export const TextFieldFilledStyles = css`
     background: ${neutralFillHoverBehavior.var};
     border-color: transparent;
   }
+
+  :host([appearance='filled']:focus-within:not(.disabled)) .root {
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  :host([appearance='filled']:not(.disabled):active)::after,
+  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    border-bottom: calc(var(--focus-outline-width) * 1px) solid ${accentFillRestBehavior.var};
+    border-bottom-left-radius: calc(var(--corner-radius) * 1px);
+    border-bottom-right-radius: calc(var(--corner-radius) * 1px);
+    z-index: 2;
+  }
+
+  :host([appearance='filled']:not(.disabled):active)::after {
+    left: 50%;
+    width: 40%;
+    transform: translateX(-50%);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  :host([appearance='filled']:not(.disabled):focus-within:not(:active))::after {
+    left: 0;
+    width: 100%;
+  }
 `.withBehaviors(
+  accentFillRestBehavior,
   neutralFillHoverBehavior,
   neutralFillRestBehavior,
   forcedColorsStylesheetBehavior(
@@ -33,11 +64,20 @@ export const TextFieldFilledStyles = css`
         background: ${SystemColors.Field};
         border-color: ${SystemColors.FieldText};
       }
-      :host([appearance='filled']:hover:not(.disabled)) .root {
+      :host([appearance='filled']:hover:not([disabled])) .root,
+      :host([appearance='filled']:focus-within:not([disabled])) .root {
         background: ${SystemColors.Field};
-        border-color: ${SystemColors.Highlight};
+        border-color: ${SystemColors.FieldText};
       }
-      :host([appearance='filled'].disabled) .root {
+      :host([appearance='filled']:active:not([disabled])) .root {
+        background: ${SystemColors.Field};
+        border-color: ${SystemColors.FieldText};
+      }
+      :host([appearance='filled']:not([disabled]):active)::after,
+      :host([appearance='filled']:not([disabled]):focus-within:not(:active))::after {
+        border-bottom-color: ${SystemColors.Highlight};
+      }
+      :host([appearance='filled'][disabled]) .root {
         border-color: ${SystemColors.GrayText};
         background: ${SystemColors.Field};
       }
@@ -50,6 +90,7 @@ export const TextFieldStyles = css`
         font-family: var(--body-font);
         outline: none;
         user-select: none;
+        position: relative;
     }
 
     .root {
@@ -178,6 +219,11 @@ export const TextFieldStyles = css`
       }
       .control {
         color: ${SystemColors.ButtonText};
+      }
+      ::placeholder,
+      ::-webkit-input-placeholder,
+      :host([disabled]) .label {
+        color: ${SystemColors.GrayText};
       }
     `,
   ),

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -221,7 +221,11 @@ export const TextFieldStyles = css`
         color: ${SystemColors.ButtonText};
       }
       ::placeholder,
-      ::-webkit-input-placeholder,
+      ::-webkit-input-placeholder {
+        color: ${SystemColors.FieldText};
+      }
+      :host(.disabled) ::placeholder,
+      :host(.disabled) ::-webkit-input-placeholder,
       :host([disabled]) .label {
         color: ${SystemColors.GrayText};
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The updated style involves adding the active state for text-field text-area and number-filed, the active state has a small underline and when focused the underline fills the width of the input. 

Created a file in the patterns directory called `input.ts`. This is where we will put different helper styles for the different types of input appearance. Currently, the only helper object is for the `filled` appearance.  

Additional changes were in the text-area component, where the display was changed to inline-flex, this removes an extra space that was being set on the bottom of the component.
High contrast style was also addressed to match the updated design.
 
text-field (rest, hover, active and focus)
![image](https://user-images.githubusercontent.com/37851220/112921330-6f932680-90bf-11eb-8274-4b7d5f84ae1d.png)
![image](https://user-images.githubusercontent.com/37851220/112921336-728e1700-90bf-11eb-8c9d-bac0fee42d6d.png)
![image](https://user-images.githubusercontent.com/37851220/112705733-4d9a6980-8e5d-11eb-865d-552c3536ebcc.png)
![image](https://user-images.githubusercontent.com/37851220/112705736-512df080-8e5d-11eb-9802-950fe421e48b.png)

text-area (rest, hover, active and focus)
![image](https://user-images.githubusercontent.com/37851220/112921303-62763780-90bf-11eb-9706-7f53cac20ba1.png)
![image](https://user-images.githubusercontent.com/37851220/112921310-64d89180-90bf-11eb-9214-a4da26c0ae55.png)
![image](https://user-images.githubusercontent.com/37851220/112705741-58ed9500-8e5d-11eb-9892-770c97fa0b45.png)
![image](https://user-images.githubusercontent.com/37851220/112705746-5e4adf80-8e5d-11eb-8a5c-0cc59bf73d34.png)

number-field (rest, hover, active and focus)
![image](https://user-images.githubusercontent.com/37851220/112921270-4e323a80-90bf-11eb-9a33-ba98c79b25a0.png)
![image](https://user-images.githubusercontent.com/37851220/112921278-51c5c180-90bf-11eb-9167-9f72a0b2894e.png)
![image](https://user-images.githubusercontent.com/37851220/112921107-0c08f900-90bf-11eb-8278-2e1afbaf177e.png)
![image](https://user-images.githubusercontent.com/37851220/112921114-0f9c8000-90bf-11eb-9d44-61e1d41eaf8b.png)

High Contrast (active and focus states)
![image](https://user-images.githubusercontent.com/37851220/112705762-6e62bf00-8e5d-11eb-86af-de27caf7322f.png)
![image](https://user-images.githubusercontent.com/37851220/112705766-70c51900-8e5d-11eb-9733-0245fb8e151e.png)
![image](https://user-images.githubusercontent.com/37851220/112705768-7458a000-8e5d-11eb-9c15-2ce7c7f92b15.png)
![image](https://user-images.githubusercontent.com/37851220/112705771-77539080-8e5d-11eb-8cff-6958bb2fa687.png)
![image](https://user-images.githubusercontent.com/37851220/112921135-1b884200-90bf-11eb-962c-509b4886be81.png)
![image](https://user-images.githubusercontent.com/37851220/112921137-1dea9c00-90bf-11eb-9bfb-de442f972ae4.png)


#### Focus areas to test

(optional)
