### PR TITLE
SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order

### DIFF
--- a/change/@fluentui-react-8e4a8495-3c58-4aa0-888e-c2aeac0dc22a.json
+++ b/change/@fluentui-react-8e4a8495-3c58-4aa0-888e-c2aeac0dc22a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "SplitButton: when primary button is disabled, secondary dropdown button is now focusable and explicitly added to tab order",
+  "comment": "SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-8e4a8495-3c58-4aa0-888e-c2aeac0dc22a.json
+++ b/change/@fluentui-react-8e4a8495-3c58-4aa0-888e-c2aeac0dc22a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "SplitButton: when primary button is disabled, secondary dropdown button is now focusable and explicitly added to tab order",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-d05ed224-52d5-4d5d-b1f0-432c0ee45392.json
+++ b/change/@fluentui-react-examples-d05ed224-52d5-4d5d-b1f0-432c0ee45392.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: when primary button is disabled, secondary dropdown button is now focusable and explicitly added to tab order",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-d05ed224-52d5-4d5d-b1f0-432c0ee45392.json
+++ b/change/@fluentui-react-examples-d05ed224-52d5-4d5d-b1f0-432c0ee45392.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "SplitButton: when primary button is disabled, secondary dropdown button is now focusable and explicitly added to tab order",
+  "comment": "SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order",
   "packageName": "@fluentui/react-examples",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
@@ -826,7 +826,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex={0}
     >
       <span
         style={
@@ -998,6 +997,31 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
                 color: WindowText;
               }
+              &:focus {
+                outline: transparent;
+                position: relative;
+              }
+              &:focus::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 3px;
+                content: "";
+                left: 3px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 3px;
+                top: 3px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                right: -2px;
+                top: -2px;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1005,7 +1029,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex={-1}
+          tabIndex={0}
           type="button"
         >
           <span

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1947,6 +1947,7 @@ export interface IButtonStyles {
     splitButtonMenuButtonExpanded?: IStyle;
     splitButtonMenuIcon?: IStyle;
     splitButtonMenuIconDisabled?: IStyle;
+    splitButtonSecondaryFocused?: IStyle;
     textContainer?: IStyle;
 }
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1945,9 +1945,9 @@ export interface IButtonStyles {
     splitButtonMenuButtonChecked?: IStyle;
     splitButtonMenuButtonDisabled?: IStyle;
     splitButtonMenuButtonExpanded?: IStyle;
+    splitButtonMenuFocused?: IStyle;
     splitButtonMenuIcon?: IStyle;
     splitButtonMenuIconDisabled?: IStyle;
-    splitButtonSecondaryFocused?: IStyle;
     textContainer?: IStyle;
 }
 

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -590,7 +590,6 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     const classNames = getSplitButtonClassNames
       ? getSplitButtonClassNames(!!disabled, !menuHidden, !!checked, !!allowDisabledFocus)
       : styles && getBaseSplitButtonClassNames(styles!, !!disabled, !menuHidden, !!checked, !!primaryDisabled);
-
     assign(buttonProps, {
       onClick: undefined,
       onPointerDown: undefined,
@@ -629,7 +628,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         ref={this._splitButtonContainer}
         data-is-focusable={true}
         onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
-        tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
+        tabIndex={(!disabled || allowDisabledFocus) && !primaryDisabled ? 0 : undefined}
         aria-roledescription={buttonProps['aria-roledescription']}
         onFocusCapture={this._onSplitContainerFocusCapture}
       >
@@ -689,7 +688,14 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     classNames: ISplitButtonClassNames | undefined,
     keytipAttributes: any,
   ): JSX.Element {
-    const { allowDisabledFocus, checked, disabled, splitButtonMenuProps, splitButtonAriaLabel } = this.props;
+    const {
+      allowDisabledFocus,
+      checked,
+      disabled,
+      splitButtonMenuProps,
+      splitButtonAriaLabel,
+      primaryDisabled,
+    } = this.props;
     const { menuHidden } = this.state;
     let menuIconProps = this.props.menuIconProps;
 
@@ -720,7 +726,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {...splitButtonProps}
         data-ktp-execute-target={keytipAttributes ? keytipAttributes['data-ktp-execute-target'] : keytipAttributes}
         onMouseDown={this._onMouseDown}
-        tabIndex={-1}
+        tabIndex={primaryDisabled ? 0 : -1}
       />
     );
   }

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -590,6 +590,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     const classNames = getSplitButtonClassNames
       ? getSplitButtonClassNames(!!disabled, !menuHidden, !!checked, !!allowDisabledFocus)
       : styles && getBaseSplitButtonClassNames(styles!, !!disabled, !menuHidden, !!checked, !!primaryDisabled);
+
     assign(buttonProps, {
       onClick: undefined,
       onPointerDown: undefined,

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -629,7 +629,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         ref={this._splitButtonContainer}
         data-is-focusable={true}
         onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
-        tabIndex={(!disabled || allowDisabledFocus) && !primaryDisabled ? 0 : undefined}
+        tabIndex={(!disabled && !primaryDisabled) || allowDisabledFocus ? 0 : undefined}
         aria-roledescription={buttonProps['aria-roledescription']}
         onFocusCapture={this._onSplitContainerFocusCapture}
       >
@@ -727,7 +727,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {...splitButtonProps}
         data-ktp-execute-target={keytipAttributes ? keytipAttributes['data-ktp-execute-target'] : keytipAttributes}
         onMouseDown={this._onMouseDown}
-        tabIndex={primaryDisabled ? 0 : -1}
+        tabIndex={primaryDisabled && !allowDisabledFocus ? 0 : -1}
       />
     );
   }

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -643,7 +643,7 @@ export interface IButtonStyles {
   splitButtonFlexContainer?: IStyle;
 
   /**
-   * Style overried for the SplitButton when only primaryButton is in a disabled state
+   * Style override for the SplitButton when only primaryButton is in a disabled state
    */
   splitButtonSecondaryFocused?: IStyle;
 }

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -641,4 +641,9 @@ export interface IButtonStyles {
    * Style override for the SplitButton FlexContainer.
    */
   splitButtonFlexContainer?: IStyle;
+
+  /**
+   * Style overried for the SplitButton when only primaryButton is in a disabled state
+   */
+  splitButtonSecondaryFocused?: IStyle;
 }

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -645,5 +645,5 @@ export interface IButtonStyles {
   /**
    * Style override for the SplitButton when only primaryButton is in a disabled state
    */
-  splitButtonSecondaryFocused?: IStyle;
+  splitButtonMenuFocused?: IStyle;
 }

--- a/packages/react/src/components/Button/SplitButton/SplitButton.classNames.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.classNames.ts
@@ -24,6 +24,14 @@ export const getSplitButtonClassNames = memoizeFunction(
         expanded && [styles.splitButtonMenuButtonExpanded],
         disabled && [styles.splitButtonMenuButtonDisabled],
         checked && !disabled && [styles.splitButtonMenuButtonChecked],
+        primaryDisabled &&
+          !disabled && [
+            {
+              selectors: {
+                ':focus': styles.splitButtonSecondaryFocused,
+              },
+            },
+          ],
       ),
 
       splitButtonContainer: mergeStyles(

--- a/packages/react/src/components/Button/SplitButton/SplitButton.classNames.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.classNames.ts
@@ -28,7 +28,7 @@ export const getSplitButtonClassNames = memoizeFunction(
           !disabled && [
             {
               selectors: {
-                ':focus': styles.splitButtonSecondaryFocused,
+                ':focus': styles.splitButtonMenuFocused,
               },
             },
           ],

--- a/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -213,7 +213,7 @@ export const getStyles = memoizeFunction(
           },
         },
       },
-      splitButtonSecondaryFocused: {
+      splitButtonMenuFocused: {
         ...getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
       },
     };

--- a/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -213,6 +213,9 @@ export const getStyles = memoizeFunction(
           },
         },
       },
+      splitButtonSecondaryFocused: {
+        ...getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
+      },
     };
 
     return concatStyleSets(splitButtonStyles, customStyles)!;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [bug-11037](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11037)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added conditional which removes `tabIndex` from splitButton div container if `primaryDisabled` .
- When `primaryDisabled`, the menu button's `tabIndex` is set to 0.
- Added `splitButtonMenuFocused` styling to add focus border to menu button when it's in focus when `primaryDisabled` and the whole button is `!disabled`. 

**Menu Button Keyboard Focus:**
![splitbutton-focus-1](https://user-images.githubusercontent.com/8649804/113614802-d0fb4e00-9607-11eb-8aff-c51fd506bf9c.JPG)
**Menu Button Keyboard Activate:**
![splitbutton-focus-2](https://user-images.githubusercontent.com/8649804/113616068-7c58d280-9609-11eb-864a-3cfadcbe68a7.JPG)
