### PR TITLE
[v7.0] DetailsList: checkbox is now linked to the rowheader which improves a11y description for each row.

### DIFF
--- a/change/@fluentui-react-examples-1e669af4-f878-409f-84e9-485b6625472b.json
+++ b/change/@fluentui-react-examples-1e669af4-f878-409f-84e9-485b6625472b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: checkbox is now linked to the rowheader which improves a11y description for each row.",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-d2c0c57c-562f-49e0-9735-6966c4149e4c.json
+++ b/change/office-ui-fabric-react-d2c0c57c-562f-49e0-9735-6966c4149e4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "DetailsList: checkbox is now linked to the rowheader which improves a11y description for each row.",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3891,6 +3891,7 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     }[];
     getRowAriaDescribedBy?: (item: any) => string;
     getRowAriaLabel?: (item: any) => string;
+    id?: string;
     item: any;
     itemIndex: number;
     onDidMount?: (row?: DetailsRowBase) => void;
@@ -3948,6 +3949,7 @@ export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
     rowClassNames: {
         [k in keyof Pick<IDetailsRowStyles, 'isMultiline' | 'isRowHeader' | 'cell' | 'cellAnimation' | 'cellPadded' | 'cellUnpadded' | 'fields'>]: string;
     };
+    rowHeaderId?: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -46,7 +46,7 @@ import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 import { CHECK_CELL_WIDTH as CHECKBOX_WIDTH } from './DetailsRowCheck.styles';
 // For every group level there is a GroupSpacer added. Importing this const to have the source value in one place.
 import { SPACER_WIDTH as GROUP_EXPAND_WIDTH } from '../GroupedList/GroupSpacer';
-import { composeRenderFunction } from '@uifabric/utilities';
+import { composeRenderFunction, getId } from '@uifabric/utilities';
 import { useConst } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IDetailsListStyleProps, IDetailsListStyles>();
@@ -178,6 +178,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     onRenderDefaultRow,
     selectionZoneRef,
   } = props;
+
+  const rowId = getId('row');
 
   const groupNestingDepth = getGroupNestingDepth(groups);
 
@@ -438,6 +440,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         compact,
         columns: adjustedColumns,
         groupNestingDepth: nestingDepth,
+        id: `${rowId}-${index}`,
         selectionMode,
         selection,
         onDidMount: onRowDidMount,
@@ -478,6 +481,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       adjustedColumns,
       selectionMode,
       selection,
+      rowId,
       onRowDidMount,
       onRowWillUnmount,
       onRenderItemColumn,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -21,7 +21,8 @@ import { SelectionMode, Selection, SelectionZone } from '../../utilities/selecti
 import { getTheme } from '../../Styling';
 import { KeyCodes } from '@uifabric/utilities';
 import { IGroup } from '../../GroupedList';
-import { IDetailsRowProps } from './DetailsRow';
+import { DetailsRow, IDetailsRowProps } from './DetailsRow';
+import { DetailsRowCheck } from './DetailsRowCheck';
 
 // Populate mock data for testing
 function mockData(count: number, isColumn: boolean = false, customDivider: boolean = false): any {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -746,4 +746,55 @@ describe('DetailsList', () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('returns an element with the correct text based on the second id passed in aria-labelledby', () => {
+    const container = document.createElement('div');
+    const columns = [
+      {
+        key: 'column1',
+        name: 'Name',
+        fieldName: 'name',
+        minWidth: 100,
+        maxWidth: 200,
+        isResizable: true,
+        isRowHeader: true,
+      },
+      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true },
+    ];
+    const items = mockData(1);
+
+    ReactDOM.render(
+      <DetailsListBase
+        items={mockData(1)}
+        columns={columns}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
+      />,
+      container,
+    );
+
+    const checkbox = container.querySelector('div[role="checkbox"][aria-label="select row"]') as HTMLElement;
+    const rowHeaderId = checkbox?.getAttribute('aria-labelledby')?.split(' ')[1];
+
+    expect(container.querySelector(`#${rowHeaderId}`)!.textContent).toEqual(items[0].name);
+  });
+
+  it('has an aria-labelledby checkboxId that matches the id of the checkbox', () => {
+    const component = renderer.create(
+      <DetailsList
+        items={mockData(5)}
+        columns={mockData(5, true)}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
+      />,
+    );
+
+    const detailsRowSource = component.root.findAllByType(DetailsRow)[0];
+    const detailsRowCheckSource = detailsRowSource.findByType(DetailsRowCheck).props;
+    const checkboxId = detailsRowCheckSource.id;
+
+    expect(checkboxId).toEqual(detailsRowCheckSource[`aria-labelledby`].split(' ')[0]);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -178,6 +178,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       dragDropEvents,
       item,
       itemIndex,
+      id,
       onRenderCheck = this._onRenderCheck,
       onRenderDetailsCheckbox,
       onRenderItemColumn,
@@ -250,6 +251,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     const rowFields = (
       <RowFields
         rowClassNames={this._rowClassNames}
+        rowHeaderId={`${id}-header`}
         cellsByColumn={cellsByColumn}
         columns={columns}
         item={item}
@@ -292,9 +294,11 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         {showCheckbox && (
           <div role="gridcell" aria-colindex={1} data-selection-toggle={true} className={this._classNames.checkCell}>
             {onRenderCheck({
+              id: id ? `${id}-checkbox` : undefined,
               selected: isSelected,
               anySelected: isSelectionModal,
               'aria-label': checkButtonAriaLabel,
+              'aria-labelledby': id ? `${id}-checkbox ${id}-header` : undefined,
               canSelect,
               compact,
               className: this._classNames.check,
@@ -321,6 +325,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
           >
             <RowFields
               rowClassNames={this._rowClassNames}
+              rowHeaderId={`${id}-header`}
               columns={[columnMeasureInfo.column]}
               item={item}
               itemIndex={itemIndex}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -197,6 +197,11 @@ export interface IDetailsRowBaseProps
    * @defaultvalue true
    */
   useFastIcons?: boolean;
+
+  /**
+   * Id for row
+   */
+  id?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -60,6 +60,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
       aria-checked={selected}
       data-selection-toggle={true}
       data-automationid="DetailsRowCheck"
+      tabIndex={-1}
     >
       {onRenderCheckbox(detailsCheckboxProps)}
     </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -35,6 +35,7 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
     getCellValueKey,
     cellsByColumn,
     enableUpdateAnimations,
+    rowHeaderId,
   } = props;
 
   const cellValueKeysRef = React.useRef<{
@@ -80,6 +81,7 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
         return (
           <div
             key={key}
+            id={column.isRowHeader ? rowHeaderId : undefined}
             role={column.isRowHeader ? 'rowheader' : 'gridcell'}
             aria-readonly
             aria-colindex={columnIndex + columnStartIndex + 1}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -53,6 +53,11 @@ export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
   };
 
   /**
+   * Id for the current row's row-header
+   */
+  rowHeaderId?: string;
+
+  /**
    * Style properties to customize cell render output.
    */
   cellStyleProps?: ICellStyleProps;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`DetailsHeader can render 1`] = `
         data-selection-toggle={true}
         id="header0-check"
         role="checkbox"
+        tabIndex={-1}
       >
         <div
           className=
@@ -1865,6 +1866,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         data-selection-toggle={true}
         id="header6-check"
         role="checkbox"
+        tabIndex={-1}
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone118"
+            data-focuszone-id="FocusZone147"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -139,7 +139,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection119"
+                        id="GroupedListSection148"
                         role="rowgroup"
                       >
                         <div
@@ -210,7 +210,7 @@ exports[`DetailsList handles paged updates to items within groups 1`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection120"
+                        id="GroupedListSection149"
                         role="rowgroup"
                       >
                         <div
@@ -364,7 +364,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone118"
+            data-focuszone-id="FocusZone147"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -405,7 +405,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection119"
+                        id="GroupedListSection148"
                         role="rowgroup"
                       >
                         <div
@@ -484,7 +484,7 @@ exports[`DetailsList handles paged updates to items within groups 2`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection120"
+                        id="GroupedListSection149"
                         role="rowgroup"
                       >
                         <div
@@ -646,7 +646,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone111"
+            data-focuszone-id="FocusZone136"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -687,7 +687,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection112"
+                        id="GroupedListSection137"
                         role="rowgroup"
                       >
                         <div
@@ -748,7 +748,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection113"
+                        id="GroupedListSection138"
                         role="rowgroup"
                       >
                         <div
@@ -809,7 +809,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection114"
+                        id="GroupedListSection139"
                         role="rowgroup"
                       >
                         <div
@@ -870,7 +870,7 @@ exports[`DetailsList handles updates to items and groups 1`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection115"
+                        id="GroupedListSection140"
                         role="rowgroup"
                       >
                         <div
@@ -1014,7 +1014,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone111"
+            data-focuszone-id="FocusZone136"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1055,7 +1055,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 1"
                         className="ms-List"
-                        id="GroupedListSection112"
+                        id="GroupedListSection137"
                         role="rowgroup"
                       >
                         <div
@@ -1116,7 +1116,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 2"
                         className="ms-List"
-                        id="GroupedListSection113"
+                        id="GroupedListSection138"
                         role="rowgroup"
                       >
                         <div
@@ -1177,7 +1177,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 3"
                         className="ms-List"
-                        id="GroupedListSection114"
+                        id="GroupedListSection139"
                         role="rowgroup"
                       >
                         <div
@@ -1238,7 +1238,7 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                       <div
                         aria-label="one 4"
                         className="ms-List"
-                        id="GroupedListSection115"
+                        id="GroupedListSection140"
                         role="rowgroup"
                       >
                         <div
@@ -1382,7 +1382,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone111"
+            data-focuszone-id="FocusZone136"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1423,7 +1423,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection116"
+                        id="GroupedListSection143"
                         role="rowgroup"
                       >
                         <div
@@ -1502,7 +1502,7 @@ exports[`DetailsList handles updates to items and groups 3`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection117"
+                        id="GroupedListSection144"
                         role="rowgroup"
                       >
                         <div
@@ -1664,7 +1664,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone111"
+            data-focuszone-id="FocusZone136"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1705,7 +1705,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 1"
                         className="ms-List"
-                        id="GroupedListSection116"
+                        id="GroupedListSection143"
                         role="rowgroup"
                       >
                         <div
@@ -1784,7 +1784,7 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                       <div
                         aria-label="two 2"
                         className="ms-List"
-                        id="GroupedListSection117"
+                        id="GroupedListSection144"
                         role="rowgroup"
                       >
                         <div
@@ -1883,2421 +1883,6 @@ exports[`DetailsList renders List correctly 1`] = `
   >
     <div
       aria-colcount={2}
-      aria-readonly="true"
-      aria-rowcount={6}
-      role="grid"
-    >
-      <div
-        className="ms-DetailsList-headerWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              ms-DetailsHeader
-              &:focus {
-                outline: none;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: #ffffff;
-                border-bottom: 1px solid #edebe9;
-                box-sizing: content-box;
-                cursor: default;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                height: 42px;
-                line-height: 42px;
-                min-width: 100%;
-                padding-bottom: 1px;
-                padding-top: 16px;
-                position: relative;
-                user-select: none;
-                vertical-align: top;
-                white-space: nowrap;
-              }
-              &:hover .ms-DetailsHeader-check {
-                opacity: 1;
-              }
-              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
-                display: block;
-              }
-          data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone7"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-          onMouseMove={[Function]}
-          role="row"
-        >
-          <div
-            aria-colindex={1}
-            aria-labelledby="header6-check"
-            className=
-                ms-DetailsHeader-cell
-                ms-DetailsHeader-cellIsCheck
-                {
-                  align-items: center;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-flex;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  outline: transparent;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-            onClick={[Function]}
-            role="columnheader"
-          >
-            <span
-              className="ms-DetailsHeader-checkTooltip"
-            >
-              <div
-                aria-checked={false}
-                className=
-                    ms-DetailsRow-check
-                    ms-DetailsHeader-check
-                    ms-DetailsRow-check--isHeader
-                    ms-Check-checkHost
-                    {
-                      height: 42px;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      opacity: 1;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      background-color: transparent;
-                      background: none;
-                      border: none;
-                      box-sizing: border-box;
-                      cursor: default;
-                      display: flex;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      justify-content: center;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      opacity: 0;
-                      outline: transparent;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      vertical-align: top;
-                      width: 48px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-automationid="DetailsRowCheck"
-                data-is-focusable={true}
-                data-selection-toggle={true}
-                id="header6-check"
-                role="checkbox"
-              >
-                <div
-                  className=
-                      ms-Check
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 18px;
-                        line-height: 1;
-                        position: relative;
-                        user-select: none;
-                        vertical-align: top;
-                        width: 18px;
-                      }
-                      &:before {
-                        background: #ffffff;
-                        border-radius: 50%;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        opacity: 1;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                      }
-                      .ms-Check-checkHost:hover & {
-                        opacity: 1;
-                      }
-                      .ms-Check-checkHost:focus & {
-                        opacity: 1;
-                      }
-                      &:hover {
-                        opacity: 1;
-                      }
-                      &:focus {
-                        opacity: 1;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-circle
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 18px;
-                          height: 18px;
-                          left: 0px;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          color: WindowText;
-                        }
-                    data-icon-name="CircleRing"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-check
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 16px;
-                          height: 18px;
-                          left: .5px;
-                          opacity: 0;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        &:hover {
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="StatusCircleCheckmark"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </div>
-              </div>
-            </span>
-          </div>
-          <div
-            aria-colindex={2}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="key"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header6-key-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header6-key"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header6-key-name"
-                >
-                  key
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-hidden={true}
-            className=
-                ms-DetailsHeader-cellSizer
-                {
-                  background: transparent;
-                  bottom: 0px;
-                  cursor: ew-resize;
-                  display: inline-block;
-                  height: inherit;
-                  outline: transparent;
-                  overflow: hidden;
-                  position: relative;
-                  top: 0px;
-                  width: 16px;
-                  z-index: 1;
-                }
-                &::-moz-focus-inner {
-                  border: 0px;
-                }
-                &:after {
-                  background: #c8c6c4;
-                  bottom: 0px;
-                  content: "";
-                  left: 50%;
-                  opacity: 0;
-                  position: absolute;
-                  top: 0px;
-                  width: 1px;
-                }
-                &:focus:after {
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                &:hover:after {
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                &.is-resizing:after {
-                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                {
-                  margin-bottom: 0px;
-                  margin-left: -16px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={false}
-            data-sizer-index={0}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            role="button"
-          />
-        </div>
-      </div>
-      <div
-        className="ms-DetailsList-contentWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <div
-              className="ms-List"
-              role="presentation"
-            >
-              <div
-                className="ms-List-surface"
-                role="presentation"
-              >
-                <div
-                  className="ms-List-page"
-                  role="presentation"
-                  style={Object {}}
-                >
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={0}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={1}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={2}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={3}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={4}
-                    role="presentation"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
-<div
-  className="ms-Viewport"
-  style={
-    Object {
-      "minHeight": 1,
-      "minWidth": 1,
-    }
-  }
->
-  <div
-    className=
-        ms-DetailsList
-        is-horizontalConstrained
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          -webkit-overflow-scrolling: touch;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          overflow-x: auto;
-          overflow-y: visible;
-          position: relative;
-        }
-        & .ms-List-cell {
-          min-height: 38px;
-          word-break: break-word;
-        }
-    data-automationid="DetailsList"
-    data-is-scrollable="false"
-  >
-    <div
-      aria-colcount={6}
-      aria-readonly="true"
-      aria-rowcount={6}
-      role="grid"
-    >
-      <div
-        className="ms-DetailsList-headerWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              ms-DetailsHeader
-              &:focus {
-                outline: none;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: #ffffff;
-                border-bottom: 1px solid #edebe9;
-                box-sizing: content-box;
-                cursor: default;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                height: 42px;
-                line-height: 42px;
-                min-width: 100%;
-                padding-bottom: 1px;
-                padding-top: 16px;
-                position: relative;
-                user-select: none;
-                vertical-align: top;
-                white-space: nowrap;
-              }
-              &:hover .ms-DetailsHeader-check {
-                opacity: 1;
-              }
-              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
-                display: block;
-              }
-          data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-          onMouseMove={[Function]}
-          role="row"
-        >
-          <div
-            aria-colindex={1}
-            aria-labelledby="header0-check"
-            className=
-                ms-DetailsHeader-cell
-                ms-DetailsHeader-cellIsCheck
-                {
-                  align-items: center;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-flex;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  outline: transparent;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-            onClick={[Function]}
-            role="columnheader"
-          >
-            <span
-              className="ms-DetailsHeader-checkTooltip"
-            >
-              <div
-                aria-checked={false}
-                className=
-                    ms-DetailsRow-check
-                    ms-DetailsHeader-check
-                    ms-DetailsRow-check--isHeader
-                    ms-Check-checkHost
-                    {
-                      height: 42px;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      opacity: 1;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      background-color: transparent;
-                      background: none;
-                      border: none;
-                      box-sizing: border-box;
-                      cursor: default;
-                      display: flex;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      justify-content: center;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      opacity: 0;
-                      outline: transparent;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      vertical-align: top;
-                      width: 48px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-automationid="DetailsRowCheck"
-                data-is-focusable={true}
-                data-selection-toggle={true}
-                id="header0-check"
-                role="checkbox"
-              >
-                <div
-                  className=
-                      ms-Check
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 18px;
-                        line-height: 1;
-                        position: relative;
-                        user-select: none;
-                        vertical-align: top;
-                        width: 18px;
-                      }
-                      &:before {
-                        background: #ffffff;
-                        border-radius: 50%;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        opacity: 1;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                      }
-                      .ms-Check-checkHost:hover & {
-                        opacity: 1;
-                      }
-                      .ms-Check-checkHost:focus & {
-                        opacity: 1;
-                      }
-                      &:hover {
-                        opacity: 1;
-                      }
-                      &:focus {
-                        opacity: 1;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-circle
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 18px;
-                          height: 18px;
-                          left: 0px;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          color: WindowText;
-                        }
-                    data-icon-name="CircleRing"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-check
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 16px;
-                          height: 18px;
-                          left: .5px;
-                          opacity: 0;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        &:hover {
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="StatusCircleCheckmark"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </div>
-              </div>
-            </span>
-          </div>
-          <div
-            aria-colindex={2}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="column_key_0"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-describedby="header0-column_key_0-tooltip"
-                aria-haspopup={false}
-                aria-labelledby="header0-column_key_0-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header0-column_key_0"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header0-column_key_0-name"
-                >
-                  Item 0
-                </span>
-              </span>
-            </span>
-          </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  width: 1px;
-                }
-            id="header0-column_key_0-tooltip"
-          >
-            column_0
-          </label>
-          <div
-            aria-colindex={3}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="column_key_1"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-describedby="header0-column_key_1-tooltip"
-                aria-haspopup={false}
-                aria-labelledby="header0-column_key_1-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header0-column_key_1"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header0-column_key_1-name"
-                >
-                  Item 1
-                </span>
-              </span>
-            </span>
-          </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  width: 1px;
-                }
-            id="header0-column_key_1-tooltip"
-          >
-            column_1
-          </label>
-          <div
-            aria-colindex={4}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="column_key_2"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-describedby="header0-column_key_2-tooltip"
-                aria-haspopup={false}
-                aria-labelledby="header0-column_key_2-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header0-column_key_2"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header0-column_key_2-name"
-                >
-                  Item 2
-                </span>
-              </span>
-            </span>
-          </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  width: 1px;
-                }
-            id="header0-column_key_2-tooltip"
-          >
-            column_2
-          </label>
-          <div
-            aria-colindex={5}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="column_key_3"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-describedby="header0-column_key_3-tooltip"
-                aria-haspopup={false}
-                aria-labelledby="header0-column_key_3-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header0-column_key_3"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header0-column_key_3-name"
-                >
-                  Item 3
-                </span>
-              </span>
-            </span>
-          </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  width: 1px;
-                }
-            id="header0-column_key_3-tooltip"
-          >
-            column_3
-          </label>
-          <div
-            aria-colindex={6}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="column_key_4"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-describedby="header0-column_key_4-tooltip"
-                aria-haspopup={false}
-                aria-labelledby="header0-column_key_4-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header0-column_key_4"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header0-column_key_4-name"
-                >
-                  Item 4
-                </span>
-              </span>
-            </span>
-          </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  width: 1px;
-                }
-            id="header0-column_key_4-tooltip"
-          >
-            column_4
-          </label>
-        </div>
-      </div>
-      <div
-        className="ms-DetailsList-contentWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone2"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <div
-              className="ms-List"
-              role="presentation"
-            >
-              <div
-                className="ms-List-surface"
-                role="presentation"
-              >
-                <div
-                  className="ms-List-page"
-                  role="presentation"
-                  style={Object {}}
-                >
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={0}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={1}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={2}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={3}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={4}
-                    role="presentation"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DetailsList renders List in compact mode correctly 1`] = `
-<div
-  className="ms-Viewport"
-  style={
-    Object {
-      "minHeight": 1,
-      "minWidth": 1,
-    }
-  }
->
-  <div
-    className=
-        ms-DetailsList
-        ms-DetailsList--Compact
-        is-horizontalConstrained
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          -webkit-overflow-scrolling: touch;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          overflow-x: auto;
-          overflow-y: visible;
-          position: relative;
-        }
-        & .ms-List-cell {
-          min-height: 32px;
-          word-break: break-word;
-        }
-    data-automationid="DetailsList"
-    data-is-scrollable="false"
-  >
-    <div
-      aria-colcount={2}
-      aria-readonly="true"
-      aria-rowcount={6}
-      role="grid"
-    >
-      <div
-        className="ms-DetailsList-headerWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              ms-DetailsHeader
-              &:focus {
-                outline: none;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: #ffffff;
-                border-bottom: 1px solid #edebe9;
-                box-sizing: content-box;
-                cursor: default;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                height: 42px;
-                line-height: 42px;
-                min-width: 100%;
-                padding-bottom: 1px;
-                padding-top: 16px;
-                position: relative;
-                user-select: none;
-                vertical-align: top;
-                white-space: nowrap;
-              }
-              &:hover .ms-DetailsHeader-check {
-                opacity: 1;
-              }
-              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
-                display: block;
-              }
-          data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone13"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-          onMouseMove={[Function]}
-          role="row"
-        >
-          <div
-            aria-colindex={1}
-            aria-labelledby="header12-check"
-            className=
-                ms-DetailsHeader-cell
-                ms-DetailsHeader-cellIsCheck
-                {
-                  align-items: center;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-flex;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  outline: transparent;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-            onClick={[Function]}
-            role="columnheader"
-          >
-            <span
-              className="ms-DetailsHeader-checkTooltip"
-            >
-              <div
-                aria-checked={false}
-                className=
-                    ms-DetailsRow-check
-                    ms-DetailsHeader-check
-                    ms-DetailsRow-check--isHeader
-                    ms-Check-checkHost
-                    {
-                      height: 42px;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      opacity: 1;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      background-color: transparent;
-                      background: none;
-                      border: none;
-                      box-sizing: border-box;
-                      cursor: default;
-                      display: flex;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      justify-content: center;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      opacity: 0;
-                      outline: transparent;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      vertical-align: top;
-                      width: 48px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-automationid="DetailsRowCheck"
-                data-is-focusable={true}
-                data-selection-toggle={true}
-                id="header12-check"
-                role="checkbox"
-              >
-                <div
-                  className=
-                      ms-Check
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 18px;
-                        line-height: 1;
-                        position: relative;
-                        user-select: none;
-                        vertical-align: top;
-                        width: 18px;
-                      }
-                      &:before {
-                        background: #ffffff;
-                        border-radius: 50%;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        opacity: 1;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                      }
-                      .ms-Check-checkHost:hover & {
-                        opacity: 1;
-                      }
-                      .ms-Check-checkHost:focus & {
-                        opacity: 1;
-                      }
-                      &:hover {
-                        opacity: 1;
-                      }
-                      &:focus {
-                        opacity: 1;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-circle
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 18px;
-                          height: 18px;
-                          left: 0px;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          color: WindowText;
-                        }
-                    data-icon-name="CircleRing"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-check
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 16px;
-                          height: 18px;
-                          left: .5px;
-                          opacity: 0;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        &:hover {
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="StatusCircleCheckmark"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </div>
-              </div>
-            </span>
-          </div>
-          <div
-            aria-colindex={2}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="key"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 120,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header12-key-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header12-key"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header12-key-name"
-                >
-                  key
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-hidden={true}
-            className=
-                ms-DetailsHeader-cellSizer
-                {
-                  background: transparent;
-                  bottom: 0px;
-                  cursor: ew-resize;
-                  display: inline-block;
-                  height: inherit;
-                  outline: transparent;
-                  overflow: hidden;
-                  position: relative;
-                  top: 0px;
-                  width: 16px;
-                  z-index: 1;
-                }
-                &::-moz-focus-inner {
-                  border: 0px;
-                }
-                &:after {
-                  background: #c8c6c4;
-                  bottom: 0px;
-                  content: "";
-                  left: 50%;
-                  opacity: 0;
-                  position: absolute;
-                  top: 0px;
-                  width: 1px;
-                }
-                &:focus:after {
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                &:hover:after {
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                &.is-resizing:after {
-                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
-                  opacity: 1;
-                  transition: opacity 0.3s linear;
-                }
-                {
-                  margin-bottom: 0px;
-                  margin-left: -16px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={false}
-            data-sizer-index={0}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            role="button"
-          />
-        </div>
-      </div>
-      <div
-        className="ms-DetailsList-contentWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone14"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <div
-              className="ms-List"
-              role="presentation"
-            >
-              <div
-                className="ms-List-surface"
-                role="presentation"
-              >
-                <div
-                  className="ms-List-page"
-                  role="presentation"
-                  style={Object {}}
-                >
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={0}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={1}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={2}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={3}
-                    role="presentation"
-                  />
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={4}
-                    role="presentation"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
-<div
-  className="ms-Viewport"
-  style={
-    Object {
-      "minHeight": 1,
-      "minWidth": 1,
-    }
-  }
->
-  <div
-    className=
-        ms-DetailsList
-        is-fixed
-        is-horizontalConstrained
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          -webkit-overflow-scrolling: touch;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          overflow-x: auto;
-          overflow-y: visible;
-          position: relative;
-        }
-        & .ms-List-cell {
-          min-height: 38px;
-          word-break: break-word;
-        }
-    data-automationid="DetailsList"
-    data-is-scrollable="false"
-  >
-    <div
-      aria-colcount={4}
       aria-readonly="true"
       aria-rowcount={6}
       role="grid"
@@ -4459,6 +2044,2425 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 data-selection-toggle={true}
                 id="header9-check"
                 role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="key"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header9-key-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header9-key"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header9-key-name"
+                >
+                  key
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className=
+                ms-DetailsHeader-cellSizer
+                {
+                  background: transparent;
+                  bottom: 0px;
+                  cursor: ew-resize;
+                  display: inline-block;
+                  height: inherit;
+                  outline: transparent;
+                  overflow: hidden;
+                  position: relative;
+                  top: 0px;
+                  width: 16px;
+                  z-index: 1;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                }
+                &:after {
+                  background: #c8c6c4;
+                  bottom: 0px;
+                  content: "";
+                  left: 50%;
+                  opacity: 0;
+                  position: absolute;
+                  top: 0px;
+                  width: 1px;
+                }
+                &:focus:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &:hover:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &.is-resizing:after {
+                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                {
+                  margin-bottom: 0px;
+                  margin-left: -16px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                }
+            data-is-focusable={false}
+            data-sizer-index={0}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone11"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={6}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone2"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header1-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header1-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_0"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header1-column_key_0-tooltip"
+                aria-haspopup={false}
+                aria-labelledby="header1-column_key_0-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column_key_0"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column_key_0-name"
+                >
+                  Item 0
+                </span>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-column_key_0-tooltip"
+          >
+            column_0
+          </label>
+          <div
+            aria-colindex={3}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_1"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header1-column_key_1-tooltip"
+                aria-haspopup={false}
+                aria-labelledby="header1-column_key_1-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column_key_1"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column_key_1-name"
+                >
+                  Item 1
+                </span>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-column_key_1-tooltip"
+          >
+            column_1
+          </label>
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_2"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header1-column_key_2-tooltip"
+                aria-haspopup={false}
+                aria-labelledby="header1-column_key_2-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column_key_2"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column_key_2-name"
+                >
+                  Item 2
+                </span>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-column_key_2-tooltip"
+          >
+            column_2
+          </label>
+          <div
+            aria-colindex={5}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_3"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header1-column_key_3-tooltip"
+                aria-haspopup={false}
+                aria-labelledby="header1-column_key_3-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column_key_3"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column_key_3-name"
+                >
+                  Item 3
+                </span>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-column_key_3-tooltip"
+          >
+            column_3
+          </label>
+          <div
+            aria-colindex={6}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_4"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header1-column_key_4-tooltip"
+                aria-haspopup={false}
+                aria-labelledby="header1-column_key_4-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header1-column_key_4"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header1-column_key_4-name"
+                >
+                  Item 4
+                </span>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  width: 1px;
+                }
+            id="header1-column_key_4-tooltip"
+          >
+            column_4
+          </label>
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone3"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList renders List in compact mode correctly 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        ms-DetailsList--Compact
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 32px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={2}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone18"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header17-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header17-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="key"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 120,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header17-key-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header17-key"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header17-key-name"
+                >
+                  key
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className=
+                ms-DetailsHeader-cellSizer
+                {
+                  background: transparent;
+                  bottom: 0px;
+                  cursor: ew-resize;
+                  display: inline-block;
+                  height: inherit;
+                  outline: transparent;
+                  overflow: hidden;
+                  position: relative;
+                  top: 0px;
+                  width: 16px;
+                  z-index: 1;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                }
+                &:after {
+                  background: #c8c6c4;
+                  bottom: 0px;
+                  content: "";
+                  left: 50%;
+                  opacity: 0;
+                  position: absolute;
+                  top: 0px;
+                  width: 1px;
+                }
+                &:focus:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &:hover:after {
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                &.is-resizing:after {
+                  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                  opacity: 1;
+                  transition: opacity 0.3s linear;
+                }
+                {
+                  margin-bottom: 0px;
+                  margin-left: -16px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                }
+            data-is-focusable={false}
+            data-sizer-index={0}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone19"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-fixed
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={4}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone14"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header13-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header13-check"
+                role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -4670,7 +4674,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-key-name"
+                aria-labelledby="header13-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4702,7 +4706,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header9-key"
+                id="header13-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -4716,7 +4720,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header9-key-name"
+                  id="header13-key-name"
                 >
                   key
                 </span>
@@ -4860,7 +4864,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-name-name"
+                aria-labelledby="header13-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4892,7 +4896,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header9-name"
+                id="header13-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -4906,7 +4910,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header9-name-name"
+                  id="header13-name-name"
                 >
                   name
                 </span>
@@ -5050,7 +5054,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-value-name"
+                aria-labelledby="header13-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5082,7 +5086,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header9-value"
+                id="header13-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -5096,7 +5100,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header9-value-name"
+                  id="header13-value-name"
                 >
                   value
                 </span>
@@ -5189,7 +5193,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone11"
+            data-focuszone-id="FocusZone15"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -5328,7 +5332,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone4"
+          data-focuszone-id="FocusZone6"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -5337,7 +5341,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header3-check"
+            aria-labelledby="header5-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -5443,8 +5447,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header3-check"
+                id="header5-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -5655,9 +5660,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header3-column_key_0-tooltip"
+                aria-describedby="header5-column_key_0-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_0-name"
+                aria-labelledby="header5-column_key_0-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5689,7 +5694,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header3-column_key_0"
+                id="header5-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -5703,7 +5708,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header3-column_key_0-name"
+                  id="header5-column_key_0-name"
                 >
                   Item 0
                 </span>
@@ -5728,7 +5733,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   position: absolute;
                   width: 1px;
                 }
-            id="header3-column_key_0-tooltip"
+            id="header5-column_key_0-tooltip"
           >
             column_0
           </label>
@@ -5815,9 +5820,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header3-column_key_1-tooltip"
+                aria-describedby="header5-column_key_1-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_1-name"
+                aria-labelledby="header5-column_key_1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5849,7 +5854,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header3-column_key_1"
+                id="header5-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -5863,7 +5868,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header3-column_key_1-name"
+                  id="header5-column_key_1-name"
                 >
                   Item 1
                 </span>
@@ -5888,7 +5893,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   position: absolute;
                   width: 1px;
                 }
-            id="header3-column_key_1-tooltip"
+            id="header5-column_key_1-tooltip"
           >
             column_1
           </label>
@@ -5975,9 +5980,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header3-column_key_2-tooltip"
+                aria-describedby="header5-column_key_2-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_2-name"
+                aria-labelledby="header5-column_key_2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6009,7 +6014,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header3-column_key_2"
+                id="header5-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -6023,7 +6028,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header3-column_key_2-name"
+                  id="header5-column_key_2-name"
                 >
                   Item 2
                 </span>
@@ -6048,7 +6053,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   position: absolute;
                   width: 1px;
                 }
-            id="header3-column_key_2-tooltip"
+            id="header5-column_key_2-tooltip"
           >
             column_2
           </label>
@@ -6135,9 +6140,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header3-column_key_3-tooltip"
+                aria-describedby="header5-column_key_3-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_3-name"
+                aria-labelledby="header5-column_key_3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6169,7 +6174,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header3-column_key_3"
+                id="header5-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -6183,7 +6188,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header3-column_key_3-name"
+                  id="header5-column_key_3-name"
                 >
                   Item 3
                 </span>
@@ -6208,7 +6213,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   position: absolute;
                   width: 1px;
                 }
-            id="header3-column_key_3-tooltip"
+            id="header5-column_key_3-tooltip"
           >
             column_3
           </label>
@@ -6295,9 +6300,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header3-column_key_4-tooltip"
+                aria-describedby="header5-column_key_4-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_4-name"
+                aria-labelledby="header5-column_key_4-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6329,7 +6334,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header3-column_key_4"
+                id="header5-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -6343,7 +6348,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header3-column_key_4-name"
+                  id="header5-column_key_4-name"
                 >
                   Item 4
                 </span>
@@ -6368,7 +6373,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   position: absolute;
                   width: 1px;
                 }
-            id="header3-column_key_4-tooltip"
+            id="header5-column_key_4-tooltip"
           >
             column_4
           </label>
@@ -6405,7 +6410,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone5"
+            data-focuszone-id="FocusZone7"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -6544,7 +6549,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone16"
+          data-focuszone-id="FocusZone22"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -6718,7 +6723,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header15-key-name"
+                aria-labelledby="header21-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6750,7 +6755,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header15-key"
+                id="header21-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -6764,7 +6769,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header15-key-name"
+                  id="header21-key-name"
                 >
                   key
                 </span>
@@ -6870,7 +6875,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone17"
+            data-focuszone-id="FocusZone23"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -6907,7 +6912,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader19"
+                        aria-labelledby="GroupHeader25"
                         aria-level={1}
                         className=
                             ms-GroupHeader
@@ -7094,7 +7099,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
-                            id="GroupHeader19"
+                            id="GroupHeader25"
                             role="gridcell"
                           >
                             <span>
@@ -7120,7 +7125,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 0"
                         className="ms-List"
-                        id="GroupedListSection18"
+                        id="GroupedListSection24"
                         role="rowgroup"
                       >
                         <div
@@ -7208,11 +7213,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone22"
+                                data-focuszone-id="FocusZone28"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
                                 data-selection-touch-invoke={true}
+                                id="row20-0"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -7394,11 +7400,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone23"
+                                data-focuszone-id="FocusZone29"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
                                 data-selection-touch-invoke={true}
+                                id="row20-1"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -7531,7 +7538,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader21"
+                        aria-labelledby="GroupHeader27"
                         aria-level={1}
                         className=
                             ms-GroupHeader
@@ -7718,7 +7725,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
-                            id="GroupHeader21"
+                            id="GroupHeader27"
                             role="gridcell"
                           >
                             <span>
@@ -7744,7 +7751,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 1"
                         className="ms-List"
-                        id="GroupedListSection20"
+                        id="GroupedListSection26"
                         role="rowgroup"
                       >
                         <div
@@ -7832,11 +7839,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone24"
+                                data-focuszone-id="FocusZone30"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
                                 data-selection-touch-invoke={true}
+                                id="row20-2"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -8018,11 +8026,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone25"
+                                data-focuszone-id="FocusZone31"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
                                 data-selection-touch-invoke={true}
+                                id="row20-3"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -8204,11 +8213,12 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone26"
+                                data-focuszone-id="FocusZone32"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}
                                 data-selection-touch-invoke={true}
+                                id="row20-4"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -194,8 +194,9 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -407,7 +408,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-key-name"
+                aria-labelledby="header1-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -439,7 +440,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-key"
+                id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -453,7 +454,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-key-name"
+                  id="header1-key-name"
                 >
                   key
                 </span>
@@ -541,7 +542,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-name-name"
+                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -573,7 +574,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-name"
+                id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -587,7 +588,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-name-name"
+                  id="header1-name-name"
                 >
                   name
                 </span>
@@ -675,7 +676,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-value-name"
+                aria-labelledby="header1-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -707,7 +708,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-value"
+                id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -721,7 +722,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-value-name"
+                  id="header1-value-name"
                 >
                   value
                 </span>
@@ -758,7 +759,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -839,6 +840,2197 @@ exports[`DetailsRow renders details list row correctly 1`] = `
 `;
 
 exports[`DetailsRow renders details list row with all rows selected correctly 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={4}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone14"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header13-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header13-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="key"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header13-key-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header13-key"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header13-key-name"
+                >
+                  key
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-colindex={3}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="name"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header13-name-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header13-name"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header13-name-name"
+                >
+                  name
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="value"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header13-value-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header13-value"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header13-value-name"
+                >
+                  value
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone15"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 0
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 1
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 2
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 3
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 4
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsRow renders details list row with checkbox visible always correctly 1`] = `
+<div
+  aria-rowindex={1}
+  aria-selected={false}
+  className=
+      ms-FocusZone
+      ms-DetailsRow
+      &:focus {
+        outline: none;
+      }
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        animation-duration: 0.367s;
+        animation-fill-mode: both;
+        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        background: #ffffff;
+        border-bottom: 1px solid #f3f2f1;
+        box-sizing: border-box;
+        color: #605e5c;
+        display: inline-flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 12px;
+        font-weight: 400;
+        min-height: 42px;
+        min-width: 100%;
+        outline: transparent;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+        text-align: left;
+        vertical-align: top;
+        white-space: nowrap;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #605e5c;
+        bottom: 1px;
+        content: "";
+        left: 1px;
+        outline: 1px solid #ffffff;
+        position: absolute;
+        right: 1px;
+        top: 1px;
+        z-index: 1;
+      }
+      .ms-List-cell:first-child &:before {
+        display: none;
+      }
+      &:hover {
+        background: #f3f2f1;
+        color: #323130;
+      }
+      &:hover .is-row-header {
+        color: #201f1e;
+      }
+      &:hover .ms-DetailsRow-check {
+        opacity: 1;
+      }
+      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+        opacity: 1;
+      }
+  data-automationid="DetailsRow"
+  data-focuszone-id="FocusZone16"
+  data-is-focusable={true}
+  data-item-index={0}
+  data-selection-index={0}
+  data-selection-touch-invoke={true}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+  role="row"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <div
+    aria-colindex={1}
+    className=
+        ms-DetailsRow-cell
+        ms-DetailsRow-cellCheck
+        {
+          box-sizing: border-box;
+          display: inline-block;
+          flex-shrink: 0;
+          margin-top: -1px;
+          min-height: 42px;
+          outline: transparent;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 1px;
+          position: relative;
+          text-overflow: ellipsis;
+          vertical-align: top;
+          white-space: nowrap;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #605e5c;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #ffffff;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        & > button {
+          max-width: 100%;
+        }
+        & [data-is-focusable='true'] {
+          outline: transparent;
+          position: relative;
+        }
+        & [data-is-focusable='true']::-moz-focus-inner {
+          border: 0;
+        }
+    data-selection-toggle={true}
+    role="gridcell"
+  >
+    <div
+      aria-checked={false}
+      className=
+          ms-DetailsRow-check
+          ms-Check-checkHost
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: center;
+            background-color: transparent;
+            background: none;
+            border: none;
+            box-sizing: border-box;
+            cursor: default;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            height: 42px;
+            justify-content: center;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            opacity: 1;
+            outline: transparent;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            vertical-align: top;
+            width: 48px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+      data-automationid="DetailsRowCheck"
+      data-selection-toggle={true}
+      role="checkbox"
+      tabIndex={-1}
+    >
+      <div
+        className=
+            ms-Check
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 1;
+              position: relative;
+              user-select: none;
+              vertical-align: top;
+              width: 18px;
+            }
+            &:before {
+              background: #ffffff;
+              border-radius: 50%;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              opacity: 1;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+            }
+            .ms-Check-checkHost:hover & {
+              opacity: 1;
+            }
+            .ms-Check-checkHost:focus & {
+              opacity: 1;
+            }
+            &:hover {
+              opacity: 1;
+            }
+            &:focus {
+              opacity: 1;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon
+              ms-Check-circle
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                color: #605e5c;
+                font-size: 18px;
+                height: 18px;
+                left: 0px;
+                position: absolute;
+                text-align: center;
+                top: 0px;
+                vertical-align: middle;
+                width: 18px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                color: WindowText;
+              }
+          data-icon-name="CircleRing"
+          role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
+        >
+          
+        </i>
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon
+              ms-Check-check
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                color: #605e5c;
+                font-size: 16px;
+                height: 18px;
+                left: .5px;
+                opacity: 0;
+                position: absolute;
+                text-align: center;
+                top: 0px;
+                vertical-align: middle;
+                width: 18px;
+              }
+              &:hover {
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                forced-color-adjust: none;
+              }
+          data-icon-name="StatusCircleCheckmark"
+          role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-DetailsRow-fields
+        {
+          align-items: stretch;
+          display: flex;
+        }
+    data-automationid="DetailsRowFields"
+    role="presentation"
+  >
+    <div
+      aria-colindex={2}
+      aria-readonly={true}
+      className=
+          ms-DetailsRow-cell
+          {
+            box-sizing: border-box;
+            display: inline-block;
+            min-height: 42px;
+            outline: transparent;
+            overflow: hidden;
+            padding-bottom: 11px;
+            padding-left: 12px;
+            padding-top: 11px;
+            position: relative;
+            text-overflow: ellipsis;
+            vertical-align: top;
+            white-space: nowrap;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #605e5c;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #ffffff;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          & > button {
+            max-width: 100%;
+          }
+          & [data-is-focusable='true'] {
+            outline: transparent;
+            position: relative;
+          }
+          & [data-is-focusable='true']::-moz-focus-inner {
+            border: 0;
+          }
+          {
+            padding-right: 8px;
+          }
+      data-automation-key="key"
+      data-automationid="DetailsRowCell"
+      role="gridcell"
+      style={
+        Object {
+          "width": "auto",
+        }
+      }
+    >
+      
+    </div>
+    <div
+      aria-colindex={3}
+      aria-readonly={true}
+      className=
+          ms-DetailsRow-cell
+          {
+            box-sizing: border-box;
+            display: inline-block;
+            min-height: 42px;
+            outline: transparent;
+            overflow: hidden;
+            padding-bottom: 11px;
+            padding-left: 12px;
+            padding-top: 11px;
+            position: relative;
+            text-overflow: ellipsis;
+            vertical-align: top;
+            white-space: nowrap;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #605e5c;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #ffffff;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          & > button {
+            max-width: 100%;
+          }
+          & [data-is-focusable='true'] {
+            outline: transparent;
+            position: relative;
+          }
+          & [data-is-focusable='true']::-moz-focus-inner {
+            border: 0;
+          }
+          {
+            padding-right: 8px;
+          }
+      data-automation-key="name"
+      data-automationid="DetailsRowCell"
+      role="gridcell"
+      style={
+        Object {
+          "width": "auto",
+        }
+      }
+    >
+      
+    </div>
+    <div
+      aria-colindex={4}
+      aria-readonly={true}
+      className=
+          ms-DetailsRow-cell
+          {
+            box-sizing: border-box;
+            display: inline-block;
+            min-height: 42px;
+            outline: transparent;
+            overflow: hidden;
+            padding-bottom: 11px;
+            padding-left: 12px;
+            padding-top: 11px;
+            position: relative;
+            text-overflow: ellipsis;
+            vertical-align: top;
+            white-space: nowrap;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #605e5c;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #ffffff;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          & > button {
+            max-width: 100%;
+          }
+          & [data-is-focusable='true'] {
+            outline: transparent;
+            position: relative;
+          }
+          & [data-is-focusable='true']::-moz-focus-inner {
+            border: 0;
+          }
+          {
+            padding-right: 8px;
+          }
+      data-automation-key="value"
+      data-automationid="DetailsRowCell"
+      role="gridcell"
+      style={
+        Object {
+          "width": "auto",
+        }
+      }
+    >
+      
+    </div>
+  </div>
+  <span
+    aria-checked={false}
+    className=
+
+        {
+          bottom: 0px;
+          display: none;
+          left: 0px;
+          position: absolute;
+          right: 0px;
+          top: -1px;
+        }
+    data-selection-toggle={true}
+    role="checkbox"
+  />
+</div>
+`;
+
+exports[`DetailsRow renders details list row with multiple selections correctly 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={4}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone6"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header5-check"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header5-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 18px;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          font-size: 16px;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="key"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header5-key-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header5-key"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header5-key-name"
+                >
+                  key
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-colindex={3}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="name"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header5-name-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header5-name"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header5-name-name"
+                >
+                  name
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="value"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 28,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-haspopup={false}
+                aria-labelledby="header5-value-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable={true}
+                id="header5-value"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header5-value-name"
+                >
+                  value
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone7"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 0
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 1
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 2
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 3
+                    </div>
+                  </div>
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  >
+                    <div>
+                      Item 4
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsRow renders details list row with one row selected correctly 1`] = `
 <div
   className="ms-Viewport"
   style={
@@ -1034,6 +3226,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 data-selection-toggle={true}
                 id="header9-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -1597,2194 +3790,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   min-width: 100%;
                 }
             data-focuszone-id="FocusZone11"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <div
-              className="ms-List"
-              role="presentation"
-            >
-              <div
-                className="ms-List-surface"
-                role="presentation"
-              >
-                <div
-                  className="ms-List-page"
-                  role="presentation"
-                  style={Object {}}
-                >
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={0}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 0
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={1}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 1
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={2}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 2
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={3}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 3
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={4}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 4
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DetailsRow renders details list row with checkbox visible always correctly 1`] = `
-<div
-  aria-rowindex={1}
-  aria-selected={false}
-  className=
-      ms-FocusZone
-      ms-DetailsRow
-      &:focus {
-        outline: none;
-      }
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        animation-duration: 0.367s;
-        animation-fill-mode: both;
-        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-        background: #ffffff;
-        border-bottom: 1px solid #f3f2f1;
-        box-sizing: border-box;
-        color: #605e5c;
-        display: inline-flex;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 12px;
-        font-weight: 400;
-        min-height: 42px;
-        min-width: 100%;
-        outline: transparent;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-        text-align: left;
-        vertical-align: top;
-        white-space: nowrap;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid #605e5c;
-        bottom: 1px;
-        content: "";
-        left: 1px;
-        outline: 1px solid #ffffff;
-        position: absolute;
-        right: 1px;
-        top: 1px;
-        z-index: 1;
-      }
-      .ms-List-cell:first-child &:before {
-        display: none;
-      }
-      &:hover {
-        background: #f3f2f1;
-        color: #323130;
-      }
-      &:hover .is-row-header {
-        color: #201f1e;
-      }
-      &:hover .ms-DetailsRow-check {
-        opacity: 1;
-      }
-      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-        opacity: 1;
-      }
-  data-automationid="DetailsRow"
-  data-focuszone-id="FocusZone12"
-  data-is-focusable={true}
-  data-item-index={0}
-  data-selection-index={0}
-  data-selection-touch-invoke={true}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseDownCapture={[Function]}
-  role="row"
-  style={
-    Object {
-      "minWidth": 0,
-    }
-  }
->
-  <div
-    aria-colindex={1}
-    className=
-        ms-DetailsRow-cell
-        ms-DetailsRow-cellCheck
-        {
-          box-sizing: border-box;
-          display: inline-block;
-          flex-shrink: 0;
-          margin-top: -1px;
-          min-height: 42px;
-          outline: transparent;
-          overflow: hidden;
-          padding-bottom: 0px;
-          padding-left: 0px;
-          padding-right: 0px;
-          padding-top: 1px;
-          position: relative;
-          text-overflow: ellipsis;
-          vertical-align: top;
-          white-space: nowrap;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #605e5c;
-          bottom: 0px;
-          content: "";
-          left: 0px;
-          outline: 1px solid #ffffff;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-          z-index: 1;
-        }
-        & > button {
-          max-width: 100%;
-        }
-        & [data-is-focusable='true'] {
-          outline: transparent;
-          position: relative;
-        }
-        & [data-is-focusable='true']::-moz-focus-inner {
-          border: 0;
-        }
-    data-selection-toggle={true}
-    role="gridcell"
-  >
-    <div
-      aria-checked={false}
-      className=
-          ms-DetailsRow-check
-          ms-Check-checkHost
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            align-items: center;
-            background-color: transparent;
-            background: none;
-            border: none;
-            box-sizing: border-box;
-            cursor: default;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            height: 42px;
-            justify-content: center;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            opacity: 1;
-            outline: transparent;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            vertical-align: top;
-            width: 48px;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid #ffffff;
-            bottom: 1px;
-            content: "";
-            left: 1px;
-            outline: 1px solid #605e5c;
-            position: absolute;
-            right: 1px;
-            top: 1px;
-            z-index: 1;
-          }
-      data-automationid="DetailsRowCheck"
-      data-selection-toggle={true}
-      role="checkbox"
-    >
-      <div
-        className=
-            ms-Check
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 18px;
-              line-height: 1;
-              position: relative;
-              user-select: none;
-              vertical-align: top;
-              width: 18px;
-            }
-            &:before {
-              background: #ffffff;
-              border-radius: 50%;
-              bottom: 1px;
-              content: "";
-              left: 1px;
-              opacity: 1;
-              position: absolute;
-              right: 1px;
-              top: 1px;
-            }
-            .ms-Check-checkHost:hover & {
-              opacity: 1;
-            }
-            .ms-Check-checkHost:focus & {
-              opacity: 1;
-            }
-            &:hover {
-              opacity: 1;
-            }
-            &:focus {
-              opacity: 1;
-            }
-      >
-        <i
-          aria-hidden={true}
-          className=
-              ms-Icon
-              ms-Check-circle
-              {
-                display: inline-block;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-              {
-                color: #605e5c;
-                font-size: 18px;
-                height: 18px;
-                left: 0px;
-                position: absolute;
-                text-align: center;
-                top: 0px;
-                vertical-align: middle;
-                width: 18px;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                color: WindowText;
-              }
-          data-icon-name="CircleRing"
-          role="presentation"
-          style={
-            Object {
-              "fontFamily": "\\"FabricMDL2Icons\\"",
-            }
-          }
-        >
-          
-        </i>
-        <i
-          aria-hidden={true}
-          className=
-              ms-Icon
-              ms-Check-check
-              {
-                display: inline-block;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-              {
-                color: #605e5c;
-                font-size: 16px;
-                height: 18px;
-                left: .5px;
-                opacity: 0;
-                position: absolute;
-                text-align: center;
-                top: 0px;
-                vertical-align: middle;
-                width: 18px;
-              }
-              &:hover {
-                opacity: 1;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                -ms-high-contrast-adjust: none;
-                forced-color-adjust: none;
-              }
-          data-icon-name="StatusCircleCheckmark"
-          role="presentation"
-          style={
-            Object {
-              "fontFamily": "\\"FabricMDL2Icons\\"",
-            }
-          }
-        >
-          
-        </i>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-DetailsRow-fields
-        {
-          align-items: stretch;
-          display: flex;
-        }
-    data-automationid="DetailsRowFields"
-    role="presentation"
-  >
-    <div
-      aria-colindex={2}
-      aria-readonly={true}
-      className=
-          ms-DetailsRow-cell
-          {
-            box-sizing: border-box;
-            display: inline-block;
-            min-height: 42px;
-            outline: transparent;
-            overflow: hidden;
-            padding-bottom: 11px;
-            padding-left: 12px;
-            padding-top: 11px;
-            position: relative;
-            text-overflow: ellipsis;
-            vertical-align: top;
-            white-space: nowrap;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid #605e5c;
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            outline: 1px solid #ffffff;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-            z-index: 1;
-          }
-          & > button {
-            max-width: 100%;
-          }
-          & [data-is-focusable='true'] {
-            outline: transparent;
-            position: relative;
-          }
-          & [data-is-focusable='true']::-moz-focus-inner {
-            border: 0;
-          }
-          {
-            padding-right: 8px;
-          }
-      data-automation-key="key"
-      data-automationid="DetailsRowCell"
-      role="gridcell"
-      style={
-        Object {
-          "width": "auto",
-        }
-      }
-    >
-      
-    </div>
-    <div
-      aria-colindex={3}
-      aria-readonly={true}
-      className=
-          ms-DetailsRow-cell
-          {
-            box-sizing: border-box;
-            display: inline-block;
-            min-height: 42px;
-            outline: transparent;
-            overflow: hidden;
-            padding-bottom: 11px;
-            padding-left: 12px;
-            padding-top: 11px;
-            position: relative;
-            text-overflow: ellipsis;
-            vertical-align: top;
-            white-space: nowrap;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid #605e5c;
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            outline: 1px solid #ffffff;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-            z-index: 1;
-          }
-          & > button {
-            max-width: 100%;
-          }
-          & [data-is-focusable='true'] {
-            outline: transparent;
-            position: relative;
-          }
-          & [data-is-focusable='true']::-moz-focus-inner {
-            border: 0;
-          }
-          {
-            padding-right: 8px;
-          }
-      data-automation-key="name"
-      data-automationid="DetailsRowCell"
-      role="gridcell"
-      style={
-        Object {
-          "width": "auto",
-        }
-      }
-    >
-      
-    </div>
-    <div
-      aria-colindex={4}
-      aria-readonly={true}
-      className=
-          ms-DetailsRow-cell
-          {
-            box-sizing: border-box;
-            display: inline-block;
-            min-height: 42px;
-            outline: transparent;
-            overflow: hidden;
-            padding-bottom: 11px;
-            padding-left: 12px;
-            padding-top: 11px;
-            position: relative;
-            text-overflow: ellipsis;
-            vertical-align: top;
-            white-space: nowrap;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid #605e5c;
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            outline: 1px solid #ffffff;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-            z-index: 1;
-          }
-          & > button {
-            max-width: 100%;
-          }
-          & [data-is-focusable='true'] {
-            outline: transparent;
-            position: relative;
-          }
-          & [data-is-focusable='true']::-moz-focus-inner {
-            border: 0;
-          }
-          {
-            padding-right: 8px;
-          }
-      data-automation-key="value"
-      data-automationid="DetailsRowCell"
-      role="gridcell"
-      style={
-        Object {
-          "width": "auto",
-        }
-      }
-    >
-      
-    </div>
-  </div>
-  <span
-    aria-checked={false}
-    className=
-
-        {
-          bottom: 0px;
-          display: none;
-          left: 0px;
-          position: absolute;
-          right: 0px;
-          top: -1px;
-        }
-    data-selection-toggle={true}
-    role="checkbox"
-  />
-</div>
-`;
-
-exports[`DetailsRow renders details list row with multiple selections correctly 1`] = `
-<div
-  className="ms-Viewport"
-  style={
-    Object {
-      "minHeight": 1,
-      "minWidth": 1,
-    }
-  }
->
-  <div
-    className=
-        ms-DetailsList
-        is-horizontalConstrained
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          -webkit-overflow-scrolling: touch;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          overflow-x: auto;
-          overflow-y: visible;
-          position: relative;
-        }
-        & .ms-List-cell {
-          min-height: 38px;
-          word-break: break-word;
-        }
-    data-automationid="DetailsList"
-    data-is-scrollable="false"
-  >
-    <div
-      aria-colcount={4}
-      aria-readonly="true"
-      aria-rowcount={6}
-      role="grid"
-    >
-      <div
-        className="ms-DetailsList-headerWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              ms-DetailsHeader
-              &:focus {
-                outline: none;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: #ffffff;
-                border-bottom: 1px solid #edebe9;
-                box-sizing: content-box;
-                cursor: default;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                height: 42px;
-                line-height: 42px;
-                min-width: 100%;
-                padding-bottom: 1px;
-                padding-top: 16px;
-                position: relative;
-                user-select: none;
-                vertical-align: top;
-                white-space: nowrap;
-              }
-              &:hover .ms-DetailsHeader-check {
-                opacity: 1;
-              }
-              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
-                display: block;
-              }
-          data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone4"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-          onMouseMove={[Function]}
-          role="row"
-        >
-          <div
-            aria-colindex={1}
-            aria-labelledby="header3-check"
-            className=
-                ms-DetailsHeader-cell
-                ms-DetailsHeader-cellIsCheck
-                {
-                  align-items: center;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-flex;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  outline: transparent;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-            onClick={[Function]}
-            role="columnheader"
-          >
-            <span
-              className="ms-DetailsHeader-checkTooltip"
-            >
-              <div
-                aria-checked={false}
-                className=
-                    ms-DetailsRow-check
-                    ms-DetailsHeader-check
-                    ms-DetailsRow-check--isHeader
-                    ms-Check-checkHost
-                    {
-                      height: 42px;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      opacity: 1;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      background-color: transparent;
-                      background: none;
-                      border: none;
-                      box-sizing: border-box;
-                      cursor: default;
-                      display: flex;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      justify-content: center;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      opacity: 0;
-                      outline: transparent;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      vertical-align: top;
-                      width: 48px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-automationid="DetailsRowCheck"
-                data-is-focusable={true}
-                data-selection-toggle={true}
-                id="header3-check"
-                role="checkbox"
-              >
-                <div
-                  className=
-                      ms-Check
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 18px;
-                        line-height: 1;
-                        position: relative;
-                        user-select: none;
-                        vertical-align: top;
-                        width: 18px;
-                      }
-                      &:before {
-                        background: #ffffff;
-                        border-radius: 50%;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        opacity: 1;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                      }
-                      .ms-Check-checkHost:hover & {
-                        opacity: 1;
-                      }
-                      .ms-Check-checkHost:focus & {
-                        opacity: 1;
-                      }
-                      &:hover {
-                        opacity: 1;
-                      }
-                      &:focus {
-                        opacity: 1;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-circle
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 18px;
-                          height: 18px;
-                          left: 0px;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          color: WindowText;
-                        }
-                    data-icon-name="CircleRing"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-check
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 16px;
-                          height: 18px;
-                          left: .5px;
-                          opacity: 0;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        &:hover {
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="StatusCircleCheckmark"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </div>
-              </div>
-            </span>
-          </div>
-          <div
-            aria-colindex={2}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="key"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header3-key-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header3-key"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header3-key-name"
-                >
-                  key
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-colindex={3}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="name"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header3-name-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header3-name"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header3-name-name"
-                >
-                  name
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-colindex={4}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="value"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header3-value-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header3-value"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header3-value-name"
-                >
-                  value
-                </span>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DetailsList-contentWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone5"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <div
-              className="ms-List"
-              role="presentation"
-            >
-              <div
-                className="ms-List-surface"
-                role="presentation"
-              >
-                <div
-                  className="ms-List-page"
-                  role="presentation"
-                  style={Object {}}
-                >
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={0}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 0
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={1}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 1
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={2}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 2
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={3}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 3
-                    </div>
-                  </div>
-                  <div
-                    className="ms-List-cell"
-                    data-automationid="ListCell"
-                    data-list-index={4}
-                    role="presentation"
-                  >
-                    <div>
-                      Item 4
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DetailsRow renders details list row with one row selected correctly 1`] = `
-<div
-  className="ms-Viewport"
-  style={
-    Object {
-      "minHeight": 1,
-      "minWidth": 1,
-    }
-  }
->
-  <div
-    className=
-        ms-DetailsList
-        is-horizontalConstrained
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          -webkit-overflow-scrolling: touch;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          overflow-x: auto;
-          overflow-y: visible;
-          position: relative;
-        }
-        & .ms-List-cell {
-          min-height: 38px;
-          word-break: break-word;
-        }
-    data-automationid="DetailsList"
-    data-is-scrollable="false"
-  >
-    <div
-      aria-colcount={4}
-      aria-readonly="true"
-      aria-rowcount={6}
-      role="grid"
-    >
-      <div
-        className="ms-DetailsList-headerWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              ms-DetailsHeader
-              &:focus {
-                outline: none;
-              }
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: #ffffff;
-                border-bottom: 1px solid #edebe9;
-                box-sizing: content-box;
-                cursor: default;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                height: 42px;
-                line-height: 42px;
-                min-width: 100%;
-                padding-bottom: 1px;
-                padding-top: 16px;
-                position: relative;
-                user-select: none;
-                vertical-align: top;
-                white-space: nowrap;
-              }
-              &:hover .ms-DetailsHeader-check {
-                opacity: 1;
-              }
-              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
-                display: block;
-              }
-          data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone7"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-          onMouseMove={[Function]}
-          role="row"
-        >
-          <div
-            aria-colindex={1}
-            aria-labelledby="header6-check"
-            className=
-                ms-DetailsHeader-cell
-                ms-DetailsHeader-cellIsCheck
-                {
-                  align-items: center;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-flex;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  outline: transparent;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-            onClick={[Function]}
-            role="columnheader"
-          >
-            <span
-              className="ms-DetailsHeader-checkTooltip"
-            >
-              <div
-                aria-checked={false}
-                className=
-                    ms-DetailsRow-check
-                    ms-DetailsHeader-check
-                    ms-DetailsRow-check--isHeader
-                    ms-Check-checkHost
-                    {
-                      height: 42px;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      opacity: 1;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      background-color: transparent;
-                      background: none;
-                      border: none;
-                      box-sizing: border-box;
-                      cursor: default;
-                      display: flex;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      justify-content: center;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      opacity: 0;
-                      outline: transparent;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      vertical-align: top;
-                      width: 48px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-automationid="DetailsRowCheck"
-                data-is-focusable={true}
-                data-selection-toggle={true}
-                id="header6-check"
-                role="checkbox"
-              >
-                <div
-                  className=
-                      ms-Check
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 18px;
-                        line-height: 1;
-                        position: relative;
-                        user-select: none;
-                        vertical-align: top;
-                        width: 18px;
-                      }
-                      &:before {
-                        background: #ffffff;
-                        border-radius: 50%;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        opacity: 1;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                      }
-                      .ms-Check-checkHost:hover & {
-                        opacity: 1;
-                      }
-                      .ms-Check-checkHost:focus & {
-                        opacity: 1;
-                      }
-                      &:hover {
-                        opacity: 1;
-                      }
-                      &:focus {
-                        opacity: 1;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-circle
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 18px;
-                          height: 18px;
-                          left: 0px;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          color: WindowText;
-                        }
-                    data-icon-name="CircleRing"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Check-check
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          color: #605e5c;
-                          font-size: 16px;
-                          height: 18px;
-                          left: .5px;
-                          opacity: 0;
-                          position: absolute;
-                          text-align: center;
-                          top: 0px;
-                          vertical-align: middle;
-                          width: 18px;
-                        }
-                        &:hover {
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="StatusCircleCheckmark"
-                    role="presentation"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </div>
-              </div>
-            </span>
-          </div>
-          <div
-            aria-colindex={2}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="key"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header6-key-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header6-key"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header6-key-name"
-                >
-                  key
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-colindex={3}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="name"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header6-name-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header6-name"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header6-name-name"
-                >
-                  name
-                </span>
-              </span>
-            </span>
-          </div>
-          <div
-            aria-colindex={4}
-            aria-sort="none"
-            className=
-                ms-DetailsHeader-cell
-                is-actionable
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  box-sizing: border-box;
-                  color: #323130;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 12px;
-                  font-weight: 400;
-                  height: 42px;
-                  line-height: inherit;
-                  margin-bottom: 0;
-                  margin-left: 0;
-                  margin-right: 0;
-                  margin-top: 0;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 12px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: left;
-                  text-overflow: ellipsis;
-                  vertical-align: top;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #f3f2f1;
-                  color: #323130;
-                }
-                &:active {
-                  background: #edebe9;
-                }
-                &:hover i[data-icon-name="GripperBarVertical"] {
-                  display: block;
-                }
-            data-automationid="ColumnsHeaderColumn"
-            data-is-draggable={false}
-            data-item-key="value"
-            draggable={false}
-            role="columnheader"
-            style={
-              Object {
-                "width": 28,
-              }
-            }
-          >
-            <span
-              className=
-
-                  {
-                    bottom: 0px;
-                    display: block;
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
-            >
-              <span
-                aria-haspopup={false}
-                aria-labelledby="header6-value-name"
-                className=
-                    ms-DetailsHeader-cellTitle
-                    {
-                      align-items: stretch;
-                      box-sizing: border-box;
-                      display: flex;
-                      flex-direction: row;
-                      justify-content: flex-start;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                data-is-focusable={true}
-                id="header6-value"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-              >
-                <span
-                  className=
-                      ms-DetailsHeader-cellName
-                      {
-                        flex: 0 1 auto;
-                        font-size: 14px;
-                        font-weight: 600;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      }
-                  id="header6-value-name"
-                >
-                  value
-                </span>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DetailsList-contentWrapper"
-        onKeyDown={[Function]}
-        role="presentation"
-      >
-        <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone8"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -89,7 +89,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -195,8 +195,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -357,7 +358,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -282,7 +282,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone4"
+            data-focuszone-id="FocusZone5"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -291,7 +291,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header3-check"
+              aria-labelledby="header4-check"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -340,7 +340,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header3-checkTooltip"
+                  aria-describedby="header4-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
@@ -399,8 +399,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                   data-automationid="DetailsRowCheck"
                   data-is-focusable={true}
                   data-selection-toggle={true}
-                  id="header3-check"
+                  id="header4-check"
                   role="checkbox"
+                  tabIndex={-1}
                 >
                   <div
                     className=
@@ -550,7 +551,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                     position: absolute;
                     width: 1px;
                   }
-              id="header3-checkTooltip"
+              id="header4-checkTooltip"
             >
               Toggle selection for all items
             </label>
@@ -635,7 +636,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header3-name-name"
+                  aria-labelledby="header4-name-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -667,7 +668,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header3-name"
+                  id="header4-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                 >
@@ -681,7 +682,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header3-name-name"
+                    id="header4-name-name"
                   >
                     Name
                   </span>
@@ -718,7 +719,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                     min-height: 1px;
                     min-width: 100%;
                   }
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone6"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -813,11 +814,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone6"
+                        data-focuszone-id="FocusZone7"
                         data-is-focusable={true}
                         data-item-index={0}
                         data-selection-index={0}
                         data-selection-touch-invoke={true}
+                        id="row3-0"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -880,6 +882,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-0-checkbox row3-0-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -928,7 +931,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-0-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -1219,11 +1224,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone7"
+                        data-focuszone-id="FocusZone8"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
                         data-selection-touch-invoke={true}
+                        id="row3-1"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1286,6 +1292,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-1-checkbox row3-1-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1334,7 +1341,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-1-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -1625,11 +1634,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone8"
+                        data-focuszone-id="FocusZone9"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
                         data-selection-touch-invoke={true}
+                        id="row3-2"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1692,6 +1702,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-2-checkbox row3-2-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1740,7 +1751,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-2-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2031,11 +2044,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone9"
+                        data-focuszone-id="FocusZone10"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
                         data-selection-touch-invoke={true}
+                        id="row3-3"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2098,6 +2112,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-3-checkbox row3-3-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2146,7 +2161,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-3-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2437,11 +2454,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone10"
+                        data-focuszone-id="FocusZone11"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
                         data-selection-touch-invoke={true}
+                        id="row3-4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2504,6 +2522,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-4-checkbox row3-4-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2552,7 +2571,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-4-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2843,11 +2864,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone11"
+                        data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
                         data-selection-touch-invoke={true}
+                        id="row3-5"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2910,6 +2932,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-5-checkbox row3-5-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2958,7 +2981,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-5-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3249,11 +3274,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone12"
+                        data-focuszone-id="FocusZone13"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
                         data-selection-touch-invoke={true}
+                        id="row3-6"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3316,6 +3342,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-6-checkbox row3-6-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3364,7 +3391,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-6-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3655,11 +3684,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone13"
+                        data-focuszone-id="FocusZone14"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
                         data-selection-touch-invoke={true}
+                        id="row3-7"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3722,6 +3752,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-7-checkbox row3-7-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3770,7 +3801,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-7-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4061,11 +4094,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone14"
+                        data-focuszone-id="FocusZone15"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
                         data-selection-touch-invoke={true}
+                        id="row3-8"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4128,6 +4162,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-8-checkbox row3-8-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4176,7 +4211,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-8-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4467,11 +4504,12 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone15"
+                        data-focuszone-id="FocusZone16"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
                         data-selection-touch-invoke={true}
+                        id="row3-9"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4534,6 +4572,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row3-9-checkbox row3-9-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4582,7 +4621,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row3-9-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -89,7 +89,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -138,7 +138,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -197,8 +197,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -348,7 +349,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -433,7 +434,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-name-name"
+                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -465,7 +466,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-name"
+                id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -479,7 +480,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-name-name"
+                  id="header1-name-name"
                 >
                   Name
                 </span>
@@ -516,7 +517,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -611,11 +612,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -678,6 +680,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -726,7 +729,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-0-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1153,11 +1158,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1220,6 +1226,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1268,7 +1275,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-1-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1695,11 +1704,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone13"
+                      data-focuszone-id="FocusZone14"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1762,6 +1772,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1810,7 +1821,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-2-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2237,11 +2250,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone17"
+                      data-focuszone-id="FocusZone18"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2304,6 +2318,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2352,7 +2367,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-3-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2779,11 +2796,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone21"
+                      data-focuszone-id="FocusZone22"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2846,6 +2864,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2894,7 +2913,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-4-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3321,11 +3342,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone25"
+                      data-focuszone-id="FocusZone26"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
                       data-selection-touch-invoke={true}
+                      id="row0-5"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3388,6 +3410,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-5-checkbox row0-5-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3436,7 +3459,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-5-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3863,11 +3888,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone29"
+                      data-focuszone-id="FocusZone30"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
                       data-selection-touch-invoke={true}
+                      id="row0-6"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3930,6 +3956,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-6-checkbox row0-6-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3978,7 +4005,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-6-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4405,11 +4434,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone33"
+                      data-focuszone-id="FocusZone34"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
                       data-selection-touch-invoke={true}
+                      id="row0-7"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4472,6 +4502,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-7-checkbox row0-7-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4520,7 +4551,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-7-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4947,11 +4980,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone37"
+                      data-focuszone-id="FocusZone38"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
                       data-selection-touch-invoke={true}
+                      id="row0-8"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -5014,6 +5048,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-8-checkbox row0-8-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5062,7 +5097,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-8-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -5489,11 +5526,12 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone41"
+                      data-focuszone-id="FocusZone42"
                       data-is-focusable={true}
                       data-item-index={9}
                       data-selection-index={9}
                       data-selection-touch-invoke={true}
+                      id="row0-9"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -5556,6 +5594,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-9-checkbox row0-9-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5604,7 +5643,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-9-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -896,7 +896,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone14"
+            data-focuszone-id="FocusZone15"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -905,7 +905,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header13-check"
+              aria-labelledby="header14-check"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -954,7 +954,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header13-checkTooltip"
+                  aria-describedby="header14-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
@@ -1013,8 +1013,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   data-automationid="DetailsRowCheck"
                   data-is-focusable={true}
                   data-selection-toggle={true}
-                  id="header13-check"
+                  id="header14-check"
                   role="checkbox"
+                  tabIndex={-1}
                 >
                   <div
                     className=
@@ -1164,7 +1165,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     position: absolute;
                     width: 1px;
                   }
-              id="header13-checkTooltip"
+              id="header14-checkTooltip"
             >
               Toggle selection for all items
             </label>
@@ -1248,7 +1249,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header13-thumbnail-tooltip"
+                  aria-describedby="header14-thumbnail-tooltip"
                   aria-haspopup={false}
                   aria-label="thumbnail"
                   className=
@@ -1285,7 +1286,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header13-thumbnail"
+                  id="header14-thumbnail"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1303,7 +1304,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         & .ms-DetailsColumn-nearIcon {
                           padding-left: 0px;
                         }
-                    id="header13-thumbnail-name"
+                    id="header14-thumbnail-name"
                   >
                     <i
                       aria-hidden={true}
@@ -1377,7 +1378,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     position: absolute;
                     width: 1px;
                   }
-              id="header13-thumbnail-tooltip"
+              id="header14-thumbnail-tooltip"
             >
               Operations for thumbnail
             </label>
@@ -1489,7 +1490,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     min-height: 1px;
                     min-width: 100%;
                   }
-              data-focuszone-id="FocusZone15"
+              data-focuszone-id="FocusZone16"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1584,11 +1585,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone16"
+                        data-focuszone-id="FocusZone17"
                         data-is-focusable={true}
                         data-item-index={0}
                         data-selection-index={0}
                         data-selection-touch-invoke={true}
+                        id="row13-0"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1651,6 +1653,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-0-checkbox row13-0-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1699,7 +1702,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-0-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -1990,11 +1995,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone17"
+                        data-focuszone-id="FocusZone18"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
                         data-selection-touch-invoke={true}
+                        id="row13-1"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2057,6 +2063,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-1-checkbox row13-1-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2105,7 +2112,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-1-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2396,11 +2405,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone18"
+                        data-focuszone-id="FocusZone19"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
                         data-selection-touch-invoke={true}
+                        id="row13-2"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2463,6 +2473,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-2-checkbox row13-2-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2511,7 +2522,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-2-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2802,11 +2815,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone19"
+                        data-focuszone-id="FocusZone20"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
                         data-selection-touch-invoke={true}
+                        id="row13-3"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2869,6 +2883,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-3-checkbox row13-3-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2917,7 +2932,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-3-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3208,11 +3225,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone20"
+                        data-focuszone-id="FocusZone21"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
                         data-selection-touch-invoke={true}
+                        id="row13-4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3275,6 +3293,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-4-checkbox row13-4-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3323,7 +3342,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-4-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3614,11 +3635,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone21"
+                        data-focuszone-id="FocusZone22"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
                         data-selection-touch-invoke={true}
+                        id="row13-5"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3681,6 +3703,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-5-checkbox row13-5-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3729,7 +3752,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-5-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4020,11 +4045,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone22"
+                        data-focuszone-id="FocusZone23"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
                         data-selection-touch-invoke={true}
+                        id="row13-6"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4087,6 +4113,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-6-checkbox row13-6-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4135,7 +4162,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-6-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4426,11 +4455,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone23"
+                        data-focuszone-id="FocusZone24"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
                         data-selection-touch-invoke={true}
+                        id="row13-7"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4493,6 +4523,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-7-checkbox row13-7-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4541,7 +4572,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-7-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4832,11 +4865,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone24"
+                        data-focuszone-id="FocusZone25"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
                         data-selection-touch-invoke={true}
+                        id="row13-8"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4899,6 +4933,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-8-checkbox row13-8-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4947,7 +4982,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-8-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -5238,11 +5275,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone25"
+                        data-focuszone-id="FocusZone26"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
                         data-selection-touch-invoke={true}
+                        id="row13-9"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -5305,6 +5343,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row13-9-checkbox row13-9-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5353,7 +5392,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row13-9-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone1"
+            data-focuszone-id="FocusZone2"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -110,7 +110,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header0-check"
+              aria-labelledby="header1-check"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -159,7 +159,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header0-checkTooltip"
+                  aria-describedby="header1-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
@@ -218,8 +218,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                   data-automationid="DetailsRowCheck"
                   data-is-focusable={true}
                   data-selection-toggle={true}
-                  id="header0-check"
+                  id="header1-check"
                   role="checkbox"
+                  tabIndex={-1}
                 >
                   <div
                     className=
@@ -369,7 +370,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                     position: absolute;
                     width: 1px;
                   }
-              id="header0-checkTooltip"
+              id="header1-checkTooltip"
             >
               Toggle selection for all items
             </label>
@@ -454,7 +455,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header0-column1-name"
+                  aria-labelledby="header1-column1-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -486,7 +487,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header0-column1"
+                  id="header1-column1"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                 >
@@ -500,7 +501,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header0-column1-name"
+                    id="header1-column1-name"
                   >
                     Name
                   </span>
@@ -644,7 +645,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header0-column2-name"
+                  aria-labelledby="header1-column2-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -676,7 +677,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header0-column2"
+                  id="header1-column2"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                 >
@@ -690,7 +691,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header0-column2-name"
+                    id="header1-column2-name"
                   >
                     Value
                   </span>
@@ -783,7 +784,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                     min-height: 1px;
                     min-width: 100%;
                   }
-              data-focuszone-id="FocusZone2"
+              data-focuszone-id="FocusZone3"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -878,11 +879,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone3"
+                        data-focuszone-id="FocusZone4"
                         data-is-focusable={true}
                         data-item-index={0}
                         data-selection-index={0}
                         data-selection-touch-invoke={true}
+                        id="row0-0"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -945,6 +947,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-0-checkbox row0-0-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -993,7 +996,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-0-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -1341,11 +1346,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone4"
+                        data-focuszone-id="FocusZone5"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
                         data-selection-touch-invoke={true}
+                        id="row0-1"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1408,6 +1414,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-1-checkbox row0-1-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1456,7 +1463,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-1-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -1804,11 +1813,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone5"
+                        data-focuszone-id="FocusZone6"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
                         data-selection-touch-invoke={true}
+                        id="row0-2"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1871,6 +1881,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-2-checkbox row0-2-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -1919,7 +1930,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-2-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2267,11 +2280,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone6"
+                        data-focuszone-id="FocusZone7"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
                         data-selection-touch-invoke={true}
+                        id="row0-3"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2334,6 +2348,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-3-checkbox row0-3-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2382,7 +2397,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-3-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -2730,11 +2747,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone7"
+                        data-focuszone-id="FocusZone8"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
                         data-selection-touch-invoke={true}
+                        id="row0-4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2797,6 +2815,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-4-checkbox row0-4-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -2845,7 +2864,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-4-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3193,11 +3214,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone8"
+                        data-focuszone-id="FocusZone9"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
                         data-selection-touch-invoke={true}
+                        id="row0-5"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3260,6 +3282,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-5-checkbox row0-5-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3308,7 +3331,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-5-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -3656,11 +3681,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone9"
+                        data-focuszone-id="FocusZone10"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
                         data-selection-touch-invoke={true}
+                        id="row0-6"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3723,6 +3749,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-6-checkbox row0-6-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -3771,7 +3798,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-6-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4119,11 +4148,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone10"
+                        data-focuszone-id="FocusZone11"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
                         data-selection-touch-invoke={true}
+                        id="row0-7"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4186,6 +4216,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-7-checkbox row0-7-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4234,7 +4265,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-7-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -4582,11 +4615,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone11"
+                        data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
                         data-selection-touch-invoke={true}
+                        id="row0-8"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4649,6 +4683,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-8-checkbox row0-8-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -4697,7 +4732,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-8-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=
@@ -5045,11 +5082,12 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone12"
+                        data-focuszone-id="FocusZone13"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
                         data-selection-touch-invoke={true}
+                        id="row0-9"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -5112,6 +5150,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           <div
                             aria-checked={false}
                             aria-label="select row"
+                            aria-labelledby="row0-9-checkbox row0-9-header"
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
@@ -5160,7 +5199,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                             data-automationid="DetailsRowCheck"
                             data-selection-toggle={true}
+                            id="row0-9-checkbox"
                             role="checkbox"
+                            tabIndex={-1}
                           >
                             <div
                               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -327,7 +327,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone4"
+              data-focuszone-id="FocusZone5"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -336,7 +336,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header3-check"
+                aria-labelledby="header4-check"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -385,7 +385,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header3-checkTooltip"
+                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
@@ -444,8 +444,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     data-automationid="DetailsRowCheck"
                     data-is-focusable={true}
                     data-selection-toggle={true}
-                    id="header3-check"
+                    id="header4-check"
                     role="checkbox"
+                    tabIndex={-1}
                   >
                     <div
                       className=
@@ -595,7 +596,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       position: absolute;
                       width: 1px;
                     }
-                id="header3-checkTooltip"
+                id="header4-checkTooltip"
               >
                 Toggle selection for all items
               </label>
@@ -680,7 +681,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header3-column1-name"
+                    aria-labelledby="header4-column1-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -712,7 +713,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header3-column1"
+                    id="header4-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -726,7 +727,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header3-column1-name"
+                      id="header4-column1-name"
                     >
                       Name
                     </span>
@@ -870,7 +871,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header3-column2-name"
+                    aria-labelledby="header4-column2-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -902,7 +903,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header3-column2"
+                    id="header4-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -916,7 +917,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header3-column2-name"
+                      id="header4-column2-name"
                     >
                       Value
                     </span>
@@ -1009,7 +1010,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone5"
+                data-focuszone-id="FocusZone6"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1104,11 +1105,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone6"
+                          data-focuszone-id="FocusZone7"
                           data-is-focusable={true}
                           data-item-index={0}
                           data-selection-index={0}
                           data-selection-touch-invoke={true}
+                          id="row3-0"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1171,6 +1173,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-0-checkbox row3-0-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1219,7 +1222,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-0-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -1567,11 +1572,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone7"
+                          data-focuszone-id="FocusZone8"
                           data-is-focusable={true}
                           data-item-index={1}
                           data-selection-index={1}
                           data-selection-touch-invoke={true}
+                          id="row3-1"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1634,6 +1640,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-1-checkbox row3-1-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1682,7 +1689,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-1-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2030,11 +2039,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone8"
+                          data-focuszone-id="FocusZone9"
                           data-is-focusable={true}
                           data-item-index={2}
                           data-selection-index={2}
                           data-selection-touch-invoke={true}
+                          id="row3-2"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2097,6 +2107,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-2-checkbox row3-2-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2145,7 +2156,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-2-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2493,11 +2506,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone9"
+                          data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
                           data-item-index={3}
                           data-selection-index={3}
                           data-selection-touch-invoke={true}
+                          id="row3-3"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2560,6 +2574,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-3-checkbox row3-3-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2608,7 +2623,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-3-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2956,11 +2973,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
+                          data-focuszone-id="FocusZone11"
                           data-is-focusable={true}
                           data-item-index={4}
                           data-selection-index={4}
                           data-selection-touch-invoke={true}
+                          id="row3-4"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3023,6 +3041,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-4-checkbox row3-4-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3071,7 +3090,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-4-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3419,11 +3440,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone11"
+                          data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
                           data-item-index={5}
                           data-selection-index={5}
                           data-selection-touch-invoke={true}
+                          id="row3-5"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3486,6 +3508,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-5-checkbox row3-5-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3534,7 +3557,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-5-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3882,11 +3907,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
+                          data-focuszone-id="FocusZone13"
                           data-is-focusable={true}
                           data-item-index={6}
                           data-selection-index={6}
                           data-selection-touch-invoke={true}
+                          id="row3-6"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3949,6 +3975,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-6-checkbox row3-6-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3997,7 +4024,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-6-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4345,11 +4374,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone13"
+                          data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
                           data-item-index={7}
                           data-selection-index={7}
                           data-selection-touch-invoke={true}
+                          id="row3-7"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4412,6 +4442,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-7-checkbox row3-7-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4460,7 +4491,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-7-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4808,11 +4841,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
+                          data-focuszone-id="FocusZone15"
                           data-is-focusable={true}
                           data-item-index={8}
                           data-selection-index={8}
                           data-selection-touch-invoke={true}
+                          id="row3-8"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4875,6 +4909,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-8-checkbox row3-8-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4923,7 +4958,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-8-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -5271,11 +5308,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone15"
+                          data-focuszone-id="FocusZone16"
                           data-is-focusable={true}
                           data-item-index={9}
                           data-selection-index={9}
                           data-selection-touch-invoke={true}
+                          id="row3-9"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -5338,6 +5376,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-9-checkbox row3-9-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5386,7 +5425,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-9-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -312,7 +312,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone4"
+              data-focuszone-id="FocusZone5"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -321,7 +321,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header3-check"
+                aria-labelledby="header4-check"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -370,7 +370,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header3-checkTooltip"
+                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
@@ -429,8 +429,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     data-automationid="DetailsRowCheck"
                     data-is-focusable={true}
                     data-selection-toggle={true}
-                    id="header3-check"
+                    id="header4-check"
                     role="checkbox"
+                    tabIndex={-1}
                   >
                     <div
                       className=
@@ -580,7 +581,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       position: absolute;
                       width: 1px;
                     }
-                id="header3-checkTooltip"
+                id="header4-checkTooltip"
               >
                 Toggle selection for all items
               </label>
@@ -665,7 +666,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header3-column1-name"
+                    aria-labelledby="header4-column1-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -697,7 +698,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header3-column1"
+                    id="header4-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -711,7 +712,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header3-column1-name"
+                      id="header4-column1-name"
                     >
                       Name
                     </span>
@@ -855,7 +856,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header3-column2-name"
+                    aria-labelledby="header4-column2-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -887,7 +888,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header3-column2"
+                    id="header4-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -901,7 +902,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header3-column2-name"
+                      id="header4-column2-name"
                     >
                       Value
                     </span>
@@ -994,7 +995,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone5"
+                data-focuszone-id="FocusZone6"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1090,11 +1091,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone6"
+                          data-focuszone-id="FocusZone7"
                           data-is-focusable={true}
                           data-item-index={0}
                           data-selection-index={0}
                           data-selection-touch-invoke={true}
+                          id="row3-0"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1157,6 +1159,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-0-checkbox row3-0-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1205,7 +1208,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-0-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -1554,11 +1559,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone7"
+                          data-focuszone-id="FocusZone8"
                           data-is-focusable={true}
                           data-item-index={1}
                           data-selection-index={1}
                           data-selection-touch-invoke={true}
+                          id="row3-1"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1621,6 +1627,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-1-checkbox row3-1-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1669,7 +1676,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-1-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2018,11 +2027,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone8"
+                          data-focuszone-id="FocusZone9"
                           data-is-focusable={true}
                           data-item-index={2}
                           data-selection-index={2}
                           data-selection-touch-invoke={true}
+                          id="row3-2"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2085,6 +2095,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-2-checkbox row3-2-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2133,7 +2144,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-2-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2482,11 +2495,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone9"
+                          data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
                           data-item-index={3}
                           data-selection-index={3}
                           data-selection-touch-invoke={true}
+                          id="row3-3"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2549,6 +2563,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-3-checkbox row3-3-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2597,7 +2612,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-3-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2946,11 +2963,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
+                          data-focuszone-id="FocusZone11"
                           data-is-focusable={true}
                           data-item-index={4}
                           data-selection-index={4}
                           data-selection-touch-invoke={true}
+                          id="row3-4"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3013,6 +3031,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-4-checkbox row3-4-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3061,7 +3080,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-4-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3410,11 +3431,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone11"
+                          data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
                           data-item-index={5}
                           data-selection-index={5}
                           data-selection-touch-invoke={true}
+                          id="row3-5"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3477,6 +3499,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-5-checkbox row3-5-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3525,7 +3548,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-5-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3874,11 +3899,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
+                          data-focuszone-id="FocusZone13"
                           data-is-focusable={true}
                           data-item-index={6}
                           data-selection-index={6}
                           data-selection-touch-invoke={true}
+                          id="row3-6"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3941,6 +3967,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-6-checkbox row3-6-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3989,7 +4016,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-6-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4338,11 +4367,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone13"
+                          data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
                           data-item-index={7}
                           data-selection-index={7}
                           data-selection-touch-invoke={true}
+                          id="row3-7"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4405,6 +4435,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-7-checkbox row3-7-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4453,7 +4484,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-7-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4802,11 +4835,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
+                          data-focuszone-id="FocusZone15"
                           data-is-focusable={true}
                           data-item-index={8}
                           data-selection-index={8}
                           data-selection-touch-invoke={true}
+                          id="row3-8"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4869,6 +4903,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-8-checkbox row3-8-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4917,7 +4952,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-8-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -5266,11 +5303,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone15"
+                          data-focuszone-id="FocusZone16"
                           data-is-focusable={true}
                           data-item-index={9}
                           data-selection-index={9}
                           data-selection-touch-invoke={true}
+                          id="row3-9"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -5333,6 +5371,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row3-9-checkbox row3-9-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5381,7 +5420,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row3-9-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -196,8 +196,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -347,7 +348,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -432,9 +433,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-describedby="header0-thumbnail-tooltip"
+                aria-describedby="header1-thumbnail-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-thumbnail-name"
+                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -466,7 +467,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-thumbnail"
+                id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
                 role="button"
@@ -481,7 +482,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-thumbnail-name"
+                  id="header1-thumbnail-name"
                 >
                   
                 </span>
@@ -506,7 +507,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-thumbnail-tooltip"
+            id="header1-thumbnail-tooltip"
           >
             Thumbnail
           </label>
@@ -540,7 +541,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -635,11 +636,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone3"
+                      data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -702,6 +704,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -750,7 +753,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-0-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1082,11 +1087,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1149,6 +1155,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1197,7 +1204,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-1-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1529,11 +1538,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1596,6 +1606,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1644,7 +1655,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-2-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1976,11 +1989,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2043,6 +2057,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2091,7 +2106,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-3-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2423,11 +2440,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2490,6 +2508,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2538,7 +2557,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-4-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2870,11 +2891,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
                       data-selection-touch-invoke={true}
+                      id="row0-5"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2937,6 +2959,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-5-checkbox row0-5-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2985,7 +3008,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-5-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3317,11 +3342,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
                       data-selection-touch-invoke={true}
+                      id="row0-6"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3384,6 +3410,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-6-checkbox row0-6-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3432,7 +3459,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-6-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3764,11 +3793,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone10"
+                      data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
                       data-selection-touch-invoke={true}
+                      id="row0-7"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3831,6 +3861,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-7-checkbox row0-7-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3879,7 +3910,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-7-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4211,11 +4244,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone11"
+                      data-focuszone-id="FocusZone12"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
                       data-selection-touch-invoke={true}
+                      id="row0-8"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4278,6 +4312,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-8-checkbox row0-8-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4326,7 +4361,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-8-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4658,11 +4695,12 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone12"
+                      data-focuszone-id="FocusZone13"
                       data-is-focusable={true}
                       data-item-index={9}
                       data-selection-index={9}
                       data-selection-touch-invoke={true}
+                      id="row0-9"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4725,6 +4763,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-9-checkbox row0-9-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4773,7 +4812,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-9-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -196,8 +196,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -347,7 +348,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -432,7 +433,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column1-name"
+                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -464,7 +465,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column1"
+                id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -478,7 +479,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column1-name"
+                  id="header1-column1-name"
                 >
                   Name
                 </span>
@@ -622,7 +623,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column2-name"
+                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -654,7 +655,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column2"
+                id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -668,7 +669,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column2-name"
+                  id="header1-column2-name"
                 >
                   Value
                 </span>
@@ -761,7 +762,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -856,11 +857,12 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -923,6 +925,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -971,7 +974,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-0-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1319,11 +1324,12 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1386,6 +1392,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1434,7 +1441,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-1-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1782,11 +1791,12 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1849,6 +1859,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1897,7 +1908,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-2-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2245,11 +2258,12 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2312,6 +2326,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2360,7 +2375,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-3-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2708,11 +2725,12 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2775,6 +2793,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2823,7 +2842,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-4-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3168,7 +3189,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
               opacity: 1;
             }
         data-automationid="DetailsRow"
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         data-is-focusable={true}
         data-item-index={-1}
         data-selection-index={-1}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -196,8 +196,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -347,7 +348,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -519,7 +520,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-thumbnail-name"
+                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -551,7 +552,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-thumbnail"
+                id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -565,7 +566,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-thumbnail-name"
+                  id="header1-thumbnail-name"
                 >
                   thumbnail
                 </span>
@@ -671,7 +672,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -907,7 +908,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                       <div
                         aria-label="group 0"
                         className="ms-List"
-                        id="GroupedListSection3"
+                        id="GroupedListSection4"
                         role="rowgroup"
                       >
                         <div
@@ -995,11 +996,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone4"
+                                data-focuszone-id="FocusZone5"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
                                 data-selection-touch-invoke={true}
+                                id="row0-0"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -1062,6 +1064,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-0-checkbox row0-0-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1110,7 +1113,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-0-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -1411,11 +1416,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone5"
+                                data-focuszone-id="FocusZone6"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
                                 data-selection-touch-invoke={true}
+                                id="row0-1"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -1478,6 +1484,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-1-checkbox row0-1-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1526,7 +1533,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-1-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -1827,11 +1836,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone6"
+                                data-focuszone-id="FocusZone7"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
                                 data-selection-touch-invoke={true}
+                                id="row0-2"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -1894,6 +1904,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-2-checkbox row0-2-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1942,7 +1953,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-2-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -2243,11 +2256,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone7"
+                                data-focuszone-id="FocusZone8"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
                                 data-selection-touch-invoke={true}
+                                id="row0-3"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -2310,6 +2324,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-3-checkbox row0-3-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2358,7 +2373,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-3-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -2659,11 +2676,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone8"
+                                data-focuszone-id="FocusZone9"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}
                                 data-selection-touch-invoke={true}
+                                id="row0-4"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -2726,6 +2744,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-4-checkbox row0-4-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2774,7 +2793,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-4-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -3075,11 +3096,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone9"
+                                data-focuszone-id="FocusZone10"
                                 data-is-focusable={true}
                                 data-item-index={5}
                                 data-selection-index={5}
                                 data-selection-touch-invoke={true}
+                                id="row0-5"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -3142,6 +3164,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-5-checkbox row0-5-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3190,7 +3213,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-5-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -3491,11 +3516,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone10"
+                                data-focuszone-id="FocusZone11"
                                 data-is-focusable={true}
                                 data-item-index={6}
                                 data-selection-index={6}
                                 data-selection-touch-invoke={true}
+                                id="row0-6"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -3558,6 +3584,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-6-checkbox row0-6-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3606,7 +3633,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-6-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -3907,11 +3936,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone11"
+                                data-focuszone-id="FocusZone12"
                                 data-is-focusable={true}
                                 data-item-index={7}
                                 data-selection-index={7}
                                 data-selection-touch-invoke={true}
+                                id="row0-7"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -3974,6 +4004,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-7-checkbox row0-7-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4022,7 +4053,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-7-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -4323,11 +4356,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone12"
+                                data-focuszone-id="FocusZone13"
                                 data-is-focusable={true}
                                 data-item-index={8}
                                 data-selection-index={8}
                                 data-selection-touch-invoke={true}
+                                id="row0-8"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -4390,6 +4424,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-8-checkbox row0-8-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4438,7 +4473,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-8-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -4739,11 +4776,12 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone13"
+                                data-focuszone-id="FocusZone14"
                                 data-is-focusable={true}
                                 data-item-index={9}
                                 data-selection-index={9}
                                 data-selection-touch-invoke={true}
+                                id="row0-9"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -4806,6 +4844,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-9-checkbox row0-9-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4854,7 +4893,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-9-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -194,8 +194,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -407,7 +408,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-thumbnail-name"
+                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -439,7 +440,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-thumbnail"
+                id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -453,7 +454,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-thumbnail-name"
+                  id="header1-thumbnail-name"
                 >
                   thumbnail
                 </span>
@@ -546,7 +547,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -642,11 +643,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone3"
+                      data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -709,6 +711,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -757,7 +760,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-0-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1048,11 +1053,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1115,6 +1121,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1163,7 +1170,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-1-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1455,11 +1464,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1522,6 +1532,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1570,7 +1581,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-2-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1861,11 +1874,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1928,6 +1942,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1976,7 +1991,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-3-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2268,11 +2285,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2335,6 +2353,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2383,7 +2402,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-4-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2674,11 +2695,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
                       data-selection-touch-invoke={true}
+                      id="row0-5"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2741,6 +2763,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-5-checkbox row0-5-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2789,7 +2812,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-5-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3081,11 +3106,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
                       data-selection-touch-invoke={true}
+                      id="row0-6"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3148,6 +3174,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-6-checkbox row0-6-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3196,7 +3223,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-6-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3487,11 +3516,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone10"
+                      data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
                       data-selection-touch-invoke={true}
+                      id="row0-7"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3554,6 +3584,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-7-checkbox row0-7-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3602,7 +3633,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-7-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3894,11 +3927,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone11"
+                      data-focuszone-id="FocusZone12"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
                       data-selection-touch-invoke={true}
+                      id="row0-8"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3961,6 +3995,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-8-checkbox row0-8-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4009,7 +4044,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-8-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4300,11 +4337,12 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone12"
+                      data-focuszone-id="FocusZone13"
                       data-is-focusable={true}
                       data-item-index={9}
                       data-selection-index={9}
                       data-selection-touch-invoke={true}
+                      id="row0-9"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4367,6 +4405,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-9-checkbox row0-9-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4415,7 +4454,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-9-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -658,7 +658,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone6"
+            data-focuszone-id="FocusZone7"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -745,7 +745,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-describedby="header5-column1-tooltip"
+                  aria-describedby="header6-column1-tooltip"
                   aria-haspopup={false}
                   aria-label="File Type"
                   className=
@@ -782,7 +782,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header5-column1"
+                  id="header6-column1"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -800,7 +800,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         & .ms-DetailsColumn-nearIcon {
                           padding-left: 0px;
                         }
-                    id="header5-column1-name"
+                    id="header6-column1-name"
                   >
                     <i
                       aria-hidden={true}
@@ -879,7 +879,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     position: absolute;
                     width: 1px;
                   }
-              id="header5-column1-tooltip"
+              id="header6-column1-tooltip"
             >
               Column operations for File type, Press to sort on File type
             </label>
@@ -964,9 +964,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-describedby="header5-column2-tooltip"
+                  aria-describedby="header6-column2-tooltip"
                   aria-haspopup={false}
-                  aria-labelledby="header5-column2-name"
+                  aria-labelledby="header6-column2-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -998,7 +998,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header5-column2"
+                  id="header6-column2"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1013,7 +1013,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header5-column2-name"
+                    id="header6-column2-name"
                   >
                     Name
                   </span>
@@ -1070,7 +1070,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     position: absolute;
                     width: 1px;
                   }
-              id="header5-column2-tooltip"
+              id="header6-column2-tooltip"
             >
               Sorted A to Z
             </label>
@@ -1211,7 +1211,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header5-column3-name"
+                  aria-labelledby="header6-column3-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1243,7 +1243,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header5-column3"
+                  id="header6-column3"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1258,7 +1258,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header5-column3-name"
+                    id="header6-column3-name"
                   >
                     Date Modified
                   </span>
@@ -1351,7 +1351,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     min-height: 1px;
                     min-width: 100%;
                   }
-              data-focuszone-id="FocusZone7"
+              data-focuszone-id="FocusZone8"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1442,11 +1442,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone8"
+                        data-focuszone-id="FocusZone9"
                         data-is-focusable={true}
                         data-item-index={0}
                         data-selection-index={0}
                         data-selection-touch-invoke={true}
+                        id="row5-0"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1614,6 +1615,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-0-header"
                             role="rowheader"
                             style={
                               Object {
@@ -1775,11 +1777,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone10"
+                        data-focuszone-id="FocusZone11"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
                         data-selection-touch-invoke={true}
+                        id="row5-1"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1947,6 +1950,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-1-header"
                             role="rowheader"
                             style={
                               Object {
@@ -2108,11 +2112,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone12"
+                        data-focuszone-id="FocusZone13"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
                         data-selection-touch-invoke={true}
+                        id="row5-2"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2280,6 +2285,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-2-header"
                             role="rowheader"
                             style={
                               Object {
@@ -2441,11 +2447,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone14"
+                        data-focuszone-id="FocusZone15"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
                         data-selection-touch-invoke={true}
+                        id="row5-3"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2613,6 +2620,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-3-header"
                             role="rowheader"
                             style={
                               Object {
@@ -2774,11 +2782,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone16"
+                        data-focuszone-id="FocusZone17"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
                         data-selection-touch-invoke={true}
+                        id="row5-4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2946,6 +2955,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-4-header"
                             role="rowheader"
                             style={
                               Object {
@@ -3107,11 +3117,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone18"
+                        data-focuszone-id="FocusZone19"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
                         data-selection-touch-invoke={true}
+                        id="row5-5"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3279,6 +3290,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-5-header"
                             role="rowheader"
                             style={
                               Object {
@@ -3440,11 +3452,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone20"
+                        data-focuszone-id="FocusZone21"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
                         data-selection-touch-invoke={true}
+                        id="row5-6"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3612,6 +3625,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-6-header"
                             role="rowheader"
                             style={
                               Object {
@@ -3773,11 +3787,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone22"
+                        data-focuszone-id="FocusZone23"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
                         data-selection-touch-invoke={true}
+                        id="row5-7"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3945,6 +3960,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-7-header"
                             role="rowheader"
                             style={
                               Object {
@@ -4106,11 +4122,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone24"
+                        data-focuszone-id="FocusZone25"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
                         data-selection-touch-invoke={true}
+                        id="row5-8"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4278,6 +4295,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-8-header"
                             role="rowheader"
                             style={
                               Object {
@@ -4439,11 +4457,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               opacity: 1;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone26"
+                        data-focuszone-id="FocusZone27"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
                         data-selection-touch-invoke={true}
+                        id="row5-9"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4611,6 +4630,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
+                            id="row5-9-header"
                             role="rowheader"
                             style={
                               Object {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -642,7 +642,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone8"
+              data-focuszone-id="FocusZone9"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -651,7 +651,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header7-check"
+                aria-labelledby="header8-check"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -700,7 +700,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header7-checkTooltip"
+                    aria-describedby="header8-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
@@ -759,8 +759,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                     data-automationid="DetailsRowCheck"
                     data-is-focusable={true}
                     data-selection-toggle={true}
-                    id="header7-check"
+                    id="header8-check"
                     role="checkbox"
+                    tabIndex={-1}
                   >
                     <div
                       className=
@@ -910,7 +911,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                       position: absolute;
                       width: 1px;
                     }
-                id="header7-checkTooltip"
+                id="header8-checkTooltip"
               >
                 Toggle selection for all items
               </label>
@@ -995,7 +996,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header7-thumbnail-name"
+                    aria-labelledby="header8-thumbnail-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1027,7 +1028,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header7-thumbnail"
+                    id="header8-thumbnail"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -1041,7 +1042,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header7-thumbnail-name"
+                      id="header8-thumbnail-name"
                     >
                       thumbnail
                     </span>
@@ -1206,7 +1207,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone9"
+                data-focuszone-id="FocusZone10"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1301,13 +1302,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
+                          data-focuszone-id="FocusZone11"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={0}
                           data-selection-index={0}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-0"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1370,6 +1372,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-0-checkbox row7-0-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1418,7 +1421,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-0-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -1709,13 +1714,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone11"
+                          data-focuszone-id="FocusZone12"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={1}
                           data-selection-index={1}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-1"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1778,6 +1784,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-1-checkbox row7-1-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1826,7 +1833,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-1-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2117,13 +2126,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
+                          data-focuszone-id="FocusZone13"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={2}
                           data-selection-index={2}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-2"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2186,6 +2196,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-2-checkbox row7-2-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2234,7 +2245,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-2-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2525,13 +2538,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone13"
+                          data-focuszone-id="FocusZone14"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={3}
                           data-selection-index={3}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-3"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2594,6 +2608,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-3-checkbox row7-3-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2642,7 +2657,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-3-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -2933,13 +2950,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
+                          data-focuszone-id="FocusZone15"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={4}
                           data-selection-index={4}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-4"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3002,6 +3020,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-4-checkbox row7-4-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3050,7 +3069,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-4-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3341,13 +3362,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone15"
+                          data-focuszone-id="FocusZone16"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={5}
                           data-selection-index={5}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-5"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3410,6 +3432,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-5-checkbox row7-5-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3458,7 +3481,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-5-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -3749,13 +3774,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone16"
+                          data-focuszone-id="FocusZone17"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={6}
                           data-selection-index={6}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-6"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3818,6 +3844,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-6-checkbox row7-6-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3866,7 +3893,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-6-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4157,13 +4186,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone17"
+                          data-focuszone-id="FocusZone18"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={7}
                           data-selection-index={7}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-7"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4226,6 +4256,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-7-checkbox row7-7-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4274,7 +4305,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-7-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4565,13 +4598,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone18"
+                          data-focuszone-id="FocusZone19"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={8}
                           data-selection-index={8}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-8"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4634,6 +4668,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-8-checkbox row7-8-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4682,7 +4717,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-8-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=
@@ -4973,13 +5010,14 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                 opacity: 1;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone19"
+                          data-focuszone-id="FocusZone20"
                           data-is-draggable={true}
                           data-is-focusable={true}
                           data-item-index={9}
                           data-selection-index={9}
                           data-selection-touch-invoke={true}
                           draggable={true}
+                          id="row7-9"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -5042,6 +5080,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             <div
                               aria-checked={false}
                               aria-label="select row"
+                              aria-labelledby="row7-9-checkbox row7-9-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5090,7 +5129,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
+                              id="row7-9-checkbox"
                               role="checkbox"
+                              tabIndex={-1}
                             >
                               <div
                                 className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -478,7 +478,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone6"
+            data-focuszone-id="FocusZone7"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -487,7 +487,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header5-check"
+              aria-labelledby="header6-check"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -536,7 +536,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header5-checkTooltip"
+                  aria-describedby="header6-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
@@ -595,8 +595,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   data-automationid="DetailsRowCheck"
                   data-is-focusable={true}
                   data-selection-toggle={true}
-                  id="header5-check"
+                  id="header6-check"
                   role="checkbox"
+                  tabIndex={-1}
                 >
                   <div
                     className=
@@ -746,7 +747,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                     position: absolute;
                     width: 1px;
                   }
-              id="header5-checkTooltip"
+              id="header6-checkTooltip"
             >
               Toggle selection for all items
             </label>
@@ -918,7 +919,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header5-name-name"
+                  aria-labelledby="header6-name-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -950,7 +951,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header5-name"
+                  id="header6-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                 >
@@ -964,7 +965,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header5-name-name"
+                    id="header6-name-name"
                   >
                     Name
                   </span>
@@ -1108,7 +1109,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header5-color-name"
+                  aria-labelledby="header6-color-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1140,7 +1141,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         z-index: 1;
                       }
                   data-is-focusable={true}
-                  id="header5-color"
+                  id="header6-color"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                 >
@@ -1154,7 +1155,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header5-color-name"
+                    id="header6-color-name"
                   >
                     Color
                   </span>
@@ -1204,7 +1205,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                     min-width: 100%;
                   }
               data-automationid="GroupedList"
-              data-focuszone-id="FocusZone7"
+              data-focuszone-id="FocusZone8"
               data-is-scrollable="false"
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1241,7 +1242,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-labelledby="GroupHeader9"
+                          aria-labelledby="GroupHeader10"
                           aria-level={1}
                           aria-selected={false}
                           className=
@@ -1606,7 +1607,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
-                              id="GroupHeader9"
+                              id="GroupHeader10"
                               role="gridcell"
                             >
                               <span>
@@ -1632,7 +1633,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           aria-label="Color: \\"red\\""
                           className="ms-List"
-                          id="GroupedListSection8"
+                          id="GroupedListSection9"
                           role="rowgroup"
                         >
                           <div
@@ -1720,11 +1721,12 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone14"
+                                  data-focuszone-id="FocusZone15"
                                   data-is-focusable={true}
                                   data-item-index={0}
                                   data-selection-index={0}
                                   data-selection-touch-invoke={true}
+                                  id="row5-0"
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
                                   onMouseDownCapture={[Function]}
@@ -1787,6 +1789,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     <div
                                       aria-checked={false}
                                       aria-label="select row"
+                                      aria-labelledby="row5-0-checkbox row5-0-header"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -1835,7 +1838,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           }
                                       data-automationid="DetailsRowCheck"
                                       data-selection-toggle={true}
+                                      id="row5-0-checkbox"
                                       role="checkbox"
+                                      tabIndex={-1}
                                     >
                                       <div
                                         className=
@@ -2201,11 +2206,12 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone15"
+                                  data-focuszone-id="FocusZone16"
                                   data-is-focusable={true}
                                   data-item-index={1}
                                   data-selection-index={1}
                                   data-selection-touch-invoke={true}
+                                  id="row5-1"
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
                                   onMouseDownCapture={[Function]}
@@ -2268,6 +2274,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     <div
                                       aria-checked={false}
                                       aria-label="select row"
+                                      aria-labelledby="row5-1-checkbox row5-1-header"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -2316,7 +2323,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           }
                                       data-automationid="DetailsRowCheck"
                                       data-selection-toggle={true}
+                                      id="row5-1-checkbox"
                                       role="checkbox"
+                                      tabIndex={-1}
                                     >
                                       <div
                                         className=
@@ -2633,7 +2642,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-labelledby="GroupHeader11"
+                          aria-labelledby="GroupHeader12"
                           aria-level={1}
                           aria-selected={false}
                           className=
@@ -2998,7 +3007,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
-                              id="GroupHeader11"
+                              id="GroupHeader12"
                               role="gridcell"
                             >
                               <span>
@@ -3024,7 +3033,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           aria-label="Color: \\"green\\""
                           className="ms-List"
-                          id="GroupedListSection10"
+                          id="GroupedListSection11"
                         >
                           <div
                             className="ms-List-surface"
@@ -3055,7 +3064,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                       >
                         <div
                           aria-expanded={true}
-                          aria-labelledby="GroupHeader13"
+                          aria-labelledby="GroupHeader14"
                           aria-level={1}
                           aria-selected={false}
                           className=
@@ -3420,7 +3429,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     text-overflow: ellipsis;
                                     white-space: nowrap;
                                   }
-                              id="GroupHeader13"
+                              id="GroupHeader14"
                               role="gridcell"
                             >
                               <span>
@@ -3446,7 +3455,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         <div
                           aria-label="Color: \\"blue\\""
                           className="ms-List"
-                          id="GroupedListSection12"
+                          id="GroupedListSection13"
                           role="rowgroup"
                         >
                           <div
@@ -3534,11 +3543,12 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone16"
+                                  data-focuszone-id="FocusZone17"
                                   data-is-focusable={true}
                                   data-item-index={2}
                                   data-selection-index={2}
                                   data-selection-touch-invoke={true}
+                                  id="row5-2"
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
                                   onMouseDownCapture={[Function]}
@@ -3601,6 +3611,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     <div
                                       aria-checked={false}
                                       aria-label="select row"
+                                      aria-labelledby="row5-2-checkbox row5-2-header"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -3649,7 +3660,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           }
                                       data-automationid="DetailsRowCheck"
                                       data-selection-toggle={true}
+                                      id="row5-2-checkbox"
                                       role="checkbox"
+                                      tabIndex={-1}
                                     >
                                       <div
                                         className=
@@ -4015,11 +4028,12 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone17"
+                                  data-focuszone-id="FocusZone18"
                                   data-is-focusable={true}
                                   data-item-index={3}
                                   data-selection-index={3}
                                   data-selection-touch-invoke={true}
+                                  id="row5-3"
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
                                   onMouseDownCapture={[Function]}
@@ -4082,6 +4096,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     <div
                                       aria-checked={false}
                                       aria-label="select row"
+                                      aria-labelledby="row5-3-checkbox row5-3-header"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4130,7 +4145,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           }
                                       data-automationid="DetailsRowCheck"
                                       data-selection-toggle={true}
+                                      id="row5-3-checkbox"
                                       role="checkbox"
+                                      tabIndex={-1}
                                     >
                                       <div
                                         className=
@@ -4496,11 +4513,12 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone18"
+                                  data-focuszone-id="FocusZone19"
                                   data-is-focusable={true}
                                   data-item-index={4}
                                   data-selection-index={4}
                                   data-selection-touch-invoke={true}
+                                  id="row5-4"
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
                                   onMouseDownCapture={[Function]}
@@ -4563,6 +4581,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     <div
                                       aria-checked={false}
                                       aria-label="select row"
+                                      aria-labelledby="row5-4-checkbox row5-4-header"
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
@@ -4611,7 +4630,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           }
                                       data-automationid="DetailsRowCheck"
                                       data-selection-toggle={true}
+                                      id="row5-4-checkbox"
                                       role="checkbox"
+                                      tabIndex={-1}
                                     >
                                       <div
                                         className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -196,8 +196,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -347,7 +348,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -519,7 +520,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-name-name"
+                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -551,7 +552,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-name"
+                id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -565,7 +566,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-name-name"
+                  id="header1-name-name"
                 >
                   Name
                 </span>
@@ -709,7 +710,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-value-name"
+                aria-labelledby="header1-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -741,7 +742,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-value"
+                id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -755,7 +756,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-value-name"
+                  id="header1-value-name"
                 >
                   Value
                 </span>
@@ -861,7 +862,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                   min-width: 100%;
                 }
             data-automationid="GroupedList"
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             data-is-scrollable="false"
             onBlur={[Function]}
             onFocus={[Function]}
@@ -898,7 +899,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader4"
+                        aria-labelledby="GroupHeader5"
                         aria-level={1}
                         aria-selected={false}
                         className=
@@ -1263,7 +1264,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
-                            id="GroupHeader4"
+                            id="GroupHeader5"
                             role="gridcell"
                           >
                             <span>
@@ -1289,7 +1290,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       <div
                         aria-label="0"
                         className="ms-List"
-                        id="GroupedListSection3"
+                        id="GroupedListSection4"
                         role="rowgroup"
                       >
                         <div
@@ -1377,11 +1378,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone5"
+                                data-focuszone-id="FocusZone6"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
                                 data-selection-touch-invoke={true}
+                                id="row0-0"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -1444,6 +1446,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-0-checkbox row0-0-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1492,7 +1495,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-0-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -1850,11 +1855,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone6"
+                                data-focuszone-id="FocusZone7"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
                                 data-selection-touch-invoke={true}
+                                id="row0-1"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -1917,6 +1923,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-1-checkbox row0-1-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -1965,7 +1972,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-1-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -2323,11 +2332,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone7"
+                                data-focuszone-id="FocusZone8"
                                 data-is-focusable={true}
                                 data-item-index={2}
                                 data-selection-index={2}
                                 data-selection-touch-invoke={true}
+                                id="row0-2"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -2390,6 +2400,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-2-checkbox row0-2-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2438,7 +2449,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-2-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -2796,11 +2809,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone8"
+                                data-focuszone-id="FocusZone9"
                                 data-is-focusable={true}
                                 data-item-index={3}
                                 data-selection-index={3}
                                 data-selection-touch-invoke={true}
+                                id="row0-3"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -2863,6 +2877,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-3-checkbox row0-3-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -2911,7 +2926,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-3-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -3269,11 +3286,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone9"
+                                data-focuszone-id="FocusZone10"
                                 data-is-focusable={true}
                                 data-item-index={4}
                                 data-selection-index={4}
                                 data-selection-touch-invoke={true}
+                                id="row0-4"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -3336,6 +3354,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-4-checkbox row0-4-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3384,7 +3403,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-4-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -3742,11 +3763,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone10"
+                                data-focuszone-id="FocusZone11"
                                 data-is-focusable={true}
                                 data-item-index={5}
                                 data-selection-index={5}
                                 data-selection-touch-invoke={true}
+                                id="row0-5"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -3809,6 +3831,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-5-checkbox row0-5-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -3857,7 +3880,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-5-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -4215,11 +4240,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone11"
+                                data-focuszone-id="FocusZone12"
                                 data-is-focusable={true}
                                 data-item-index={6}
                                 data-selection-index={6}
                                 data-selection-touch-invoke={true}
+                                id="row0-6"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -4282,6 +4308,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-6-checkbox row0-6-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4330,7 +4357,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-6-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -4688,11 +4717,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone12"
+                                data-focuszone-id="FocusZone13"
                                 data-is-focusable={true}
                                 data-item-index={7}
                                 data-selection-index={7}
                                 data-selection-touch-invoke={true}
+                                id="row0-7"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -4755,6 +4785,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-7-checkbox row0-7-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -4803,7 +4834,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-7-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -5161,11 +5194,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone13"
+                                data-focuszone-id="FocusZone14"
                                 data-is-focusable={true}
                                 data-item-index={8}
                                 data-selection-index={8}
                                 data-selection-touch-invoke={true}
+                                id="row0-8"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -5228,6 +5262,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-8-checkbox row0-8-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5276,7 +5311,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-8-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=
@@ -5634,11 +5671,12 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       opacity: 1;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone14"
+                                data-focuszone-id="FocusZone15"
                                 data-is-focusable={true}
                                 data-item-index={9}
                                 data-selection-index={9}
                                 data-selection-touch-invoke={true}
+                                id="row0-9"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
@@ -5701,6 +5739,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   <div
                                     aria-checked={false}
                                     aria-label="select row"
+                                    aria-labelledby="row0-9-checkbox row0-9-header"
                                     className=
                                         ms-DetailsRow-check
                                         ms-Check-checkHost
@@ -5749,7 +5788,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         }
                                     data-automationid="DetailsRowCheck"
                                     data-selection-toggle={true}
+                                    id="row0-9-checkbox"
                                     role="checkbox"
+                                    tabIndex={-1}
                                   >
                                     <div
                                       className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header0-check"
+            aria-labelledby="header1-check"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <div
                 aria-checked={false}
-                aria-describedby="header0-checkTooltip"
+                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -196,8 +196,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header0-check"
+                id="header1-check"
                 role="checkbox"
+                tabIndex={-1}
               >
                 <div
                   className=
@@ -347,7 +348,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                   position: absolute;
                   width: 1px;
                 }
-            id="header0-checkTooltip"
+            id="header1-checkTooltip"
           >
             Toggle selection for all items
           </label>
@@ -432,7 +433,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-filepath-name"
+                aria-labelledby="header1-filepath-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -464,7 +465,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-filepath"
+                id="header1-filepath"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -478,7 +479,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-filepath-name"
+                  id="header1-filepath-name"
                 >
                   File path
                 </span>
@@ -566,7 +567,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-size-name"
+                aria-labelledby="header1-size-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -598,7 +599,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-size"
+                id="header1-size"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -612,7 +613,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-size-name"
+                  id="header1-size-name"
                 >
                   Size
                 </span>
@@ -649,7 +650,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -744,11 +745,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone3"
+                      data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -811,6 +813,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-0-checkbox row0-0-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -859,7 +862,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-0-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1281,11 +1286,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1348,6 +1354,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-1-checkbox row0-1-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1396,7 +1403,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-1-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -1818,11 +1827,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1885,6 +1895,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-2-checkbox row0-2-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -1933,7 +1944,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-2-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2355,11 +2368,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2422,6 +2436,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-3-checkbox row0-3-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -2470,7 +2485,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-3-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -2892,11 +2909,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2959,6 +2977,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-4-checkbox row0-4-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3007,7 +3026,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-4-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3429,11 +3450,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
                       data-selection-touch-invoke={true}
+                      id="row0-5"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -3496,6 +3518,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-5-checkbox row0-5-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -3544,7 +3567,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-5-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -3966,11 +3991,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
                       data-selection-touch-invoke={true}
+                      id="row0-6"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4033,6 +4059,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-6-checkbox row0-6-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4081,7 +4108,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-6-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -4503,11 +4532,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone10"
+                      data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
                       data-selection-touch-invoke={true}
+                      id="row0-7"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -4570,6 +4600,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-7-checkbox row0-7-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -4618,7 +4649,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-7-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=
@@ -5040,11 +5073,12 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone11"
+                      data-focuszone-id="FocusZone12"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
                       data-selection-touch-invoke={true}
+                      id="row0-8"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -5107,6 +5141,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         <div
                           aria-checked={false}
                           aria-label="select row"
+                          aria-labelledby="row0-8-checkbox row0-8-header"
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
@@ -5155,7 +5190,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               }
                           data-automationid="DetailsRowCheck"
                           data-selection-toggle={true}
+                          id="row0-8-checkbox"
                           role="checkbox"
+                          tabIndex={-1}
                         >
                           <div
                             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -646,6 +646,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -1175,6 +1176,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -1704,6 +1706,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -2635,6 +2638,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -3164,6 +3168,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -3693,6 +3698,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -4624,6 +4630,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -5153,6 +5160,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=
@@ -5682,6 +5690,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 data-automationid="DetailsRowCheck"
                                 data-selection-toggle={true}
                                 role="checkbox"
+                                tabIndex={-1}
                               >
                                 <div
                                   className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -257,7 +257,7 @@ Array [
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone2"
+              data-focuszone-id="FocusZone3"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -380,7 +380,7 @@ Array [
                           z-index: 1;
                         }
                     data-is-focusable={true}
-                    id="header1-thumbnail"
+                    id="header2-thumbnail"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -397,7 +397,7 @@ Array [
                           & .ms-DetailsColumn-nearIcon {
                             padding-left: 0px;
                           }
-                      id="header1-thumbnail-name"
+                      id="header2-thumbnail-name"
                     >
                       <i
                         aria-hidden={true}
@@ -483,7 +483,7 @@ Array [
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone3"
+                data-focuszone-id="FocusZone4"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -168,7 +168,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column1-name"
+                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -200,7 +200,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column1"
+                id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -214,7 +214,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column1-name"
+                  id="header1-column1-name"
                 >
                   Variant
                 </span>
@@ -358,7 +358,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column2-name"
+                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -390,7 +390,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column2"
+                id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -404,7 +404,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column2-name"
+                  id="header1-column2-name"
                 >
                   Example
                 </span>
@@ -497,7 +497,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -588,11 +588,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone3"
+                      data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -835,11 +836,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1082,11 +1084,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1329,11 +1332,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone6"
+                      data-focuszone-id="FocusZone7"
                       data-is-focusable={true}
                       data-item-index={3}
                       data-selection-index={3}
                       data-selection-touch-invoke={true}
+                      id="row0-3"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1576,11 +1580,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone7"
+                      data-focuszone-id="FocusZone8"
                       data-is-focusable={true}
                       data-item-index={4}
                       data-selection-index={4}
                       data-selection-touch-invoke={true}
+                      id="row0-4"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1823,11 +1828,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone8"
+                      data-focuszone-id="FocusZone9"
                       data-is-focusable={true}
                       data-item-index={5}
                       data-selection-index={5}
                       data-selection-touch-invoke={true}
+                      id="row0-5"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2070,11 +2076,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone9"
+                      data-focuszone-id="FocusZone10"
                       data-is-focusable={true}
                       data-item-index={6}
                       data-selection-index={6}
                       data-selection-touch-invoke={true}
+                      id="row0-6"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2317,11 +2324,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone10"
+                      data-focuszone-id="FocusZone11"
                       data-is-focusable={true}
                       data-item-index={7}
                       data-selection-index={7}
                       data-selection-touch-invoke={true}
+                      id="row0-7"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2564,11 +2572,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone11"
+                      data-focuszone-id="FocusZone12"
                       data-is-focusable={true}
                       data-item-index={8}
                       data-selection-index={8}
                       data-selection-touch-invoke={true}
+                      id="row0-8"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -2811,11 +2820,12 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone12"
+                      data-focuszone-id="FocusZone13"
                       data-is-focusable={true}
                       data-item-index={9}
                       data-selection-index={9}
                       data-selection-touch-invoke={true}
+                      id="row0-9"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone1"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -168,7 +168,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column1-name"
+                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -200,7 +200,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column1"
+                id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -214,7 +214,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column1-name"
+                  id="header1-column1-name"
                 >
                   Variant
                 </span>
@@ -358,7 +358,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-column2-name"
+                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -390,7 +390,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                       z-index: 1;
                     }
                 data-is-focusable={true}
-                id="header0-column2"
+                id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
               >
@@ -404,7 +404,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header0-column2-name"
+                  id="header1-column2-name"
                 >
                   Example
                 </span>
@@ -497,7 +497,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone2"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -588,11 +588,12 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone3"
+                      data-focuszone-id="FocusZone4"
                       data-is-focusable={true}
                       data-item-index={0}
                       data-selection-index={0}
                       data-selection-touch-invoke={true}
+                      id="row0-0"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -837,11 +838,12 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone4"
+                      data-focuszone-id="FocusZone5"
                       data-is-focusable={true}
                       data-item-index={1}
                       data-selection-index={1}
                       data-selection-touch-invoke={true}
+                      id="row0-1"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
@@ -1086,11 +1088,12 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                             opacity: 1;
                           }
                       data-automationid="DetailsRow"
-                      data-focuszone-id="FocusZone5"
+                      data-focuszone-id="FocusZone6"
                       data-is-focusable={true}
                       data-item-index={2}
                       data-selection-index={2}
                       data-selection-touch-invoke={true}
+                      id="row0-2"
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}


### PR DESCRIPTION
cherry-pick of #17245 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14891
- [x] Related to bug [6397 ](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/6397)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Generated `rowId` in `DetailsList` and passed that down as prop to `DetailsRow` along with the item's index
- Used `rowId` and item index to deterministically create a `checkboxId `and `rowHeaderId` which are attached to the checkbox and rowHeader (if there is one) respectively.
- Added `aria-labelledby` attribute to checkbox passing in `checkboxId` and `rowHeaderId` so whenever there is a rowHeader, the ally tree will give the checkbox a more descriptive name that links it to the rowHeader.
- Added test cases 
