### PR TITLE
ContextualMenu: focused div when menu is opened now has role = "menu"

### DIFF
--- a/change/@fluentui-react-04f5f86f-838a-4cfe-84ae-c6cf92f99e95.json
+++ b/change/@fluentui-react-04f5f86f-838a-4cfe-84ae-c6cf92f99e95.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "ContextualMenu: element that's focused when menu is opened now has role = \"menu\"",
+  "comment": "ContextualMenu: focused div when menu is opened now has role = menu",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-04f5f86f-838a-4cfe-84ae-c6cf92f99e95.json
+++ b/change/@fluentui-react-04f5f86f-838a-4cfe-84ae-c6cf92f99e95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: element that's focused when menu is opened now has role = \"menu\"",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -988,8 +988,7 @@ describe('Button', () => {
       }
 
       it('If button has text, contextual menu has aria-labelledBy attribute set', () => {
-        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text');
-        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
+        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text');
 
         expect(contextualMenuElement).not.toBeNull();
         expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
@@ -997,8 +996,11 @@ describe('Button', () => {
       });
 
       it('If button has a text child, contextual menu has aria-labelledBy attribute set', () => {
-        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(null, 'Button Text', true);
-        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
+        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
+          null,
+          'Button Text',
+          true,
+        );
 
         expect(contextualMenuElement).not.toBeNull();
         expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
@@ -1006,8 +1008,7 @@ describe('Button', () => {
       });
 
       it('If button has no text, contextual menu has no aria-label or aria-labelledBy attributes', () => {
-        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement();
-        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
+        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement();
 
         expect(contextualMenuElement).not.toBeNull();
         expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();
@@ -1016,11 +1017,10 @@ describe('Button', () => {
 
       it('If button has text but ariaLabel provided in menuProps, contextual menu has aria-label set', () => {
         const explicitLabel = 'ExplicitLabel';
-        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
+        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
           { ariaLabel: explicitLabel },
           'Button Text',
         );
-        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
         expect(contextualMenuElement?.getAttribute('aria-label')).toEqual(explicitLabel);
@@ -1059,11 +1059,10 @@ describe('Button', () => {
       it(`If button has text but labelElementId provided in menuProps, contextual menu has
       aria-labelledBy reflecting labelElementId`, () => {
         const explicitLabelElementId = 'id_ExplicitLabel';
-        const menuWrapper = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
+        const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
           { labelElementId: explicitLabelElementId },
           'Button Text',
         );
-        const contextualMenuElement = menuWrapper.querySelector('[role="menu"]');
 
         expect(contextualMenuElement).not.toBeNull();
         expect(contextualMenuElement?.getAttribute('aria-label')).toBeNull();

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -446,7 +446,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
               directionalHintFixed={directionalHintFixed}
               alignTargetEdge={alignTargetEdge}
               hidden={this.props.hidden || menuContext.hidden}
-              ref={hostElement}
             >
               <div
                 style={contextMenuStyle}
@@ -456,6 +455,9 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                 onKeyDown={this._onMenuKeyDown}
                 onKeyUp={this._onKeyUp}
                 onFocusCapture={onMenuFocusCapture}
+                ref={hostElement}
+                aria-labelledby={labelElementId}
+                role={'menu'}
               >
                 {title && <div className={this._classNames.title}> {title} </div>}
                 {items && items.length
@@ -522,15 +524,15 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     defaultRender?: IRenderFunction<IContextualMenuListProps>,
   ): JSX.Element => {
     let indexCorrection = 0;
-    const { ariaLabel, items, labelElementId, totalItemCount, hasCheckmarks, hasIcons, role } = menuListProps;
+    const { ariaLabel, items, totalItemCount, hasCheckmarks, hasIcons } = menuListProps;
+
     return (
       <ul
         className={this._classNames.list}
         aria-label={ariaLabel}
-        aria-labelledby={labelElementId}
         onKeyDown={this._onKeyDown}
         onKeyUp={this._onKeyUp}
-        role={role ?? 'menu'}
+        role={'presentation'}
       >
         {items.map((item, index) => {
           const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
@@ -546,7 +548,11 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
     const { focusZoneAs: ChildrenRenderer = FocusZone } = this.props;
-    return <ChildrenRenderer {...this._adjustedFocusZoneProps}>{children}</ChildrenRenderer>;
+    return (
+      <ChildrenRenderer {...this._adjustedFocusZoneProps} role={'presentation'}>
+        {children}
+      </ChildrenRenderer>
+    );
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -446,6 +446,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
               directionalHintFixed={directionalHintFixed}
               alignTargetEdge={alignTargetEdge}
               hidden={this.props.hidden || menuContext.hidden}
+              ref={hostElement}
             >
               <div
                 style={contextMenuStyle}
@@ -455,7 +456,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                 onKeyDown={this._onMenuKeyDown}
                 onKeyUp={this._onKeyUp}
                 onFocusCapture={onMenuFocusCapture}
-                ref={hostElement}
+                aria-label={ariaLabel}
                 aria-labelledby={labelElementId}
                 role={'menu'}
               >
@@ -524,16 +525,10 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     defaultRender?: IRenderFunction<IContextualMenuListProps>,
   ): JSX.Element => {
     let indexCorrection = 0;
-    const { ariaLabel, items, totalItemCount, hasCheckmarks, hasIcons } = menuListProps;
+    const { items, totalItemCount, hasCheckmarks, hasIcons } = menuListProps;
 
     return (
-      <ul
-        className={this._classNames.list}
-        aria-label={ariaLabel}
-        onKeyDown={this._onKeyDown}
-        onKeyUp={this._onKeyUp}
-        role={'presentation'}
-      >
+      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role={'presentation'}>
         {items.map((item, index) => {
           const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
           if (item.itemType !== ContextualMenuItemType.Divider && item.itemType !== ContextualMenuItemType.Header) {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -543,11 +543,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   private _renderFocusZone(children: JSX.Element | null): JSX.Element {
     const { focusZoneAs: ChildrenRenderer = FocusZone } = this.props;
-    return (
-      <ChildrenRenderer {...this._adjustedFocusZoneProps} role={'presentation'}>
-        {children}
-      </ChildrenRenderer>
-    );
+    return <ChildrenRenderer {...this._adjustedFocusZoneProps}>{children}</ChildrenRenderer>;
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1357,7 +1357,7 @@ describe('ContextualMenu', () => {
   });
 
   describe('onRenderMenuList function tests', () => {
-    it('List has default role as menu.', () => {
+    it('List has default role as presentation.', () => {
       const items: IContextualMenuItem[] = [
         {
           text: 'TestText 1',
@@ -1372,34 +1372,7 @@ describe('ContextualMenu', () => {
       const internalList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
 
       expect(internalList).toBeTruthy();
-      expect(internalList.getAttribute('role')).toEqual('menu');
-    });
-
-    it('List applies role that is set by custom onRenderMenuList function.', () => {
-      const items: IContextualMenuItem[] = [
-        {
-          text: 'TestText 1',
-          key: 'TestKey1',
-        },
-      ];
-
-      const onRenderMenuList: IRenderFunction<IContextualMenuListProps> = (props, defaultRender) => {
-        if (props) {
-          props.role = 'grid';
-        }
-        return defaultRender?.(props) ?? null;
-      };
-
-      ReactTestUtils.act(() => {
-        ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-          <ContextualMenu items={items} onRenderMenuList={onRenderMenuList} />,
-        );
-      });
-
-      const internalList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-
-      expect(internalList).toBeTruthy();
-      expect(internalList.getAttribute('role')).toEqual('grid');
+      expect(internalList.getAttribute('role')).toEqual('presentation');
     });
   });
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -9,10 +9,10 @@ import { IContextualMenuProps, IContextualMenuStyles, IContextualMenu } from './
 import { CalloutContent } from '../Callout/CalloutContent';
 import { ContextualMenu } from './ContextualMenu';
 import { canAnyMenuItemsCheck } from './ContextualMenu.base';
-import { IContextualMenuItem, ContextualMenuItemType, IContextualMenuListProps } from './ContextualMenu.types';
+import { IContextualMenuItem, ContextualMenuItemType } from './ContextualMenu.types';
 import { IContextualMenuRenderItem, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import { DefaultButton, IButton } from '../../Button';
-import { IRenderFunction, resetIds } from '@fluentui/utilities';
+import { resetIds } from '@fluentui/utilities';
 import { isConformant } from '../../common/isConformant';
 
 describe('ContextualMenu', () => {

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -264,6 +264,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                role="menu"
                 tabIndex={-1}
               >
                 <div
@@ -288,6 +289,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   onMouseDownCapture={[Function]}
+                  role="presentation"
                 >
                   <ul
                     className=
@@ -306,7 +308,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                         }
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
-                    role="menu"
+                    role="presentation"
                   >
                     <li
                       className=

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -289,7 +289,6 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   onMouseDownCapture={[Function]}
-                  role="presentation"
                 >
                   <ul
                     className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17628 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ContextualMenu: element that's focused when menu is opened now has role = "menu"

- Moved `role = menu`, `aria-label` and `aria-labelledby` attributes to container div which is the element that gains focus when menu is opened.
- Updated all elements in between container div and first menu item to have `role = presentation`.
- Updated Button tests to account for role changes as element with attributes `role='menu'`, `aria-label` and `aria-labelledby` were moved from `onRenderMenuList` to the container div.
- Removed 1 `onRenderMenuList` unit test from `ContextualMenu` since `role` will be static as `"presentation"` moving forward.
