### PR TITLE
chore: add cleanup to SizeAuditor pipeline

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -9,6 +9,8 @@ variables:
 
 jobs:
   - job: build_react
+    workspace:
+      clean: all
     timeoutInMinutes: 75
     pool: 'Self Host Ubuntu'
     steps:
@@ -42,7 +44,11 @@ jobs:
           PathtoPublish: 'apps/test-bundles/dist'
           ArtifactName: distdrop-react
 
+      - template: .devops/templates/cleanup.yml
+
   - job: build_converged
+    workspace:
+      clean: all
     timeoutInMinutes: 75
     pool: 'Self Host Ubuntu'
     steps:
@@ -76,7 +82,11 @@ jobs:
           PathtoPublish: 'apps/test-bundles/dist'
           ArtifactName: distdrop-converged
 
+      - template: .devops/templates/cleanup.yml
+
   - job: build_northstar
+    workspace:
+      clean: all
     timeoutInMinutes: 75
     pool: 'Self Host Ubuntu'
     steps:
@@ -109,6 +119,8 @@ jobs:
         inputs:
           PathtoPublish: 'apps/test-bundles/dist'
           ArtifactName: distdrop-northstar
+
+      - template: .devops/templates/cleanup.yml
 
   - job: merge
     pool:


### PR DESCRIPTION
#### Description of changes

A followup for #17582. As @ecraig12345 suggested, we are using custom pool of machines, but we should also properly clean up to avoid weird glitches on builds:

![An example of broken build](https://user-images.githubusercontent.com/14183168/112981207-2395bf80-915b-11eb-8996-552607763028.png)
