### PR TITLE
fix(makeStyles): support ordering for pseudo selectors

### DIFF
--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -206,11 +206,8 @@ storiesOf('MakeStyles', module)
 
 // Pseudo selectors stories
 
-storiesOf('MakeStyles:pseudo', module).add('insertion is ordered', () => {
-  const classesA = useFocusStylesA();
-  const classesB = useFocusStylesB();
-
-  return (
+storiesOf('MakeStyles:pseudo', module)
+  .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
         .wait('.testWrapper')
@@ -224,17 +221,24 @@ storiesOf('MakeStyles:pseudo', module).add('insertion is ordered', () => {
         .end()}
     >
       <div className="testWrapper" style={{ width: '300px' }}>
-        <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
-          <p>When element is focused - border color & text color should match</p>
-
-          <div className={classesA.root} id="boxA" tabIndex={0}>
-            A focusable element
-          </div>
-          <div className={classesB.root} id="boxB" tabIndex={0}>
-            A focusable element
-          </div>
-        </div>
+        {story()}
       </div>
     </Screener>
-  );
-});
+  ))
+  .addStory('insertion is ordered', () => {
+    const classesA = useFocusStylesA();
+    const classesB = useFocusStylesB();
+
+    return (
+      <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
+        <p>When element is focused - border color & text color should match</p>
+
+        <div className={classesA.root} id="boxA" tabIndex={0}>
+          A focusable element
+        </div>
+        <div className={classesB.root} id="boxB" tabIndex={0}>
+          A focusable element
+        </div>
+      </div>
+    );
+  });

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -73,7 +73,7 @@ const BoxWithPseudo: React.FC = () => {
 
   return (
     <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
-      <p>When element is focused - border color & text color should match</p>
+      <p>When element is focused & hovered - border color & text color should match</p>
 
       <div className={classesA.root} id="boxA" tabIndex={0}>
         A focusable element
@@ -227,13 +227,14 @@ storiesOf('MakeStyles (pseudo)', module)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
+        .snapshot('normal', { cropTo: '.testWrapper' })
         .focus('#boxA')
-        .snapshot('boxA: :focus', { cropTo: '.testWrapper' })
+        .snapshot('boxA, focus', { cropTo: '.testWrapper' })
         .hover('#boxA')
-        .snapshot('boxA: :focus+:hover', { cropTo: '.testWrapper' })
+        .snapshot('boxA, focus+hover', { cropTo: '.testWrapper' })
         .focus('#boxB')
         .hover('#boxB')
-        .snapshot('boxB: :focus+:hover', { cropTo: '.testWrapper' })
+        .snapshot('boxB, focus+hover', { cropTo: '.testWrapper' })
         .end()}
     >
       <div className="testWrapper" style={{ width: '300px' }}>

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -147,26 +147,6 @@ storiesOf('MakeStyles', module)
     </Screener>
   ))
 
-  // Pseudo selectors stories
-
-  .addStory('pseudo: insertion is ordered', () => {
-    const classesA = useFocusStylesA();
-    const classesB = useFocusStylesB();
-
-    return (
-      <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
-        <p>When element is focused - border color & text color should match</p>
-
-        <div className={classesA.root} tabIndex={0}>
-          A focusable element
-        </div>
-        <div className={classesB.root} tabIndex={0}>
-          A focusable element
-        </div>
-      </div>
-    );
-  })
-
   // RTL stories
   // Check for details: packages/react-examples/src/react-make-styles/RTL/RTL.stories.tsx
 
@@ -223,3 +203,38 @@ storiesOf('MakeStyles', module)
       </FluentProvider>
     </FluentProvider>
   ));
+
+// Pseudo selectors stories
+
+storiesOf('MakeStyles:pseudo', module).addStory('pseudo: insertion is ordered', () => {
+  const classesA = useFocusStylesA();
+  const classesB = useFocusStylesB();
+
+  return (
+    <Screener
+      steps={new Screener.Steps()
+        .wait('.testWrapper')
+        .focus('#boxA')
+        .snapshot('boxA: :focus', { cropTo: '.testWrapper' })
+        .hover('#boxA')
+        .snapshot('boxA: :focus+:hover', { cropTo: '.testWrapper' })
+        .focus('#boxB')
+        .hover('#boxB')
+        .snapshot('boxB: :focus+:hover', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      <div className="testWrapper" style={{ width: '300px' }}>
+        <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
+          <p>When element is focused - border color & text color should match</p>
+
+          <div className={classesA.root} id="boxA" tabIndex={0}>
+            A focusable element
+          </div>
+          <div className={classesB.root} id="boxB" tabIndex={0}>
+            A focusable element
+          </div>
+        </div>
+      </div>
+    </Screener>
+  );
+});

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -3,7 +3,7 @@ import { FluentProvider } from '@fluentui/react-provider';
 import { webLightTheme } from '@fluentui/react-theme';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import Screener from 'screener-storybook/src/screener';
+import Screener, { Steps } from 'screener-storybook/src/screener';
 
 const useStyles = makeStyles({
   box: theme => ({
@@ -65,6 +65,24 @@ const Box: React.FC = props => {
   const classes = useStyles();
 
   return <div className={classes.box}>{props.children}</div>;
+};
+
+const BoxWithPseudo: React.FC = () => {
+  const classesA = useFocusStylesA();
+  const classesB = useFocusStylesB();
+
+  return (
+    <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
+      <p>When element is focused - border color & text color should match</p>
+
+      <div className={classesA.root} id="boxA" tabIndex={0}>
+        A focusable element
+      </div>
+      <div className={classesB.root} id="boxB" tabIndex={0}>
+        A focusable element
+      </div>
+    </div>
+  );
 };
 
 const Container: React.FC<{ className?: string; primary?: boolean }> = props => {
@@ -138,18 +156,17 @@ export const Propagation = () => (
   </>
 );
 
+// RTL stories
+// Check for details: packages/react-examples/src/react-make-styles/RTL/RTL.stories.tsx
+
 storiesOf('MakeStyles', module)
   .addDecorator(story => (
-    <Screener steps={new Screener.Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
+    <Screener steps={new Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
       <div className="testWrapper" style={{ width: '300px' }}>
         {story()}
       </div>
     </Screener>
   ))
-
-  // RTL stories
-  // Check for details: packages/react-examples/src/react-make-styles/RTL/RTL.stories.tsx
-
   .addStory('RTL: two components in a single Provider', () => (
     <FluentProvider dir="rtl" theme={webLightTheme}>
       <Box>مرحبا بالعالم!</Box>
@@ -206,10 +223,10 @@ storiesOf('MakeStyles', module)
 
 // Pseudo selectors stories
 
-storiesOf('MakeStyles', module)
+storiesOf('MakeStyles (pseudo)', module)
   .addDecorator(story => (
     <Screener
-      steps={new Screener.Steps()
+      steps={new Steps()
         .focus('#boxA')
         .snapshot('boxA: :focus', { cropTo: '.testWrapper' })
         .hover('#boxA')
@@ -224,20 +241,4 @@ storiesOf('MakeStyles', module)
       </div>
     </Screener>
   ))
-  .addStory('pseudo: insertion is ordered', () => {
-    const classesA = useFocusStylesA();
-    const classesB = useFocusStylesB();
-
-    return (
-      <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
-        <p>When element is focused - border color & text color should match</p>
-
-        <div className={classesA.root} id="boxA" tabIndex={0}>
-          A focusable element
-        </div>
-        <div className={classesB.root} id="boxB" tabIndex={0}>
-          A focusable element
-        </div>
-      </div>
-    );
-  });
+  .addStory('insertion is ordered', () => <BoxWithPseudo />);

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -157,10 +157,10 @@ storiesOf('MakeStyles', module)
       <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
         <p>When element is focused - border color & text color should match</p>
 
-        <div className={classesA.root} tabIndex={1}>
+        <div className={classesA.root} tabIndex={0}>
           A focusable element
         </div>
-        <div className={classesB.root} tabIndex={1}>
+        <div className={classesB.root} tabIndex={0}>
           A focusable element
         </div>
       </div>

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -206,7 +206,7 @@ storiesOf('MakeStyles', module)
 
 // Pseudo selectors stories
 
-storiesOf('MakeStyles:pseudo', module).addStory('pseudo: insertion is ordered', () => {
+storiesOf('MakeStyles:pseudo', module).add('insertion is ordered', () => {
   const classesA = useFocusStylesA();
   const classesB = useFocusStylesB();
 

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -206,11 +206,10 @@ storiesOf('MakeStyles', module)
 
 // Pseudo selectors stories
 
-storiesOf('MakeStyles:pseudo', module)
+storiesOf('MakeStyles', module)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
-        .wait('.testWrapper')
         .focus('#boxA')
         .snapshot('boxA: :focus', { cropTo: '.testWrapper' })
         .hover('#boxA')
@@ -225,7 +224,7 @@ storiesOf('MakeStyles:pseudo', module)
       </div>
     </Screener>
   ))
-  .addStory('insertion is ordered', () => {
+  .addStory('pseudo: insertion is ordered', () => {
     const classesA = useFocusStylesA();
     const classesB = useFocusStylesB();
 

--- a/apps/vr-tests/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests/src/stories/MakeStyles.stories.tsx
@@ -34,6 +34,33 @@ const useStyles = makeStyles({
   },
 });
 
+const useFocusStylesA = makeStyles({
+  root: {
+    border: '3px solid blue',
+    padding: '10px',
+
+    ':focus': {
+      color: 'red',
+    },
+    ':hover': {
+      color: 'blue',
+    },
+  },
+});
+const useFocusStylesB = makeStyles({
+  root: {
+    border: '3px solid orange',
+    padding: '10px',
+
+    ':hover': {
+      color: 'orange',
+    },
+    ':focus': {
+      color: 'green',
+    },
+  },
+});
+
 const Box: React.FC = props => {
   const classes = useStyles();
 
@@ -119,6 +146,26 @@ storiesOf('MakeStyles', module)
       </div>
     </Screener>
   ))
+
+  // Pseudo selectors stories
+
+  .addStory('pseudo: insertion is ordered', () => {
+    const classesA = useFocusStylesA();
+    const classesB = useFocusStylesB();
+
+    return (
+      <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
+        <p>When element is focused - border color & text color should match</p>
+
+        <div className={classesA.root} tabIndex={1}>
+          A focusable element
+        </div>
+        <div className={classesB.root} tabIndex={1}>
+          A focusable element
+        </div>
+      </div>
+    );
+  })
 
   // RTL stories
   // Check for details: packages/react-examples/src/react-make-styles/RTL/RTL.stories.tsx

--- a/change/@fluentui-make-styles-aeb6e58e-b40f-4163-bda3-7cf222fb2325.json
+++ b/change/@fluentui-make-styles-aeb6e58e-b40f-4163-bda3-7cf222fb2325.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(makeStyles): support ordering for pseudo selectors",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/ax.ts
+++ b/packages/make-styles/src/ax.ts
@@ -1,6 +1,6 @@
 import { DEFINITION_LOOKUP_TABLE, HASH_LENGTH, RTL_PREFIX, SEQUENCE_PREFIX } from './constants';
 import { hashString } from './runtime/utils/hashString';
-import { MakeStylesMatchedDefinitions } from './types';
+import { MakeStylesReducedDefinitions } from './types';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
 const axCachedResults: Record<string, string> = {};
@@ -33,7 +33,7 @@ export function ax(dir: 'ltr' | 'rtl', classNames: (string | false | undefined)[
   // Is used as a cache key to avoid object merging
   let sequenceMatch = '';
 
-  const sequenceMappings: MakeStylesMatchedDefinitions[] = [];
+  const sequenceMappings: MakeStylesReducedDefinitions[] = [];
 
   for (let i = 0; i < classNames.length; i++) {
     const className = classNames[i];
@@ -103,7 +103,7 @@ export function ax(dir: 'ltr' | 'rtl', classNames: (string | false | undefined)[
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   // eslint-disable-next-line prefer-spread
-  const resultDefinitions: MakeStylesMatchedDefinitions = Object.assign.apply<MakeStylesMatchedDefinitions[]>(
+  const resultDefinitions: MakeStylesReducedDefinitions = Object.assign.apply<MakeStylesReducedDefinitions[]>(
     Object,
     // .assign() mutates the first object, we can't mutate mappings as it will produce invalid results later
     [{}].concat(sequenceMappings),
@@ -116,11 +116,11 @@ export function ax(dir: 'ltr' | 'rtl', classNames: (string | false | undefined)[
     const resultDefinition = resultDefinitions[property];
 
     if (isRtl) {
-      const rtlPrefix = isRtl && resultDefinition[2] ? RTL_PREFIX : '';
+      const rtlPrefix = isRtl && resultDefinition[3] ? RTL_PREFIX : '';
 
-      atomicClassNames += rtlPrefix + resultDefinition[0] + ' ';
+      atomicClassNames += rtlPrefix + resultDefinition[1] + ' ';
     } else {
-      atomicClassNames += resultDefinition[0] + ' ';
+      atomicClassNames += resultDefinition[1] + ' ';
     }
   }
 

--- a/packages/make-styles/src/constants.ts
+++ b/packages/make-styles/src/constants.ts
@@ -1,4 +1,4 @@
-import { MakeStylesMatchedDefinitions } from './types';
+import { MakeStylesReducedDefinitions } from './types';
 
 export const HASH_PREFIX = 'f';
 export const HASH_LENGTH = 7;
@@ -8,4 +8,4 @@ export const RTL_PREFIX = 'r';
 
 export const SEQUENCE_PREFIX = '__';
 
-export const DEFINITION_LOOKUP_TABLE: Record<string, MakeStylesMatchedDefinitions> = {};
+export const DEFINITION_LOOKUP_TABLE: Record<string, MakeStylesReducedDefinitions> = {};

--- a/packages/make-styles/src/makeStaticStyles.test.ts
+++ b/packages/make-styles/src/makeStaticStyles.test.ts
@@ -1,11 +1,9 @@
-import { getCSSRules } from '@fluentui/test-utilities';
 import { createDOMRenderer, MakeStylesDOMRenderer, resetDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStaticStyles } from './makeStaticStyles';
-import { cssRulesSerializer, makeStylesRulesSerializer } from './utils/test/snapshotSerializer';
+import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
 import { makeStyles } from './makeStyles';
 
-expect.addSnapshotSerializer(cssRulesSerializer);
-expect.addSnapshotSerializer(makeStylesRulesSerializer);
+expect.addSnapshotSerializer(makeStylesRendererSerializer);
 
 describe('makeStaticStyles', () => {
   let renderer: MakeStylesDOMRenderer;
@@ -31,7 +29,7 @@ describe('makeStaticStyles', () => {
 
     useStyles({ renderer });
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       body {
         background: blue;
         -webkit-transition: all 4s ease;
@@ -62,7 +60,7 @@ describe('makeStaticStyles', () => {
 
     useStyles({ renderer });
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       @font-face {
         font-family: Open Sans;
         src: url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
@@ -79,7 +77,7 @@ describe('makeStaticStyles', () => {
 
     useStyles({ renderer });
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       body {
         background: red;
       }
@@ -106,7 +104,7 @@ describe('makeStaticStyles', () => {
     useStyles({ renderer });
     useStyles2({ renderer });
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       body {
         background: blue;
       }
@@ -128,7 +126,7 @@ describe('makeStaticStyles', () => {
     useStaticStyles({ renderer });
     expect(useStyles({ dir: 'ltr', renderer, tokens: {} }).root).toBe('__xgtdzt0 fy9yzz70 f4ybsrx0');
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       @font-face {
         font-family: Open Sans;
         src: url("/fonts/OpenSans-Regular-webfont.woff") format("woff");

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -1,10 +1,8 @@
-import { getCSSRules } from '@fluentui/test-utilities';
-
 import { createDOMRenderer, MakeStylesDOMRenderer, resetDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStyles } from './makeStyles';
-import { cssRulesSerializer } from './utils/test/snapshotSerializer';
+import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
 
-expect.addSnapshotSerializer(cssRulesSerializer);
+expect.addSnapshotSerializer(makeStylesRendererSerializer);
 
 function createFakeDocument(): Document {
   const doc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null);
@@ -32,7 +30,7 @@ describe('makeStyles', () => {
     });
     expect(computeClasses({ dir: 'ltr', renderer, tokens: {} }).root).toEqual('__ncdyee0 fe3e8s90');
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s90 {
         color: red;
       }
@@ -48,7 +46,7 @@ describe('makeStyles', () => {
     });
     expect(computeClasses({ dir: 'ltr', renderer, tokens: {} }).root).toEqual('__1fslksb fe3e8s90 f1euv43f');
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s90 {
         color: red;
       }
@@ -72,7 +70,7 @@ describe('makeStyles', () => {
     expect(ltrClasses).toEqual('__947mlk0 frdkuqy0 f1c8chgj');
     expect(rtlClasses).toEqual('__hcjvlo0 rfrdkuqy0 rf1c8chgj');
 
-    expect(getCSSRules(renderer.styleElement)).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       .frdkuqy0 {
         padding-left: 10px;
       }
@@ -105,8 +103,7 @@ describe('makeStyles', () => {
     });
     expect(computeClasses({ dir: 'rtl', renderer, tokens: {} }).root).toBe('__194gjlt rf1g6ul6r f1cpbl36 f1t9cprh');
 
-    const rules = getCSSRules(renderer.styleElement);
-    expect(rules).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       @-webkit-keyframes rf1q8eu9e {
         from {
           -webkit-transform: rotate(0deg);
@@ -152,9 +149,9 @@ describe('makeStyles', () => {
     // Classes emitted by different renderers can be the same
     expect(classesA).toBe(classesB);
     // Style elements should be different for different renderers
-    expect(rendererA.styleElement).not.toBe(rendererB.styleElement);
+    expect(rendererA.styleElements['']).not.toBe(rendererB.styleElements['']);
 
-    expect(getCSSRules(rendererA.styleElement)).toMatchInlineSnapshot(`
+    expect(rendererA).toMatchInlineSnapshot(`
       .f22iagw0 {
         display: flex;
       }
@@ -162,7 +159,7 @@ describe('makeStyles', () => {
         padding-right: 10px;
       }
     `);
-    expect(getCSSRules(rendererB.styleElement)).toMatchInlineSnapshot(`
+    expect(rendererB).toMatchInlineSnapshot(`
       .f22iagw0 {
         display: flex;
       }

--- a/packages/make-styles/src/makeStyles.ts
+++ b/packages/make-styles/src/makeStyles.ts
@@ -1,6 +1,7 @@
 import { DEFINITION_LOOKUP_TABLE, SEQUENCE_PREFIX } from './constants';
-import { createCSSVariablesProxy, resolveStyleRules } from './runtime/index';
+import { createCSSVariablesProxy } from './runtime/createCSSVariablesProxy';
 import { hashString } from './runtime/utils/hashString';
+import { resolveStyleRules } from './runtime/resolveStyleRules';
 import {
   MakeStylesOptions,
   MakeStylesRenderer,

--- a/packages/make-styles/src/renderer/createDOMRenderer.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer.ts
@@ -1,11 +1,69 @@
-import { MakeStylesRenderer } from '../types';
+import { MakeStylesRenderer, StyleBucketName } from '../types';
 import { RTL_PREFIX } from '../constants';
 
 export interface MakeStylesDOMRenderer extends MakeStylesRenderer {
   insertionCache: Record<string, true>;
   index: number;
 
-  styleElement: HTMLStyleElement;
+  styleElements: Partial<Record<StyleBucketName, HTMLStyleElement>>;
+}
+
+/**
+ * Ordered style buckets using their short pseudo name.
+ */
+const styleBucketOrdering: StyleBucketName[] = [
+  // catch-all
+  '',
+  // link
+  'l',
+  // visited
+  'v',
+  // focus-within
+  'w',
+  // focus
+  'f',
+  // focus-visible
+  'i',
+  // hover
+  'h',
+  // active
+  'a',
+  // at-rules
+  't',
+];
+
+/**
+ * Lazily adds a `<style>` bucket to the `<head>`. This will ensure that the style buckets are ordered.
+ */
+function lazyAddStyleBucketToHead(
+  bucketName: StyleBucketName,
+  target: Document,
+  renderer: MakeStylesDOMRenderer,
+): HTMLStyleElement {
+  if (!renderer.styleElements[bucketName]) {
+    let currentBucketIndex = styleBucketOrdering.indexOf(bucketName) + 1;
+    let nextBucketFromCache = null;
+
+    // Find the next bucket which we will add our new style bucket before.
+    for (; currentBucketIndex < styleBucketOrdering.length; currentBucketIndex++) {
+      const nextBucket = renderer.styleElements[styleBucketOrdering[currentBucketIndex]];
+      if (nextBucket) {
+        nextBucketFromCache = nextBucket;
+        break;
+      }
+    }
+
+    const tag = target.createElement('style');
+
+    if (process.env.NODE_ENV !== 'production') {
+      tag.dataset.MakeStylesBucket = bucketName || 'default';
+    }
+
+    renderer.styleElements[bucketName] = tag;
+    target.head.insertBefore(tag, nextBucketFromCache);
+  }
+
+  return renderer.styleElements[bucketName]!;
 }
 
 const renderers = new WeakMap<Document, MakeStylesDOMRenderer>();
@@ -13,33 +71,29 @@ let lastIndex = 0;
 
 /* eslint-disable guard-for-in */
 
-export function createDOMRenderer(targetDocument: Document = document): MakeStylesDOMRenderer {
-  const value: MakeStylesDOMRenderer | undefined = renderers.get(targetDocument);
+export function createDOMRenderer(target: Document = document): MakeStylesDOMRenderer {
+  const value: MakeStylesDOMRenderer | undefined = renderers.get(target);
 
   if (value) {
     return value;
   }
 
-  const styleElement = targetDocument.createElement('style');
-
-  styleElement.setAttribute('make-styles', 'RULE');
-  targetDocument.head.appendChild(styleElement);
-
   const renderer: MakeStylesDOMRenderer = {
     insertionCache: {},
-    index: 0,
-    styleElement,
+    styleElements: {},
 
     id: `d${lastIndex++}`,
+    index: 0,
+
     insertDefinitions: function insertStyles(dir, definitions): string {
       let classes = '';
 
       for (const propName in definitions) {
         const definition = definitions[propName];
-        // 👆 [className, css, rtlCSS?]
+        // 👆 [bucketName, className, css, rtlCSS?]
 
-        const className = definition[0];
-        const rtlCSS = definition[2];
+        const className = definition[1];
+        const rtlCSS = definition[3];
 
         const ruleClassName = className && (dir === 'rtl' && rtlCSS ? RTL_PREFIX + className : className);
 
@@ -53,15 +107,15 @@ export function createDOMRenderer(targetDocument: Document = document): MakeStyl
           continue;
         }
 
-        const css = definition[1];
+        const bucketName = definition[0];
+        const css = definition[2];
         const ruleCSS = dir === 'rtl' ? rtlCSS || css : css;
 
-        renderer.insertionCache[cacheKey] = true;
+        const styleEl = lazyAddStyleBucketToHead(bucketName, target, renderer);
+
         try {
-          if (renderer.styleElement.sheet instanceof CSSStyleSheet) {
-            renderer.styleElement.sheet.insertRule(ruleCSS, renderer.index);
-            renderer.index++;
-          }
+          (styleEl.sheet as CSSStyleSheet).insertRule(ruleCSS, renderer.index);
+          renderer.index++;
         } catch (e) {
           // We've disabled these warnings due to false-positive errors with browser prefixes
           if (process.env.NODE_ENV !== 'production' && !ignoreSuffixesRegex.test(ruleCSS)) {
@@ -69,13 +123,15 @@ export function createDOMRenderer(targetDocument: Document = document): MakeStyl
             console.error(`There was a problem inserting the following rule: "${ruleCSS}"`, e);
           }
         }
+
+        renderer.insertionCache[cacheKey] = true;
       }
 
       return classes.slice(0, -1);
     },
   };
 
-  renderers.set(targetDocument, renderer);
+  renderers.set(target, renderer);
 
   return renderer;
 }

--- a/packages/make-styles/src/runtime/compileCSS.test.ts
+++ b/packages/make-styles/src/runtime/compileCSS.test.ts
@@ -38,6 +38,33 @@ describe('compileCSS', () => {
     `);
   });
 
+  it('handles at-rules', () => {
+    expect(
+      compileCSS({
+        ...defaultOptions,
+        media: '(max-width: 100px)',
+        property: 'color',
+        value: 'red',
+      }),
+    ).toMatchInlineSnapshot(`
+      Array [
+        "@media (max-width: 100px){.foo{color:red;}}",
+      ]
+    `);
+    expect(
+      compileCSS({
+        ...defaultOptions,
+        support: '(display: table-cell)',
+        property: 'color',
+        value: 'red',
+      }),
+    ).toMatchInlineSnapshot(`
+      Array [
+        "@supports (display: table-cell){.foo{color:red;}}",
+      ]
+    `);
+  });
+
   it('handles rtl properties', () => {
     expect(
       compileCSS({

--- a/packages/make-styles/src/runtime/getStyleBucketName.test.ts
+++ b/packages/make-styles/src/runtime/getStyleBucketName.test.ts
@@ -1,0 +1,19 @@
+import { getStyleBucketName } from './getStyleBucketName';
+
+describe('getStyleBucketName', () => {
+  it('returns bucketName based on mapping', () => {
+    expect(getStyleBucketName(' :link', '', '')).toBe('l');
+    expect(getStyleBucketName(' :hover ', '', '')).toBe('h');
+
+    expect(getStyleBucketName(':link', '', '')).toBe('l');
+    expect(getStyleBucketName(':visited', '', '')).toBe('v');
+    expect(getStyleBucketName(':focus-within', '', '')).toBe('w');
+    expect(getStyleBucketName(':focus', '', '')).toBe('f');
+    expect(getStyleBucketName(':focus-visible', '', '')).toBe('i');
+    expect(getStyleBucketName(':hover', '', '')).toBe('h');
+    expect(getStyleBucketName(':active', '', '')).toBe('a');
+
+    expect(getStyleBucketName(':active', '(max-width: 100px)', '')).toBe('t');
+    expect(getStyleBucketName(':active', '', '(display: table-cell)')).toBe('t');
+  });
+});

--- a/packages/make-styles/src/runtime/getStyleBucketName.ts
+++ b/packages/make-styles/src/runtime/getStyleBucketName.ts
@@ -1,0 +1,67 @@
+import { StyleBucketName } from '../types';
+
+/**
+ * Maps the long pseudo name to the short pseudo name. Pseudos that match here will be ordered, everything else will
+ * make their way to default style bucket. We reduce the pseudo name to save bundlesize.
+ * Thankfully there aren't any overlaps, see: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes.
+ */
+const pseudosMap: Record<string, StyleBucketName | undefined> = {
+  // :focus-within
+  'us-w': 'w',
+  // :focus-visible
+  'us-v': 'i',
+
+  // :link
+  nk: 'l',
+  // :visited
+  si: 'v',
+  // :focus
+  cu: 'f',
+  // :hover
+  ve: 'h',
+  // :active
+  ti: 'a',
+};
+
+/**
+ * Gets the bucket depending on the pseudo.
+ *
+ * Input:
+ *
+ * ```
+ * ":hover"
+ * ":focus:hover"
+ * ```
+ *
+ * Output:
+ *
+ * ```
+ * "h"
+ * "f"
+ * ```
+ */
+export function getStyleBucketName(pseudo: string, media: string, support: string): StyleBucketName {
+  // We are grouping all the at-rules like @media, @supports etc under `t` bucket.
+  if (media || support) {
+    return 't';
+  }
+
+  const normalizedPseudo = pseudo.trim();
+
+  if (normalizedPseudo.charCodeAt(0) === 58 /* ":" */) {
+    // We send through a subset of the string instead of the full pseudo name.
+    // For example:
+    // - `"focus-visible"` name would instead of `"us-v"`.
+    // - `"focus"` name would instead of `"us"`.
+    // Return a mapped pseudo else default bucket.
+
+    return (
+      pseudosMap[normalizedPseudo.slice(4, 8)] /* allows to avoid collisions between "focus-visible" & "focus" */ ||
+      pseudosMap[normalizedPseudo.slice(3, 5)] ||
+      ''
+    );
+  }
+
+  // Return default bucket
+  return '';
+}

--- a/packages/make-styles/src/runtime/index.ts
+++ b/packages/make-styles/src/runtime/index.ts
@@ -1,2 +1,0 @@
-export { createCSSVariablesProxy } from './createCSSVariablesProxy';
-export { resolveStyleRules } from './resolveStyleRules';

--- a/packages/make-styles/src/runtime/resolveStaticStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStaticStyleRules.test.ts
@@ -1,9 +1,14 @@
-import { resolveStaticStyleRules } from './resolveStaticStyleRules';
+import { resetDOMRenderer } from '../renderer/createDOMRenderer';
 import { makeStylesRulesSerializer } from '../utils/test/snapshotSerializer';
+import { resolveStaticStyleRules } from './resolveStaticStyleRules';
 
 expect.addSnapshotSerializer(makeStylesRulesSerializer);
 
 describe('resolveStaticStyleRules', () => {
+  beforeEach(() => {
+    resetDOMRenderer();
+  });
+
   it('handles font-face', () => {
     expect(
       resolveStaticStyleRules({

--- a/packages/make-styles/src/runtime/resolveStaticStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStaticStyleRules.ts
@@ -26,5 +26,9 @@ export function resolveStaticStyleRules(
 
 function addResolvedStyles(styles: string, result: Record<string, MakeStylesResolvedRule> = {}): void {
   const staticCSSKey = HASH_PREFIX + hashString(styles);
-  result[staticCSSKey] = [undefined, styles /* static rules do not support RTL transforms */];
+  result[staticCSSKey] = [
+    '', // static rules support be inserted into default bucket
+    undefined,
+    styles, // static rules do not support RTL transforms
+  ];
 }

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -5,7 +5,7 @@ import { makeStylesRulesSerializer } from '../utils/test/snapshotSerializer';
 expect.addSnapshotSerializer(makeStylesRulesSerializer);
 
 function getFirstClassName(resolvedStyles: Record<string, MakeStylesResolvedRule>): string {
-  return resolvedStyles[Object.keys(resolvedStyles)[0]][0] as string;
+  return resolvedStyles[Object.keys(resolvedStyles)[0]][1] as string;
 }
 
 describe('resolveStyleRules', () => {

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -12,6 +12,7 @@ import { isNestedSelector } from './utils/isNestedSelector';
 import { isSupportQuerySelector } from './utils/isSupportQuerySelector';
 import { normalizeNestedProperty } from './utils/normalizeNestedProperty';
 import { isObject } from './utils/isObject';
+import { getStyleBucketName } from './getStyleBucketName';
 
 export function resolveStyleRules(
   styles: MakeStyles,
@@ -57,7 +58,7 @@ export function resolveStyleRules(
         rtlValue: flippedInRtl ? rtlDefinition.value : undefined,
       });
 
-      result[key] = [className, cssRules[0], cssRules[1]];
+      result[key] = [getStyleBucketName(pseudo, media, support), className, cssRules[0], cssRules[1]];
     } else if (property === 'animationName') {
       const animationNames = Array.isArray(value) ? value : [value];
       let keyframeCSS = '';
@@ -82,7 +83,12 @@ export function resolveStyleRules(
 
       const animationName = names.join(' ');
       const animationNameRtl = namesRtl.join(' ');
-      result[animationName] = [undefined, keyframeCSS, keyframeRtlCSS || undefined];
+      result[animationName] = [
+        '', // keyframes should be inserted into default bucket
+        undefined,
+        keyframeCSS,
+        keyframeRtlCSS || undefined,
+      ];
       resolveStyleRules({ animationName }, unstable_cssPriority, pseudo, media, support, result, animationNameRtl);
     } else if (isObject(value)) {
       if (isNestedSelector(property)) {

--- a/packages/make-styles/src/types.ts
+++ b/packages/make-styles/src/types.ts
@@ -7,11 +7,9 @@ export interface MakeStyles extends Omit<CSSProperties, 'animationName'> {
   animationName?: object | string;
 }
 
-export type MakeStylesMatcher<Selectors> = ((selectors: Selectors) => boolean | undefined) | null;
 export type MakeStylesStyleFunctionRule<Tokens> = (tokens: Tokens) => MakeStyles;
 export type MakeStylesStyleRule<Tokens> = MakeStyles | MakeStylesStyleFunctionRule<Tokens>;
 
-export type MakeStylesDefinition<Selectors, Tokens> = [MakeStylesMatcher<Selectors>, MakeStylesStyleRule<Tokens>];
 export interface MakeStylesOptions<Tokens> {
   dir: 'ltr' | 'rtl';
   renderer: MakeStylesRenderer;
@@ -46,20 +44,42 @@ export interface MakeStaticStylesOptions {
 
 // Build time / runtime types
 
-export type MakeStylesResolvedRule = [/* className */ string | undefined, /* css */ string, /* rtlCSS */ string?];
-
-export type MakeStylesResolvedDefinition<Selectors, Tokens> = [
-  MakeStylesMatcher<Selectors>,
-  MakeStylesStyleRule<Tokens> | undefined,
-  Record<string, MakeStylesResolvedRule>,
+export type MakeStylesResolvedRule = [
+  /* bucketName */ StyleBucketName,
+  /* className */ string | undefined,
+  /* css */ string,
+  /* rtlCSS */ string?,
 ];
 
 // Renderer types
 
-export type MakeStylesMatchedDefinitions = Record<string, MakeStylesResolvedRule>;
+export type MakeStylesReducedDefinitions = Record<string, MakeStylesResolvedRule>;
 
 export interface MakeStylesRenderer {
   id: string;
 
-  insertDefinitions(dir: 'ltr' | 'rtl', resolvedDefinitions: MakeStylesMatchedDefinitions): string;
+  insertDefinitions(dir: 'ltr' | 'rtl', resolvedDefinitions: MakeStylesReducedDefinitions): string;
 }
+
+/**
+ * Buckets under which we will group our stylesheets.
+ */
+export type StyleBucketName =
+  // default
+  | ''
+  // link
+  | 'l'
+  // visited
+  | 'v'
+  // focus-within
+  | 'w'
+  // focus
+  | 'f'
+  // focus-visible
+  | 'i'
+  // hover
+  | 'h'
+  // active
+  | 'a'
+  // at-rules (@media, @support)
+  | 't';


### PR DESCRIPTION
- [x] Addresses an existing issue: Fixes #17607
- [x] Include a change request file using `$ yarn change`

## Description of changes

This PR adds the concept of style buckets inspired by [Compiled](https://github.com/atlassian-labs/compiled): style rules insertion is ordered to follow LVFHA order.

- **L**ink
- **V**isited
- **F**ocus within, **F**ocus, **F**ocus visible
- **H**over
- **A**ctive

What it means on practice? The behavior of pseudo selectors becomes predictable as they will be inserted always in the same order: rules will be inserted into different style nodes are ordered.

## How it works?

Styles are inserted into different nodes based on their priority, see `styleBucketOrdering`. Style nodes are created on demand, a sample output is below:

```html
<style data-make-styles-bucket>
  .abc {
    color: red;
  }
  .def {
    color: blue;
  }
</style>
<style data-make-styles-bucket="focus">
  .hkl:focus {
    color: green;
  }
  .mno:focus {
    color: magenta;
  }
</style>
<style data-make-styles-bucket="hover">
  .prq:hover {
    color: orange;
  }
</style>
```

## Implementation details

A signature of resolved rules was changed to include a style bucket name:

```ts
// before
const ruleBefore = [
  "abcd" // className,
  ".abcd { color: red }", // CSS rule
 // optional CSS rule for RTL
];
// after
const ruleAfter = [
  "", // style bucket name, "" means default
  "abcd" // className,
  ".abcd { color: red }", // CSS rule
 // optional CSS rule for RTL
];
```

_Why we have this in resolved rules?_ This allows us to perform style bucket computations during build step and avoid runtime work.

I also changed the process of insertion to DOM (`createDOMRenderer.ts`), now it creates style nodes on demand to have style rules ordered.

## Trade-offs

Other pseudo selectors including media queries may unexpectedly clash:

```ts
makeStyles({
  root: {
    ":hover": {}, // will be inserted to ":hover" bucket
    ".some-class :hover": {} // will be inserted to "default" bucket
    ":hover:focus": {} // will be inserted to ":hover" bucket
  }
});
```
