### PR TITLE
chore: bump rtl-css-js

### DIFF
--- a/change/@fluentui-make-styles-4384e264-118e-4a41-a69a-06cf4cb30e6c.json
+++ b/change/@fluentui-make-styles-4384e264-118e-4a41-a69a-06cf4cb30e6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: bump rtl-css-js",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/package.json
+++ b/packages/make-styles/package.json
@@ -30,7 +30,7 @@
     "@emotion/hash": "^0.8.0",
     "csstype": "^2.6.7",
     "inline-style-expand-shorthand": "^1.2.0",
-    "rtl-css-js": "^1.14.0",
+    "rtl-css-js": "^1.14.1",
     "stylis": "^4.0.6",
     "tslib": "^1.10.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23877,10 +23877,10 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-rtl-css-js@^1.1.3, rtl-css-js@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.0.tgz#daa4f192a92509e292a0519f4b255e6e3c076b7d"
-  integrity sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==
+rtl-css-js@^1.1.3, rtl-css-js@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.1.tgz#f79781d6a0c510abe73fde60aa3cbe9dfd134a45"
+  integrity sha512-G9N1s/6329FpJr8k9e1U/Lg0IDWThv99sb7k0IrXHjSnubxe01h52/ajsPRafJK1/2Vqrhz3VKLe3E1dx6jS9Q==
   dependencies:
     "@babel/runtime" "^7.1.2"
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR bumps `rtl-css-js` to include [kentcdodds/rtl-css-js#55](https://github.com/kentcdodds/rtl-css-js/pull/55) that fixes ESM exports.

![Bundle size decreased for 1KB](https://user-images.githubusercontent.com/14183168/113685403-812f8c00-96c6-11eb-92e5-0ba2d772e00b.png)

We're saving 1KB for `makeStyles()`, not a big deal, but it's for free 😉

