### PR TITLE
chore: integrate nx devtools

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,376 @@
+{
+  "npmScope": "fluentui",
+  "implicitDependencies": {
+    "workspace.json": "*",
+    "package.json": {
+      "dependencies": "*",
+      "devDependencies": "*"
+    },
+    "nx.json": "*"
+  },
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "@nrwl/workspace/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "test", "lint", "package", "prepare"],
+        "strictlyOrderedTargets": ["build", "package", "prepare"]
+      }
+    }
+  },
+  "projects": {
+    "a11y-tests": {
+      "implicitDependencies": []
+    },
+    "codesandbox-react-northstar-template": {
+      "implicitDependencies": []
+    },
+    "codesandbox-react-template": {
+      "implicitDependencies": []
+    },
+    "perf-test": {
+      "implicitDependencies": []
+    },
+    "@fluentui/pr-deploy-site": {
+      "implicitDependencies": []
+    },
+    "@fluentui/public-docsite": {
+      "implicitDependencies": []
+    },
+    "@fluentui/public-docsite-resources": {
+      "implicitDependencies": []
+    },
+    "server-rendered-app": {
+      "implicitDependencies": []
+    },
+    "ssr-tests": {
+      "implicitDependencies": []
+    },
+    "test-bundles": {
+      "implicitDependencies": []
+    },
+    "theming-designer": {
+      "implicitDependencies": []
+    },
+    "todo-app": {
+      "implicitDependencies": []
+    },
+    "vr-tests": {
+      "implicitDependencies": []
+    },
+    "@fluentui/a11y-testing": {
+      "implicitDependencies": []
+    },
+    "@fluentui/api-docs": {
+      "implicitDependencies": []
+    },
+    "@fluentui/azure-themes": {
+      "implicitDependencies": []
+    },
+    "@fluentui/babel-make-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/codemods": {
+      "implicitDependencies": []
+    },
+    "@fluentui/common-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/cra-template": {
+      "implicitDependencies": []
+    },
+    "@fluentui/date-time-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/dom-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/eslint-plugin": {
+      "implicitDependencies": []
+    },
+    "@fluentui/example-data": {
+      "implicitDependencies": []
+    },
+    "@fluentui/ability-attributes": {
+      "implicitDependencies": []
+    },
+    "@fluentui/accessibility": {
+      "implicitDependencies": []
+    },
+    "@fluentui/circulars-test": {
+      "implicitDependencies": []
+    },
+    "@fluentui/code-sandbox": {
+      "implicitDependencies": []
+    },
+    "@fluentui/digest": {
+      "implicitDependencies": []
+    },
+    "@fluentui/docs": {
+      "implicitDependencies": []
+    },
+    "@fluentui/docs-components": {
+      "implicitDependencies": []
+    },
+    "@fluentui/e2e": {
+      "implicitDependencies": []
+    },
+    "@fluentui/local-sandbox": {
+      "implicitDependencies": []
+    },
+    "@fluentui/noop": {
+      "implicitDependencies": []
+    },
+    "@fluentui/perf": {
+      "implicitDependencies": []
+    },
+    "@fluentui/perf-test": {
+      "implicitDependencies": []
+    },
+    "@fluentui/projects-test": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-bindings": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-builder": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-component-event-listener": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-component-nesting-registry": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-component-ref": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-icons-northstar": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-northstar": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-northstar-emotion-renderer": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-northstar-fela-renderer": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-northstar-prototypes": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-northstar-styles-renderer": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-proptypes": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-telemetry": {
+      "implicitDependencies": []
+    },
+    "@fluentui/state": {
+      "implicitDependencies": []
+    },
+    "@fluentui/styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/font-icons-mdl2": {
+      "implicitDependencies": []
+    },
+    "@fluentui/foundation-legacy": {
+      "implicitDependencies": []
+    },
+    "@fluentui/jest-serializer-make-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/jest-serializer-merge-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/keyboard-key": {
+      "implicitDependencies": []
+    },
+    "@fluentui/make-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/merge-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/monaco-editor": {
+      "implicitDependencies": []
+    },
+    "@fluentui/public-docsite-setup": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-accordion": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-avatar": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-badge": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-button": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-cards": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-charting": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-checkbox": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-components": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-compose": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-conformance": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-context-selector": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-date-time": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-divider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-docsite-components": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-examples": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-experiments": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-file-type-icons": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-flex": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-focus": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-hooks": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-icon-provider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-icons-mdl2": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-icons-mdl2-branded": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-image": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-link": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-make-styles": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-menu": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-monaco-editor": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-popup": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-portal": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-positioning": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-provider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-shared-contexts": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-slider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-storybook": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-tabs": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-tabster": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-text": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-theme": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-theme-provider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-toggle": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-tooltip": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/react-window-provider": {
+      "implicitDependencies": []
+    },
+    "@fluentui/scheme-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/set-version": {
+      "implicitDependencies": []
+    },
+    "@fluentui/storybook": {
+      "implicitDependencies": []
+    },
+    "@fluentui/style-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/test-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/theme": {
+      "implicitDependencies": []
+    },
+    "@fluentui/theme-samples": {
+      "implicitDependencies": []
+    },
+    "@fluentui/utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/web-components": {
+      "implicitDependencies": []
+    },
+    "@fluentui/webpack-utilities": {
+      "implicitDependencies": []
+    },
+    "@fluentui/scripts": {
+      "implicitDependencies": []
+    }
+  },
+  "affected": {
+    "defaultBase": "master"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -135,7 +135,10 @@
     "webpack-cli": "4.3.1",
     "webpack-dev-server": "4.0.0-beta.0",
     "tmp": "0.2.1",
-    "yargs": "13.3.2"
+    "yargs": "13.3.2",
+    "@nrwl/workspace": "12.1.0",
+    "@nrwl/cli": "12.1.0",
+    "@nrwl/tao": "12.1.0"
   },
   "license": "MIT",
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rename-package": "node -r ./scripts/ts-node-register ./scripts/rename-package.ts",
     "run:published": "node ./scripts/monorepo/runPublished.js",
     "runto:lerna": "node ./scripts/monorepo/runTo.js",
-    "satisfied": "satisfied --skip-invalid --ignore \"sass|@testing-library\"",
+    "satisfied": "satisfied --skip-invalid --ignore \"sass|@testing-library|@nrwl/workspace\"",
     "scrub": "node ./scripts/scrub.js",
     "start": "node scripts/start.js",
     "start:legacy": "yarn workspace @fluentui/public-docsite-resources start",

--- a/workspace.json
+++ b/workspace.json
@@ -1,0 +1,473 @@
+{
+  "version": 2,
+  "projects": {
+    "a11y-tests": {
+      "root": "apps/a11y-tests",
+      "projectType": "application"
+    },
+    "codesandbox-react-northstar-template": {
+      "root": "apps/codesandbox-react-northstar-template",
+      "projectType": "application"
+    },
+    "codesandbox-react-template": {
+      "root": "apps/codesandbox-react-template",
+      "projectType": "application"
+    },
+    "perf-test": {
+      "root": "apps/perf-test",
+      "projectType": "application"
+    },
+    "@fluentui/pr-deploy-site": {
+      "root": "apps/pr-deploy-site",
+      "projectType": "application"
+    },
+    "@fluentui/public-docsite": {
+      "root": "apps/public-docsite",
+      "projectType": "application"
+    },
+    "@fluentui/public-docsite-resources": {
+      "root": "apps/public-docsite-resources",
+      "projectType": "application"
+    },
+    "server-rendered-app": {
+      "root": "apps/server-rendered-app",
+      "projectType": "application"
+    },
+    "ssr-tests": {
+      "root": "apps/ssr-tests",
+      "projectType": "application"
+    },
+    "test-bundles": {
+      "root": "apps/test-bundles",
+      "projectType": "application"
+    },
+    "theming-designer": {
+      "root": "apps/theming-designer",
+      "projectType": "application"
+    },
+    "todo-app": {
+      "root": "apps/todo-app",
+      "projectType": "application"
+    },
+    "vr-tests": {
+      "root": "apps/vr-tests",
+      "projectType": "application"
+    },
+    "@fluentui/a11y-testing": {
+      "root": "packages/a11y-testing",
+      "projectType": "library"
+    },
+    "@fluentui/api-docs": {
+      "root": "packages/api-docs",
+      "projectType": "library"
+    },
+    "@fluentui/azure-themes": {
+      "root": "packages/azure-themes",
+      "projectType": "library"
+    },
+    "@fluentui/babel-make-styles": {
+      "root": "packages/babel-make-styles",
+      "projectType": "library"
+    },
+    "@fluentui/codemods": {
+      "root": "packages/codemods",
+      "projectType": "library"
+    },
+    "@fluentui/common-styles": {
+      "root": "packages/common-styles",
+      "projectType": "library"
+    },
+    "@fluentui/cra-template": {
+      "root": "packages/cra-template",
+      "projectType": "library"
+    },
+    "@fluentui/date-time-utilities": {
+      "root": "packages/date-time-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/dom-utilities": {
+      "root": "packages/dom-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/eslint-plugin": {
+      "root": "packages/eslint-plugin",
+      "projectType": "library"
+    },
+    "@fluentui/example-data": {
+      "root": "packages/example-data",
+      "projectType": "library"
+    },
+    "@fluentui/ability-attributes": {
+      "root": "packages/fluentui/ability-attributes",
+      "projectType": "library"
+    },
+    "@fluentui/accessibility": {
+      "root": "packages/fluentui/accessibility",
+      "projectType": "library"
+    },
+    "@fluentui/circulars-test": {
+      "root": "packages/fluentui/circulars-test",
+      "projectType": "library"
+    },
+    "@fluentui/code-sandbox": {
+      "root": "packages/fluentui/code-sandbox",
+      "projectType": "library"
+    },
+    "@fluentui/digest": {
+      "root": "packages/fluentui/digest",
+      "projectType": "library"
+    },
+    "@fluentui/docs": {
+      "root": "packages/fluentui/docs",
+      "projectType": "library"
+    },
+    "@fluentui/docs-components": {
+      "root": "packages/fluentui/docs-components",
+      "projectType": "library"
+    },
+    "@fluentui/e2e": {
+      "root": "packages/fluentui/e2e",
+      "projectType": "library"
+    },
+    "@fluentui/local-sandbox": {
+      "root": "packages/fluentui/local-sandbox",
+      "projectType": "library"
+    },
+    "@fluentui/noop": {
+      "root": "packages/fluentui",
+      "projectType": "library"
+    },
+    "@fluentui/perf": {
+      "root": "packages/fluentui/perf",
+      "projectType": "library"
+    },
+    "@fluentui/perf-test": {
+      "root": "packages/fluentui/perf-test",
+      "projectType": "library"
+    },
+    "@fluentui/projects-test": {
+      "root": "packages/fluentui/projects-test",
+      "projectType": "library"
+    },
+    "@fluentui/react-bindings": {
+      "root": "packages/fluentui/react-bindings",
+      "projectType": "library"
+    },
+    "@fluentui/react-builder": {
+      "root": "packages/fluentui/react-builder",
+      "projectType": "library"
+    },
+    "@fluentui/react-component-event-listener": {
+      "root": "packages/fluentui/react-component-event-listener",
+      "projectType": "library"
+    },
+    "@fluentui/react-component-nesting-registry": {
+      "root": "packages/fluentui/react-component-nesting-registry",
+      "projectType": "library"
+    },
+    "@fluentui/react-component-ref": {
+      "root": "packages/fluentui/react-component-ref",
+      "projectType": "library"
+    },
+    "@fluentui/react-icons-northstar": {
+      "root": "packages/fluentui/react-icons-northstar",
+      "projectType": "library"
+    },
+    "@fluentui/react-northstar": {
+      "root": "packages/fluentui/react-northstar",
+      "projectType": "library"
+    },
+    "@fluentui/react-northstar-emotion-renderer": {
+      "root": "packages/fluentui/react-northstar-emotion-renderer",
+      "projectType": "library"
+    },
+    "@fluentui/react-northstar-fela-renderer": {
+      "root": "packages/fluentui/react-northstar-fela-renderer",
+      "projectType": "library"
+    },
+    "@fluentui/react-northstar-prototypes": {
+      "root": "packages/fluentui/react-northstar-prototypes",
+      "projectType": "library"
+    },
+    "@fluentui/react-northstar-styles-renderer": {
+      "root": "packages/fluentui/react-northstar-styles-renderer",
+      "projectType": "library"
+    },
+    "@fluentui/react-proptypes": {
+      "root": "packages/fluentui/react-proptypes",
+      "projectType": "library"
+    },
+    "@fluentui/react-telemetry": {
+      "root": "packages/fluentui/react-telemetry",
+      "projectType": "library"
+    },
+    "@fluentui/state": {
+      "root": "packages/fluentui/state",
+      "projectType": "library"
+    },
+    "@fluentui/styles": {
+      "root": "packages/fluentui/styles",
+      "projectType": "library"
+    },
+    "@fluentui/font-icons-mdl2": {
+      "root": "packages/font-icons-mdl2",
+      "projectType": "library"
+    },
+    "@fluentui/foundation-legacy": {
+      "root": "packages/foundation-legacy",
+      "projectType": "library"
+    },
+    "@fluentui/jest-serializer-make-styles": {
+      "root": "packages/jest-serializer-make-styles",
+      "projectType": "library"
+    },
+    "@fluentui/jest-serializer-merge-styles": {
+      "root": "packages/jest-serializer-merge-styles",
+      "projectType": "library"
+    },
+    "@fluentui/keyboard-key": {
+      "root": "packages/keyboard-key",
+      "projectType": "library"
+    },
+    "@fluentui/make-styles": {
+      "root": "packages/make-styles",
+      "projectType": "library"
+    },
+    "@fluentui/merge-styles": {
+      "root": "packages/merge-styles",
+      "projectType": "library"
+    },
+    "@fluentui/monaco-editor": {
+      "root": "packages/monaco-editor",
+      "projectType": "library"
+    },
+    "@fluentui/public-docsite-setup": {
+      "root": "packages/public-docsite-setup",
+      "projectType": "library"
+    },
+    "@fluentui/react": {
+      "root": "packages/react",
+      "projectType": "library"
+    },
+    "@fluentui/react-accordion": {
+      "root": "packages/react-accordion",
+      "projectType": "library"
+    },
+    "@fluentui/react-avatar": {
+      "root": "packages/react-avatar",
+      "projectType": "library"
+    },
+    "@fluentui/react-badge": {
+      "root": "packages/react-badge",
+      "projectType": "library"
+    },
+    "@fluentui/react-button": {
+      "root": "packages/react-button",
+      "projectType": "library"
+    },
+    "@fluentui/react-cards": {
+      "root": "packages/react-cards",
+      "projectType": "library"
+    },
+    "@fluentui/react-charting": {
+      "root": "packages/react-charting",
+      "projectType": "library"
+    },
+    "@fluentui/react-checkbox": {
+      "root": "packages/react-checkbox",
+      "projectType": "library"
+    },
+    "@fluentui/react-components": {
+      "root": "packages/react-components",
+      "projectType": "library"
+    },
+    "@fluentui/react-compose": {
+      "root": "packages/react-compose",
+      "projectType": "library"
+    },
+    "@fluentui/react-conformance": {
+      "root": "packages/react-conformance",
+      "projectType": "library"
+    },
+    "@fluentui/react-context-selector": {
+      "root": "packages/react-context-selector",
+      "projectType": "library"
+    },
+    "@fluentui/react-date-time": {
+      "root": "packages/react-date-time",
+      "projectType": "library"
+    },
+    "@fluentui/react-divider": {
+      "root": "packages/react-divider",
+      "projectType": "library"
+    },
+    "@fluentui/react-docsite-components": {
+      "root": "packages/react-docsite-components",
+      "projectType": "library"
+    },
+    "@fluentui/react-examples": {
+      "root": "packages/react-examples",
+      "projectType": "library"
+    },
+    "@fluentui/react-experiments": {
+      "root": "packages/react-experiments",
+      "projectType": "library"
+    },
+    "@fluentui/react-file-type-icons": {
+      "root": "packages/react-file-type-icons",
+      "projectType": "library"
+    },
+    "@fluentui/react-flex": {
+      "root": "packages/react-flex",
+      "projectType": "library"
+    },
+    "@fluentui/react-focus": {
+      "root": "packages/react-focus",
+      "projectType": "library"
+    },
+    "@fluentui/react-hooks": {
+      "root": "packages/react-hooks",
+      "projectType": "library"
+    },
+    "@fluentui/react-icon-provider": {
+      "root": "packages/react-icon-provider",
+      "projectType": "library"
+    },
+    "@fluentui/react-icons-mdl2": {
+      "root": "packages/react-icons-mdl2",
+      "projectType": "library"
+    },
+    "@fluentui/react-icons-mdl2-branded": {
+      "root": "packages/react-icons-mdl2-branded",
+      "projectType": "library"
+    },
+    "@fluentui/react-image": {
+      "root": "packages/react-image",
+      "projectType": "library"
+    },
+    "@fluentui/react-link": {
+      "root": "packages/react-link",
+      "projectType": "library"
+    },
+    "@fluentui/react-make-styles": {
+      "root": "packages/react-make-styles",
+      "projectType": "library"
+    },
+    "@fluentui/react-menu": {
+      "root": "packages/react-menu",
+      "projectType": "library"
+    },
+    "@fluentui/react-monaco-editor": {
+      "root": "packages/react-monaco-editor",
+      "projectType": "library"
+    },
+    "@fluentui/react-popup": {
+      "root": "packages/react-popup",
+      "projectType": "library"
+    },
+    "@fluentui/react-portal": {
+      "root": "packages/react-portal",
+      "projectType": "library"
+    },
+    "@fluentui/react-positioning": {
+      "root": "packages/react-positioning",
+      "projectType": "library"
+    },
+    "@fluentui/react-provider": {
+      "root": "packages/react-provider",
+      "projectType": "library"
+    },
+    "@fluentui/react-shared-contexts": {
+      "root": "packages/react-shared-contexts",
+      "projectType": "library"
+    },
+    "@fluentui/react-slider": {
+      "root": "packages/react-slider",
+      "projectType": "library"
+    },
+    "@fluentui/react-storybook": {
+      "root": "packages/react-storybook",
+      "projectType": "library"
+    },
+    "@fluentui/react-tabs": {
+      "root": "packages/react-tabs",
+      "projectType": "library"
+    },
+    "@fluentui/react-tabster": {
+      "root": "packages/react-tabster",
+      "projectType": "library"
+    },
+    "@fluentui/react-text": {
+      "root": "packages/react-text",
+      "projectType": "library"
+    },
+    "@fluentui/react-theme": {
+      "root": "packages/react-theme",
+      "projectType": "library"
+    },
+    "@fluentui/react-theme-provider": {
+      "root": "packages/react-theme-provider",
+      "projectType": "library"
+    },
+    "@fluentui/react-toggle": {
+      "root": "packages/react-toggle",
+      "projectType": "library"
+    },
+    "@fluentui/react-tooltip": {
+      "root": "packages/react-tooltip",
+      "projectType": "library"
+    },
+    "@fluentui/react-utilities": {
+      "root": "packages/react-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/react-window-provider": {
+      "root": "packages/react-window-provider",
+      "projectType": "library"
+    },
+    "@fluentui/scheme-utilities": {
+      "root": "packages/scheme-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/set-version": {
+      "root": "packages/set-version",
+      "projectType": "library"
+    },
+    "@fluentui/storybook": {
+      "root": "packages/storybook",
+      "projectType": "library"
+    },
+    "@fluentui/style-utilities": {
+      "root": "packages/style-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/test-utilities": {
+      "root": "packages/test-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/theme": {
+      "root": "packages/theme",
+      "projectType": "library"
+    },
+    "@fluentui/theme-samples": {
+      "root": "packages/theme-samples",
+      "projectType": "library"
+    },
+    "@fluentui/utilities": {
+      "root": "packages/utilities",
+      "projectType": "library"
+    },
+    "@fluentui/web-components": {
+      "root": "packages/web-components",
+      "projectType": "library"
+    },
+    "@fluentui/webpack-utilities": {
+      "root": "packages/webpack-utilities",
+      "projectType": "library"
+    },
+    "@fluentui/scripts": {
+      "root": "scripts",
+      "projectType": "library"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,97 @@
     node-gyp "^6.1.0"
     read-package-json-fast "^1.1.3"
 
+"@nrwl/cli@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-12.1.0.tgz#5be2954c4e4fe6eca4aab5ef246ed2dd40baa7d9"
+  integrity sha512-taxuvzIOC8Gkfw1aobyK/T343xfMTUVCbfJFPzks5EAR6uREUPDv6mmSZXZBcRfjmLnZ3R3EmK+DJ2JaQHZ+uQ==
+  dependencies:
+    "@nrwl/tao" "12.1.0"
+    chalk "4.1.0"
+    v8-compile-cache "2.3.0"
+    yargs "15.4.1"
+    yargs-parser "20.0.0"
+
+"@nrwl/devkit@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-12.1.0.tgz#76a0e6377edf2430cef4b28104ea181c186b44db"
+  integrity sha512-A9PVqLmLgCrKyAOhdh49zDRf4fixed6o0miSc1pjdLOAcX1886fijJPzPK8v7qaCDnbS8AcNVnoFY77H4TB1Dw==
+  dependencies:
+    "@nrwl/tao" "12.1.0"
+    ejs "^3.1.5"
+    ignore "^5.0.4"
+    semver "7.3.4"
+    strip-json-comments "^3.1.1"
+    tslib "^2.0.0"
+
+"@nrwl/jest@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/jest/-/jest-12.1.0.tgz#60108a66ea679ce677f98ecb626f5730ca0d7d2c"
+  integrity sha512-LO9DogQ5QowBUzQzrGRaanSLIO5r279LaKDECGEqaUiR7SQFXByRxTrRHCRc74PaWuNjuIqoueDnzba3rC1pMQ==
+  dependencies:
+    "@nrwl/devkit" "12.1.0"
+    jest-resolve "^26.6.2"
+    rxjs "^6.5.4"
+    strip-json-comments "^3.1.1"
+    tslib "^2.0.0"
+
+"@nrwl/linter@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/linter/-/linter-12.1.0.tgz#1e96de84d59e4fd4cd7ac1489406cbf648c1da85"
+  integrity sha512-KFyMXwtR2uzOtQmRMwm9a3a4C9kQuquICWznExFsCXGGg5DPWvTitbwOquNvh3FHCDDIeH+fptJM8DmTqN1E4A==
+  dependencies:
+    "@nrwl/devkit" "12.1.0"
+    glob "7.1.4"
+    minimatch "3.0.4"
+    tmp "~0.2.1"
+    tslib "^2.0.0"
+
+"@nrwl/tao@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-12.1.0.tgz#5527ba8a6fb2e7dfb06c59e1f08936553989360e"
+  integrity sha512-jg7yS8ywnkgFIPUwb2TYurmcjznY9BVMMIp4sLGC1IPwuFaDyXE/ieJGd3YUfjI6rkHcAv0sKDJRyl1Y2ADVjA==
+  dependencies:
+    chalk "4.1.0"
+    enquirer "~2.3.6"
+    fs-extra "^9.1.0"
+    rxjs "^6.5.4"
+    rxjs-for-await "0.0.2"
+    semver "7.3.4"
+    strip-json-comments "^3.1.1"
+    tmp "~0.2.1"
+    tslib "^2.0.0"
+    yargs-parser "20.0.0"
+
+"@nrwl/workspace@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/workspace/-/workspace-12.1.0.tgz#53de4dfe0234b893305add8b321fe7b2af8a215d"
+  integrity sha512-idv0Ziag8edHdbOaq+6RJLwsiJ6GcL0wEVfBQiBZ4QVkH1ddB4QRhiFXcT5WmFmdH3W3dpdJUPa0N7CSpeJPzA==
+  dependencies:
+    "@nrwl/cli" "12.1.0"
+    "@nrwl/devkit" "12.1.0"
+    "@nrwl/jest" "12.1.0"
+    "@nrwl/linter" "12.1.0"
+    axios "0.21.1"
+    chalk "4.1.0"
+    cosmiconfig "^4.0.0"
+    dotenv "8.2.0"
+    enquirer "~2.3.6"
+    flat "^5.0.2"
+    fs-extra "^9.1.0"
+    glob "7.1.4"
+    ignore "^5.0.4"
+    minimatch "3.0.4"
+    npm-run-all "^4.1.5"
+    open "^7.4.2"
+    resolve "1.17.0"
+    rxjs "^6.5.4"
+    semver "7.3.4"
+    strip-json-comments "^3.1.1"
+    tmp "~0.2.1"
+    tslib "^2.0.0"
+    yargs "15.4.1"
+    yargs-parser "20.0.0"
+
 "@octokit/auth-token@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.0.tgz#b64178975218b99e4dfe948253f0673cbbb59d9f"
@@ -6933,6 +7024,13 @@ axe-sarif-converter@^2.0.1:
     "@types/sarif" "2.1.1"
     axe-core "^3.2.2"
 
+axios@0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.1.tgz#2a3b1271ec722d48a4cd4b3fcc20c853326a49a7"
@@ -9620,6 +9718,16 @@ cosmiconfig@7.0.0, cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  integrity sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -11029,15 +11137,15 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv@8.2.0, dotenv@^8.0.0, dotenv@^8.1.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
-
-dotenv@^8.0.0, dotenv@^8.1.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 dotparser@^1.0.0:
   version "1.0.0"
@@ -11142,7 +11250,7 @@ ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-ejs@^3.1.2:
+ejs@^3.1.2, ejs@^3.1.5:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
@@ -11336,7 +11444,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^3.2.1"
 
-enquirer@^2.3.6:
+enquirer@^2.3.6, enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -12909,6 +13017,11 @@ flat@^4.1.0:
   dependencies:
     is-buffer "~2.0.3"
 
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 flatted@^2.0.0, flatted@^2.0.1, flatted@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
@@ -12938,6 +13051,11 @@ follow-redirects@^1.0.0:
   integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   dependencies:
     debug "^3.2.6"
+
+follow-redirects@^1.10.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.0.tgz#f5d260f95c5f8c105894491feee5dc8993b402fe"
+  integrity sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -13162,7 +13280,7 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -13621,6 +13739,18 @@ glob@7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -14871,7 +15001,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -15316,6 +15446,13 @@ is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.3.0.tgz#d341652e3408bca69c4671b79a0954a3d349f887"
+  integrity sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==
   dependencies:
     has "^1.0.3"
 
@@ -16311,6 +16448,11 @@ jest-pnp-resolver@^1.2.1:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
+jest-pnp-resolver@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
+  integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
+
 jest-react-fela@^10.6.1:
   version "10.6.1"
   resolved "https://registry.yarnpkg.com/jest-react-fela/-/jest-react-fela-10.6.1.tgz#8851fa3ed70b9908b7f8f7cef254926ffc4fad72"
@@ -16352,6 +16494,20 @@ jest-resolve@^24.9.0:
     chalk "^2.0.1"
     jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
+
+jest-resolve@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.2.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507"
+  integrity sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^26.6.2"
+    read-pkg-up "^7.0.1"
+    resolve "^1.18.1"
+    slash "^3.0.0"
 
 jest-runner@^24.9.0:
   version "24.9.0"
@@ -16605,6 +16761,14 @@ js-yaml@^3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.0:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -18544,6 +18708,11 @@ memory-streams@^0.1.3:
   dependencies:
     readable-stream "~1.0.2"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -19776,6 +19945,21 @@ npm-registry-fetch@^8.1.3:
     minizlib "^2.0.0"
     npm-package-arg "^8.0.0"
 
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -20096,7 +20280,7 @@ open@^7.0.0:
   dependencies:
     is-wsl "^2.1.0"
 
-open@^7.0.2, open@^7.0.3:
+open@^7.0.2, open@^7.0.3, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -20955,6 +21139,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -23317,7 +23506,7 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^2.0.2:
+require-from-string@^2.0.1, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -23418,6 +23607,13 @@ resolve@1.15.1, resolve@^1.1.7, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.4.0
   dependencies:
     path-parse "^1.0.6"
 
+resolve@1.17.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.17.0, resolve@~1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
@@ -23440,11 +23636,12 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.7.1, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.17.0, resolve@~1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+resolve@^1.18.1:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 resolve@~1.12.0:
@@ -23687,6 +23884,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rxjs-for-await@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/rxjs-for-await/-/rxjs-for-await-0.0.2.tgz#26598a1d6167147cc192172970e7eed4e620384b"
+  integrity sha512-IJ8R/ZCFMHOcDIqoABs82jal00VrZx8Xkgfe7TOKoaRPAW5nH/VFlG23bXpeGdrmtqI9UobFPgUKgCuFc7Lncw==
+
 rxjs@>=6.4.0, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5, rxjs@^6.6.0:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
@@ -23698,6 +23900,13 @@ rxjs@^6.3.3:
   version "6.6.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
   integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.4:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -24002,6 +24211,13 @@ semver@7.3.2, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@7.3.4, semver@^7.3.4, semver@~7.3.0:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^5.0.3, semver@^5.1.0, semver@^5.5, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -24016,13 +24232,6 @@ semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.4, semver@~7.3.0:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
-  dependencies:
-    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -24202,7 +24411,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
@@ -25190,7 +25399,7 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.0.1, strip-json-comments@~3.1.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -27030,6 +27239,11 @@ uuid@^8.0.0, uuid@^8.1.0, uuid@^8.3.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v8-compile-cache@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
@@ -28095,6 +28309,11 @@ yargs-parser@13.1.2, yargs-parser@^13.1.0, yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.0.0.tgz#c65a1daaa977ad63cebdd52159147b789a4e19a9"
+  integrity sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA==
+
 yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
@@ -28170,6 +28389,23 @@ yargs@13.3.2, yargs@^13.2.2, yargs@^13.3.0, yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
+yargs@15.4.1, yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
+
 yargs@^11.0.0:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.1.tgz#5052efe3446a4df5ed669c995886cc0f13702766"
@@ -28204,23 +28440,6 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
-
-yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
-  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.2"
 
 yargs@^16.0.3, yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #16889 
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- adds nx devtools integration
- integrates nx with existing create-package plop generator (for nx.json and workspace.json)

---

### About NX demo

## CI

1. dev changes implementation of react-image (contrived example - adding console.log)
2. now his CI pipeline would run only at affected tree, which will drastically speed up CI
- Run tests only on affected tree: `nx affected --base=origin/master --target=test`
- Run build only on affected tree: `nx affected --base=origin/master --target=build`
- Run lint only on affected tree: `nx affected --base=origin/master --target=lint`
![image](https://user-images.githubusercontent.com/1223799/113132439-bcd9da00-921e-11eb-85bf-a3b4257a3008.png)

**Actionables:** 
- get rid of react-examples - instead use proper hierarchical storybook config ()
- this will again, drastically speed up pipeline 

## DX (migration phase)

- all existing commands work as expected from root of monorepo

```sh
nx run @fluentui/react-image:start
nx run @fluentui/react-image:test

# etc....
```

- this is ok as 1st step, although to get proper DX we need to gradually migrate to leverage nx executors

> Why:  
> - when I run `nx run @fluentui/react-image:test --help` , I'll get nothing
> - ![image](https://user-images.githubusercontent.com/1223799/113133237-b39d3d00-921f-11eb-9109-d792bbedd5f4.png)
>
> Where we wanna go:
> -
![image](https://user-images.githubusercontent.com/1223799/113133327-d16aa200-921f-11eb-9c8a-8b1b0eaf8e34.png)


## DX (caching)

- local cache by default, running repeated commands (like `nx run @fui/react-mage:test`) will finish instantly if there were no code changes in particular project