### PR TITLE
display submenu icon for menuitems

### DIFF
--- a/packages/react-menu/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.test.tsx
@@ -4,6 +4,7 @@ import { MenuItem } from './MenuItem';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
+import { MenuTriggerContextProvider } from '../../contexts/menuTriggerContext';
 
 describe('MenuItem', () => {
   isConformant({
@@ -39,5 +40,18 @@ describe('MenuItem', () => {
 
     // Assert
     expect(document.activeElement).toBe(menuitem);
+  });
+
+  it('should render submenu indicator icon if wrapped by menu trigger context', () => {
+    // Arrange
+    const slot = 'submenu';
+    const { getByText } = render(
+      <MenuTriggerContextProvider value={true}>
+        <MenuItem submenuIndicator={slot}>Item</MenuItem>
+      </MenuTriggerContextProvider>,
+    );
+
+    // Assert
+    getByText(slot);
   });
 });

--- a/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
@@ -6,6 +6,16 @@ export interface MenuItemProps extends ComponentProps, React.HTMLAttributes<HTML
    * Icon slot rendered before children content
    */
   icon?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
+   * Icon slot that shows the indicator for a submenu
+   */
+  submenuIndicator?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
+   * If the menu item is a trigger for a submenu
+   */
+  hasSubmenu?: boolean;
 }
 
 export interface MenuItemState extends MenuItemProps {
@@ -17,4 +27,9 @@ export interface MenuItemState extends MenuItemProps {
    * Icon slot when processed by internal state
    */
   icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
+
+  /**
+   * Icon slot that shows the indicator for a submenu
+   */
+  submenuIndicator?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }

--- a/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`MenuItem renders a default state 1`] = `
 <div
   className=""
+  onClick={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}
   role="menuitem"

--- a/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
@@ -13,6 +13,7 @@ export const renderMenuItem = (state: MenuItemState) => {
     <slots.root {...slotProps.root}>
       <slots.icon {...slotProps.icon} />
       {state.children}
+      {state.hasSubmenu && <slots.submenuIndicator {...slotProps.submenuIndicator} />}
     </slots.root>
   );
 };

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -5,7 +5,8 @@ const useStyles = makeStyles({
   root: theme => ({
     color: theme.alias.color.neutral.neutralForeground1,
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
-    paddingRight: '12px',
+    // TODO when introducing secondary text right padding might need to change
+    paddingRight: '8px',
     paddingLeft: '12px',
     height: '32px',
     display: 'flex',
@@ -26,7 +27,12 @@ const useStyles = makeStyles({
   icon: {
     width: '20px',
     height: '20px',
-    marginRight: '9px',
+    marginRight: '8px',
+  },
+  submenuIndicator: {
+    width: '20px',
+    height: '20px',
+    marginLeft: 'auto',
   },
 });
 
@@ -37,5 +43,9 @@ export const useMenuItemStyles = (state: MenuItemState) => {
 
   if (state.icon) {
     state.icon.className = ax(styles.icon, state.icon.className);
+  }
+
+  if (state.submenuIndicator) {
+    state.submenuIndicator.className = ax(styles.submenuIndicator, state.submenuIndicator.className);
   }
 };

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
 import { render, fireEvent } from '@testing-library/react';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
@@ -92,7 +93,7 @@ describe('MenuItemCheckbox', () => {
     // Arrange
     const checkedValues = { test: ['1'] };
     const checkmark = 'xxx';
-    const { container } = render(
+    const { getByRole } = render(
       <TestMenuListContextProvider context={{ checkedValues }}>
         <MenuItemCheckbox name="test" value="1" checkmark={checkmark}>
           Checkbox
@@ -101,7 +102,7 @@ describe('MenuItemCheckbox', () => {
     );
 
     // Assert
-    expect(container.querySelector('[role="menuitemcheckbox"]')?.getAttribute('aria-checked')).toEqual('true');
+    expect(getByRole('menuitemcheckbox').getAttribute('aria-checked')).toEqual('true');
   });
 
   it.each([
@@ -112,7 +113,7 @@ describe('MenuItemCheckbox', () => {
     const checkboxName = 'name';
     const checkedValues = { [checkboxName]: checkedItems };
     const spy = jest.fn();
-    const { container } = render(
+    const { getByRole } = render(
       <TestMenuListContextProvider context={{ checkedValues, toggleCheckbox: spy }}>
         <MenuItemCheckbox name={checkboxName} value={'1'}>
           Checkbox
@@ -121,11 +122,29 @@ describe('MenuItemCheckbox', () => {
     );
 
     // Act
-    const menuitem = container.querySelector('[role="menuitemcheckbox"]');
-    menuitem && fireEvent.click(menuitem);
+    fireEvent.click(getByRole('menuitemcheckbox'));
 
     // Assert
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(expect.anything(), checkboxName, '1', expectedCheckedState);
+  });
+
+  it.each([[EnterKey], [SpacebarKey]])('should call toggleCheckbox with %s key', keyCode => {
+    // Arrange
+    const spy = jest.fn();
+    const { getByRole } = render(
+      <TestMenuListContextProvider context={{ toggleCheckbox: spy }}>
+        <MenuItemCheckbox name="test" value={'1'}>
+          Checkbox
+        </MenuItemCheckbox>
+      </TestMenuListContextProvider>,
+    );
+
+    // Act
+    fireEvent.keyDown(getByRole('menuitemcheckbox'), { keyCode });
+    fireEvent.keyUp(getByRole('menuitemcheckbox'), { keyCode });
+
+    // Assert
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
 import { render, fireEvent } from '@testing-library/react';
 import { MenuItemRadio } from './MenuItemRadio';
 import { ReactWrapper } from 'enzyme';
@@ -91,7 +92,7 @@ describe('MenuItemRadio', () => {
   it('should set aria-checked value to true if value is checked', () => {
     // Arrange
     const checkedValues = { test: ['1'] };
-    const { container } = render(
+    const { getByRole } = render(
       <TestMenuListContextProvider context={{ checkedValues }}>
         <MenuItemRadio name="test" value="1">
           Radio
@@ -100,7 +101,7 @@ describe('MenuItemRadio', () => {
     );
 
     // Assert
-    expect(container.querySelector('[role="menuitemradio"]')?.getAttribute('aria-checked')).toEqual('true');
+    expect(getByRole('menuitemradio').getAttribute('aria-checked')).toEqual('true');
   });
 
   it('should selectRadio handler on click', () => {
@@ -109,7 +110,7 @@ describe('MenuItemRadio', () => {
     const radioValue = '1';
     const checkedValues = { [radioName]: [] };
     const spy = jest.fn();
-    const { container } = render(
+    const { getByRole } = render(
       <TestMenuListContextProvider context={{ checkedValues, selectRadio: spy }}>
         <MenuItemRadio name={radioName} value={radioValue}>
           Radio
@@ -118,11 +119,29 @@ describe('MenuItemRadio', () => {
     );
 
     // Act
-    const menuitem = container.querySelector('[role="menuitemradio"]');
-    menuitem && fireEvent.click(menuitem);
+    fireEvent.click(getByRole('menuitemradio'));
 
     // Assert
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(expect.anything(), radioName, radioValue, false);
+  });
+
+  it.each([[EnterKey], [SpacebarKey]])('should call selectRadio with %s key', keyCode => {
+    // Arrange
+    const spy = jest.fn();
+    const { getByRole } = render(
+      <TestMenuListContextProvider context={{ selectRadio: spy }}>
+        <MenuItemRadio name="test" value={'1'}>
+          Radio
+        </MenuItemRadio>
+      </TestMenuListContextProvider>,
+    );
+
+    // Act
+    fireEvent.keyDown(getByRole('menuitemradio'), { keyCode });
+    fireEvent.keyUp(getByRole('menuitemradio'), { keyCode });
+
+    // Assert
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-menu/src/selectable/useCheckmarkStyles.ts
+++ b/packages/react-menu/src/selectable/useCheckmarkStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles({
   root: {
     width: '16px',
     height: '16px',
-    marginRight: '9px',
+    marginRight: '8px',
     visibility: 'hidden',
   },
   rootChecked: {

--- a/packages/react-menu/src/utils/DefaultIcons.tsx
+++ b/packages/react-menu/src/utils/DefaultIcons.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { ax, makeStyles } from '@fluentui/react-make-styles';
+import { getNativeProps, htmlElementProperties } from '@fluentui/react-utilities';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    speak: 'none',
+    width: '1em',
+    height: '1em',
+  },
+  svg: {
+    height: '100%',
+    fill: 'currentColor',
+    verticalAlign: 'top',
+  },
+});
+
+//
+// !!!   A temporary workaround to avoid dependencies on any icon packages.
+// !!!   A usage of converged icon package should be considered.
+//
+
+const useIconProps = (props: React.HTMLAttributes<HTMLSpanElement>) => {
+  const containerProps = props['aria-label']
+    ? {}
+    : {
+        role: 'presentation',
+        ['aria-hidden']: true,
+      };
+  const nativeProps = getNativeProps<React.HTMLAttributes<HTMLElement>>(props, htmlElementProperties);
+  const styles = useStyles();
+
+  const rootClasses = styles.root;
+  const svgClasses = styles.svg;
+
+  return { containerProps, nativeProps, rootClasses, svgClasses };
+};
+
+export const renderIcon = (
+  SVGElement: (props: { svgClasses: string }) => JSX.Element,
+): React.FC<React.HTMLAttributes<HTMLSpanElement>> => props => {
+  const { containerProps, nativeProps, rootClasses, svgClasses } = useIconProps(props);
+
+  return React.createElement(
+    'span',
+    {
+      ...containerProps,
+      ...nativeProps,
+      className: ax(rootClasses, props.className),
+    },
+    <SVGElement svgClasses={svgClasses} />,
+  );
+};
+
+export const ChevronRightIcon = renderIcon(props => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" className={props.svgClasses}>
+    <path d="M515 1955l930-931L515 93l90-90 1022 1021L605 2045l-90-90z" />
+  </svg>
+));


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Leverages the the `MenuTriggerContext` to render a chevron icon for submenu triggers

Also some small style fixes

#### Focus areas to test

(optional)
