### PR TITLE
Improve menu controlling with `onOpenChange`

### DIFF
--- a/change/@fluentui-react-examples-d9736c46-fadc-4e20-a59f-6db0937a0c81.json
+++ b/change/@fluentui-react-examples-d9736c46-fadc-4e20-a59f-6db0937a0c81.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update controlled menu example",
+  "packageName": "@fluentui/react-examples",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-22e0ffca-d1c9-4dc8-9075-d91377e78c61.json
+++ b/change/@fluentui-react-menu-22e0ffca-d1c9-4dc8-9075-d91377e78c61.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support onOpenChange for controlled menu",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -61,7 +61,7 @@ export const MenuTriggerInteractions = () => {
 };
 
 export const NestedSubmenus = () => (
-  <Menu onOpenChange={open => console.log('open', open)}>
+  <Menu>
     <MenuTrigger>
       <button>Toggle menu</button>
     </MenuTrigger>

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -34,7 +34,6 @@ export const DefaultOpen = () => <TextOnly defaultOpen />;
 export const ControlledPopup = () => {
   const [open, setOpen] = React.useState(false);
   const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
-    console.log('xxxx');
     setOpen(data.open);
   };
 

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -33,10 +33,15 @@ export const DefaultOpen = () => <TextOnly defaultOpen />;
 
 export const ControlledPopup = () => {
   const [open, setOpen] = React.useState(false);
+  const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
+    console.log('xxxx');
+    setOpen(data.open);
+  };
+
   return (
-    <Menu open={open}>
+    <Menu open={open} onOpenChange={onOpenChange}>
       <MenuTrigger>
-        <button onClick={() => setOpen(s => !s)}>Toggle menu</button>
+        <button>Toggle menu</button>
       </MenuTrigger>
 
       <MenuList>
@@ -57,7 +62,7 @@ export const MenuTriggerInteractions = () => {
 };
 
 export const NestedSubmenus = () => (
-  <Menu>
+  <Menu onOpenChange={open => console.log('open', open)}>
     <MenuTrigger>
       <button>Toggle menu</button>
     </MenuTrigger>

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -193,7 +193,7 @@ export interface MenuProps extends MenuListProps {
     onContext?: boolean;
     // (undocumented)
     onHover?: boolean;
-    onOpenChange?: (e: React.SyntheticEvent<HTMLElement>, data: OnOpenChangeData) => void;
+    onOpenChange?: (e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>, data: OnOpenChangeData) => void;
     open?: boolean;
     position?: PositioningProps['position'];
 }
@@ -213,7 +213,7 @@ export interface MenuState extends MenuProps {
     menuTrigger: React.ReactNode;
     open: boolean;
     ref: React.MutableRefObject<HTMLElement>;
-    setOpen: (e: React.SyntheticEvent<HTMLElement>, open: boolean) => void;
+    setOpen: (e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>, open: boolean) => void;
     triggerId: string;
     triggerRef: React.MutableRefObject<HTMLElement>;
 }

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -193,6 +193,7 @@ export interface MenuProps extends MenuListProps {
     onContext?: boolean;
     // (undocumented)
     onHover?: boolean;
+    onOpenChange?: (e: React.SyntheticEvent<HTMLElement>, data: OnOpenChangeData) => void;
     open?: boolean;
     position?: PositioningProps['position'];
 }
@@ -212,7 +213,7 @@ export interface MenuState extends MenuProps {
     menuTrigger: React.ReactNode;
     open: boolean;
     ref: React.MutableRefObject<HTMLElement>;
-    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    setOpen: (e: React.SyntheticEvent<HTMLElement>, open: boolean) => void;
     triggerId: string;
     triggerRef: React.MutableRefObject<HTMLElement>;
 }
@@ -234,6 +235,10 @@ export const menuTriggerShorthandProps: (keyof MenuTriggerProps)[];
 // @public (undocumented)
 export interface MenuTriggerState extends MenuTriggerProps {
     ref: React.MutableRefObject<HTMLElement>;
+}
+
+// @public
+export interface OnOpenChangeData extends Pick<MenuState, 'open'> {
 }
 
 // @public

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -193,7 +193,7 @@ export interface MenuProps extends MenuListProps {
     onContext?: boolean;
     // (undocumented)
     onHover?: boolean;
-    onOpenChange?: (e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>, data: OnOpenChangeData) => void;
+    onOpenChange?: (e: OpenMenuEvents, data: OnOpenChangeData) => void;
     open?: boolean;
     position?: PositioningProps['position'];
 }
@@ -213,7 +213,7 @@ export interface MenuState extends MenuProps {
     menuTrigger: React.ReactNode;
     open: boolean;
     ref: React.MutableRefObject<HTMLElement>;
-    setOpen: (e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>, open: boolean) => void;
+    setOpen: (e: OpenMenuEvents, open: boolean) => void;
     triggerId: string;
     triggerRef: React.MutableRefObject<HTMLElement>;
 }
@@ -240,6 +240,9 @@ export interface MenuTriggerState extends MenuTriggerProps {
 // @public
 export interface OnOpenChangeData extends Pick<MenuState, 'open'> {
 }
+
+// @public
+export type OpenMenuEvents = MouseEvent | TouchEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>;
 
 // @public
 export const renderMenu: (state: MenuState) => JSX.Element;

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -82,6 +82,52 @@ describe('Menu', () => {
     getByRole('menu');
   });
 
+  it.each([true, false])('should call onOpenChange when the menu is controlled with open: %s', open => {
+    // Arrange
+    const onOpenChange = jest.fn();
+    const { getByRole } = render(
+      <Menu open={open} onOpenChange={onOpenChange}>
+        <MenuTrigger>
+          <button>Menu trigger</button>
+        </MenuTrigger>
+        <MenuList>
+          <MenuItem>Item</MenuItem>
+        </MenuList>
+      </Menu>,
+    );
+
+    // Act
+    fireEvent.click(getByRole('button'));
+
+    // Assert
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(expect.anything(), { open: !open });
+  });
+
+  it('should call onOpenChange when menu is opened and closed', () => {
+    // Arrange
+    const onOpenChange = jest.fn();
+    const { getByRole } = render(
+      <Menu onOpenChange={onOpenChange}>
+        <MenuTrigger>
+          <button>Menu trigger</button>
+        </MenuTrigger>
+        <MenuList>
+          <MenuItem>Item</MenuItem>
+        </MenuList>
+      </Menu>,
+    );
+
+    // Act
+    fireEvent.click(getByRole('button'));
+    fireEvent.click(getByRole('menuitem'));
+
+    // Assert
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, expect.anything(), { open: true });
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, expect.anything(), { open: false });
+  });
+
   it('should not menu after clicking on a disabled menuitem', () => {
     // Arrange
     const { getByRole, queryByRole } = render(

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -22,10 +22,7 @@ export interface MenuProps extends MenuListProps {
    * Call back when the component requests to change value
    * The `open` value is used as a hint when directly controlling the component
    */
-  onOpenChange?: (
-    e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>,
-    data: OnOpenChangeData,
-  ) => void;
+  onOpenChange?: (e: OpenMenuEvents, data: OnOpenChangeData) => void;
 
   /**
    * Whether the popup is open by default
@@ -75,10 +72,7 @@ export interface MenuState extends MenuProps {
   /**
    * Callback to open/close the popup
    */
-  setOpen: (
-    e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>,
-    open: boolean,
-  ) => void;
+  setOpen: (e: OpenMenuEvents, open: boolean) => void;
 
   /**
    * Internal react node that just simplifies handling children
@@ -120,3 +114,13 @@ export interface MenuState extends MenuProps {
  * Data attached to open/close events
  */
 export interface OnOpenChangeData extends Pick<MenuState, 'open'> {}
+
+/**
+ * The supported events that will trigger open/close of the menu
+ */
+export type OpenMenuEvents =
+  | MouseEvent
+  | TouchEvent
+  | React.MouseEvent<HTMLElement>
+  | React.KeyboardEvent<HTMLElement>
+  | React.FocusEvent<HTMLElement>;

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -22,7 +22,10 @@ export interface MenuProps extends MenuListProps {
    * Call back when the component requests to change value
    * The `open` value is used as a hint when directly controlling the component
    */
-  onOpenChange?: (e: React.SyntheticEvent<HTMLElement>, data: OnOpenChangeData) => void;
+  onOpenChange?: (
+    e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>,
+    data: OnOpenChangeData,
+  ) => void;
 
   /**
    * Whether the popup is open by default
@@ -72,7 +75,10 @@ export interface MenuState extends MenuProps {
   /**
    * Callback to open/close the popup
    */
-  setOpen: (e: React.SyntheticEvent<HTMLElement>, open: boolean) => void;
+  setOpen: (
+    e: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>,
+    open: boolean,
+  ) => void;
 
   /**
    * Internal react node that just simplifies handling children

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -19,6 +19,12 @@ export interface MenuProps extends MenuListProps {
   open?: boolean;
 
   /**
+   * Call back when the component requests to change value
+   * The `open` value is used as a hint when directly controlling the component
+   */
+  onOpenChange?: (e: React.SyntheticEvent<HTMLElement>, data: OnOpenChangeData) => void;
+
+  /**
    * Whether the popup is open by default
    */
   defaultOpen?: boolean;
@@ -66,7 +72,7 @@ export interface MenuState extends MenuProps {
   /**
    * Callback to open/close the popup
    */
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setOpen: (e: React.SyntheticEvent<HTMLElement>, open: boolean) => void;
 
   /**
    * Internal react node that just simplifies handling children
@@ -103,3 +109,8 @@ export interface MenuState extends MenuProps {
    */
   isSubmenu: boolean;
 }
+
+/**
+ * Data attached to open/close events
+ */
+export interface OnOpenChangeData extends Pick<MenuState, 'open'> {}

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -99,7 +99,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   useOnClickOutside({
     element: document,
     refs: [state.menuPopupRef, triggerRef],
-    callback: e => state.setOpen((e as unknown) as React.MouseEvent<HTMLElement>, false),
+    callback: e => state.setOpen(e, false),
   });
 
   return state;

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -78,11 +78,20 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
   // TODO fix useControllableValue typing
   state.open = open !== undefined ? open : state.open;
+  const { onOpenChange } = state;
   state.setOpen = React.useCallback(
-    (...args) => {
-      setOpen(...args);
+    (e, shouldOpen) => {
+      setOpen(prevOpen => {
+        // More than one event (mouse, focus, keyboard) can request the popup to close
+        // We assume the first event is the correct one
+        if (prevOpen !== shouldOpen) {
+          onOpenChange?.(e, { open: shouldOpen });
+        }
+
+        return shouldOpen;
+      });
     },
-    [setOpen],
+    [setOpen, onOpenChange],
   );
 
   useMenuSelectableState(state);
@@ -90,7 +99,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   useOnClickOutside({
     element: document,
     refs: [state.menuPopupRef, triggerRef],
-    callback: () => setOpen(false),
+    callback: e => state.setOpen((e as unknown) as React.MouseEvent<HTMLElement>, false),
   });
 
   return state;

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -78,7 +78,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
   // TODO fix useControllableValue typing
   state.open = open !== undefined ? open : state.open;
-  const { onOpenChange } = state;
+  const onOpenChange: MenuState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
   state.setOpen = React.useCallback(
     (e, shouldOpen) => {
       setOpen(prevOpen => {

--- a/packages/react-menu/src/components/Menu/useMenuPopup.ts
+++ b/packages/react-menu/src/components/Menu/useMenuPopup.ts
@@ -38,7 +38,7 @@ export const useMenuPopup = (state: UseMenuPopupState) => {
 
     newProps.onMouseEnter = (e: React.MouseEvent<HTMLElement>) => {
       if (onHover && !onContext) {
-        setOpen(true);
+        setOpen(e, true);
       }
 
       originalProps?.onMouseEnter?.(e);
@@ -46,7 +46,7 @@ export const useMenuPopup = (state: UseMenuPopupState) => {
 
     newProps.onBlur = (e: React.FocusEvent<HTMLElement>) => {
       if (isOutsideMenu({ triggerRef, menuPopupRef, event: e })) {
-        setOpen(false);
+        setOpen(e, false);
       }
       originalProps?.onBlur?.(e);
     };
@@ -54,7 +54,7 @@ export const useMenuPopup = (state: UseMenuPopupState) => {
     newProps.onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       const keyCode = getCode(e);
       if (keyCode === keyboardKey.Escape || (isSubmenu && keyCode === keyboardKey.ArrowLeft)) {
-        setOpen(false);
+        setOpen(e, false);
         dismissedWithKeyboardRef.current = true;
         e.stopPropagation(); // Left and Escape should only close one menu at a time
       }
@@ -72,7 +72,7 @@ export const useMenuPopup = (state: UseMenuPopupState) => {
     // Assumption made that all clicks will close the popup if propagated from children
     // To stop clicks from closing the menu call stopPropagation
     newProps.onClick = (e: React.MouseEvent<HTMLElement>) => {
-      setOpen(false);
+      setOpen(e, false);
       originalProps?.onClick?.(e);
     };
 

--- a/packages/react-menu/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.test.tsx
@@ -122,4 +122,30 @@ describe('MenuItem', () => {
     // TODO use classname assertion once classnames are added to slots
     expect(getByRole('menuitem').querySelectorAll('span').length).toBe(2);
   });
+
+  it('Should note render checkmark slot if hasCheckmark context value is false', () => {
+    // Arrange
+    const { getByRole } = render(
+      <MenuListProvider value={{ hasCheckmarks: false }}>
+        <MenuItem>Item</MenuItem>
+      </MenuListProvider>,
+    );
+
+    // Assert
+    // TODO use classname assertion once classnames are added to slots
+    expect(getByRole('menuitem').querySelectorAll('span').length).toBe(1);
+  });
+
+  it('Should render empty icon slot if hasIcons context value is false', () => {
+    // Arrange
+    const { getByRole } = render(
+      <MenuListProvider value={{ hasIcons: false }}>
+        <MenuItem>Item</MenuItem>
+      </MenuListProvider>,
+    );
+
+    // Assert
+    // TODO use classname assertion once classnames are added to slots
+    expect(getByRole('menuitem').querySelectorAll('span').length).toBe(1);
+  });
 });

--- a/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -11,12 +11,6 @@ exports[`MenuItem renders a default state 1`] = `
 >
   <span
     className=""
-  />
-  <span
-    className=""
-  />
-  <span
-    className=""
   >
     Default MenuItem
   </span>

--- a/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -35,8 +35,8 @@ export const useMenuItem = (
   const state = mergeProps(
     {
       ref: useMergedRefs(ref, React.useRef(null)),
-      icon: { as: 'span', children: hasIcons && '' },
-      checkmark: { as: 'span', children: hasCheckmarks && '' },
+      icon: { as: 'span', children: hasIcons ? '' : undefined },
+      checkmark: { as: 'span', children: hasCheckmarks ? '' : undefined },
       submenuIndicator: { as: 'span', children: <ChevronRightIcon /> },
       content: { as: 'span', children: props.children },
       secondaryContent: { as: 'span' },
@@ -44,6 +44,7 @@ export const useMenuItem = (
       tabIndex: 0,
       hasSubmenu,
       'aria-disabled': props.disabled,
+      dummy: { foo: 'xxx ' },
     },
     defaultProps && resolveShorthandProps(defaultProps, menuItemShorthandProps),
     resolveShorthandProps(props, menuItemShorthandProps),

--- a/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -31,9 +31,6 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
   </span>
   <span
     className=""
-  />
-  <span
-    className=""
   >
     Default MenuItemCheckbox
   </span>

--- a/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -31,9 +31,6 @@ exports[`MenuItemRadio renders a default state 1`] = `
   </span>
   <span
     className=""
-  />
-  <span
-    className=""
   >
     Default MenuItemRadio
   </span>

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.test.tsx
@@ -56,7 +56,7 @@ describe('useTriggerElement', () => {
 
       // Assert
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(true);
+      expect(spy).toHaveBeenCalledWith(expect.anything(), true);
     });
 
     it('should not open menu if child is disabled', () => {
@@ -98,7 +98,7 @@ describe('useTriggerElement', () => {
 
       // Assert
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(expectedValue);
+      expect(spy).toHaveBeenCalledWith(expect.anything(), expectedValue);
     });
 
     it.each([
@@ -157,7 +157,7 @@ describe('useTriggerElement', () => {
 
       // Assert
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(true);
+      expect(spy).toHaveBeenCalledWith(expect.anything(), true);
     });
 
     it('should not open menu if child is disabled', () => {
@@ -204,7 +204,7 @@ describe('useTriggerElement', () => {
 
     // Assert
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(true);
+    expect(spy).toHaveBeenCalledWith(expect.anything(), true);
   });
 
   it('should open menu on down arrow for root trigger', () => {
@@ -220,6 +220,6 @@ describe('useTriggerElement', () => {
 
     // Assert
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(true);
+    expect(spy).toHaveBeenCalledWith(expect.anything(), true);
   });
 });

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -39,15 +39,15 @@ export const useTriggerElement = (state: UseTriggerElementState): MenuTriggerSta
   // TODO also need to warn on React.Fragment usage
   const child = React.Children.only(state.children);
 
-  const onContextMenu = useEventCallback((e: React.MouseEvent) => {
+  const onContextMenu = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
     if (onContext) {
       e.preventDefault();
-      setOpen(true);
+      setOpen(e, true);
     }
     child.props?.onContextMenu?.(e);
   });
 
-  const onClick = useEventCallback((e: React.MouseEvent) => {
+  const onClick = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
     // Click event will close the menu popup
     // Therefore, do not propagate click events to parent popup for nested menu trigger
     if (isSubmenu) {
@@ -55,12 +55,12 @@ export const useTriggerElement = (state: UseTriggerElementState): MenuTriggerSta
     }
 
     if (!onContext) {
-      setOpen(!open);
+      setOpen(e, !open);
     }
     child.props?.onClick?.(e);
   });
 
-  const onKeyDown = useEventCallback((e: React.KeyboardEvent) => {
+  const onKeyDown = useEventCallback((e: React.KeyboardEvent<HTMLElement>) => {
     if (shouldPreventDefaultOnKeyDown(e)) {
       e.preventDefault();
       openedWithKeyboardRef.current = true;
@@ -73,23 +73,23 @@ export const useTriggerElement = (state: UseTriggerElementState): MenuTriggerSta
       ((isSubmenu && keyCode === keyboardKey.ArrowRight) || (!isSubmenu && keyCode === keyboardKey.ArrowDown))
     ) {
       openedWithKeyboardRef.current = true;
-      setOpen(true);
+      setOpen(e, true);
     }
 
     child.props?.onKeyDown?.(e);
   });
 
-  const onMouseEnter = useEventCallback((e: React.MouseEvent) => {
+  const onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
     if (onHover && !onContext) {
-      setOpen(true);
+      setOpen(e, true);
     }
     child.props?.onMouseEnter?.(e);
   });
 
   // no mouse leave, since mouse enter sets focus for menu items
-  const onBlur = useEventCallback((e: React.FocusEvent) => {
+  const onBlur = useEventCallback((e: React.FocusEvent<HTMLElement>) => {
     if (isOutsideMenu({ menuPopupRef, triggerRef, event: e })) {
-      setOpen(false);
+      setOpen(e, false);
     }
 
     child.props?.onBlur?.(e);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds `onOpenChange` callback to the `Menu` which is called when the internals of the menu component request a change to the open state of the menu.

When the menu is not controlled (i.e. no `open`) prop, this callback can be used to watch the changes of the menu internal state.

When the menu is controlled, allows the consumer to benefit from the popup edge cases that are used internally.