### PR TITLE
CollapsibleSection: Add aria-expanded attribute to button to improve docsite a11y experience

### DIFF
--- a/change/@fluentui-react-experiments-a5dcf468-a0e0-402a-b3ee-8f9fbd535cdf.json
+++ b/change/@fluentui-react-experiments-a5dcf468-a0e0-402a-b3ee-8f9fbd535cdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "CollapsibleSection: Add aria-expanded attribute to button to improve docsite a11y experience",
+  "packageName": "@fluentui/react-experiments",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
@@ -25,6 +25,7 @@ export const CollapsibleSectionView: ICollapsibleSectionComponent['view'] = prop
         onClick={onClick}
         onKeyDown={onKeyDown}
         indent={indent}
+        aria-expanded={!props.collapsed}
       />
       {!collapsed && <Slots.body>{children}</Slots.body>}
     </Slots.root>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug [11491](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11491) 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Adds `aria-expanded` to collapsible buttons in docsite side nav