### PR TITLE
(7.0) Fix Capitalization links in docs

### DIFF
--- a/change/@fluentui-react-examples-cb4489d5-256e-44c1-bdda-3ee8c9f53b4e.json
+++ b/change/@fluentui-react-examples-cb4489d5-256e-44c1-bdda-3ee8c9f53b4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Capitalization links in docs",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/docs/DetailsListBestPractices.md
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/docs/DetailsListBestPractices.md
@@ -7,9 +7,7 @@
 
 ### Content
 
-- Use sentence-style capitalization for column headers—only capitalize the first word. For more info, see [Capitalization] in the Microsoft Writing Style Guide.
-
-[capitalization]: https://docs.microsoft.com/style-guide/capitalization
+- Use sentence-style capitalization for column headers—only capitalize the first word. For more info, see [Capitalization](https://docs.microsoft.com/style-guide/capitalization) in the Microsoft Writing Style Guide.
 
 ### FAQ
 

--- a/packages/react-examples/src/office-ui-fabric-react/Panel/docs/PanelBestPractices.md
+++ b/packages/react-examples/src/office-ui-fabric-react/Panel/docs/PanelBestPractices.md
@@ -26,10 +26,8 @@
 
 - Titles should explain the panel content in clear, concise, and specific terms.
 - Keep the length of the title to one line, if possible.
-- Use sentence-style capitalization—only capitalize the first word. For more info, see [Capitalization] in the Microsoft Writing Style Guide.
+- Use sentence-style capitalization—only capitalize the first word. For more info, see [Capitalization](https://docs.microsoft.com/style-guide/capitalization) in the Microsoft Writing Style Guide.
 - Don’t put a period at the end of the title.
-
-[capitalization]: https://docs.microsoft.com/style-guide/capitalization
 
 #### Button labels
 


### PR DESCRIPTION
Fix a couple of links in doc markdown that used invalid formatting.

Cherry-pick of #17596