### PR TITLE
[v7.0] SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order

### DIFF
--- a/change/@fluentui-react-examples-5e562d82-31e2-4df5-a620-1872d61d5aae.json
+++ b/change/@fluentui-react-examples-5e562d82-31e2-4df5-a620-1872d61d5aae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-ab968d31-53db-499e-898c-0fad05a3afb7.json
+++ b/change/office-ui-fabric-react-ab968d31-53db-499e-898c-0fad05a3afb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "SplitButton: when primary button is disabled, menu button is now focusable and explicitly added to tab order",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2128,6 +2128,7 @@ export interface IButtonStyles {
     splitButtonMenuButtonChecked?: IStyle;
     splitButtonMenuButtonDisabled?: IStyle;
     splitButtonMenuButtonExpanded?: IStyle;
+    splitButtonMenuFocused?: IStyle;
     splitButtonMenuIcon?: IStyle;
     splitButtonMenuIconDisabled?: IStyle;
     textContainer?: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -626,7 +626,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         ref={this._splitButtonContainer}
         data-is-focusable={true}
         onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
-        tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
+        tabIndex={(!disabled && !primaryDisabled) || allowDisabledFocus ? 0 : undefined}
         aria-roledescription={buttonProps['aria-roledescription']}
         onFocusCapture={this._onSplitContainerFocusCapture}
       >
@@ -686,7 +686,14 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     classNames: ISplitButtonClassNames | undefined,
     keytipAttributes: any,
   ): JSX.Element {
-    const { allowDisabledFocus, checked, disabled, splitButtonMenuProps, splitButtonAriaLabel } = this.props;
+    const {
+      allowDisabledFocus,
+      checked,
+      disabled,
+      splitButtonMenuProps,
+      splitButtonAriaLabel,
+      primaryDisabled,
+    } = this.props;
     const { menuHidden } = this.state;
     let menuIconProps = this.props.menuIconProps;
 
@@ -717,7 +724,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {...splitButtonProps}
         data-ktp-execute-target={keytipAttributes ? keytipAttributes['data-ktp-execute-target'] : keytipAttributes}
         onMouseDown={this._onMouseDown}
-        tabIndex={-1}
+        tabIndex={primaryDisabled && !allowDisabledFocus ? 0 : -1}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -646,4 +646,9 @@ export interface IButtonStyles {
    * Style override for the SplitButton FlexContainer.
    */
   splitButtonFlexContainer?: IStyle;
+
+  /**
+   * Style override for the SplitButton when only primaryButton is in a disabled state
+   */
+  splitButtonMenuFocused?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.classNames.ts
@@ -24,6 +24,14 @@ export const getSplitButtonClassNames = memoizeFunction(
         expanded && [styles.splitButtonMenuButtonExpanded],
         disabled && [styles.splitButtonMenuButtonDisabled],
         checked && !disabled && [styles.splitButtonMenuButtonChecked],
+        primaryDisabled &&
+          !disabled && [
+            {
+              selectors: {
+                ':focus': styles.splitButtonMenuFocused,
+              },
+            },
+          ],
       ),
 
       splitButtonContainer: mergeStyles(

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -213,6 +213,9 @@ export const getStyles = memoizeFunction(
           },
         },
       },
+      splitButtonMenuFocused: {
+        ...getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
+      },
     };
 
     return concatStyleSets(splitButtonStyles, customStyles)!;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
@@ -828,7 +828,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex={0}
     >
       <span
         style={
@@ -1000,6 +999,31 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-Button-menuIcon {
                 color: WindowText;
               }
+              &:focus {
+                outline: transparent;
+                position: relative;
+              }
+              &:focus::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 3px;
+                content: "";
+                left: 3px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 3px;
+                top: 3px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                right: -2px;
+                top: -2px;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1007,7 +1031,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           onKeyUp={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex={-1}
+          tabIndex={0}
           type="button"
         >
           <span


### PR DESCRIPTION
cherry-pick of #17698 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes [bug-11037](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11037)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added conditional which removes `tabIndex` from splitButton div container if `primaryDisabled` .
- When `primaryDisabled`, the menu button's `tabIndex` is set to 0.
- Added `splitButtonMenuFocused` styling to add focus border to menu button when it's in focus when `primaryDisabled` and the whole button is `!disabled`. 

**Menu Button Keyboard Focus:**
![splitbutton-focus-1](https://user-images.githubusercontent.com/8649804/113614802-d0fb4e00-9607-11eb-8aff-c51fd506bf9c.JPG)
**Menu Button Keyboard Activate:**
![splitbutton-focus-2](https://user-images.githubusercontent.com/8649804/113616068-7c58d280-9609-11eb-864a-3cfadcbe68a7.JPG)
