### PR TITLE
Add focus style and name to Textfield show password button

### DIFF
--- a/change/@fluentui-react-7c24dd0e-1ba1-4928-9ca2-dccd86def9f5.json
+++ b/change/@fluentui-react-7c24dd0e-1ba1-4928-9ca2-dccd86def9f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add focus style and label to Textfield show password button",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-5b25aa9b-b2a9-4911-8007-8fcf7fec55d3.json
+++ b/change/@fluentui-react-examples-5b25aa9b-b2a9-4911-8007-8fcf7fec55d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add accessible name to Textfield show password button",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
@@ -26,7 +26,12 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
-        <TextField label="Password with reveal button" type="password" canRevealPassword />
+        <TextField
+          label="Password with reveal button"
+          type="password"
+          canRevealPassword
+          revealPasswordLabel="Show Password"
+        />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -2098,6 +2098,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             value=""
           />
           <button
+            aria-label="Show Password"
+            aria-pressed={false}
             className=
                 ms-TextField-reveal
                 ms-Button
@@ -2123,7 +2125,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   color: Highlight;
                 }
                 &:focus {
-                  outline: 0px;
+                  outline-offset: -3px;
+                  outline: 2px solid currentColor;
                 }
             onClick={[Function]}
             type="button"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8083,6 +8083,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     prefix?: string;
     readOnly?: boolean;
     resizable?: boolean;
+    revealPasswordLabel?: string;
     styles?: IStyleFunctionOrObject<ITextFieldStyleProps, ITextFieldStyles>;
     suffix?: string;
     theme?: ITheme;

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -206,6 +206,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       styles,
       autoAdjustHeight,
       canRevealPassword,
+      revealPasswordLabel = 'Show password',
       type,
       onRenderPrefix = this._onRenderPrefix,
       onRenderSuffix = this._onRenderSuffix,
@@ -248,7 +249,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {iconProps && <Icon className={classNames.icon} {...iconProps} />}
             {hasRevealButton && (
               // Explicitly set type="button" since the default button type within a form is "submit"
-              <button className={classNames.revealButton} onClick={this._onRevealButtonClick} type="button">
+              <button
+                className={classNames.revealButton}
+                onClick={this._onRevealButtonClick}
+                aria-label={revealPasswordLabel}
+                aria-pressed={!!isRevealingPassword}
+                type="button"
+              >
                 <span className={classNames.revealSpan}>
                   <Icon
                     className={classNames.revealIcon}

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -439,7 +439,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
               },
             },
           },
-          ':focus': { outline: 0 },
+          ':focus': {
+            outline: '2px solid currentColor',
+            outlineOffset: '-3px',
+          },
         },
       },
       hasIcon && {

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -262,6 +262,11 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * the `type` prop is set to `'password'`).
    */
   canRevealPassword?: boolean;
+
+  /**
+   * Accessible name for the reveal password button (will be ignored unless canRevealPassword is true)
+   */
+  revealPasswordLabel?: string;
 }
 
 /**

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1454,6 +1454,8 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
         value=""
       />
       <button
+        aria-label="Show password"
+        aria-pressed={false}
         className=
             ms-TextField-reveal
             ms-Button
@@ -1479,7 +1481,8 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
               color: Highlight;
             }
             &:focus {
-              outline: 0px;
+              outline-offset: -3px;
+              outline: 2px solid currentColor;
             }
         onClick={[Function]}
         type="button"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to [11637]
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates the Textfield Show Password button with the following changes:

- Adds a visible focus style that matches the textfield focus style
- Adds an accessible name to the button, and a Textfield property to set it
