### PR TITLE
Fix create-site-manifests in v6 release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,4 @@ yarn.lock
 
 # Fabric website
 apps/fabric-website/flights/
-/site-manifests/
+apps/fabric-website/site-manifests/

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -96,12 +96,13 @@ steps:
   # create-site-manifests is a script defined in @fluentui/public-docsite-setup.
   # It generates manifest files used to load the current version on developer.microsoft.com/fluentui.
   - script: |
-      npm run create-site-manifests ./packages/office-ui-fabric-react
+      npx create-site-manifests ../../packages/office-ui-fabric-react
+    workingDirectory: apps/fabric-website
     displayName: 'Generate website manifests'
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathtoPublish: ./site-manifests
+      pathtoPublish: ./apps/fabric-website/site-manifests
       artifactName: 'fabric-website-manifests'
       publishLocation: 'Container'
     displayName: 'Publish Artifact: Website manifests'


### PR DESCRIPTION
Follow-up to #17633: correct the way `create-site-manifests` was being called in the release build. `create-site-manifests` is a `bin` script from `@fluentui/public-docsite-setup`, and with rush/pnpm, it's necessary to call that script using `npx` in the folder where the dependency is installed.