### PR TITLE
Insert try-catch block to ignore suffix errors

### DIFF
--- a/change/@fluentui-make-styles-30e65f99-b6f9-4335-860d-70126c3a986b.json
+++ b/change/@fluentui-make-styles-30e65f99-b6f9-4335-860d-70126c3a986b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Insert try-catch block to ignore suffix errors",
+  "packageName": "@fluentui/make-styles",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17580 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds a  try-catch block to ignore errors relative to inserting unrecognized suffixes in Chrome.
