### PR TITLE
BREAKING CHANGE(MenuItem): use chevron as submenu indicator bg image

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Change background image of `MenuItem` submenu indicator to chevrons @yuanboxue-amber ([#17664](https://github.com/microsoft/fluentui/pull/17664))
+
+
 ## Features
 - Add `borderActive4` color slot @notandrew ([#17391](https://github.com/microsoft/fluentui/pull/17391))
 - Add `Pill` base componet @assuncaocharles ([#17500](https://github.com/microsoft/fluentui/pull/17500))
@@ -25,8 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `PillImage` base componet @assuncaocharles ([#17600](https://github.com/microsoft/fluentui/pull/17600))
 - Add `PillIcon` base componet @assuncaocharles ([#17600](https://github.com/microsoft/fluentui/pull/17600))
 - Add `PillGroup` componet @assuncaocharles ([#17601](https://github.com/microsoft/fluentui/pull/17601))
-- Use `ChevronDownIcon` and `ChevronEndIcon` as submenu indicator for `MenuItem` @yuanboxue-amber ([#17664](https://github.com/microsoft/fluentui/pull/17664))
-
 ## Fixes
 - Add success to AlertDismissAction propTypes @jurokapsiar ([#17542](https://github.com/microsoft/fluentui/pull/17542))
 - Add `overflowSentinel` slot to fix `Toolbar` overflow when parent container does not have fixed width @ling1726 ([#17451](https://github.com/microsoft/fluentui/pull/17451))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `PillImage` base componet @assuncaocharles ([#17600](https://github.com/microsoft/fluentui/pull/17600))
 - Add `PillIcon` base componet @assuncaocharles ([#17600](https://github.com/microsoft/fluentui/pull/17600))
 - Add `PillGroup` componet @assuncaocharles ([#17601](https://github.com/microsoft/fluentui/pull/17601))
+- Use `ChevronDownIcon` and `ChevronEndIcon` as submenu indicator for `MenuItem` @yuanboxue-amber ([#17664](https://github.com/microsoft/fluentui/pull/17664))
 
 ## Fixes
 - Add success to AlertDismissAction propTypes @jurokapsiar ([#17542](https://github.com/microsoft/fluentui/pull/17542))

--- a/packages/fluentui/docs/src/examples/components/Menu/Rtl/MenuExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Rtl/MenuExample.rtl.tsx
@@ -1,12 +1,28 @@
 import * as React from 'react';
-import { Menu } from '@fluentui/react-northstar';
+import { Menu, Provider } from '@fluentui/react-northstar';
 
 const items = [
-  { key: 'editorials', content: 'افتتاحيات' },
+  {
+    key: 'editorials',
+    content: 'افتتاحيات',
+    menu: {
+      items: [
+        {
+          key: 'events1',
+          content: 'الأحداث القادمة',
+        },
+      ],
+    },
+  },
   { key: 'review', content: 'التعليقات' },
   { key: 'events', content: 'الأحداث القادمة' },
 ];
 
-const MenuExample = () => <Menu defaultActiveIndex={0} items={items} />;
+const MenuExample = () => (
+  <Provider rtl>
+    <Menu defaultActiveIndex={0} items={items} />
+    <Menu defaultActiveIndex={0} vertical items={items} />
+  </Provider>
+);
 
 export default MenuExample;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -41,7 +41,6 @@ import { ComponentEventHandler, ShorthandValue, ShorthandCollection } from '../.
 import { Popper, PopperShorthandProps, partitionPopperPropsFromShorthand } from '../../utils/positioner';
 
 import { MenuContext, MenuItemSubscribedValue } from './menuContext';
-import { ChevronEndIcon, ChevronDownIcon } from '@fluentui/react-icons-northstar';
 
 export interface MenuItemSlotClassNames {
   submenu: string;
@@ -215,6 +214,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       secondary,
       active,
       vertical,
+      indicator,
       disabled,
       underlined,
       iconOnly,
@@ -227,12 +227,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       variables,
       on,
     } = props;
-
-    let indicator = props.indicator;
-    if (indicator === undefined) {
-      indicator = vertical ? <ChevronEndIcon /> : <ChevronDownIcon />;
-    }
-
     const [menu, positioningProps] = partitionPopperPropsFromShorthand(props.menu);
 
     const [menuOpen, setMenuOpen] = useAutoControlled({
@@ -689,4 +683,5 @@ MenuItem.propTypes = {
 MenuItem.defaultProps = {
   as: 'a',
   wrapper: {},
+  indicator: {},
 };

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -41,6 +41,7 @@ import { ComponentEventHandler, ShorthandValue, ShorthandCollection } from '../.
 import { Popper, PopperShorthandProps, partitionPopperPropsFromShorthand } from '../../utils/positioner';
 
 import { MenuContext, MenuItemSubscribedValue } from './menuContext';
+import { ChevronEndIcon, ChevronDownIcon } from '@fluentui/react-icons-northstar';
 
 export interface MenuItemSlotClassNames {
   submenu: string;
@@ -214,7 +215,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       secondary,
       active,
       vertical,
-      indicator,
       disabled,
       underlined,
       iconOnly,
@@ -227,6 +227,12 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       variables,
       on,
     } = props;
+
+    let indicator = props.indicator;
+    if (indicator === undefined) {
+      indicator = vertical ? <ChevronEndIcon /> : <ChevronDownIcon />;
+    }
+
     const [menu, positioningProps] = partitionPopperPropsFromShorthand(props.menu);
 
     const [menuOpen, setMenuOpen] = useAutoControlled({
@@ -683,5 +689,4 @@ MenuItem.propTypes = {
 MenuItem.defaultProps = {
   as: 'a',
   wrapper: {},
-  indicator: {},
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
@@ -2,9 +2,10 @@ import { pxToRem } from '../../../../utils';
 import { MenuVariables } from './menuVariables';
 import { MenuItemIndicatorStylesProps } from '../../../../components/Menu/MenuItemIndicator';
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
+import { submenuIndicatorUrl, submenuIndicatorDirection } from './submenuIndicatorUrl';
 
 export const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStylesProps, MenuVariables> = {
-  root: ({ props: p, variables: v }) => {
+  root: ({ props: p, variables: v, rtl }) => {
     return {
       position: 'relative',
       float: 'right',
@@ -24,23 +25,26 @@ export const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndica
       overflow: 'hidden',
       height: pxToRem(16),
       width: pxToRem(16),
+      backgroundSize: pxToRem(16),
 
-      color: v.indicatorColor,
+      backgroundImage: submenuIndicatorUrl(v.indicatorColor),
 
       ...(p.active && {
-        color: v.activeIndicatorColor,
+        backgroundImage: submenuIndicatorUrl(v.activeIndicatorColor),
 
         ...(p.primary && {
-          color: v.activePrimaryIndicatorColor,
+          backgroundImage: submenuIndicatorUrl(v.activePrimaryIndicatorColor),
 
           ...(p.vertical && {
-            color: v.activePrimaryVerticalIndicatorColor,
+            backgroundImage: submenuIndicatorUrl(v.activePrimaryVerticalIndicatorColor),
           }),
         }),
       }),
 
-      ...(p.underlined && { color: v.indicatorColor }),
-      ...(p.iconOnly && { color: v.indicatorColor }),
+      ...(p.underlined && { backgroundImage: submenuIndicatorUrl(v.indicatorColor) }),
+      ...(p.iconOnly && { backgroundImage: submenuIndicatorUrl(v.indicatorColor) }),
+
+      ...submenuIndicatorDirection(p.vertical, rtl),
     };
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
@@ -2,10 +2,9 @@ import { pxToRem } from '../../../../utils';
 import { MenuVariables } from './menuVariables';
 import { MenuItemIndicatorStylesProps } from '../../../../components/Menu/MenuItemIndicator';
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { submenuIndicatorUrl } from './submenuIndicatorUrl';
 
 export const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStylesProps, MenuVariables> = {
-  root: ({ props: p, variables: v, rtl }) => {
+  root: ({ props: p, variables: v }) => {
     return {
       position: 'relative',
       float: 'right',
@@ -20,32 +19,28 @@ export const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndica
         left: 'unset',
       }),
 
-      ...(rtl && {
-        transform: `scaleX(-1)`,
-      }),
       content: '" "',
       display: 'block',
       overflow: 'hidden',
       height: pxToRem(16),
       width: pxToRem(16),
-      backgroundSize: pxToRem(16),
 
-      backgroundImage: submenuIndicatorUrl(v.indicatorColor, p.vertical),
+      color: v.indicatorColor,
 
       ...(p.active && {
-        backgroundImage: submenuIndicatorUrl(v.activeIndicatorColor, p.vertical),
+        color: v.activeIndicatorColor,
 
         ...(p.primary && {
-          backgroundImage: submenuIndicatorUrl(v.activePrimaryIndicatorColor, p.vertical),
+          color: v.activePrimaryIndicatorColor,
 
           ...(p.vertical && {
-            backgroundImage: submenuIndicatorUrl(v.activePrimaryVerticalIndicatorColor, p.vertical),
+            color: v.activePrimaryVerticalIndicatorColor,
           }),
         }),
       }),
 
-      ...(p.underlined && { backgroundImage: submenuIndicatorUrl(v.indicatorColor, p.vertical) }),
-      ...(p.iconOnly && { backgroundImage: submenuIndicatorUrl(v.indicatorColor, p.vertical) }),
+      ...(p.underlined && { color: v.indicatorColor }),
+      ...(p.iconOnly && { color: v.indicatorColor }),
     };
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
@@ -5,7 +5,6 @@ import { menuItemClassName } from '../../../../components/Menu/MenuItem';
 import { menuItemIndicatorClassName } from '../../../../components/Menu/MenuItemIndicator';
 import { getColorScheme } from '../../colors';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { submenuIndicatorUrl } from './submenuIndicatorUrl';
 import {
   horizontalPillsRightMargin,
   verticalPillsBottomMargin,
@@ -159,10 +158,10 @@ export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperS
         }),
 
         [`&>.${menuItemClassName}>.${menuItemIndicatorClassName}`]: {
-          backgroundImage: submenuIndicatorUrl(v.indicatorColorHover, vertical),
+          color: v.indicatorColorHover,
 
           ...(primary && {
-            backgroundImage: submenuIndicatorUrl(v.primaryIndicatorColorHover, vertical),
+            color: v.primaryIndicatorColorHover,
           }),
         },
       },

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
@@ -5,6 +5,7 @@ import { menuItemClassName } from '../../../../components/Menu/MenuItem';
 import { menuItemIndicatorClassName } from '../../../../components/Menu/MenuItemIndicator';
 import { getColorScheme } from '../../colors';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { submenuIndicatorUrl, submenuIndicatorDirection } from './submenuIndicatorUrl';
 import {
   horizontalPillsRightMargin,
   verticalPillsBottomMargin,
@@ -13,7 +14,7 @@ import {
 } from './menuItemStyles';
 
 export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperStylesProps, MenuVariables> = {
-  root: ({ props, variables: v }): ICSSInJSStyle => {
+  root: ({ props, variables: v, rtl }): ICSSInJSStyle => {
     const {
       active,
       disabled,
@@ -158,11 +159,13 @@ export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperS
         }),
 
         [`&>.${menuItemClassName}>.${menuItemIndicatorClassName}`]: {
-          color: v.indicatorColorHover,
+          backgroundImage: submenuIndicatorUrl(v.indicatorColorHover),
 
           ...(primary && {
-            color: v.primaryIndicatorColorHover,
+            backgroundImage: submenuIndicatorUrl(v.primaryIndicatorColorHover),
           }),
+
+          ...submenuIndicatorDirection(vertical, rtl),
         },
       },
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
@@ -1,9 +1,0 @@
-export const submenuIndicatorUrl = (color: string, vertical: boolean) => {
-  return vertical
-    ? `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
-        color,
-      )}' viewBox='8 8 16 16'%3E%3Cpath d='M19 16l-4-3.5v7z' /%3E%3C/svg%3E")`
-    : `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
-        color,
-      )}' viewBox='8 8 16 16'%3E%3Cpath d='M16 19l3.5-4h-7z' /%3E%3C/svg%3E")`;
-};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
@@ -1,0 +1,14 @@
+export const submenuIndicatorUrl = (color: string) => {
+  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
+    color,
+  )}' focusable='false' viewBox='8 8 16 16'%3E%3Cpath d='M19.49,16a.91.91,0,0,1-.29.7l-5,5a1,1,0,0,1-.71.3,1,1,0,0,1-1-1,1,1,0,0,1,.29-.7L17.08,16l-4.3-4.29a1,1,0,0,1-.29-.71,1,1,0,0,1,1.71-.71l5,5A1,1,0,0,1,19.49,16Z' /%3E%3C/svg%3E")`;
+};
+
+export const submenuIndicatorDirection = (vertical: boolean, rtl: boolean) =>
+  vertical
+    ? rtl
+      ? {
+          transform: `scaleX(-1)`,
+        }
+      : {}
+    : { transform: `rotate(${rtl ? -90 : 90}deg)` };


### PR DESCRIPTION
 ### Description of changes

MenuItem uses a triangle background image for submenu indicator.
This PR changes this triangle to chevron, to be aligned with toolbarMenuItem's indicator.
>NOTE: it is still a background image!!!

RTL example in docsite is updated with submenu to reflect indicator change.

### Visual difference:

- before:
![image](https://user-images.githubusercontent.com/28751745/113283841-19a1c700-92e9-11eb-8db4-0f9adaf7e1ac.png)

- after:
![image](https://user-images.githubusercontent.com/28751745/113309049-0e5d9400-9307-11eb-80e2-edc614551887.png)

### Initiative behind this PR
TMP is trying to use _chevron_ for indicator. And it was difficult for them to get rid of the existing _triangle_ indicator in MenuItem.

My original plan was to switch to icon instead of background image, because I thought background image cannot be overriden. But it was my misunderstanding, it actually can be. 
In such case, the only advantage of changing background image to icon, would be easier styling of colors. But since TMP should be using fluent theme instead of custom color, this advantage is not so important.

Still, the overriding of background image is not intuitive, and TMP is not using triangle. So after a discussion with the team, we decide to change triangle to chevron so TMP does not need to override it. And also it is aligned with the indicator of ToolbarMenuItem.

