### PR TITLE
More shared website setup utility fixes

### DIFF
--- a/apps/pr-deploy-site/.eslintrc.json
+++ b/apps/pr-deploy-site/.eslintrc.json
@@ -6,8 +6,8 @@
       // pr-deploy-site.js is run without transpiling in all browsers, which means it must use
       // IE 11-compatible syntax as long as we still support IE 11.
       "files": ["pr-deploy-site.js"],
-      "plugins": ["es5"],
-      "extends": ["plugin:es5/no-es2015"],
+      "plugins": ["es"],
+      "extends": ["plugin:es/restrict-to-es2015"],
       "rules": {
         // turn off conflicting or unwanted rules from normal set
         "curly": "off",

--- a/apps/pr-deploy-site/just.config.ts
+++ b/apps/pr-deploy-site/just.config.ts
@@ -1,7 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import { series, task, copyInstructionsTask, copyInstructions } from '@fluentui/scripts';
+import { series, task, copyInstructionsTask, copyInstructions, cleanTask } from '@fluentui/scripts';
 import { findGitRoot, getAllPackageInfo } from '@fluentui/scripts/monorepo/index';
+
+task('clean', cleanTask());
 
 const gitRoot = findGitRoot();
 const instructions = copyInstructions.copyFilesToDestinationDirectory(

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
+    "clean": "just-scripts clean",
     "generate:site": "just-scripts generate:site",
     "lint": "eslint --ext .js,.ts ."
   },

--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 const path = require('path');
+const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const resources = require('../../scripts/webpack/webpack-resources');
 const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
@@ -34,6 +35,7 @@ module.exports = function(env, argv) {
       outDir: path.join(__dirname, 'dist'),
       isProduction: isProductionArg,
       CopyWebpackPlugin,
+      webpack,
     }),
     // Rest of the site
     ...resources.createConfig(

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const path = require('path');
+const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const resources = require('../../scripts/webpack/webpack-resources');
 const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
@@ -21,6 +22,7 @@ module.exports = [
     outDir: path.join(__dirname, outDir),
     isProduction: false,
     CopyWebpackPlugin,
+    webpack,
   }),
   // Rest of site
   resources.createServeConfig(

--- a/change/@fluentui-public-docsite-1b7503b9-fe11-4d0d-ba31-a7071f146c88.json
+++ b/change/@fluentui-public-docsite-1b7503b9-fe11-4d0d-ba31-a7071f146c88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update website setup script to pass in webpack",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-setup-f197e139-85f9-42e6-aab9-f120c977c9db.json
+++ b/change/@fluentui-public-docsite-setup-f197e139-85f9-42e6-aab9-f120c977c9db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove es2019 syntax from website setup script, and pass in webpack instance",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "copy-webpack-plugin": "8.1.0",
     "cross-env": "^5.1.4",
     "css-loader": "5.0.1",
-    "eslint-plugin-es5": "1.5.0",
+    "eslint-plugin-es": "4.1.0",
     "danger": "^6.0.5",
     "file-loader": "6.2.0",
     "gulp": "^4.0.2",

--- a/packages/public-docsite-setup/.eslintrc.json
+++ b/packages/public-docsite-setup/.eslintrc.json
@@ -7,6 +7,12 @@
       "rules": {
         "no-console": "off"
       }
+    },
+    {
+      "files": ["bin/*.js", "scripts/*.js"],
+      "plugins": ["es"],
+      // These files need to work with Node 8 (for 5.0 and 6.0 branches)
+      "extends": ["plugin:es/restrict-to-es2017"]
     }
   ]
 }

--- a/packages/public-docsite-setup/package.json
+++ b/packages/public-docsite-setup/package.json
@@ -20,7 +20,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
-    "lint": "just-scripts lint"
+    "lint": "just-scripts lint && eslint ./bin/*.js ./scripts/*.js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/public-docsite-setup/scripts/getLoadSiteConfig.js
+++ b/packages/public-docsite-setup/scripts/getLoadSiteConfig.js
@@ -1,23 +1,23 @@
 // @ts-check
 const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
 
 /**
  * Gets a webpack config which copies `@fluentui/public-docsite-setup/index.html` to `outDir` and
  * generates `loadSite.js` used to load the site for the given library version.
  *
- * Should work with webpack 4+. Requires `copy-webpack-plugin` 4+ to be installed.
+ * Should work with webpack 4+ and `copy-webpack-plugin` 4+.
  *
  * @param {object} options
  * @param {string} options.libraryPath Path to the main library: `@fluentui/react` or `office-ui-fabric-react`
  * @param {string} options.outDir Absolute path to the output directory
  * @param {boolean} options.isProduction Whether to do a production build (same filename is used regardless)
  * @param {*} options.CopyWebpackPlugin Constructor for `copy-webpack-plugin` 4+
- * @returns {webpack.Configuration}
+ * @param {import('webpack')} options.webpack Result of `require('webpack')`, to ensure the correct one is used
+ * @returns {import('webpack').Configuration}
  */
 function getLoadSiteConfig(options) {
-  const { libraryPath, outDir, isProduction, CopyWebpackPlugin } = options;
+  const { libraryPath, outDir, isProduction, CopyWebpackPlugin, webpack } = options;
   const setupPackagePath = path.dirname(require.resolve('@fluentui/public-docsite-setup/package.json'));
   const libraryVersion = JSON.parse(fs.readFileSync(`${libraryPath}/package.json`, 'utf-8')).version;
 
@@ -26,7 +26,7 @@ function getLoadSiteConfig(options) {
   let copyPlugin;
   try {
     copyPlugin = new CopyWebpackPlugin({ patterns: copyPatterns });
-  } catch {
+  } catch (err) {
     // copy-webpack-plugin >= 6 requires Node 10+ and takes an object containing patterns.
     // Fabric 5 and 6 still support Node 8, so they need to use copy-webpack-plugin@5 which
     // takes the patterns themselves as the first parameter.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11835,10 +11835,13 @@ eslint-plugin-deprecation@^1.1.0:
     tslib "^1.10.0"
     tsutils "^3.0.0"
 
-eslint-plugin-es5@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
-  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
+eslint-plugin-es@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
+  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
 
 eslint-plugin-import@^2.20.1, eslint-plugin-import@^2.21.0:
   version "2.22.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Follow-up of #17568 and #17660... Fix two more issues for v5:
- Pass `webpack` in to `getLoadSiteConfig` to ensure the correct version is used (v5 has multiple versions of webpack installed)
- Fix Node 8-incompatible syntax (apparently optional `catch` bindings are an ES2019 feature) and use [`eslint-plugin-es`](https://eslint-plugin-es.mysticatea.dev/) to prevent similar issues from being introduced in the future

I also updated `pr-deploy-site` to use `eslint-plugin-es` instead of `eslint-plugin-es5` since `-es` handles the same thing in a more generalized way.