### PR TITLE
Command bar dark

### DIFF
--- a/change/@fluentui-azure-themes-7c449883-1242-4561-96d9-3bdf0c32e023.json
+++ b/change/@fluentui-azure-themes-7c449883-1242-4561-96d9-3bdf0c32e023.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Azure Theme Command Bar Styling",
+  "packageName": "@fluentui/azure-themes",
+  "email": "aidanmc95@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -289,10 +289,17 @@ export const DarkSemanticColors: IAzureSemanticColors = {
         color: BaseColors.GRAY_F3F2F1,
       },
       hover: {
+        background: BaseColors.GRAY_252423,
         color: BaseColors.GRAY_FAF9F8,
       },
       disabled: {
         color: BaseColors.GRAY_797775,
+      },
+      selected: {
+        background: BaseColors.GRAY_292827,
+      },
+      selectedHover: {
+        background: BaseColors.GRAY_323130,
       },
     },
   },
@@ -484,10 +491,17 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
         color: BaseColors.WHITE,
       },
       hover: {
+        background: BaseColors.BLUE_00FFFF,
         color: BaseColors.GRAY_1B1A19,
       },
       disabled: {
         color: BaseColors.GREEN_0AFF00,
+      },
+      selected: {
+        background: BaseColors.BLUE_00FFFF,
+      },
+      selectedHover: {
+        background: BaseColors.BLUE_00FFFF,
       },
     },
   },
@@ -679,10 +693,17 @@ export const LightSemanticColors: IAzureSemanticColors = {
         color: BaseColors.GRAY_323130,
       },
       hover: {
+        background: BaseColors.GRAY_F3F2F1,
         color: BaseColors.GRAY_201F1E,
       },
       disabled: {
         color: BaseColors.GRAY_A19F9D,
+      },
+      selected: {
+        background: BaseColors.GRAY_EDEBE9,
+      },
+      selectedHover: {
+        background: BaseColors.GRAY_F3F2F1,
       },
     },
   },
@@ -874,10 +895,17 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
         color: BaseColors.BLACK,
       },
       hover: {
+        background: BaseColors.PURPLE_800080,
         color: BaseColors.WHITE,
       },
       disabled: {
         color: BaseColors.RED_800000,
+      },
+      selected: {
+        background: BaseColors.PURPLE_800080,
+      },
+      selectedHover: {
+        background: BaseColors.PURPLE_800080,
       },
     },
   },

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -288,15 +288,20 @@ export const DarkSemanticColors: IAzureSemanticColors = {
       root: {
         color: BaseColors.GRAY_F3F2F1,
       },
-      hover: {
-        background: BaseColors.GRAY_252423,
-        color: BaseColors.GRAY_FAF9F8,
-      },
       disabled: {
         color: BaseColors.GRAY_797775,
       },
+      focus: {
+        borderColor: BaseColors.GRAY_A19F9D,
+      },
+      hover: {
+        background: BaseColors.GRAY_252423,
+        color: BaseColors.GRAY_FAF9F8,
+        icon: BaseColors.BLUE_3AA0F3,
+      },
       selected: {
         background: BaseColors.GRAY_292827,
+        icon: BaseColors.BLUE_6CB8F6,
       },
       selectedHover: {
         background: BaseColors.GRAY_323130,
@@ -490,15 +495,20 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
       root: {
         color: BaseColors.WHITE,
       },
-      hover: {
-        background: BaseColors.BLUE_00FFFF,
-        color: BaseColors.GRAY_1B1A19,
-      },
       disabled: {
         color: BaseColors.GREEN_0AFF00,
       },
+      focus: {
+        borderColor: 'none',
+      },
+      hover: {
+        background: BaseColors.BLUE_00FFFF,
+        color: BaseColors.GRAY_1B1A19,
+        icon: BaseColors.BLACK,
+      },
       selected: {
         background: BaseColors.BLUE_00FFFF,
+        icon: BaseColors.BLACK,
       },
       selectedHover: {
         background: BaseColors.BLUE_00FFFF,
@@ -692,15 +702,20 @@ export const LightSemanticColors: IAzureSemanticColors = {
       root: {
         color: BaseColors.GRAY_323130,
       },
-      hover: {
-        background: BaseColors.GRAY_F3F2F1,
-        color: BaseColors.GRAY_201F1E,
-      },
       disabled: {
         color: BaseColors.GRAY_A19F9D,
       },
+      focus: {
+        borderColor: BaseColors.GRAY_605E5C,
+      },
+      hover: {
+        background: BaseColors.GRAY_F3F2F1,
+        color: BaseColors.GRAY_201F1E,
+        icon: BaseColors.BLUE_106EBE,
+      },
       selected: {
         background: BaseColors.GRAY_EDEBE9,
+        icon: BaseColors.BLUE_005A9E,
       },
       selectedHover: {
         background: BaseColors.GRAY_F3F2F1,
@@ -894,15 +909,20 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
       root: {
         color: BaseColors.BLACK,
       },
-      hover: {
-        background: BaseColors.PURPLE_800080,
-        color: BaseColors.WHITE,
-      },
       disabled: {
         color: BaseColors.RED_800000,
       },
+      focus: {
+        borderColor: 'none',
+      },
+      hover: {
+        background: BaseColors.PURPLE_800080,
+        color: BaseColors.WHITE,
+        icon: BaseColors.WHITE,
+      },
       selected: {
         background: BaseColors.PURPLE_800080,
+        icon: BaseColors.WHITE,
       },
       selectedHover: {
         background: BaseColors.PURPLE_800080,

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -718,7 +718,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
         icon: BaseColors.BLUE_005A9E,
       },
       selectedHover: {
-        background: BaseColors.GRAY_F3F2F1,
+        background: BaseColors.GRAY_E1DFDD,
       },
     },
   },

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -283,7 +283,18 @@ export const DarkSemanticColors: IAzureSemanticColors = {
     },
   },
   commandBar: {
-    border: BaseColors.GRAY_605E5C,
+    border: BaseColors.GRAY_323130,
+    button: {
+      root: {
+        color: BaseColors.GRAY_F3F2F1,
+      },
+      hover: {
+        color: BaseColors.GRAY_FAF9F8,
+      },
+      disabled: {
+        color: BaseColors.GRAY_797775,
+      },
+    },
   },
   datePicker: {
     rest: {
@@ -468,6 +479,17 @@ export const HighContrastDarkSemanticColors: IAzureSemanticColors = {
   },
   commandBar: {
     border: BaseColors.GRAY_605E5C,
+    button: {
+      root: {
+        color: BaseColors.WHITE,
+      },
+      hover: {
+        color: BaseColors.GRAY_1B1A19,
+      },
+      disabled: {
+        color: BaseColors.GREEN_0AFF00,
+      },
+    },
   },
   datePicker: {
     rest: {
@@ -652,6 +674,17 @@ export const LightSemanticColors: IAzureSemanticColors = {
   },
   commandBar: {
     border: BaseColors.GRAY_CCCCCC,
+    button: {
+      root: {
+        color: BaseColors.GRAY_323130,
+      },
+      hover: {
+        color: BaseColors.GRAY_201F1E,
+      },
+      disabled: {
+        color: BaseColors.GRAY_A19F9D,
+      },
+    },
   },
   datePicker: {
     rest: {
@@ -836,6 +869,17 @@ export const HighContrastLightSemanticColors: IAzureSemanticColors = {
   },
   commandBar: {
     border: BaseColors.GRAY_CCCCCC,
+    button: {
+      root: {
+        color: BaseColors.BLACK,
+      },
+      hover: {
+        color: BaseColors.WHITE,
+      },
+      disabled: {
+        color: BaseColors.RED_800000,
+      },
+    },
   },
   datePicker: {
     rest: {

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -89,6 +89,9 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
 
   // extended
+  commandBarButtonText: DarkSemanticColors.commandBar.button.root.color,
+  commandBarButtonTextDisabled: DarkSemanticColors.commandBar.button.disabled.color,
+  commandBarButtonTextHover: DarkSemanticColors.commandBar.button.hover.color,
   controlAccent: DarkSemanticColors.controlOutlines.accent,
   controlBackground: DarkSemanticColors.controlOutlines.background,
   controlOutline: DarkSemanticColors.controlOutlines.rest,

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -89,6 +89,12 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
 
   // extended
+  commandBarButtonAfterColor: DarkSemanticColors.commandBar.button.focus.borderColor,
+  commandBarButtonBackgroundHover: DarkSemanticColors.commandBar.button.hover.background,
+  commandBarButtonBackgroundSelected: DarkSemanticColors.commandBar.button.selected.background,
+  commandBarButtonBackgroundSelectedHover: DarkSemanticColors.commandBar.button.selectedHover.background,
+  commandBarButtonIconHover: DarkSemanticColors.commandBar.button.hover.icon,
+  commandBarButtonIconSelected: DarkSemanticColors.commandBar.button.selected.icon,
   commandBarButtonText: DarkSemanticColors.commandBar.button.root.color,
   commandBarButtonTextDisabled: DarkSemanticColors.commandBar.button.disabled.color,
   commandBarButtonTextHover: DarkSemanticColors.commandBar.button.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -87,6 +87,9 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   rowBorder: HighContrastDarkSemanticColors.detailsRow.border,
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
+  commandBarButtonText: HighContrastDarkSemanticColors.commandBar.button.root.color,
+  commandBarButtonTextDisabled: HighContrastDarkSemanticColors.commandBar.button.disabled.color,
+  commandBarButtonTextHover: HighContrastDarkSemanticColors.commandBar.button.hover.color,
   controlAccent: HighContrastDarkSemanticColors.controlOutlines.accent,
   controlBackground: HighContrastDarkSemanticColors.controlOutlines.background,
   controlOutline: HighContrastDarkSemanticColors.controlOutlines.rest,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -87,6 +87,12 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   rowBorder: HighContrastDarkSemanticColors.detailsRow.border,
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
+  commandBarButtonAfterColor: HighContrastDarkSemanticColors.commandBar.button.focus.borderColor,
+  commandBarButtonBackgroundHover: HighContrastDarkSemanticColors.commandBar.button.hover.background,
+  commandBarButtonBackgroundSelected: HighContrastDarkSemanticColors.commandBar.button.selected.background,
+  commandBarButtonBackgroundSelectedHover: HighContrastDarkSemanticColors.commandBar.button.selectedHover.background,
+  commandBarButtonIconHover: HighContrastDarkSemanticColors.commandBar.button.hover.icon,
+  commandBarButtonIconSelected: HighContrastDarkSemanticColors.commandBar.button.selected.icon,
   commandBarButtonText: HighContrastDarkSemanticColors.commandBar.button.root.color,
   commandBarButtonTextDisabled: HighContrastDarkSemanticColors.commandBar.button.disabled.color,
   commandBarButtonTextHover: HighContrastDarkSemanticColors.commandBar.button.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -88,6 +88,12 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   tabHover: HighContrastLightSemanticColors.tabs.hover,
   variantBorder: HighContrastLightSemanticColors.controlOutlines.rest,
   // extended
+  commandBarButtonAfterColor: HighContrastLightSemanticColors.commandBar.button.focus.borderColor,
+  commandBarButtonBackgroundHover: HighContrastLightSemanticColors.commandBar.button.hover.background,
+  commandBarButtonBackgroundSelected: HighContrastLightSemanticColors.commandBar.button.selected.background,
+  commandBarButtonBackgroundSelectedHover: HighContrastLightSemanticColors.commandBar.button.selectedHover.background,
+  commandBarButtonIconHover: HighContrastLightSemanticColors.commandBar.button.hover.icon,
+  commandBarButtonIconSelected: HighContrastLightSemanticColors.commandBar.button.selected.icon,
   commandBarButtonText: HighContrastLightSemanticColors.commandBar.button.root.color,
   commandBarButtonTextDisabled: HighContrastLightSemanticColors.commandBar.button.disabled.color,
   commandBarButtonTextHover: HighContrastLightSemanticColors.commandBar.button.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -88,6 +88,9 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   tabHover: HighContrastLightSemanticColors.tabs.hover,
   variantBorder: HighContrastLightSemanticColors.controlOutlines.rest,
   // extended
+  commandBarButtonText: HighContrastLightSemanticColors.commandBar.button.root.color,
+  commandBarButtonTextDisabled: HighContrastLightSemanticColors.commandBar.button.disabled.color,
+  commandBarButtonTextHover: HighContrastLightSemanticColors.commandBar.button.hover.color,
   controlAccent: HighContrastLightSemanticColors.controlOutlines.accent,
   controlBackground: HighContrastLightSemanticColors.controlOutlines.background,
   controlOutline: HighContrastLightSemanticColors.controlOutlines.rest,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -87,6 +87,9 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   tabHover: LightSemanticColors.tabs.hover,
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
+  commandBarButtonText: LightSemanticColors.commandBar.button.root.color,
+  commandBarButtonTextDisabled: LightSemanticColors.commandBar.button.disabled.color,
+  commandBarButtonTextHover: LightSemanticColors.commandBar.button.hover.color,
   controlAccent: LightSemanticColors.controlOutlines.accent,
   controlBackground: LightSemanticColors.controlOutlines.background,
   controlOutline: LightSemanticColors.controlOutlines.rest,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -87,6 +87,12 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   tabHover: LightSemanticColors.tabs.hover,
   variantBorder: CommonSemanticColors.dividers.lineSeparator,
   // extended
+  commandBarButtonAfterColor: LightSemanticColors.commandBar.button.focus.borderColor,
+  commandBarButtonBackgroundHover: LightSemanticColors.commandBar.button.hover.background,
+  commandBarButtonBackgroundSelected: LightSemanticColors.commandBar.button.selected.background,
+  commandBarButtonBackgroundSelectedHover: LightSemanticColors.commandBar.button.selectedHover.background,
+  commandBarButtonIconHover: LightSemanticColors.commandBar.button.hover.icon,
+  commandBarButtonIconSelected: LightSemanticColors.commandBar.button.selected.icon,
   commandBarButtonText: LightSemanticColors.commandBar.button.root.color,
   commandBarButtonTextDisabled: LightSemanticColors.commandBar.button.disabled.color,
   commandBarButtonTextHover: LightSemanticColors.commandBar.button.hover.color,

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -140,6 +140,17 @@ export interface IAzureSemanticColors {
   };
   commandBar: {
     border: string;
+    button: {
+      root: {
+        color: string;
+      };
+      hover: {
+        color: string;
+      };
+      disabled: {
+        color: string;
+      };
+    };
   };
   datePicker: {
     rest: {

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -147,12 +147,17 @@ export interface IAzureSemanticColors {
       hover: {
         background: string;
         color: string;
+        icon: string;
       };
       disabled: {
         color: string;
       };
+      focus: {
+        borderColor: string;
+      };
       selected: {
         background: string;
+        icon: string;
       };
       selectedHover: {
         background: string;

--- a/packages/azure-themes/src/azure/IAzureSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IAzureSemanticColors.ts
@@ -145,10 +145,17 @@ export interface IAzureSemanticColors {
         color: string;
       };
       hover: {
+        background: string;
         color: string;
       };
       disabled: {
         color: string;
+      };
+      selected: {
+        background: string;
+      };
+      selectedHover: {
+        background: string;
       };
     };
   };

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -35,6 +35,12 @@ export interface IExtendedSemanticColors extends ISemanticColors {
   choiceGroupContainerBorder: string;
   choiceGroupContainerBorderStyle: string;
   choiceGroupUncheckedDotHover: string;
+  commandBarButtonAfterColor: string;
+  commandBarButtonBackgroundHover: string;
+  commandBarButtonBackgroundSelected: string;
+  commandBarButtonBackgroundSelectedHover: string;
+  commandBarButtonIconHover: string;
+  commandBarButtonIconSelected: string;
   commandBarButtonText: string;
   commandBarButtonTextHover: string;
   commandBarButtonTextDisabled: string;

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -35,6 +35,9 @@ export interface IExtendedSemanticColors extends ISemanticColors {
   choiceGroupContainerBorder: string;
   choiceGroupContainerBorderStyle: string;
   choiceGroupUncheckedDotHover: string;
+  commandBarButtonText: string;
+  commandBarButtonTextHover: string;
+  commandBarButtonTextDisabled: string;
   commandBarBorder: string;
   controlAccent: string;
   controlBackground: string;

--- a/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
@@ -71,8 +71,16 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
       },
     },
     rootChecked: {
-      backgroundColor: semanticColors.listItemBackgroundChecked,
-      color: semanticColors.bodyText,
+      backgroundColor: extendedSemanticColors.commandBarButtonBackgroundSelected,
+      color: extendedSemanticColors.commandBarButtonTextHover,
+      selectors: {
+        '.ms-Button-icon': {
+          color: extendedSemanticColors.commandBarButtonIconSelected,
+        },
+        '.ms-Button-menuIcon': {
+          color: extendedSemanticColors.commandBarButtonTextHover,
+        },
+      },
     },
     rootDisabled: {
       backgroundColor: semanticColors.bodyBackground,

--- a/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
@@ -18,7 +18,7 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
       ...getFocusStyle(theme, { inset: 2 }),
       fontSize: theme.fonts.medium.fontSize,
       backgroundColor: semanticColors.bodyBackground,
-      color: semanticColors.bodyText,
+      color: extendedSemanticColors.commandBarButtonText,
       paddingLeft: 4,
       paddingRight: 4,
     },
@@ -48,7 +48,7 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
     },
     rootHovered: {
       backgroundColor: semanticColors.menuItemBackgroundHovered,
-      color: semanticColors.buttonTextHovered,
+      color: extendedSemanticColors.commandBarButtonTextHover,
       selectors: {
         '.ms-Button-icon': {
           color: extendedSemanticColors.iconButtonFillHovered,
@@ -76,7 +76,7 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
     },
     rootDisabled: {
       backgroundColor: semanticColors.bodyBackground,
-      color: semanticColors.disabledBodyText,
+      color: extendedSemanticColors.commandBarButtonTextDisabled,
     },
     rootFocused: {
       backgroundColor: semanticColors.menuItemBackgroundHovered,

--- a/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
@@ -23,50 +23,50 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
       paddingRight: 4,
     },
     rootExpanded: {
-      backgroundColor: semanticColors.menuItemBackgroundHovered,
-      color: semanticColors.buttonTextHovered,
+      backgroundColor: extendedSemanticColors.commandBarButtonBackgroundHover,
+      color: extendedSemanticColors.commandBarButtonTextHover,
       selectors: {
         '.ms-Button-icon': {
-          color: extendedSemanticColors.iconButtonFillHovered,
+          color: extendedSemanticColors.commandBarButtonIconHover,
         },
         '.ms-Button-menuIcon': {
-          color: semanticColors.buttonTextHovered,
+          color: extendedSemanticColors.commandBarButtonTextHover,
         },
       },
     },
     rootExpandedHovered: {
-      backgroundColor: semanticColors.menuItemBackgroundHovered,
-      color: semanticColors.buttonTextHovered,
+      backgroundColor: extendedSemanticColors.commandBarButtonBackgroundSelectedHover,
+      color: extendedSemanticColors.commandBarButtonTextHover,
       selectors: {
         '.ms-Button-icon': {
-          color: extendedSemanticColors.iconButtonFillHovered,
+          color: extendedSemanticColors.commandBarButtonIconSelected,
         },
         '.ms-Button-menuIcon': {
-          color: extendedSemanticColors.buttonTextHovered,
+          color: extendedSemanticColors.commandBarButtonTextHover,
         },
       },
     },
     rootHovered: {
-      backgroundColor: semanticColors.menuItemBackgroundHovered,
+      backgroundColor: extendedSemanticColors.commandBarButtonBackgroundHover,
       color: extendedSemanticColors.commandBarButtonTextHover,
       selectors: {
         '.ms-Button-icon': {
-          color: extendedSemanticColors.iconButtonFillHovered,
+          color: extendedSemanticColors.commandBarButtonIconHover,
         },
         '.ms-Button-menuIcon': {
-          color: semanticColors.buttonTextHovered,
+          color: extendedSemanticColors.commandBarButtonTextHover,
         },
       },
     },
     rootPressed: {
-      backgroundColor: semanticColors.menuItemBackgroundPressed,
-      color: semanticColors.buttonTextHovered,
+      backgroundColor: extendedSemanticColors.commandBarButtonBackgroundSelected,
+      color: extendedSemanticColors.commandBarButtonTextHover,
       selectors: {
         '.ms-Button-icon': {
-          color: extendedSemanticColors.iconButtonFillHovered,
+          color: extendedSemanticColors.commandBarButtonIconSelected,
         },
         '.ms-Button-menuIcon': {
-          color: extendedSemanticColors.buttonTextHovered,
+          color: extendedSemanticColors.commandBarButtonTextHover,
         },
       },
     },
@@ -77,6 +77,14 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
     rootDisabled: {
       backgroundColor: semanticColors.bodyBackground,
       color: extendedSemanticColors.commandBarButtonTextDisabled,
+      selectors: {
+        '.ms-Button-icon': {
+          color: extendedSemanticColors.commandBarButtonTextDisabled,
+        },
+        '.ms-Button-menuIcon': {
+          color: extendedSemanticColors.commandBarButtonTextDisabled,
+        },
+      },
     },
     rootFocused: {
       backgroundColor: semanticColors.menuItemBackgroundHovered,
@@ -87,6 +95,9 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
         },
         '.ms-Button-menuIcon': {
           color: semanticColors.buttonTextHovered,
+        },
+        '::after': {
+          outlineColor: `${extendedSemanticColors.commandBarButtonAfterColor} !important`,
         },
       },
     },


### PR DESCRIPTION
### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

### Description of changes

- IAzureSemanticColors.ts
  - commandBar 
    - Button: Added 
      - root: Added 
        - color: Added 
      - disabled: Added 
        - color: Added 
      - focus: Added 
        - borderColor: Added 
      - hover: Added 
        - background: Added 
        - color: Added 
        - icon: Added 
      - selected: Added 
        - background: Added 
        - icon: Added 
      - selectedHover: Added 
        - background: Added 
- AzureColors.ts 
  - Dark 
    - CommandBar 
      - Border: GRAY_605E5C -> GRAY_323130 

- AzureTheme*.ts 
  - commandBarButtonAfterColor: Added 
  - commandBarButtonBackgroundHover: Added 
  - commandBarButtonBackgroundSelected: Added 
  - commandBarButtonBackgroundSelectedHover: Added 
  - commandBarButtonIconHover: Added 
  - commandBarButtonIconSelected: Added 
  - commandBarButtonText: Added 
  - commandBarButtonTextDisabled: Added 
  - commandBarButtonTextHover: Added 

### Dark

#### Rest:
- Changes
  - Color

Before: 
<img width="73" alt="CommandBarButtonDarkRest" src="https://user-images.githubusercontent.com/35254365/112903120-f6360c80-909b-11eb-8403-6494778cfe71.PNG">

After: 
<img width="81" alt="CommandBarButtonDarkRestChange" src="https://user-images.githubusercontent.com/35254365/112903146-fd5d1a80-909b-11eb-9e5f-aec705c26778.PNG">

#### Disabled:
- Changes
  - Color
  - Icon Color

Before: 
<img width="90" alt="CommandBarButtonDarkDisabled" src="https://user-images.githubusercontent.com/35254365/112903006-d0106c80-909b-11eb-9d77-4b2165f02fb2.PNG">

After: 
<img width="96" alt="CommandBarButtonDarkDisabledChange" src="https://user-images.githubusercontent.com/35254365/112903027-d7d01100-909b-11eb-8336-008442e5f877.PNG">

#### Expanded:
- Changes
  - Color
  - Background
  - Icon Color

Before: 
<img width="93" alt="CommandBarButtonDarkExpanded" src="https://user-images.githubusercontent.com/35254365/112903343-3b5a3e80-909c-11eb-9bb9-2107130a2bfe.PNG">

After: 
<img width="99" alt="CommandBarButtonDarkExpandedChange" src="https://user-images.githubusercontent.com/35254365/112903361-3f865c00-909c-11eb-9424-5944418ca71f.PNG">

#### Expanded Hover:
- Changes
  - Color
  - Background
  - Icon Color

Before: 
<img width="93" alt="CommandBarButtonDarkExpandedHover" src="https://user-images.githubusercontent.com/35254365/112903412-54fb8600-909c-11eb-92bc-dd580be85dec.PNG">

After: 
<img width="98" alt="CommandBarButtonDarkExpandedHoverChange" src="https://user-images.githubusercontent.com/35254365/112903421-5927a380-909c-11eb-9024-b06cabae1cc2.PNG">

#### Focus:
- Changes
  - Color
  - Border Color
  - Icon Color

Before: 
<img width="81" alt="CommandBarButtonDarkFocus" src="https://user-images.githubusercontent.com/35254365/112903463-65136580-909c-11eb-96a7-68b7791cff19.PNG">

After: 
<img width="81" alt="CommandBarButtonDarkFocusChange" src="https://user-images.githubusercontent.com/35254365/112903482-69d81980-909c-11eb-819b-944e49220a43.PNG">

#### Hover:
- Changes
  - Color
  - Background
  - Icon Color

Before:
<img width="81" alt="CommandBarButtonDarkHover" src="https://user-images.githubusercontent.com/35254365/112903511-73fa1800-909c-11eb-912d-e507598dbf9d.PNG">

After: 
<img width="82" alt="CommandBarButtonDarkHoverChange" src="https://user-images.githubusercontent.com/35254365/112903544-7e1c1680-909c-11eb-86b1-97c34113ed83.PNG">

#### Pressed:
- Changes
  - Color
  - Background
  - Icon color
  
Before: 
<img width="81" alt="CommandBarButtonDarkPressed" src="https://user-images.githubusercontent.com/35254365/112903575-8c6a3280-909c-11eb-9b11-a9decdc27ec6.PNG">

After: 
<img width="81" alt="CommandBarButtonDarkPressedChange" src="https://user-images.githubusercontent.com/35254365/112903585-90965000-909c-11eb-98a0-b9c6b68334d9.PNG">

### Light

#### Expanded:
- Changes
  - Icon Color

Before: 
<img width="94" alt="CommandBarButtonExpanded" src="https://user-images.githubusercontent.com/35254365/112903643-a99f0100-909c-11eb-8728-1385d47a2504.PNG">

After: 
<img width="99" alt="CommandBarButtonExpandedChange" src="https://user-images.githubusercontent.com/35254365/112903653-ac99f180-909c-11eb-9044-769ee8b7f973.PNG">

#### Expanded Hover:
- Changes
  - Icon Color
  - Background
 
Before: 
<img width="93" alt="CommandBarButtonExpandedHover" src="https://user-images.githubusercontent.com/35254365/112903694-b91e4a00-909c-11eb-891a-b099421ee15d.PNG">

After: 
<img width="92" alt="CommandBarButtonExpandedHoverChange" src="https://user-images.githubusercontent.com/35254365/112903705-bde2fe00-909c-11eb-9ea8-6ff7ef54af45.PNG">

#### Hover:
- Changes
  - Icon Color
 
Before: 
<img width="79" alt="CommandBarButtonHover" src="https://user-images.githubusercontent.com/35254365/112903755-ccc9b080-909c-11eb-9bf0-bcdafd5429a8.PNG">

After: 
<img width="79" alt="CommandBarButtonHoverChange" src="https://user-images.githubusercontent.com/35254365/112903774-d226fb00-909c-11eb-9f6e-c428c73bde1e.PNG">

#### Pressed:
- Changes
  - Icon Color
 
Before: 
<img width="78" alt="CommandBarButtonPressed" src="https://user-images.githubusercontent.com/35254365/112903804-db17cc80-909c-11eb-9a1f-5cf66de59cd1.PNG">

After: 
<img width="78" alt="CommandBarButtonPressedChange" src="https://user-images.githubusercontent.com/35254365/112903810-de12bd00-909c-11eb-9338-d174612f7fd2.PNG">

#### Focus:
- Changes
  - Icon Color
  - Border Color

Before: 
<img width="81" alt="CommandBarButtonFocus" src="https://user-images.githubusercontent.com/35254365/112917103-d6601200-90b6-11eb-9b55-e7f48f04b2f7.PNG">

After: 
<img width="78" alt="CommandBarButtonFocusChange" src="https://user-images.githubusercontent.com/35254365/112917109-db24c600-90b6-11eb-97f5-2af81e291fcd.PNG">


















