### PR TITLE
Support content and secondary content slots in menuitem

### DIFF
--- a/change/@fluentui-react-examples-89c2f6a0-0d1e-4048-809e-909eb98adf05.json
+++ b/change/@fluentui-react-examples-89c2f6a0-0d1e-4048-809e-909eb98adf05.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support content and secondary content slots for menu item",
+  "packageName": "@fluentui/react-examples",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-7be7d614-789e-49d5-9ed0-65577529ac50.json
+++ b/change/@fluentui-react-menu-7be7d614-789e-49d5-9ed0-65577529ac50.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support content and secondary content slots for menu item",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -14,24 +14,24 @@ import {
 import { CutIcon, PasteIcon, EditIcon, AcceptIcon } from '@fluentui/react-icons-mdl2';
 import { boolean } from '@storybook/addon-knobs';
 
-export const MenuExample = (props: Pick<MenuProps, 'onHover' | 'onContext' | 'defaultOpen'>) => (
+export const TextOnly = (props: Pick<MenuProps, 'onHover' | 'onContext' | 'defaultOpen'>) => (
   <Menu onHover={props.onHover} onContext={props.onContext} defaultOpen={props.defaultOpen}>
     <MenuTrigger>
       <button>Toggle menu</button>
     </MenuTrigger>
 
     <MenuList>
-      <MenuItem>Item 1</MenuItem>
-      <MenuItem>Item 1</MenuItem>
-      <MenuItem disabled>Item 1</MenuItem>
-      <MenuItem>Item 1</MenuItem>
+      <MenuItem>New </MenuItem>
+      <MenuItem>New Window</MenuItem>
+      <MenuItem disabled>Open File</MenuItem>
+      <MenuItem>Open Folder</MenuItem>
     </MenuList>
   </Menu>
 );
 
-export const MenuDefaultOpenExample = () => <MenuExample defaultOpen />;
+export const DefaultOpen = () => <TextOnly defaultOpen />;
 
-export const MenuControlledExample = () => {
+export const ControlledPopup = () => {
   const [open, setOpen] = React.useState(false);
   return (
     <Menu open={open}>
@@ -40,10 +40,10 @@ export const MenuControlledExample = () => {
       </MenuTrigger>
 
       <MenuList>
-        <MenuItem>Item 1</MenuItem>
-        <MenuItem>Item 1</MenuItem>
-        <MenuItem disabled>Item 1</MenuItem>
-        <MenuItem>Item 1</MenuItem>
+        <MenuItem>New </MenuItem>
+        <MenuItem>New Window</MenuItem>
+        <MenuItem disabled>Open File</MenuItem>
+        <MenuItem>Open Folder</MenuItem>
       </MenuList>
     </Menu>
   );
@@ -53,50 +53,50 @@ export const MenuTriggerInteractions = () => {
   const context = boolean('context', false);
   const hover = boolean('hover', false);
 
-  return <MenuExample onContext={context} onHover={hover} />;
+  return <TextOnly onContext={context} onHover={hover} />;
 };
 
-export const NestedMenus = () => (
+export const NestedSubmenus = () => (
   <Menu>
     <MenuTrigger>
       <button>Toggle menu</button>
     </MenuTrigger>
 
     <MenuList>
-      <MenuItem>Item 1</MenuItem>
-      <MenuItem>Item 1</MenuItem>
-      <MenuItem disabled>Item 1</MenuItem>
-      <MenuItem>Item 1</MenuItem>
+      <MenuItem>New </MenuItem>
+      <MenuItem>New Window</MenuItem>
+      <MenuItem disabled>Open File</MenuItem>
+      <MenuItem>Open Folder</MenuItem>
       <Menu>
         <MenuTrigger>
-          <MenuItem>Open 1</MenuItem>
+          <MenuItem>Preferences</MenuItem>
         </MenuTrigger>
 
         <MenuList>
-          <MenuItem>Item 1</MenuItem>
-          <MenuItem>Item 1</MenuItem>
-          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Settings</MenuItem>
+          <MenuItem>Online Services Settings</MenuItem>
+          <MenuItem>Extensions</MenuItem>
           <Menu>
             <MenuTrigger>
-              <MenuItem>Open 2</MenuItem>
+              <MenuItem>Appearance</MenuItem>
             </MenuTrigger>
 
             <MenuList>
-              <MenuItem>Item 1</MenuItem>
-              <MenuItem>Item 1</MenuItem>
-              <MenuItem disabled>Item 1</MenuItem>
-              <MenuItem>Item 1</MenuItem>
+              <MenuItem>Centered Layout</MenuItem>
+              <MenuItem>Zen</MenuItem>
+              <MenuItem disabled>Zoom In</MenuItem>
+              <MenuItem>Zoom Out</MenuItem>
             </MenuList>
           </Menu>
           <Menu>
             <MenuTrigger>
-              <MenuItem>Open 3</MenuItem>
+              <MenuItem>Editor Layout</MenuItem>
             </MenuTrigger>
 
             <MenuList>
-              <MenuItem>Item 1</MenuItem>
-              <MenuItem>Item 1</MenuItem>
-              <MenuItem>Item 1</MenuItem>
+              <MenuItem>Split Up</MenuItem>
+              <MenuItem>Split Down</MenuItem>
+              <MenuItem>Single</MenuItem>
             </MenuList>
           </Menu>
         </MenuList>
@@ -105,7 +105,7 @@ export const NestedMenus = () => (
   </Menu>
 );
 
-export const MenuSelectionExample = () => (
+export const SelectionGroup = () => (
   <Menu>
     <MenuTrigger>
       <button>Toggle menu</button>
@@ -114,29 +114,65 @@ export const MenuSelectionExample = () => (
     <MenuList>
       <MenuGroup>
         <MenuGroupHeader>Checkbox group</MenuGroupHeader>
-        <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut" checkmark={<AcceptIcon />}>
-          Cut
+        <MenuItemCheckbox
+          secondaryContent="Ctrl+N"
+          icon={<CutIcon />}
+          name="edit"
+          value="cut"
+          checkmark={<AcceptIcon />}
+        >
+          Show Menu Bar
         </MenuItemCheckbox>
-        <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste" checkmark={<AcceptIcon />}>
-          Paste
+        <MenuItemCheckbox
+          secondaryContent="Ctrl+Shift+N"
+          icon={<PasteIcon />}
+          name="edit"
+          value="paste"
+          checkmark={<AcceptIcon />}
+        >
+          Show Side Bar
         </MenuItemCheckbox>
-        <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit" checkmark={<AcceptIcon />}>
-          Edit
+        <MenuItemCheckbox
+          secondaryContent="Ctrl+Shift+O"
+          icon={<EditIcon />}
+          name="edit"
+          value="edit"
+          checkmark={<AcceptIcon />}
+        >
+          Show Status Bar
         </MenuItemCheckbox>
         <MenuItemCheckbox disabled icon={<EditIcon />} name="disabled" value="disabled" checkmark={<AcceptIcon />}>
-          Disabled
+          Show Debug Panel
         </MenuItemCheckbox>
       </MenuGroup>
       <MenuDivider />
       <MenuGroup>
         <MenuGroupHeader>Radio group</MenuGroupHeader>
-        <MenuItemRadio icon={<CutIcon />} name="font" value="segoe" checkmark={<AcceptIcon />}>
+        <MenuItemRadio
+          secondaryContent="Ctrl+N"
+          icon={<CutIcon />}
+          name="font"
+          value="segoe"
+          checkmark={<AcceptIcon />}
+        >
           Segoe
         </MenuItemRadio>
-        <MenuItemRadio icon={<PasteIcon />} name="font" value="calibri" checkmark={<AcceptIcon />}>
+        <MenuItemRadio
+          secondaryContent="Ctrl+Shift+N"
+          icon={<PasteIcon />}
+          name="font"
+          value="calibri"
+          checkmark={<AcceptIcon />}
+        >
           Caliri
         </MenuItemRadio>
-        <MenuItemRadio icon={<EditIcon />} name="font" value="arial" checkmark={<AcceptIcon />}>
+        <MenuItemRadio
+          secondaryContent="Ctrl+Shift+N"
+          icon={<EditIcon />}
+          name="font"
+          value="arial"
+          checkmark={<AcceptIcon />}
+        >
           Arial
         </MenuItemRadio>
       </MenuGroup>

--- a/packages/react-examples/src/react-menu/MenuList/MenuList.stories.tsx
+++ b/packages/react-examples/src/react-menu/MenuList/MenuList.stories.tsx
@@ -20,7 +20,8 @@ const useStyles = makeStyles({
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
     minWidth: '128px',
     minHeight: '48px',
-    maxWidth: '128px',
+    maxWidth: '300px',
+    width: 'max-content',
     boxShadow: `${theme.alias.shadow.shadow16}`,
     paddingTop: '4px',
     paddingBottom: '4px',
@@ -32,7 +33,7 @@ const Container: React.FC = props => {
   return <div className={styles.container}>{props.children}</div>;
 };
 
-export const MenuListExample = () => (
+export const TextOnly = () => (
   <Container>
     <MenuList>
       <MenuItem>Cut</MenuItem>
@@ -42,7 +43,17 @@ export const MenuListExample = () => (
   </Container>
 );
 
-export const MenuListWithIconsExample = () => (
+export const ShortcutText = () => (
+  <Container>
+    <MenuList>
+      <MenuItem secondaryContent="Ctrl+N">New File</MenuItem>
+      <MenuItem secondaryContent="Ctrl+Shift+N">New Window</MenuItem>
+      <MenuItem secondaryContent="Ctrl+O">Open File</MenuItem>
+    </MenuList>
+  </Container>
+);
+
+export const WithIconsExample = () => (
   <Container>
     <MenuList>
       <MenuItem icon={<CutIcon />}>Cut</MenuItem>
@@ -52,7 +63,7 @@ export const MenuListWithIconsExample = () => (
   </Container>
 );
 
-export const MenuListWithGroups = () => (
+export const WithGroups = () => (
   <Container>
     <MenuList>
       <MenuGroup>
@@ -72,7 +83,7 @@ export const MenuListWithGroups = () => (
   </Container>
 );
 
-export const MenuListWithDivider = () => (
+export const WithDivider = () => (
   <Container>
     <MenuList>
       <MenuItem icon={<CutIcon />}>Cut</MenuItem>
@@ -86,7 +97,7 @@ export const MenuListWithDivider = () => (
   </Container>
 );
 
-export const MenuListWithCheckboxes = (props: { defaultCheckedValues?: MenuListProps['defaultCheckedValues'] }) => {
+export const CheckboxItems = (props: { defaultCheckedValues?: MenuListProps['defaultCheckedValues'] }) => {
   const checkmark = <AcceptIcon />;
 
   return (
@@ -106,7 +117,7 @@ export const MenuListWithCheckboxes = (props: { defaultCheckedValues?: MenuListP
   );
 };
 
-export const MenuListWithRadios = () => {
+export const RadioItems = () => {
   const checkmark = <AcceptIcon />;
 
   return (
@@ -126,9 +137,9 @@ export const MenuListWithRadios = () => {
   );
 };
 
-export const DefaultCheckedValues = () => <MenuListWithCheckboxes defaultCheckedValues={{ edit: ['cut'] }} />;
+export const DefaultCheckedValues = () => <CheckboxItems defaultCheckedValues={{ edit: ['cut'] }} />;
 
-export const MenuListWithSelectionGroups = () => {
+export const SelectionGroups = () => {
   const checkmark = <AcceptIcon />;
 
   return (
@@ -220,7 +231,7 @@ export const MemoCheckboxItems = () => {
   );
 };
 
-export const MenuListWithCheckboxesControlled = () => {
+export const CheckboxItemsControlled = () => {
   const checkmark = <AcceptIcon />;
   const [checkedValues, setCheckedValues] = React.useState<Record<string, string[]>>({});
   const onChange = (e: React.SyntheticEvent, name: string, items: string[]) => {
@@ -246,7 +257,7 @@ export const MenuListWithCheckboxesControlled = () => {
   );
 };
 
-export const MenuListWithRadiosControlled = () => {
+export const RadioItemsControlled = () => {
   const checkmark = <AcceptIcon />;
   const [checkedValues, setCheckedValues] = React.useState<Record<string, string[]>>({ checkbox: ['2'] });
   const onChange = (e: React.SyntheticEvent, name: string, items: string[]) => {

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -65,7 +65,7 @@ export interface MenuItemCheckboxProps extends ComponentProps, React.HTMLAttribu
 }
 
 // @public
-export const menuItemCheckboxShorthandProps: readonly ("icon" | "submenuIndicator" | "checkmark")[];
+export const menuItemCheckboxShorthandProps: readonly ("content" | "icon" | "submenuIndicator" | "secondaryContent" | "checkmark")[];
 
 // @public (undocumented)
 export interface MenuItemCheckboxState extends MenuItemState, MenuItemSelectableState {
@@ -76,9 +76,11 @@ export interface MenuItemCheckboxState extends MenuItemState, MenuItemSelectable
 
 // @public (undocumented)
 export interface MenuItemProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+    content?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
     disabled?: boolean;
     hasSubmenu?: boolean;
     icon?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+    secondaryContent?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
     submenuIndicator?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }
 
@@ -92,7 +94,7 @@ export interface MenuItemRadioProps extends ComponentProps, React.HTMLAttributes
 }
 
 // @public
-export const menuItemRadioShorthandProps: readonly ("icon" | "submenuIndicator" | "checkmark")[];
+export const menuItemRadioShorthandProps: readonly ("content" | "icon" | "submenuIndicator" | "secondaryContent" | "checkmark")[];
 
 // @public (undocumented)
 export interface MenuItemRadioState extends MenuItemState, MenuItemSelectableState {
@@ -116,12 +118,14 @@ export interface MenuItemSelectableState extends MenuItemSelectableProps {
 }
 
 // @public
-export const menuItemShorthandProps: readonly ["icon", "submenuIndicator"];
+export const menuItemShorthandProps: readonly ["icon", "submenuIndicator", "content", "secondaryContent"];
 
 // @public (undocumented)
 export interface MenuItemState extends MenuItemProps {
+    content: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
     icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLSpanElement>>;
     ref: React.MutableRefObject<HTMLElement>;
+    secondaryContent: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
     submenuIndicator?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }
 

--- a/packages/react-menu/src/components/Menu/useMenuStyles.ts
+++ b/packages/react-menu/src/components/Menu/useMenuStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles({
     minWidth: '128px',
     minHeight: '48px',
     maxWidth: '300px',
-    width: 'fit-content',
+    width: 'max-content',
     boxShadow: `${theme.alias.shadow.shadow16}`,
     paddingTop: '4px',
     paddingBottom: '4px',

--- a/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
@@ -13,7 +13,8 @@ export interface MenuItemProps extends ComponentProps, React.HTMLAttributes<HTML
   submenuIndicator?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 
   /**
-   * Slot for the component children, avoid in favour of children and classnames for customization
+   * Component children are placed in this slot
+   * Avoid using the `children` property in this slot in favour of Component children whenever possible
    */
   content?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 

--- a/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.types.ts
@@ -13,6 +13,16 @@ export interface MenuItemProps extends ComponentProps, React.HTMLAttributes<HTML
   submenuIndicator?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 
   /**
+   * Slot for the component children, avoid in favour of children and classnames for customization
+   */
+  content?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
+   * Secondary content rendered opposite the primary content (e.g Shortcut text)
+   */
+  secondaryContent?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
    * If the menu item is a trigger for a submenu
    */
   hasSubmenu?: boolean;
@@ -28,6 +38,7 @@ export interface MenuItemState extends MenuItemProps {
    * Ref to the root slot
    */
   ref: React.MutableRefObject<HTMLElement>;
+
   /**
    * Icon slot when processed by internal state
    */
@@ -37,4 +48,14 @@ export interface MenuItemState extends MenuItemProps {
    * Icon slot that shows the indicator for a submenu
    */
   submenuIndicator?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
+   * Slot for the component children, avoid in favour of children and classnames for customization
+   */
+  content: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
+  /**
+   * Secondary content rendered opposite the primary content (e.g Shortcut text)
+   */
+  secondaryContent: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }

--- a/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -9,6 +9,10 @@ exports[`MenuItem renders a default state 1`] = `
   role="menuitem"
   tabIndex={0}
 >
-  Default MenuItem
+  <span
+    className=""
+  >
+    Default MenuItem
+  </span>
 </div>
 `;

--- a/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
@@ -12,7 +12,8 @@ export const renderMenuItem = (state: MenuItemState) => {
   return (
     <slots.root {...slotProps.root}>
       <slots.icon {...slotProps.icon} />
-      {state.children}
+      <slots.content {...slotProps.content} />
+      <slots.secondaryContent {...slotProps.secondaryContent} />
       {state.hasSubmenu && <slots.submenuIndicator {...slotProps.submenuIndicator} />}
     </slots.root>
   );

--- a/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -15,7 +15,7 @@ import { ChevronRightIcon } from '../../utils/DefaultIcons';
  * Consts listing which props are shorthand props.
  */
 // TODO introduce content slot for styling
-export const menuItemShorthandProps = ['icon', 'submenuIndicator'] as const;
+export const menuItemShorthandProps = ['icon', 'submenuIndicator', 'content', 'secondaryContent'] as const;
 
 // eslint-disable-next-line deprecation/deprecation
 const mergeProps = makeMergePropsCompat<MenuItemState>({ deepMerge: menuItemShorthandProps });
@@ -35,6 +35,8 @@ export const useMenuItem = (
       ref: useMergedRefs(ref, React.useRef(null)),
       icon: { as: 'span' },
       submenuIndicator: { as: 'span', children: <ChevronRightIcon /> },
+      content: { as: 'span', children: props.children },
+      secondaryContent: { as: 'span' },
       role: 'menuitem',
       tabIndex: 0,
       hasSubmenu,

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -5,7 +5,6 @@ const useStyles = makeStyles({
   root: theme => ({
     color: theme.alias.color.neutral.neutralForeground1,
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
-    // TODO when introducing secondary text right padding might need to change
     paddingRight: '8px',
     paddingLeft: '12px',
     height: '32px',
@@ -24,6 +23,22 @@ const useStyles = makeStyles({
       color: theme.alias.color.neutral.neutralForeground2Hover,
     },
   }),
+  content: {
+    marginRight: '8px',
+    backgroundColor: 'transparent',
+    flexGrow: 1,
+  },
+  secondaryContent: theme => ({
+    color: theme.alias.color.neutral.neutralForeground3,
+    ':hover': {
+      color: theme.alias.color.neutral.neutralForeground3Hover,
+    },
+
+    ':focus': {
+      backgroundColor: theme.alias.color.neutral.neutralBackground1Hover,
+      color: theme.alias.color.neutral.neutralForeground3Hover,
+    },
+  }),
   icon: {
     width: '20px',
     height: '20px',
@@ -32,7 +47,6 @@ const useStyles = makeStyles({
   submenuIndicator: {
     width: '20px',
     height: '20px',
-    marginLeft: 'auto',
   },
   disabled: theme => ({
     backgroundColor: theme.alias.color.neutral.neutralBackgroundDisabled,
@@ -53,6 +67,10 @@ const useStyles = makeStyles({
 export const useMenuItemStyles = (state: MenuItemState) => {
   const styles = useStyles();
   state.className = ax(styles.root, state.disabled && styles.disabled, state.className);
+  state.content.className = ax(styles.content, state.content.className);
+  if (state.secondaryContent) {
+    state.secondaryContent.className = ax(!state.disabled && styles.secondaryContent, state.secondaryContent.className);
+  }
 
   if (state.icon) {
     state.icon.className = ax(styles.icon, state.icon.className);

--- a/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -11,6 +11,10 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
   role="menuitemcheckbox"
   tabIndex={0}
 >
-  Default MenuItemCheckbox
+  <span
+    className=""
+  >
+    Default MenuItemCheckbox
+  </span>
 </div>
 `;

--- a/packages/react-menu/src/components/MenuItemCheckbox/renderMenuItemCheckbox.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/renderMenuItemCheckbox.tsx
@@ -11,7 +11,8 @@ export const renderMenuItemCheckbox = (state: MenuItemCheckboxState) => {
     <slots.root {...slotProps.root}>
       <slots.checkmark {...slotProps.checkmark} />
       <slots.icon {...slotProps.icon} />
-      {state.children}
+      <slots.content {...slotProps.content} />
+      <slots.secondaryContent {...slotProps.secondaryContent} />
     </slots.root>
   );
 };

--- a/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -11,6 +11,10 @@ exports[`MenuItemRadio renders a default state 1`] = `
   role="menuitemradio"
   tabIndex={0}
 >
-  Default MenuItemRadio
+  <span
+    className=""
+  >
+    Default MenuItemRadio
+  </span>
 </div>
 `;

--- a/packages/react-menu/src/components/MenuItemRadio/renderMenuItemRadio.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/renderMenuItemRadio.tsx
@@ -14,7 +14,8 @@ export const renderMenuItemRadio = (state: MenuItemRadioState) => {
     <slots.root {...slotProps.root}>
       <slots.checkmark {...slotProps.checkmark} />
       <slots.icon {...slotProps.icon} />
-      {state.children}
+      <slots.content {...slotProps.content} />
+      <slots.secondaryContent {...slotProps.secondaryContent} />
     </slots.root>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Supports shortcut text for menu items as `secondaryContent`, in order to make layouting easier, it was necessary to create a `content`  slot for component children.

**TODO** check with designers if there should be a minimum space between content and shortcut text

![image](https://user-images.githubusercontent.com/20744592/113170504-8613bc00-923e-11eb-9311-cb3e55fff950.png)


#### Focus areas to test

(optional)
