### PR TITLE
Allow buttons to have both aria-label and -labelledby

### DIFF
--- a/change/@fluentui-react-462db8c4-a638-44ce-a428-b38ea652a7e9.json
+++ b/change/@fluentui-react-462db8c4-a638-44ce-a428-b38ea652a7e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow both aria-label and aria-labelledby on buttons",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -198,18 +198,15 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       ariaDescribedBy = (nativeProps as any)['aria-describedby'];
     }
 
-    // If an explicit ariaLabel is given, use that as the label and we're done.
     // If an explicit aria-labelledby is given, use that and we're done.
-    // If any kind of description is given (which will end up as an aria-describedby attribute),
-    // set the labelledby element. Otherwise, the button is labeled implicitly by the descendent
-    // text on the button (if it exists). Never set both aria-label and aria-labelledby.
+    // If any kind of description is given (which will end up as an aria-describedby attribute)
+    // and no ariaLabel is specified, set the labelledby element.
+    // Otherwise, the button is labeled implicitly by the descendent text on the button (if it exists).
     let ariaLabelledBy = undefined;
-    if (!resolvedAriaLabel) {
-      if ((nativeProps as any)['aria-labelledby']) {
-        ariaLabelledBy = (nativeProps as any)['aria-labelledby'];
-      } else if (ariaDescribedBy) {
-        ariaLabelledBy = this._hasText() ? _labelId : undefined;
-      }
+    if ((nativeProps as any)['aria-labelledby']) {
+      ariaLabelledBy = (nativeProps as any)['aria-labelledby'];
+    } else if (ariaDescribedBy && !resolvedAriaLabel) {
+      ariaLabelledBy = this._hasText() ? _labelId : undefined;
     }
 
     const dataIsFocusable =


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue (no existing issue, but another PR has a dependency on this one)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Right now the BaseButton doesn't allow buttons to have both `aria-label` and `aria-labelledby`, which is an issue for self-referencing `aria-labelledby` ids. For example, if you have something like this:

```html
<li>
  <span id="item-text">Green</span>
  <button id="item-action" aria-label="Remove" aria-labelledby="item-action item-text">x</button>
</li>
```

You need both `aria-label` and `aria-labelledby` to create the text "Remove Green". In more complex examples, you definitely want the option of relying on computed name from content rather than trying to calculate `aria-label` strings (e.g. if you had text + an image in the first span).