### PR TITLE
fix(DatePicker): input doesn't change with selectedDate

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add success to AlertDismissAction propTypes @jurokapsiar ([#17542](https://github.com/microsoft/fluentui/pull/17542))
 - Add `overflowSentinel` slot to fix `Toolbar` overflow when parent container does not have fixed width @ling1726 ([#17451](https://github.com/microsoft/fluentui/pull/17451))
 - For `Tree`, fix non-leaf `treeItem` so `onTitleClick` can be invoked from space/enter key @yuanboxue-amber ([#17619](https://github.com/microsoft/fluentui/pull/17619))
+- Fix `Datepicker` so its `Input` value changes on `selectedDate` prop change @yuanboxue-amber ([#17644](https://github.com/microsoft/fluentui/pull/17644))
 
 ### Performance
 - Optimize memory consumption in `useStyles()` @layershifter ([#17521](https://github.com/microsoft/fluentui/pull/17521))

--- a/packages/fluentui/e2e/tests/datepickerWithControlledSelectedDate-example.tsx
+++ b/packages/fluentui/e2e/tests/datepickerWithControlledSelectedDate-example.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Datepicker, Button } from '@fluentui/react-northstar';
+
+const defaultSelectedDate = new Date(2020, 6, 23, 0, 0, 0, 0);
+const getNextDay = (date: Date) => {
+  date.setDate(date.getDate() + 1);
+  return new Date(date.getTime());
+};
+
+const DatepickerExample = () => {
+  const [selectedDate, setSelectedDate] = React.useState(undefined);
+  return (
+    <>
+      <Datepicker
+        today={new Date(2020, 6, 23, 0, 0, 0, 0)}
+        defaultSelectedDate={defaultSelectedDate}
+        selectedDate={selectedDate}
+      />
+      <Button
+        className="select-next-day"
+        content="Select the next day"
+        onClick={() => {
+          setSelectedDate(selectedDate => {
+            if (!selectedDate) {
+              return getNextDay(defaultSelectedDate);
+            }
+            return getNextDay(selectedDate);
+          });
+        }}
+      />
+    </>
+  );
+};
+
+export default DatepickerExample;

--- a/packages/fluentui/e2e/tests/datepickerWithControlledSelectedDate.spec.ts
+++ b/packages/fluentui/e2e/tests/datepickerWithControlledSelectedDate.spec.ts
@@ -1,0 +1,60 @@
+describe('Datepicker with controlled selected date', () => {
+  const selectors: any = {
+    DatepickerClassName: 'ui-datepicker',
+    CalendarClassName: 'ui-datepicker__calendar',
+    CalendarGridRowClassName: 'ui-datepicker__calendargridrow',
+    CellClassName: 'ui-datepicker__calendarcell',
+    CellButtonClassName: 'ui-datepicker__calendarcellbutton',
+  };
+
+  const datepicker = `.${selectors.DatepickerClassName}`;
+  const datepickerButton = `.${selectors.DatepickerClassName}>button`;
+  const datepickerCalendar = `.${selectors.CalendarClassName}`;
+
+  const datepickerInput = `.ui-input__input`;
+  const ButtonControlsSelectedDate = `.ui-button.select-next-day`;
+
+  const datepickerCalendarCell = index => {
+    const row = Math.floor((index - 1) / 7);
+    const col = index - row * 7;
+    return `.${selectors.CalendarGridRowClassName}:nth-child(${row})
+              >.${selectors.CellClassName}:nth-child(${col})
+              >.${selectors.CellButtonClassName}`;
+  };
+
+  const STARTING_DAY = {
+    inputValue: 'July 23, 2020',
+    date: '23',
+    cellNumberInCalendar: 32, // July 23, 2020 is the 32nd cell in calendar
+  };
+  const NEXT_DAY = {
+    inputValue: 'July 24, 2020',
+    date: '24',
+    cellNumberInCalendar: 33,
+  };
+
+  const expectSelectDateIsFocusedOnCalendarOpen = ({ date, cellNumberInCalendar }) => {
+    cy.focusOn(datepickerButton);
+    cy.waitForSelectorAndPressKey(datepickerButton, '{enter}'); // open calendar
+    cy.visible(datepickerCalendar);
+
+    cy.isFocused(datepickerCalendarCell(cellNumberInCalendar));
+    cy.expectTextOf(datepickerCalendarCell(cellNumberInCalendar), date);
+  };
+
+  beforeEach(() => {
+    cy.gotoTestCase(__filename, datepicker);
+  });
+
+  it('Should display default selected date on first render', () => {
+    cy.visible(datepickerInput);
+    cy.get(datepickerInput).should('have.value', STARTING_DAY.inputValue);
+    expectSelectDateIsFocusedOnCalendarOpen(STARTING_DAY);
+  });
+
+  it('should change selected date on clicking the "Select the next day" button', () => {
+    cy.clickOn(ButtonControlsSelectedDate);
+    cy.get(datepickerInput).should('have.value', NEXT_DAY.inputValue);
+    expectSelectDateIsFocusedOnCalendarOpen(NEXT_DAY);
+  });
+});

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -226,7 +226,10 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     value: props.selectedDate,
     initialValue: undefined,
   });
-  const [formattedDate, setFormattedDate] = React.useState<string>(valueFormatter(selectedDate));
+  const [formattedDate, setFormattedDate] = useAutoControlled({
+    defaultValue: valueFormatter(selectedDate),
+    value: valueFormatter(selectedDate),
+  });
 
   const restrictedDatesOptions: IRestrictedDatesOptions = {
     minDate: props.minDate,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -213,7 +213,10 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     'aria-labelledby': ariaLabelledby,
     'aria-invalid': ariaInvalid,
   } = props;
-  const valueFormatter = date => (date ? formatMonthDayYear(date, dateFormatting) : '');
+  const valueFormatter = React.useCallback(date => (date ? formatMonthDayYear(date, dateFormatting) : ''), [
+    dateFormatting,
+    formatMonthDayYear,
+  ]);
 
   const [openState, setOpenState] = useAutoControlled<boolean>({
     defaultValue: props.defaultCalendarOpenState,
@@ -226,10 +229,12 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     value: props.selectedDate,
     initialValue: undefined,
   });
-  const [formattedDate, setFormattedDate] = useAutoControlled({
-    defaultValue: valueFormatter(selectedDate),
-    value: valueFormatter(selectedDate),
-  });
+
+  const [formattedDate, setFormattedDate] = React.useState<string>(valueFormatter(selectedDate));
+
+  React.useEffect(() => {
+    setFormattedDate(valueFormatter(selectedDate));
+  }, [selectedDate, valueFormatter]);
 
   const restrictedDatesOptions: IRestrictedDatesOptions = {
     minDate: props.minDate,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #17505
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The bug: when `Datepicker` has controlled prop `selectedDate` specified, the datepicker `Input`'s value does not change when `selectedDate` change.
The fix: `Input`'s value is `formattedDate`. Add a useEffect to change `formattedDate` when `selectedDate` change
The test: Added cypress e2e for Datepicker with controlled selectedDate.

#### Focus areas to test

(optional)
