### PR TITLE
Use full library path in shared website config utility

### DIFF
--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = function(env, argv) {
   return [
     // Copy index.html and generate bootstrap script
     getLoadSiteConfig({
-      libraryName: '@fluentui/react',
+      libraryPath: path.dirname(require.resolve('@fluentui/react/package.json')),
       outDir: path.join(__dirname, 'dist'),
       isProduction: isProductionArg,
       CopyWebpackPlugin,

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -17,7 +17,7 @@ const outDir = 'dist';
 module.exports = [
   // Copy index.html and generate bootstrap script
   getLoadSiteConfig({
-    libraryName: '@fluentui/react',
+    libraryPath: path.dirname(require.resolve('@fluentui/react/package.json')),
     outDir: path.join(__dirname, outDir),
     isProduction: false,
     CopyWebpackPlugin,

--- a/change/@fluentui-public-docsite-02a9a6f7-773e-44c4-8674-d6a2df56366d.json
+++ b/change/@fluentui-public-docsite-02a9a6f7-773e-44c4-8674-d6a2df56366d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass full library path to config utility",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-setup-b7a0e92f-c3c2-441f-b115-4b3961bb18ce.json
+++ b/change/@fluentui-public-docsite-setup-b7a0e92f-c3c2-441f-b115-4b3961bb18ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Pass in library path instead of name to config utility",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/public-docsite-setup/README.md
+++ b/packages/public-docsite-setup/README.md
@@ -15,7 +15,7 @@ The most important file in this package is `src/loadSite.ts`, which handles vari
 
    module.exports = [
      getLoadSiteConfig({
-       libraryName: '@fluentui/react', // or 'office-ui-fabric-react' if appropriate
+       libraryPath: 'path/to/@fluentui/react', // or 'office-ui-fabric-react' if appropriate
        outDir: path.join(__dirname, 'dist'), // full path to output directory
        isProduction: isProductionArg, // whether to do a minified build (filename is the same regardless)
      }),

--- a/packages/public-docsite-setup/scripts/getLoadSiteConfig.js
+++ b/packages/public-docsite-setup/scripts/getLoadSiteConfig.js
@@ -1,4 +1,5 @@
 // @ts-check
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 
@@ -9,16 +10,16 @@ const webpack = require('webpack');
  * Should work with webpack 4+. Requires `copy-webpack-plugin` 4+ to be installed.
  *
  * @param {object} options
- * @param {string} options.libraryName Name of the main library: `@fluentui/react` or `office-ui-fabric-react`
+ * @param {string} options.libraryPath Path to the main library: `@fluentui/react` or `office-ui-fabric-react`
  * @param {string} options.outDir Absolute path to the output directory
  * @param {boolean} options.isProduction Whether to do a production build (same filename is used regardless)
  * @param {*} options.CopyWebpackPlugin Constructor for `copy-webpack-plugin` 4+
  * @returns {webpack.Configuration}
  */
 function getLoadSiteConfig(options) {
-  const { libraryName, outDir, isProduction, CopyWebpackPlugin } = options;
+  const { libraryPath, outDir, isProduction, CopyWebpackPlugin } = options;
   const setupPackagePath = path.dirname(require.resolve('@fluentui/public-docsite-setup/package.json'));
-  const libraryVersion = require(`${libraryName}/package.json`).version;
+  const libraryVersion = JSON.parse(fs.readFileSync(`${libraryPath}/package.json`, 'utf-8')).version;
 
   /** @type {ConstructorParameters<import('copy-webpack-plugin')>[0]['patterns']} */
   const copyPatterns = [{ from: path.join(setupPackagePath, 'index.html'), to: outDir }];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #14691
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Follow-up to #17568: in the shared website setup utility, apparently using `require.resolve` to get the path to `office-ui-fabric-react` doesn't work in v6. Change the utility to take the full library path instead.