### PR TITLE
Add resize group customization hook

### DIFF
--- a/change/@fluentui-react-75fd1db2-782d-4623-bfa8-9d4fd0e92385.json
+++ b/change/@fluentui-react-75fd1db2-782d-4623-bfa8-9d4fd0e92385.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add customization hook for ResizeGroup in CommandBar",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3145,6 +3145,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
     overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowButtonProps?: IButtonProps;
     overflowItems?: ICommandBarItemProps[];
+    resizeGroupAs?: IComponentAs<IResizeGroupProps>;
     shiftOnReduce?: boolean;
     styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
     theme?: ITheme;

--- a/packages/react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.base.tsx
@@ -74,6 +74,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       dataDidRender,
       onReduceData = this._onReduceData,
       onGrowData = this._onGrowData,
+      resizeGroupAs: ResizeGroupAs = ResizeGroup,
     } = this.props;
 
     const commandBarData: ICommandBarData = {
@@ -94,7 +95,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     return (
-      <ResizeGroup
+      <ResizeGroupAs
         {...nativeProps}
         componentRef={this._resizeGroup}
         data={commandBarData}

--- a/packages/react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/react/src/components/CommandBar/CommandBar.types.ts
@@ -5,6 +5,7 @@ import { ICommandBarData } from './CommandBar.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { ITooltipHostProps } from '../../Tooltip';
+import { IResizeGroupProps } from '../ResizeGroup/ResizeGroup.types';
 
 /**
  * {@docCategory CommandBar}
@@ -52,6 +53,11 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * computed overflow items.
    */
   overflowButtonProps?: IButtonProps;
+
+  /**
+   * Custom component for the ResizeGroup.
+   */
+  resizeGroupAs?: IComponentAs<IResizeGroupProps>;
 
   /**
    * Custom component for the overflow button.


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

@jaredmitchell1 on our team, for hack week, implemented a seemingly faster way of resizing the CommandBar than ResizeGroup. Rather than fork the CommandBar in our repo, @micahgodbolt suggested adding a custom rendering hook for the ResizeGroup. This way, we can prove out the change, and later contribute the improvements back to this codebase if they pan out.

#### Focus areas to test

(optional)
