### PR TITLE
fix(Tree): invoke `onTitleClick` from keyboad for non-leaf item

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Fixes
 - Add success to AlertDismissAction propTypes @jurokapsiar ([#17542](https://github.com/microsoft/fluentui/pull/17542))
 - Add `overflowSentinel` slot to fix `Toolbar` overflow when parent container does not have fixed width @ling1726 ([#17451](https://github.com/microsoft/fluentui/pull/17451))
+- For `Tree`, fix non-leaf `treeItem` so `onTitleClick` can be invoked from space/enter key @yuanboxue-amber ([#17619](https://github.com/microsoft/fluentui/pull/17619))
 
 ## Documentation
 - Update left nav in UI Builder to separate add components from navigator @codepretty ([#17002](https://github.com/microsoft/fluentui/pull/17002))

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -167,6 +167,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
         }
         e.stopPropagation();
         toggleItemActive(e, id);
+        _.invoke(props, 'onTitleClick', e, props);
       },
       focusParent: e => {
         e.preventDefault();

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -228,4 +228,54 @@ describe('Tree', () => {
       checkOpenTitles(wrapper, ['1', '2', '21', '211', '22', '3']);
     });
   });
+
+  describe.only('onTitleClick', () => {
+    const mockRootTitleClick = jest.fn();
+    const mockLeafTitleClick = jest.fn();
+    const items = [
+      {
+        id: 'root',
+        title: 'root',
+        onTitleClick: mockRootTitleClick,
+        items: [
+          {
+            id: 'leaf',
+            title: 'leaf',
+            onTitleClick: mockLeafTitleClick,
+          },
+        ],
+      },
+    ];
+
+    beforeEach(() => {
+      mockLeafTitleClick.mockClear();
+      mockRootTitleClick.mockClear();
+    });
+
+    it('should be called on click for both leaf/non-leaf item', () => {
+      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
+
+      getTitles(wrapper)
+        .at(1) // leaf
+        .simulate('click');
+      expect(mockLeafTitleClick).toHaveBeenCalledTimes(1);
+      getItems(wrapper)
+        .at(0) // root
+        .simulate('click');
+      expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be called on Enter key for both leaf/non-leaf item', () => {
+      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
+
+      getTitles(wrapper)
+        .at(1) // leaf
+        .simulate('keydown', { key: 'Enter' });
+      expect(mockLeafTitleClick).toHaveBeenCalledTimes(1);
+      getItems(wrapper)
+        .at(0) // root
+        .simulate('keydown', { key: 'Enter' });
+      expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -277,7 +277,7 @@ describe('Tree', () => {
     });
 
     it.each(['Enter', ' '])('should be called on "%s" key for non-leaf item', key => {
-      getRoot().simulate('keydown', { key: ' ' });
+      getRoot().simulate('keydown', { key });
       expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -229,7 +229,7 @@ describe('Tree', () => {
     });
   });
 
-  describe.only('onTitleClick', () => {
+  describe('onTitleClick', () => {
     const mockRootTitleClick = jest.fn();
     const mockLeafTitleClick = jest.fn();
     const items = [
@@ -247,41 +247,38 @@ describe('Tree', () => {
       },
     ];
 
+    const getRoot = () => {
+      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
+      return getItems(wrapper).at(0);
+    };
+    const getLeaf = () => {
+      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
+      return getTitles(wrapper).at(1);
+    };
+
     beforeEach(() => {
       mockLeafTitleClick.mockClear();
       mockRootTitleClick.mockClear();
     });
 
-    it('should be called on click for both leaf/non-leaf item', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
-
-      getTitles(wrapper)
-        .at(1) // leaf
-        .simulate('click');
+    it('should be called on click for leaf item', () => {
+      getLeaf().simulate('click');
       expect(mockLeafTitleClick).toHaveBeenCalledTimes(1);
-      getItems(wrapper)
-        .at(0) // root
-        .simulate('click');
+    });
+
+    it('should be called on click for non-leaf item', () => {
+      getRoot().simulate('click');
       expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should be called on Enter/Space key for both leaf/non-leaf item', () => {
-      const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
+    it.each(['Enter', ' '])('should be called on "%s" key for leaf item', key => {
+      getLeaf().simulate('keydown', { key });
+      expect(mockLeafTitleClick).toHaveBeenCalledTimes(1);
+    });
 
-      getTitles(wrapper)
-        .at(1) // leaf
-        .simulate('keydown', { key: 'Enter' });
-      getTitles(wrapper)
-        .at(1) // leaf
-        .simulate('keydown', { key: ' ' });
-      expect(mockLeafTitleClick).toHaveBeenCalledTimes(2);
-      getItems(wrapper)
-        .at(0) // root
-        .simulate('keydown', { key: 'Enter' });
-      getItems(wrapper)
-        .at(0) // root
-        .simulate('keydown', { key: ' ' });
-      expect(mockRootTitleClick).toHaveBeenCalledTimes(2);
+    it.each(['Enter', ' '])('should be called on "%s" key for non-leaf item', key => {
+      getRoot().simulate('keydown', { key: ' ' });
+      expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -265,17 +265,23 @@ describe('Tree', () => {
       expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should be called on Enter key for both leaf/non-leaf item', () => {
+    it('should be called on Enter/Space key for both leaf/non-leaf item', () => {
       const wrapper = mountWithProvider(<Tree items={items} defaultActiveItemIds={['root']} />);
 
       getTitles(wrapper)
         .at(1) // leaf
         .simulate('keydown', { key: 'Enter' });
-      expect(mockLeafTitleClick).toHaveBeenCalledTimes(1);
+      getTitles(wrapper)
+        .at(1) // leaf
+        .simulate('keydown', { key: ' ' });
+      expect(mockLeafTitleClick).toHaveBeenCalledTimes(2);
       getItems(wrapper)
         .at(0) // root
         .simulate('keydown', { key: 'Enter' });
-      expect(mockRootTitleClick).toHaveBeenCalledTimes(1);
+      getItems(wrapper)
+        .at(0) // root
+        .simulate('keydown', { key: ' ' });
+      expect(mockRootTitleClick).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`TreeItem` has `onTitleClick` prop. This prop should be invoked both from click and from keyboard. Currently it is broken by PR #16199. Now keyboard interaction on a non-leaf treeItem will not invoke `onTitleClick`

This PR fix this and added UT.

#### Focus areas to test

(optional)
