### PR TITLE
Update Picker semantics to ARIA 1.2 combobox pattern

### DIFF
--- a/change/@fluentui-react-ad7cb31f-576b-4583-b7e7-d0a953fbafaa.json
+++ b/change/@fluentui-react-ad7cb31f-576b-4583-b7e7-d0a953fbafaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BasePicker to use ARIA 1.2 combobox pattern",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-e22be9e6-08e0-4cd8-8c7f-aab3431e17c4.json
+++ b/change/@fluentui-react-examples-e22be9e6-08e0-4cd8-8c7f-aab3431e17c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use visible labels for Picker examples",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
@@ -14,7 +14,6 @@ const toggleStyles: Partial<IToggleStyles> = { root: { margin: '10px 0' } };
 const inputProps: IInputProps = {
   onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
   onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),
-  'aria-label': 'Tag picker',
 };
 
 const pickerSuggestionsProps: IBasePickerSuggestionsProps = {
@@ -81,7 +80,9 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
         checked={tagPicker}
         onChange={toggleIsTagPickerVisible}
       />
-      Filter items in suggestions: This picker will filter added items from the search suggestions.
+      <label htmlFor="picker1">
+        Filter items in suggestions: This picker will filter added items from the search suggestions.
+      </label>
       <TagPicker
         removeButtonAriaLabel="Remove"
         onResolveSuggestions={filterSuggestedTags}
@@ -89,10 +90,15 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
         pickerSuggestionsProps={pickerSuggestionsProps}
         itemLimit={2}
         disabled={tagPicker}
-        inputProps={inputProps}
+        inputProps={{
+          ...inputProps,
+          id: 'picker1',
+        }}
       />
       <br />
-      Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
+      <label htmlFor="picker2">
+        Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
+      </label>
       <TagPicker
         removeButtonAriaLabel="Remove"
         componentRef={picker}
@@ -102,7 +108,10 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
         pickerSuggestionsProps={pickerSuggestionsProps}
         itemLimit={2}
         disabled={tagPicker}
-        inputProps={inputProps}
+        inputProps={{
+          ...inputProps,
+          id: 'picker2',
+        }}
       />
     </div>
   );

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -45,19 +45,15 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -88,11 +84,12 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="Tag Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -121,6 +118,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
                   display: none;
                 }
             data-lpignore={true}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -130,7 +128,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -8,19 +8,15 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -51,11 +47,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -85,6 +82,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
                 }
             data-lpignore={true}
             disabled={false}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -94,7 +92,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -9,19 +9,15 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
       onKeyDown={[Function]}
     >
       <div
-        aria-expanded={false}
-        aria-haspopup="dialog"
         className=
             ms-FocusZone
             &:focus {
               outline: none;
             }
         data-focuszone-id="FocusZone1"
-        id="combobox-id__0"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="combobox"
       >
         <div
           className="ms-SelectionZone"
@@ -52,11 +48,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                 &:hover {
                   border-color: #323130;
                 }
-            role="presentation"
           >
             <input
               aria-autocomplete="both"
-              aria-controls=" "
+              aria-controls=""
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoCapitalize="off"
               autoComplete="off"
               className=
@@ -85,6 +82,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   }
               data-lpignore={true}
               disabled={false}
+              id="combobox-id__0"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -94,7 +92,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               onFocus={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
-              role="textbox"
+              role="combobox"
               spellCheck={false}
               style={
                 Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -8,19 +8,15 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -51,11 +47,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -85,6 +82,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
                 }
             data-lpignore={true}
             disabled={false}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -94,7 +92,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -10,8 +10,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
       onKeyDown={[Function]}
     >
       <div
-        aria-expanded={false}
-        aria-haspopup="dialog"
         className=
             ms-BasePicker-text
             {
@@ -28,11 +26,11 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             &:hover {
               border-color: #323130;
             }
-        role="combobox"
       >
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-expanded={false}
+          aria-haspopup="listbox"
           aria-label="People Picker"
           autoCapitalize="off"
           autoComplete="off"
@@ -71,7 +69,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           style={
             Object {
               "fontFamily": "inherit",

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -8,19 +8,15 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -51,11 +47,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -85,6 +82,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
                 }
             data-lpignore={true}
             disabled={false}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -94,7 +92,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -8,19 +8,15 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -51,7 +47,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <span
             className=
@@ -1405,8 +1400,10 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
           </span>
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
             aria-describedby="selected-items-id__0"
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -1436,6 +1433,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                 }
             data-lpignore={true}
             disabled={false}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -1445,7 +1443,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -8,19 +8,15 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone1"
-      id="combobox-id__0"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -51,11 +47,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
@@ -85,6 +82,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
                 }
             data-lpignore={true}
             disabled={false}
+            id="combobox-id__0"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -94,7 +92,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -140,26 +140,26 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       </button>
     </div>
   </div>
-  Filter items in suggestions: This picker will filter added items from the search suggestions.
+  <label
+    htmlFor="picker1"
+  >
+    Filter items in suggestions: This picker will filter added items from the search suggestions.
+  </label>
   <div
     className="ms-BasePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone2"
-      id="combobox-id__1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -190,12 +190,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
-            aria-label="Tag picker"
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             autoCapitalize="off"
             autoComplete="off"
             className=
@@ -224,6 +224,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                 }
             data-lpignore={true}
             disabled={false}
+            id="picker1"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -233,7 +234,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {
@@ -247,26 +248,26 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     </div>
   </div>
   <br />
-  Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
+  <label
+    htmlFor="picker2"
+  >
+    Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
+  </label>
   <div
     className="ms-BasePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="dialog"
       className=
           ms-FocusZone
           &:focus {
             outline: none;
           }
       data-focuszone-id="FocusZone4"
-      id="combobox-id__3"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      role="combobox"
     >
       <div
         className="ms-SelectionZone"
@@ -297,12 +298,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               &:hover {
                 border-color: #323130;
               }
-          role="presentation"
         >
           <input
             aria-autocomplete="both"
-            aria-controls=" "
-            aria-label="Tag picker"
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
             autoCapitalize="off"
             autoComplete="off"
             className=
@@ -331,6 +332,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                 }
             data-lpignore={true}
             disabled={false}
+            id="picker2"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -340,7 +342,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onFocus={[Function]}
             onInput={[Function]}
             onKeyDown={[Function]}
-            role="textbox"
+            role="combobox"
             spellCheck={false}
             style={
               Object {

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -244,12 +244,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused, items } = this.state;
     const { className, inputProps, disabled, theme, styles } = this.props;
-
-    const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert
-      ? this._ariaMap.selectedSuggestionAlert
-      : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
-    const canAddItems = this.canAddItems();
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -281,19 +276,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
           componentRef={this.focusZone}
           direction={FocusZoneDirection.bidirectional}
           shouldEnterInnerZone={this._shouldFocusZoneEnterInnerZone}
-          role={canAddItems ? 'combobox' : undefined}
-          id={canAddItems ? this._ariaMap.combobox : undefined}
-          aria-label={canAddItems ? this.props['aria-label'] : undefined}
-          aria-expanded={canAddItems ? !!this.state.suggestionsVisible : undefined}
-          aria-owns={canAddItems ? suggestionsAvailable || undefined : undefined}
-          // Dialog is an acceptable child of a combobox according to the aria specs: https://www.w3.org/TR/wai-aria-practices/#combobox
-          // Currently accessibility insights will flag this as not a valid child because the AXE rules are
-          // out of date. Tracking issue: https://github.com/dequelabs/axe-core/issues/1009
-          aria-haspopup={suggestionsAvailable && this.suggestionStore.suggestions.length > 0 ? 'listbox' : 'dialog'}
         >
           {this.getSuggestionsAlert(classNames.screenReaderText)}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={classNames.text} role="presentation">
+            <div className={classNames.text}>
               {items.length > 0 && (
                 <span id={this._ariaMap.selectedItems} className={classNames.itemsWrapper} role={'list'}>
                   {this.renderItems()}
@@ -305,16 +291,19 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
                   {...(inputProps as any)}
                   className={classNames.input}
                   componentRef={this.input}
+                  id={inputProps?.id ? inputProps.id : this._ariaMap.combobox}
                   onClick={this.onClick}
                   onFocus={this.onInputFocus}
                   onBlur={this.onInputBlur}
                   onInputValueChange={this.onInputChange}
                   suggestedDisplayValue={suggestedDisplayValue}
-                  aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
-                  aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}
                   aria-activedescendant={this.getActiveDescendant()}
-                  aria-labelledby={this.props['aria-label'] ? this._ariaMap.combobox : undefined}
-                  role={'textbox'}
+                  aria-controls={suggestionsAvailable}
+                  aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
+                  aria-expanded={!!this.state.suggestionsVisible}
+                  aria-haspopup="listbox"
+                  aria-label={this.props['aria-label'] || inputProps?.['aria-label']}
+                  role="combobox"
                   disabled={disabled}
                   onInputChange={this.props.onInputChange}
                 />
@@ -1000,9 +989,6 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
     const { suggestedDisplayValue, isFocused } = this.state;
     const { className, inputProps, disabled, theme, styles } = this.props;
 
-    const selectedSuggestionAlertId: string | undefined = this.props.enableSelectedSuggestionAlert
-      ? this._ariaMap.selectedSuggestionAlert
-      : '';
     const suggestionsAvailable: string | undefined = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
@@ -1036,16 +1022,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       <div ref={this.root} onBlur={this.onBlur}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
           {this.getSuggestionsAlert(classNames.screenReaderText)}
-          <div
-            className={classNames.text}
-            aria-owns={suggestionsAvailable || undefined}
-            aria-expanded={!!this.state.suggestionsVisible}
-            // Dialog is an acceptable child of a combobox according to the aria specs: https://www.w3.org/TR/wai-aria-practices/#combobox
-            // Currently accessibility insights will flag this as not a valid child because the AXE rules are
-            // out of date. Tracking issue: https://github.com/dequelabs/axe-core/issues/1009
-            aria-haspopup={suggestionsAvailable && this.suggestionStore.suggestions.length > 0 ? 'listbox' : 'dialog'}
-            role="combobox"
-          >
+          <div className={classNames.text}>
             <Autofill
               {...(inputProps as any)}
               className={classNames.input}
@@ -1056,9 +1033,11 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               onInputValueChange={this.onInputChange}
               suggestedDisplayValue={suggestedDisplayValue}
               aria-activedescendant={this.getActiveDescendant()}
-              role="textbox"
+              aria-controls={suggestionsAvailable || undefined}
+              aria-expanded={!!this.state.suggestionsVisible}
+              aria-haspopup="listbox"
+              role="combobox"
               disabled={disabled}
-              aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}
               onInputChange={this.props.onInputChange}
             />
           </div>

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -7,19 +7,15 @@ exports[`PeoplePicker renders correctly 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -50,11 +46,12 @@ exports[`PeoplePicker renders correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-        role="presentation"
       >
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className=
@@ -82,6 +79,7 @@ exports[`PeoplePicker renders correctly 1`] = `
                 display: none;
               }
           data-lpignore={true}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -91,7 +89,7 @@ exports[`PeoplePicker renders correctly 1`] = `
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {
@@ -113,19 +111,15 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -156,7 +150,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
             &:hover {
               border-color: #323130;
             }
-        role="presentation"
       >
         <span
           className=
@@ -618,8 +611,10 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
         </span>
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
           aria-describedby="selected-items-id__0"
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className=
@@ -647,6 +642,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                 display: none;
               }
           data-lpignore={true}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -656,7 +652,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -346,12 +346,15 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
 
   private _renderSuggestions(): JSX.Element | null {
     const {
+      isMostRecentlyUsedVisible,
+      mostRecentlyUsedHeaderText,
       onRenderSuggestion,
       removeSuggestionAriaLabel,
       suggestionsItemClassName,
       resultsMaximumNumber,
       showRemoveButtons,
       suggestionsContainerAriaLabel,
+      suggestionsHeaderText,
       suggestionsListId,
     } = this.props;
 
@@ -379,17 +382,24 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       return null;
     }
 
+    // MostRecently Used text should supercede the header text if it's there and available.
+    let headerText: string | undefined = suggestionsHeaderText;
+    if (isMostRecentlyUsedVisible && mostRecentlyUsedHeaderText) {
+      headerText = mostRecentlyUsedHeaderText;
+    }
+
     return (
       <div
         className={this._classNames.suggestionsContainer}
         id={suggestionsListId}
         role="listbox"
-        aria-label={suggestionsContainerAriaLabel}
+        aria-label={suggestionsContainerAriaLabel || headerText}
       >
         {suggestions.map((suggestion, index) => (
           <div
             ref={suggestion.selected ? this._selectedElement : undefined}
             key={(suggestion.item as any).key ? (suggestion.item as any).key : index}
+            role="presentation"
           >
             <StyledTypedSuggestionsItem
               suggestionModel={suggestion}

--- a/packages/react/src/components/pickers/Suggestions/SuggestionsItem.tsx
+++ b/packages/react/src/components/pickers/Suggestions/SuggestionsItem.tsx
@@ -66,7 +66,7 @@ export class SuggestionsItem<T> extends React.Component<ISuggestionItemProps<T>,
         };
 
     return (
-      <div className={classNames.root}>
+      <div className={classNames.root} role="presentation">
         <CommandButton
           onClick={onClick}
           className={classNames.itemButton}

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`Suggestions renders a list properly 1`] = `
     className="ms-Suggestions-container"
     role="listbox"
   >
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -44,6 +46,7 @@ exports[`Suggestions renders a list properly 1`] = `
               right: 0px;
               top: 0px;
             }
+        role="presentation"
       >
         <button
           aria-selected={true}
@@ -165,7 +168,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -182,6 +187,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -297,7 +303,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -314,6 +322,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -429,7 +438,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -446,6 +457,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -561,7 +573,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -578,6 +592,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -693,7 +708,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -710,6 +727,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -825,7 +843,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -842,6 +862,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -957,7 +978,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -974,6 +997,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1089,7 +1113,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1106,6 +1132,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1221,7 +1248,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1238,6 +1267,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1353,7 +1383,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1370,6 +1402,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1485,7 +1518,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1502,6 +1537,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1617,7 +1653,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1634,6 +1672,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1749,7 +1788,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1766,6 +1807,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -1881,7 +1923,9 @@ exports[`Suggestions renders a list properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -1898,6 +1942,7 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2041,7 +2086,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         }
     role="listbox"
   >
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2072,6 +2119,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               right: 0px;
               top: 0px;
             }
+        role="presentation"
       >
         <button
           aria-selected={true}
@@ -2193,7 +2241,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2210,6 +2260,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2325,7 +2376,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2342,6 +2395,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2457,7 +2511,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2474,6 +2530,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2589,7 +2646,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2606,6 +2665,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2721,7 +2781,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2738,6 +2800,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2853,7 +2916,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -2870,6 +2935,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -2985,7 +3051,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3002,6 +3070,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3117,7 +3186,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3134,6 +3205,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3249,7 +3321,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3266,6 +3340,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3381,7 +3456,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3398,6 +3475,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3513,7 +3591,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3530,6 +3610,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3645,7 +3726,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3662,6 +3745,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3777,7 +3861,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3794,6 +3880,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -3909,7 +3996,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -3926,6 +4015,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4058,7 +4148,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
     className="ms-Suggestions-container"
     role="listbox"
   >
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4075,6 +4167,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4190,7 +4283,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4207,6 +4302,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4322,7 +4418,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4339,6 +4437,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4454,7 +4553,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4471,6 +4572,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4586,7 +4688,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4603,6 +4707,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4718,7 +4823,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4735,6 +4842,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4850,7 +4958,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4867,6 +4977,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -4982,7 +5093,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -4999,6 +5112,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5114,7 +5228,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5145,6 +5261,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               right: 0px;
               top: 0px;
             }
+        role="presentation"
       >
         <button
           aria-selected={true}
@@ -5266,7 +5383,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5283,6 +5402,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5398,7 +5518,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5415,6 +5537,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5530,7 +5653,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5547,6 +5672,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5662,7 +5788,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5679,6 +5807,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5794,7 +5923,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5811,6 +5942,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}
@@ -5926,7 +6058,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
         </button>
       </div>
     </div>
-    <div>
+    <div
+      role="presentation"
+    >
       <div
         className=
             ms-Suggestions-item
@@ -5943,6 +6077,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+        role="presentation"
       >
         <button
           aria-selected={false}

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -7,19 +7,15 @@ exports[`TagPicker renders correctly 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -50,7 +46,6 @@ exports[`TagPicker renders correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-        role="presentation"
       >
         <span
           className=
@@ -261,8 +256,10 @@ exports[`TagPicker renders correctly 1`] = `
         </span>
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
           aria-describedby="selected-items-id__0"
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className=
@@ -290,6 +287,7 @@ exports[`TagPicker renders correctly 1`] = `
                 display: none;
               }
           data-lpignore={true}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -299,7 +297,7 @@ exports[`TagPicker renders correctly 1`] = `
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {
@@ -321,19 +319,15 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -364,7 +358,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-        role="presentation"
       >
         <span
           className=
@@ -575,8 +568,10 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
         </span>
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
           aria-describedby="selected-items-id__0"
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className=
@@ -604,6 +599,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                 display: none;
               }
           data-lpignore={true}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -613,7 +609,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -7,19 +7,15 @@ exports[`BasePicker renders correctly 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -35,15 +31,17 @@ exports[`BasePicker renders correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="presentation"
       >
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className="ms-BasePicker-input"
           data-lpignore={true}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -53,7 +51,7 @@ exports[`BasePicker renders correctly 1`] = `
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {
@@ -75,19 +73,15 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
   onKeyDown={[Function]}
 >
   <div
-    aria-expanded={false}
-    aria-haspopup="dialog"
     className=
         ms-FocusZone
         &:focus {
           outline: none;
         }
     data-focuszone-id="FocusZone1"
-    id="combobox-id__0"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="combobox"
   >
     <div
       className="ms-SelectionZone"
@@ -103,11 +97,12 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="presentation"
       >
         <input
           aria-autocomplete="both"
-          aria-controls=" "
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
           autoCapitalize="off"
           autoComplete="off"
           className="ms-BasePicker-input testclass "
@@ -123,7 +118,7 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Bitte einen Benutzer angeben..."
-          role="textbox"
+          role="combobox"
           spellCheck={false}
           style={
             Object {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: precursor to fixing multiple picker a11y issues
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Updates BasePicker to follow the 1.2 combobox pattern, with `role="combobox"` + `aria-controls` on the input element
- Updates the Suggestions listbox to fall back on the visible label as an accessible name, if no explicit aria-label is provided
- Updates the TagPicker example to use label elements to label pickers, and have the picker name match the visible text label.
