### PR TITLE
[v7.0] VirtualizedComboBox: ARIA attributes now have valid values after passing id and arialabelledby attributes to List component

### DIFF
--- a/change/office-ui-fabric-react-db02ed89-a3cd-4afd-847d-235ab80e085f.json
+++ b/change/office-ui-fabric-react-db02ed89-a3cd-4afd-847d-235ab80e085f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "VirtualizedComboBox: ARIA attributes now have valid values after passing id and arialabelledby attributes to List component",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-db02ed89-a3cd-4afd-847d-235ab80e085f.json
+++ b/change/office-ui-fabric-react-db02ed89-a3cd-4afd-847d-235ab80e085f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "VirtualizedComboBox: ARIA attributes now have valid values after passing id and arialabelledby attributes to List component",
+  "comment": "VirtualizedComboBox: Now passes id and arialabelledby attributes to List component to ensure ARIA attributes have valid valuesd",
   "packageName": "office-ui-fabric-react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1247,6 +1247,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
     } = props;
 
     const { isOpen } = this.state;
+    const id = this._id;
 
     const comboBoxMenuWidth =
       useComboBoxAsMenuWidth && this._comboBoxWrapper.current
@@ -1279,7 +1280,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
       >
         {onRenderUpperContent(this.props, this._onRenderUpperContent)}
         <div className={this._classNames.optionsContainerWrapper} ref={this._comboBoxMenu}>
-          {(onRenderList as any)({ ...props }, this._onRenderList)}
+          {(onRenderList as any)({ ...props, id }, this._onRenderList)}
         </div>
         {onRenderLowerContent(this.props, this._onRenderLowerContent)}
       </Callout>

--- a/packages/office-ui-fabric-react/src/components/ComboBox/VirtualizedComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/VirtualizedComboBox.tsx
@@ -54,13 +54,15 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
   }
 
   protected _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem } = props;
+    const { id, onRenderItem } = props;
 
     // Render virtualized list
     return (
       <List
         componentRef={this._list}
         role="listbox"
+        id={`${id}-list`}
+        aria-labelledby={`${id}-label`}
         items={props.options}
         // eslint-disable-next-line react/jsx-no-bind
         onRenderCell={onRenderItem ? (item: ISelectableOption) => onRenderItem(item) : () => null}


### PR DESCRIPTION
cherry-pick of #17455 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [10688](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10688)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- `VirtualizedComboBox` uses the `List` component to render the ComboBox options and the container div of `List` was missing the `id` and `aria-labelledby` attributes.
- Those attributes have now been added to `List` via prop passing.

Errors Resolved: 
![Combobox](https://user-images.githubusercontent.com/8649804/111370999-1acec500-8656-11eb-8367-eeac56a12f54.JPG)

