### PR TITLE
7.0: Fix recipients drag drop copy

### DIFF
--- a/change/@uifabric-experiments-4db61fee-d371-48e0-83cf-b9b900703feb.json
+++ b/change/@uifabric-experiments-4db61fee-d371-48e0-83cf-b9b900703feb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing drag and drop by specifying effect allowed to be move",
+  "packageName": "@uifabric/experiments",
+  "email": "angon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -254,6 +254,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     /* eslint-disable-next-line eqeqeq */
     const draggedItemIndex = itemIndex != null ? itemIndex! : -1;
     setDraggedIndex(draggedItemIndex);
+    if (event && event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+    }
     if (event) {
       const dataList = event?.dataTransfer?.items;
       if (serializeItemsForDrag && customClipboardType) {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -254,6 +254,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     /* eslint-disable-next-line eqeqeq */
     const draggedItemIndex = itemIndex != null ? itemIndex! : -1;
     setDraggedIndex(draggedItemIndex);
+    // Set effectAllowed to be only move so that browser doesn't incorrectly copy instead
     if (event && event.dataTransfer) {
       event.dataTransfer.effectAllowed = 'move';
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Backporting to v7:

Browsers have some heuristic to determine the dropEffect (copy, move, etc.). Recently we found a bug where in some cases chromium was setting the dropEffect to copy instead of move, and therefore the item drag and dropped was not being deleted from drag source.

The solution is adding effectAllowed to be only 'move' in _onDragStart

#### Focus areas to test

(optional)
