### PR TITLE
Pickers: Improving picker tag selection accessibility

### DIFF
--- a/change/@fluentui-react-39740eb8-4b3a-42eb-8c4c-6938f59d123e.json
+++ b/change/@fluentui-react-39740eb8-4b3a-42eb-8c4c-6938f59d123e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Accessibility update for picker selected item semantics and focus behavior\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-43ed2ad1-99ec-4200-a9c8-b4ee31b5e0c8.json
+++ b/change/@fluentui-react-examples-43ed2ad1-99ec-4200-a9c8-b4ee31b5e0c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update picker examples with labels\"",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Announced/Announced.SearchResults.Example.tsx
+++ b/packages/react-examples/src/react/Announced/Announced.SearchResults.Example.tsx
@@ -65,6 +65,8 @@ export const AnnouncedSearchResultsExample: React.FunctionComponent = () => {
       </Text>
       {hasFilterText && <Announced message={`${suggestionCount} color tag${suggestionCount === 1 ? '' : 's'} found`} />}
       <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Selected colors"
         onResolveSuggestions={onFilterChanged}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={pickerSuggestionsProps}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Compact.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Compact.Example.tsx
@@ -96,6 +96,8 @@ export const PeoplePickerCompactExample: React.FunctionComponent = () => {
         onEmptyInputFocus={returnMostRecentlyUsed}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={suggestionProps}
+        selectionAriaLabel={'Selected contacts'}
+        removeButtonAriaLabel={'Remove'}
         className={'ms-PeoplePicker'}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Controlled.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Controlled.Example.tsx
@@ -89,12 +89,15 @@ export const PeoplePickerControlledExample: React.FunctionComponent = () => {
           pickerSuggestionsProps={suggestionProps}
           className={'ms-PeoplePicker'}
           key={'controlled'}
+          selectionAriaLabel={'Selected contacts'}
+          removeButtonAriaLabel={'Remove'}
           selectedItems={currentSelectedItems}
           // eslint-disable-next-line react/jsx-no-bind
           onChange={onItemsChange}
           inputProps={{
             onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
             onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),
+            'aria-label': 'Contacts',
           }}
           componentRef={picker}
           resolveDelay={300}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.LimitedSearch.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.LimitedSearch.Example.tsx
@@ -116,6 +116,8 @@ export const PeoplePickerLimitedSearchExample: React.FunctionComponent = () => {
         className={'ms-PeoplePicker'}
         onGetMoreResults={onFilterChanged}
         pickerSuggestionsProps={limitedSearchSuggestionProps}
+        selectionAriaLabel={'Selected contacts'}
+        removeButtonAriaLabel={'Remove'}
         onRemoveSuggestion={onRemoveSuggestion}
         /* eslint-enable react/jsx-no-bind */
         inputProps={{

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -98,6 +98,8 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
         className={'ms-PeoplePicker'}
         pickerSuggestionsProps={suggestionProps}
         key={'list'}
+        selectionAriaLabel={'Selected contacts'}
+        removeButtonAriaLabel={'Remove'}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
         onValidateInput={validateInput}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Normal.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Normal.Example.tsx
@@ -101,6 +101,7 @@ export const PeoplePickerNormalExample: React.FunctionComponent = () => {
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
         onValidateInput={validateInput}
+        selectionAriaLabel={'Selected contacts'}
         removeButtonAriaLabel={'Remove'}
         inputProps={{
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.PreselectedItems.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.PreselectedItems.Example.tsx
@@ -98,6 +98,8 @@ export const PeoplePickerPreselectedItemsExample: React.FunctionComponent = () =
         className={'ms-PeoplePicker'}
         defaultSelectedItems={peopleList.slice(0, 3)}
         key={'list'}
+        selectionAriaLabel={'Selected contacts'}
+        removeButtonAriaLabel={'Remove'}
         pickerSuggestionsProps={suggestionProps}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.ProcessSelection.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.ProcessSelection.Example.tsx
@@ -100,6 +100,7 @@ export const PeoplePickerProcessSelectionExample: React.FunctionComponent = () =
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
         onValidateInput={validateInput}
+        selectionAriaLabel={'Selected contacts'}
         removeButtonAriaLabel={'Remove'}
         onItemSelected={onItemSelected}
         inputProps={{

--- a/packages/react-examples/src/react/Pickers/Picker.CustomResult.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/Picker.CustomResult.Example.tsx
@@ -384,6 +384,8 @@ export const PickerCustomResultExample: React.FunctionComponent = () => {
         onRenderItem={SelectedDocumentItem}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={pickerSuggestionsProps}
+        selectionAriaLabel="Selected documents"
+        selectionRole="group"
         disabled={isPickerDisabled}
         inputProps={inputProps}
       />

--- a/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
@@ -85,6 +85,7 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
       </label>
       <TagPicker
         removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Selected colors"
         onResolveSuggestions={filterSuggestedTags}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={pickerSuggestionsProps}
@@ -101,6 +102,7 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
       </label>
       <TagPicker
         removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Selected colors"
         componentRef={picker}
         onResolveSuggestions={filterSelectedTags}
         onItemSelected={onItemSelected}

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
   <div
     className="ms-BasePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -49,7 +49,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
       hidden={true}
       id="selected-items-id__0-label"
     >
-      Tag Picker
+      Selected colors
     </span>
     <div
       className="ms-SelectionZone"

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -44,100 +44,94 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Tag Picker
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="Tag Picker"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="Tag Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -7,101 +7,95 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="People Picker"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -162,7 +156,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -190,7 +184,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -321,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -349,7 +343,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
   <div
     className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -8,100 +8,95 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
       onBlur={[Function]}
       onKeyDown={[Function]}
     >
+      <span
+        hidden={true}
+        id="selected-items-id__0-label"
+      >
+        Selected contacts
+      </span>
       <div
-        className=
-            ms-FocusZone
-            &:focus {
-              outline: none;
-            }
-        data-focuszone-id="FocusZone1"
-        onFocus={[Function]}
+        className="ms-SelectionZone"
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onDoubleClick={[Function]}
+        onFocusCapture={[Function]}
         onKeyDown={[Function]}
+        onKeyDownCapture={[Function]}
+        onMouseDown={[Function]}
         onMouseDownCapture={[Function]}
+        role="presentation"
       >
         <div
-          className="ms-SelectionZone"
-          onClick={[Function]}
-          onContextMenu={[Function]}
-          onDoubleClick={[Function]}
-          onFocusCapture={[Function]}
-          onKeyDown={[Function]}
-          onKeyDownCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseDownCapture={[Function]}
-          role="presentation"
-        >
-          <div
-            className=
-                ms-BasePicker-text
-                {
-                  align-items: center;
-                  border-radius: 2px;
-                  border: 1px solid #605e5c;
-                  box-sizing: border-box;
-                  display: flex;
-                  flex-wrap: wrap;
-                  min-height: 30px;
-                  min-width: 180px;
-                  position: relative;
-                }
-                &:hover {
-                  border-color: #323130;
-                }
-          >
-            <input
-              aria-autocomplete="both"
-              aria-controls=""
-              aria-expanded={false}
-              aria-haspopup="listbox"
-              autoCapitalize="off"
-              autoComplete="off"
-              className=
-                  ms-BasePicker-input
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    align-self: flex-end;
-                    background-color: transparent;
-                    border-radius: 2px;
-                    border: none;
-                    color: #323130;
-                    flex-grow: 1;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    outline: none;
-                    padding-bottom: 0;
-                    padding-left: 6px;
-                    padding-right: 6px;
-                    padding-top: 0;
-                  }
-                  &::-ms-clear {
-                    display: none;
-                  }
-              data-lpignore={true}
-              disabled={false}
-              id="combobox-id__0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onClick={[Function]}
-              onCompositionEnd={[Function]}
-              onCompositionStart={[Function]}
-              onCompositionUpdate={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              onKeyDown={[Function]}
-              role="combobox"
-              spellCheck={false}
-              style={
-                Object {
-                  "fontFamily": "inherit",
-                }
+          className=
+              ms-BasePicker-text
+              {
+                align-items: center;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-sizing: border-box;
+                display: flex;
+                flex-wrap: wrap;
+                min-height: 30px;
+                min-width: 180px;
+                position: relative;
               }
-              value=""
-            />
-          </div>
+              &:hover {
+                border-color: #323130;
+              }
+        >
+          <input
+            aria-autocomplete="both"
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-label="Contacts"
+            autoCapitalize="off"
+            autoComplete="off"
+            className=
+                ms-BasePicker-input
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-self: flex-end;
+                  background-color: transparent;
+                  border-radius: 2px;
+                  border: none;
+                  color: #323130;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 30px;
+                  outline: none;
+                  padding-bottom: 0;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+            data-lpignore={true}
+            disabled={false}
+            id="combobox-id__0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onCompositionEnd={[Function]}
+            onCompositionStart={[Function]}
+            onCompositionUpdate={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            role="combobox"
+            spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
+            value=""
+          />
         </div>
       </div>
     </div>
@@ -2093,7 +2088,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-37"
+      id="checkbox-36"
       onChange={[Function]}
       type="checkbox"
     />
@@ -2121,7 +2116,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-37"
+      htmlFor="checkbox-36"
     >
       <div
         className=
@@ -2252,7 +2247,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-38"
+      id="checkbox-37"
       onChange={[Function]}
       type="checkbox"
     />
@@ -2280,7 +2275,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-38"
+      htmlFor="checkbox-37"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -6,6 +6,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
     <div
       className="ms-BasePicker ms-PeoplePicker"
       onBlur={[Function]}
+      onFocus={[Function]}
       onKeyDown={[Function]}
     >
       <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
   <div
     className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -7,101 +7,95 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="People Picker"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -162,7 +156,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -190,7 +184,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -321,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -349,7 +343,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -4,6 +4,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
 <div>
   <div
     onBlur={[Function]}
+    onFocus={[Function]}
   >
     <div
       className="ms-BasePicker ms-PeoplePicker"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -60,6 +60,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               }
           data-lpignore={true}
           disabled={false}
+          id="combobox-id__0"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -92,17 +93,9 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
       role="presentation"
     >
       <div
-        className=
-            ms-FocusZone
-            ms-BasePicker-selectedItems
-            &:focus {
-              outline: none;
-            }
-        data-focuszone-id="FocusZone1"
+        aria-label="Selected contacts"
+        className="ms-BasePicker-selectedItems"
         id="selected-items-id__0"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
         role="list"
       />
     </div>
@@ -164,7 +157,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -192,7 +185,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -323,7 +316,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -351,7 +344,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -7,101 +7,95 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="People Picker"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -162,7 +156,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -190,7 +184,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -321,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -349,7 +343,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
   <div
     className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
   <div
     className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -7,1452 +7,1447 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
+            }
+            &:hover {
+              border-color: #323130;
+            }
       >
-        <div
+        <span
+          aria-labelledby="selected-items-id__0-label"
           className=
-              ms-BasePicker-text
+              ms-BasePicker-itemsWrapper
               {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
+                max-width: 100%;
               }
-              &:hover {
-                border-color: #323130;
-              }
+          id="selected-items-id__0"
+          role="list"
         >
-          <span
+          <div
             className=
-                ms-BasePicker-itemsWrapper
+                ms-PickerPersona-container
                 {
-                  display: flex;
-                  flex-wrap: wrap;
-                  max-width: 100%;
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
                 }
-            id="selected-items-id__0"
-            role="list"
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
           >
             <div
-              aria-labelledby="selectedItemPersona-id__28"
               className=
-                  ms-PickerPersona-container
+                  ms-PickerItem-content
                   {
-                    align-items: center;
-                    background: #f3f2f1;
-                    border-radius: 15px;
-                    cursor: default;
-                    display: inline-flex;
-                    margin-bottom: 1px;
-                    margin-left: 2px;
-                    margin-right: 2px;
-                    margin-top: 1px;
-                    max-width: 300px;
+                    flex: 0 1 auto;
+                    max-width: 100%;
                     min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__27"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--online
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: content-box;
+                            background-color: #6BB700;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: Highlight;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Annie Lindqvist
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Designer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__27 selectedItemPersona-id__27"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
                     outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
                     position: relative;
+                    text-align: center;
+                    text-decoration: none;
                     user-select: none;
-                    vertical-align: middle;
+                    width: 24px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: -1px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: -1px;
+                    left: 2px;
                     outline: 1px solid #605e5c;
                     position: absolute;
-                    right: -1px;
-                    top: -1px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
-                  &:hover {
-                    background: #edebe9;
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
                   }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: 1px solid WindowText;
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
                   }
               data-is-focusable={true}
-              data-is-sub-focuszone={true}
               data-selection-index={0}
-              role="listitem"
+              id="id__27"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              <div
+              <span
                 className=
-                    ms-PickerItem-content
+                    ms-Button-flexContainer
                     {
-                      flex: 0 1 auto;
-                      max-width: 100%;
-                      min-width: 0px;
-                      overflow: hidden;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
                     }
-                id="selectedItemPersona-id__28"
+                data-automationid="splitbuttonprimary"
               >
-                <div
+                <i
+                  aria-hidden={true}
                   className=
-                      ms-Persona
-                      ms-Persona--size24
-                      ms-Persona--online
+                      ms-Button-icon
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        align-items: center;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        color: #323130;
-                        display: flex;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 24px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        min-width: 24px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
                       }
-                      & .contextualHost {
-                        display: none;
-                      }
+                  data-icon-name="Cancel"
                 >
-                  <div
-                    className=
-                        ms-Persona-coin
-                        ms-Persona--size24
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                        }
-                    role="presentation"
-                  >
-                    <div
-                      className=
-                          ms-Persona-imageArea
-                          {
-                            flex: 0 0 auto;
-                            height: 24px;
-                            position: relative;
-                            text-align: center;
-                            width: 24px;
-                          }
-                      role="presentation"
-                    >
-                      <div
-                        className=
-                            ms-Image
-                            ms-Persona-image
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              border-radius: 50%;
-                              border: 0px;
-                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                              font-size: 14px;
-                              font-weight: 400;
-                              height: 24px;
-                              left: 0px;
-                              margin-right: 10px;
-                              overflow: hidden;
-                              perspective: 1px;
-                              position: absolute;
-                              top: 0px;
-                              width: 24px;
-                            }
-                        style={
-                          Object {
-                            "height": 24,
-                            "width": 24,
-                          }
-                        }
-                      >
-                        <img
-                          alt=""
-                          className=
-                              ms-Image-image
-                              ms-Image-image--cover
-                              ms-Image-image--portrait
-                              is-notLoaded
-                              is-fadeIn
-                              {
-                                display: block;
-                                height: 100%;
-                                object-fit: cover;
-                                opacity: 0;
-                                width: 100%;
-                              }
-                          onError={[Function]}
-                          onLoad={[Function]}
-                          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                        />
-                      </div>
-                      <div
-                        className=
-                            ms-Persona-presence
-                            {
-                              -ms-high-contrast-adjust: none;
-                              background-clip: content-box;
-                              background-color: #6BB700;
-                              border-radius: 50%;
-                              border: 2px solid #ffffff;
-                              bottom: -2px;
-                              box-sizing: content-box;
-                              forced-color-adjust: none;
-                              height: 8px;
-                              position: absolute;
-                              right: -2px;
-                              text-align: center;
-                              top: auto;
-                              width: 8px;
-                            }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                              background-color: Highlight;
-                              border-color: Window;
-                            }
-                        role="presentation"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className=
-                        ms-Persona-details
-                        {
-                          display: flex;
-                          flex-direction: column;
-                          justify-content: space-around;
-                          min-width: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-align: left;
-                          width: 100%;
-                        }
-                  >
-                    <div
-                      className=
-                          ms-Persona-primaryText
-                          {
-                            color: #323130;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                          &:hover {
-                            color: #201f1e;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Annie Lindqvist
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-secondaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 12px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Designer
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-tertiaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        In a meeting
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-optionalText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Available at 4:00pm
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <button
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-PickerItem-removeButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 15px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #323130;
-                      cursor: pointer;
-                      display: inline-block;
-                      flex: 0 0 auto;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 24px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      width: 24px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid transparent;
-                      bottom: 2px;
-                      content: "";
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      background: #c8c6c4;
-                      color: #201f1e;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #005a9e;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Button-icon
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          display: inline-block;
-                          flex-shrink: 0;
-                          font-family: "FabricMDL2Icons";
-                          font-size: 12px;
-                          font-style: normal;
-                          font-weight: normal;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          speak: none;
-                          text-align: center;
-                        }
-                    data-icon-name="Cancel"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="selectedItemPersona-id__29"
-              className=
-                  ms-PickerPersona-container
-                  {
-                    align-items: center;
-                    background: #f3f2f1;
-                    border-radius: 15px;
-                    cursor: default;
-                    display: inline-flex;
-                    margin-bottom: 1px;
-                    margin-left: 2px;
-                    margin-right: 2px;
-                    margin-top: 1px;
-                    max-width: 300px;
-                    min-width: 0px;
-                    outline: transparent;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: middle;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: -1px;
-                    content: "";
-                    left: -1px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: -1px;
-                    top: -1px;
-                    z-index: 1;
-                  }
-                  &:hover {
-                    background: #edebe9;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: 1px solid WindowText;
-                  }
-              data-is-focusable={true}
-              data-is-sub-focuszone={true}
-              data-selection-index={1}
-              role="listitem"
-            >
-              <div
-                className=
-                    ms-PickerItem-content
-                    {
-                      flex: 0 1 auto;
-                      max-width: 100%;
-                      min-width: 0px;
-                      overflow: hidden;
-                    }
-                id="selectedItemPersona-id__29"
-              >
-                <div
-                  className=
-                      ms-Persona
-                      ms-Persona--size24
-                      ms-Persona--busy
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        align-items: center;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        color: #323130;
-                        display: flex;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 24px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        min-width: 24px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      & .contextualHost {
-                        display: none;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Persona-coin
-                        ms-Persona--size24
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                        }
-                    role="presentation"
-                  >
-                    <div
-                      className=
-                          ms-Persona-imageArea
-                          {
-                            flex: 0 0 auto;
-                            height: 24px;
-                            position: relative;
-                            text-align: center;
-                            width: 24px;
-                          }
-                      role="presentation"
-                    >
-                      <div
-                        className=
-                            ms-Image
-                            ms-Persona-image
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              border-radius: 50%;
-                              border: 0px;
-                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                              font-size: 14px;
-                              font-weight: 400;
-                              height: 24px;
-                              left: 0px;
-                              margin-right: 10px;
-                              overflow: hidden;
-                              perspective: 1px;
-                              position: absolute;
-                              top: 0px;
-                              width: 24px;
-                            }
-                        style={
-                          Object {
-                            "height": 24,
-                            "width": 24,
-                          }
-                        }
-                      >
-                        <img
-                          alt=""
-                          className=
-                              ms-Image-image
-                              ms-Image-image--cover
-                              ms-Image-image--portrait
-                              is-notLoaded
-                              is-fadeIn
-                              {
-                                display: block;
-                                height: 100%;
-                                object-fit: cover;
-                                opacity: 0;
-                                width: 100%;
-                              }
-                          onError={[Function]}
-                          onLoad={[Function]}
-                          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
-                        />
-                      </div>
-                      <div
-                        className=
-                            ms-Persona-presence
-                            {
-                              -ms-high-contrast-adjust: none;
-                              background-clip: content-box;
-                              background-color: #C43148;
-                              border-radius: 50%;
-                              border: 2px solid #ffffff;
-                              bottom: -2px;
-                              box-sizing: content-box;
-                              forced-color-adjust: none;
-                              height: 8px;
-                              position: absolute;
-                              right: -2px;
-                              text-align: center;
-                              top: auto;
-                              width: 8px;
-                            }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                              background-color: WindowText;
-                              border-color: Window;
-                            }
-                        role="presentation"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className=
-                        ms-Persona-details
-                        {
-                          display: flex;
-                          flex-direction: column;
-                          justify-content: space-around;
-                          min-width: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-align: left;
-                          width: 100%;
-                        }
-                  >
-                    <div
-                      className=
-                          ms-Persona-primaryText
-                          {
-                            color: #323130;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                          &:hover {
-                            color: #201f1e;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Aaron Reid
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-secondaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 12px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Designer
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-tertiaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        In a meeting
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-optionalText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Available at 4:00pm
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <button
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-PickerItem-removeButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 15px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #323130;
-                      cursor: pointer;
-                      display: inline-block;
-                      flex: 0 0 auto;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 24px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      width: 24px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid transparent;
-                      bottom: 2px;
-                      content: "";
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      background: #c8c6c4;
-                      color: #201f1e;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #005a9e;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Button-icon
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          display: inline-block;
-                          flex-shrink: 0;
-                          font-family: "FabricMDL2Icons";
-                          font-size: 12px;
-                          font-style: normal;
-                          font-weight: normal;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          speak: none;
-                          text-align: center;
-                        }
-                    data-icon-name="Cancel"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="selectedItemPersona-id__30"
-              className=
-                  ms-PickerPersona-container
-                  {
-                    align-items: center;
-                    background: #f3f2f1;
-                    border-radius: 15px;
-                    cursor: default;
-                    display: inline-flex;
-                    margin-bottom: 1px;
-                    margin-left: 2px;
-                    margin-right: 2px;
-                    margin-top: 1px;
-                    max-width: 300px;
-                    min-width: 0px;
-                    outline: transparent;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: middle;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: -1px;
-                    content: "";
-                    left: -1px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: -1px;
-                    top: -1px;
-                    z-index: 1;
-                  }
-                  &:hover {
-                    background: #edebe9;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: 1px solid WindowText;
-                  }
-              data-is-focusable={true}
-              data-is-sub-focuszone={true}
-              data-selection-index={2}
-              role="listitem"
-            >
-              <div
-                className=
-                    ms-PickerItem-content
-                    {
-                      flex: 0 1 auto;
-                      max-width: 100%;
-                      min-width: 0px;
-                      overflow: hidden;
-                    }
-                id="selectedItemPersona-id__30"
-              >
-                <div
-                  className=
-                      ms-Persona
-                      ms-Persona--size24
-                      ms-Persona--donotdisturb
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        align-items: center;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        color: #323130;
-                        display: flex;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
-                        height: 24px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        min-width: 24px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      & .contextualHost {
-                        display: none;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Persona-coin
-                        ms-Persona--size24
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                        }
-                    role="presentation"
-                  >
-                    <div
-                      className=
-                          ms-Persona-imageArea
-                          {
-                            flex: 0 0 auto;
-                            height: 24px;
-                            position: relative;
-                            text-align: center;
-                            width: 24px;
-                          }
-                      role="presentation"
-                    >
-                      <div
-                        className=
-                            ms-Image
-                            ms-Persona-image
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              border-radius: 50%;
-                              border: 0px;
-                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                              font-size: 14px;
-                              font-weight: 400;
-                              height: 24px;
-                              left: 0px;
-                              margin-right: 10px;
-                              overflow: hidden;
-                              perspective: 1px;
-                              position: absolute;
-                              top: 0px;
-                              width: 24px;
-                            }
-                        style={
-                          Object {
-                            "height": 24,
-                            "width": 24,
-                          }
-                        }
-                      >
-                        <img
-                          alt=""
-                          className=
-                              ms-Image-image
-                              ms-Image-image--cover
-                              ms-Image-image--portrait
-                              is-notLoaded
-                              is-fadeIn
-                              {
-                                display: block;
-                                height: 100%;
-                                object-fit: cover;
-                                opacity: 0;
-                                width: 100%;
-                              }
-                          onError={[Function]}
-                          onLoad={[Function]}
-                          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
-                        />
-                      </div>
-                      <div
-                        className=
-                            ms-Persona-presence
-                            {
-                              -ms-high-contrast-adjust: none;
-                              background-clip: content-box;
-                              background-color: #C50F1F;
-                              border-radius: 50%;
-                              border: 2px solid #ffffff;
-                              bottom: -2px;
-                              box-sizing: content-box;
-                              forced-color-adjust: none;
-                              height: 8px;
-                              position: absolute;
-                              right: -2px;
-                              text-align: center;
-                              top: auto;
-                              width: 8px;
-                            }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                              background-color: WindowText;
-                              border-color: Window;
-                            }
-                        role="presentation"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className=
-                        ms-Persona-details
-                        {
-                          display: flex;
-                          flex-direction: column;
-                          justify-content: space-around;
-                          min-width: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-align: left;
-                          width: 100%;
-                        }
-                  >
-                    <div
-                      className=
-                          ms-Persona-primaryText
-                          {
-                            color: #323130;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                          &:hover {
-                            color: #201f1e;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Alex Lundberg
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-secondaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 12px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Software Developer
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-tertiaryText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        In a meeting
-                      </div>
-                    </div>
-                    <div
-                      className=
-                          ms-Persona-optionalText
-                          {
-                            color: #605e5c;
-                            display: none;
-                            font-size: 14px;
-                            font-weight: 400;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                          }
-                      dir="auto"
-                    >
-                      <div
-                        className=
-                            ms-TooltipHost
-                            {
-                              display: inline;
-                            }
-                        onBlurCapture={[Function]}
-                        onFocusCapture={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        Available at 4:00pm
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <button
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-PickerItem-removeButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 15px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #323130;
-                      cursor: pointer;
-                      display: inline-block;
-                      flex: 0 0 auto;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 24px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      width: 24px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid transparent;
-                      bottom: 2px;
-                      content: "";
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      background: #c8c6c4;
-                      color: #201f1e;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #005a9e;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Button-icon
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          display: inline-block;
-                          flex-shrink: 0;
-                          font-family: "FabricMDL2Icons";
-                          font-size: 12px;
-                          font-style: normal;
-                          font-weight: normal;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          speak: none;
-                          text-align: center;
-                        }
-                    data-icon-name="Cancel"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </div>
-          </span>
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-describedby="selected-items-id__0"
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="People Picker"
-            autoCapitalize="off"
-            autoComplete="off"
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-BasePicker-input
+                ms-PickerPersona-container
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
                 }
-                &::-ms-clear {
-                  display: none;
+                &::-moz-focus-inner {
+                  border: 0;
                 }
-            data-lpignore={true}
-            disabled={false}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-PickerItem-content
+                  {
+                    flex: 0 1 auto;
+                    max-width: 100%;
+                    min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__28"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--busy
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: content-box;
+                            background-color: #C43148;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: WindowText;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Aaron Reid
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Designer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__28 selectedItemPersona-id__28"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
+                  }
+              data-is-focusable={true}
+              data-selection-index={1}
+              id="id__28"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+          <div
+            className=
+                ms-PickerPersona-container
+                {
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-PickerItem-content
+                  {
+                    flex: 0 1 auto;
+                    max-width: 100%;
+                    min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__29"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--donotdisturb
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: content-box;
+                            background-color: #C50F1F;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: WindowText;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Alex Lundberg
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Software Developer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__29 selectedItemPersona-id__29"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
+                  }
+              data-is-focusable={true}
+              data-selection-index={2}
+              id="id__29"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </span>
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-describedby="selected-items-id__0"
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
             }
-            value=""
-          />
-        </div>
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -1513,7 +1508,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-26"
+      id="checkbox-25"
       onChange={[Function]}
       type="checkbox"
     />
@@ -1541,7 +1536,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-26"
+      htmlFor="checkbox-25"
     >
       <div
         className=
@@ -1672,7 +1667,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-27"
+      id="checkbox-26"
       onChange={[Function]}
       type="checkbox"
     />
@@ -1700,7 +1695,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-27"
+      htmlFor="checkbox-26"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
   <div
     className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -7,101 +7,95 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-label="People Picker"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="combobox-id__0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -162,7 +156,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -190,7 +184,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -321,7 +315,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-3"
+      id="checkbox-2"
       onChange={[Function]}
       type="checkbox"
     />
@@ -349,7 +343,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-3"
+      htmlFor="checkbox-2"
     >
       <div
         className=

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -148,6 +148,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   <div
     className="ms-BasePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span
@@ -250,6 +251,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   <div
     className="ms-BasePicker"
     onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <span

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -150,100 +150,94 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__1-label"
+    >
+      Selected colors
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone2"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="picker1"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="picker1"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>
@@ -258,100 +252,94 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
+    <span
+      hidden={true}
+      id="selected-items-id__2-label"
+    >
+      Selected colors
+    </span>
     <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone4"
-      onFocus={[Function]}
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
       onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="presentation"
     >
       <div
-        className="ms-SelectionZone"
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDoubleClick={[Function]}
-        onFocusCapture={[Function]}
-        onKeyDown={[Function]}
-        onKeyDownCapture={[Function]}
-        onMouseDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <div
-          className=
-              ms-BasePicker-text
-              {
-                align-items: center;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                display: flex;
-                flex-wrap: wrap;
-                min-height: 30px;
-                min-width: 180px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-        >
-          <input
-            aria-autocomplete="both"
-            aria-controls=""
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            autoCapitalize="off"
-            autoComplete="off"
-            className=
-                ms-BasePicker-input
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-self: flex-end;
-                  background-color: transparent;
-                  border-radius: 2px;
-                  border: none;
-                  color: #323130;
-                  flex-grow: 1;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 30px;
-                  outline: none;
-                  padding-bottom: 0;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-            data-lpignore={true}
-            disabled={false}
-            id="picker2"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            role="combobox"
-            spellCheck={false}
-            style={
-              Object {
-                "fontFamily": "inherit",
-              }
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
             }
-            value=""
-          />
-        </div>
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="picker2"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
       </div>
     </div>
   </div>

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -329,6 +329,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     protected onClick: (ev: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
     protected onEmptyInputFocus(): void;
     // (undocumented)
+    protected onFocus: () => void;
+    // (undocumented)
     protected onGetMoreResults: () => void;
     // (undocumented)
     protected onInputBlur: (ev: React.FocusEvent<HTMLInputElement | Autofill>) => void;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1587,6 +1587,8 @@ export interface IBasePickerProps<T> extends React.Props<any> {
         input: string;
     }) => string) | string;
     selectedItems?: T[];
+    selectionAriaLabel?: string;
+    selectionRole?: string;
     styles?: IStyleFunctionOrObject<IBasePickerStyleProps, IBasePickerStyles>;
     theme?: ITheme;
 }

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -17,7 +17,6 @@ import { ICSSPixelUnitRule } from '@fluentui/merge-styles/lib/IRawStyleBase';
 import { ICSSRule } from '@fluentui/merge-styles/lib/IRawStyleBase';
 import { IDateFormatting } from '@fluentui/date-time-utilities';
 import { IDayGridOptions } from '@fluentui/date-time-utilities';
-import { IFocusZone } from '@fluentui/react-focus';
 import { IFocusZoneProps } from '@fluentui/react-focus';
 import { IFontStyles } from '@fluentui/style-utilities';
 import { IHTMLSlot } from '@fluentui/foundation-legacy';
@@ -310,8 +309,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // (undocumented)
     focusInput(): void;
     // (undocumented)
-    protected focusZone: React.RefObject<IFocusZone>;
-    // (undocumented)
     protected getActiveDescendant(): string | undefined;
     // (undocumented)
     static getDerivedStateFromProps(newProps: IBasePickerProps<any>): {
@@ -371,7 +368,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     protected root: React.RefObject<HTMLDivElement>;
     // (undocumented)
     protected selection: Selection;
-    // (undocumented)
+    // @deprecated (undocumented)
     protected _shouldFocusZoneEnterInnerZone: (ev: React.KeyboardEvent<HTMLElement>) => boolean;
     // (undocumented)
     protected suggestionElement: React.RefObject<ISuggestions<T>>;

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -568,7 +568,7 @@ describe('BasePicker', () => {
       root,
     );
 
-    let input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'bl';
     ReactTestUtils.Simulate.input(input);

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -274,6 +274,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 
     const comboLabel = this.props['aria-label'] || inputProps?.['aria-label'];
 
+    // selectionAriaLabel is contained in a separate <span> rather than an aria-label on the items list
+    // because if the items list has an aria-label, the aria-describedby on the input will only read
+    // that label instead of all the selected items. Using aria-labelledby instead fixes this, since
+    // aria-describedby and aria-labelledby will not follow a second aria-labelledby
     return (
       <div ref={this.root} className={classNames.root} onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
         {this.getSuggestionsAlert(classNames.screenReaderText)}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -10,7 +10,7 @@ import {
   initializeComponentRef,
 } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
-import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { IFocusZone } from '../../FocusZone';
 import { Callout } from '../../Callout';
 import { Selection, SelectionZone, SelectionMode } from '../../utilities/selection/index';
 import { DirectionalHint } from '../../common/DirectionalHint';
@@ -179,8 +179,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
   }
 
   public focus() {
-    if (this.focusZone.current) {
-      this.focusZone.current.focus();
+    if (this.input.current) {
+      this.input.current.focus();
     }
   }
 
@@ -243,7 +243,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused, items } = this.state;
-    const { className, inputProps, disabled, theme, styles } = this.props;
+    const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
@@ -270,47 +270,48 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
           screenReaderText: legacyStyles.screenReaderOnly,
         };
 
+    const comboLabel = this.props['aria-label'] || inputProps?.['aria-label'];
+
     return (
       <div ref={this.root} className={classNames.root} onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
-        <FocusZone
-          componentRef={this.focusZone}
-          direction={FocusZoneDirection.bidirectional}
-          shouldEnterInnerZone={this._shouldFocusZoneEnterInnerZone}
-        >
-          {this.getSuggestionsAlert(classNames.screenReaderText)}
-          <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={classNames.text}>
-              {items.length > 0 && (
-                <span id={this._ariaMap.selectedItems} className={classNames.itemsWrapper} role={'list'}>
-                  {this.renderItems()}
-                </span>
-              )}
-              {this.canAddItems() && (
-                <Autofill
-                  spellCheck={false}
-                  {...(inputProps as any)}
-                  className={classNames.input}
-                  componentRef={this.input}
-                  id={inputProps?.id ? inputProps.id : this._ariaMap.combobox}
-                  onClick={this.onClick}
-                  onFocus={this.onInputFocus}
-                  onBlur={this.onInputBlur}
-                  onInputValueChange={this.onInputChange}
-                  suggestedDisplayValue={suggestedDisplayValue}
-                  aria-activedescendant={this.getActiveDescendant()}
-                  aria-controls={suggestionsAvailable}
-                  aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
-                  aria-expanded={!!this.state.suggestionsVisible}
-                  aria-haspopup="listbox"
-                  aria-label={this.props['aria-label'] || inputProps?.['aria-label']}
-                  role="combobox"
-                  disabled={disabled}
-                  onInputChange={this.props.onInputChange}
-                />
-              )}
-            </div>
-          </SelectionZone>
-        </FocusZone>
+        {this.getSuggestionsAlert(classNames.screenReaderText)}
+        <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
+          <div className={classNames.text}>
+            {items.length > 0 && (
+              <span
+                id={this._ariaMap.selectedItems}
+                className={classNames.itemsWrapper}
+                role={selectionRole}
+                aria-label={selectionAriaLabel || comboLabel}
+              >
+                {this.renderItems()}
+              </span>
+            )}
+            {this.canAddItems() && (
+              <Autofill
+                spellCheck={false}
+                {...(inputProps as any)}
+                className={classNames.input}
+                componentRef={this.input}
+                id={inputProps?.id ? inputProps.id : this._ariaMap.combobox}
+                onClick={this.onClick}
+                onFocus={this.onInputFocus}
+                onBlur={this.onInputBlur}
+                onInputValueChange={this.onInputChange}
+                suggestedDisplayValue={suggestedDisplayValue}
+                aria-activedescendant={this.getActiveDescendant()}
+                aria-controls={suggestionsAvailable}
+                aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
+                aria-expanded={!!this.state.suggestionsVisible}
+                aria-haspopup="listbox"
+                aria-label={comboLabel}
+                role="combobox"
+                disabled={disabled}
+                onInputChange={this.props.onInputChange}
+              />
+            )}
+          </div>
+        </SelectionZone>
         {this.renderSuggestions()}
       </div>
     );
@@ -987,7 +988,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BasePicker<T, P> {
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused } = this.state;
-    const { className, inputProps, disabled, theme, styles } = this.props;
+    const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
 
     const suggestionsAvailable: string | undefined = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
     // TODO
@@ -1018,6 +1019,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
           input: css('ms-BasePicker-input', legacyStyles.pickerInput, inputProps && inputProps.className),
           screenReaderText: legacyStyles.screenReaderOnly,
         };
+
+    const comboLabel = this.props['aria-label'] || inputProps?.['aria-label'];
+
     return (
       <div ref={this.root} onBlur={this.onBlur}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
@@ -1036,7 +1040,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               aria-controls={suggestionsAvailable || undefined}
               aria-expanded={!!this.state.suggestionsVisible}
               aria-haspopup="listbox"
+              aria-label={comboLabel}
               role="combobox"
+              id={inputProps?.id ? inputProps.id : this._ariaMap.combobox}
               disabled={disabled}
               onInputChange={this.props.onInputChange}
             />
@@ -1044,17 +1050,14 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
         </div>
         {this.renderSuggestions()}
         <SelectionZone selection={this.selection} selectionMode={SelectionMode.single}>
-          <FocusZone
-            componentRef={this.focusZone}
-            className="ms-BasePicker-selectedItems" // just a className hook without any styles applied to it.
-            isCircularNavigation={true}
-            direction={FocusZoneDirection.bidirectional}
-            shouldEnterInnerZone={this._shouldFocusZoneEnterInnerZone}
+          <div
             id={this._ariaMap.selectedItems}
-            role={'list'}
+            className="ms-BasePicker-selectedItems" // just a className hook without any styles applied to it.
+            role={selectionRole}
+            aria-label={selectionAriaLabel || comboLabel}
           >
             {this.renderItems()}
-          </FocusZone>
+          </div>
         </SelectionZone>
       </div>
     );

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -279,7 +279,13 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // that label instead of all the selected items. Using aria-labelledby instead fixes this, since
     // aria-describedby and aria-labelledby will not follow a second aria-labelledby
     return (
-      <div ref={this.root} className={classNames.root} onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
+      <div
+        ref={this.root}
+        className={classNames.root}
+        onKeyDown={this.onKeyDown}
+        onFocus={this.onFocus}
+        onBlur={this.onBlur}
+      >
         {this.getSuggestionsAlert(classNames.screenReaderText)}
         <span id={`${this._ariaMap.selectedItems}-label`} hidden>
           {selectionAriaLabel || comboLabel}
@@ -543,8 +549,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // For example when an item is selected or removed from the selected list it should be treated
     // as though the input is still focused.
     if (!this.state.isFocused) {
-      this.setState({ isFocused: true });
-
       this._userTriggeredSuggestions();
 
       if (this.props.inputProps && this.props.inputProps.onFocus) {
@@ -597,6 +601,12 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // Only primary (left) clicks show suggestions.
     if (ev.button === 0) {
       this._userTriggeredSuggestions();
+    }
+  };
+
+  protected onFocus = () => {
+    if (!this.state.isFocused) {
+      this.setState({ isFocused: true });
     }
   };
 
@@ -1035,7 +1045,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
     const comboLabel = this.props['aria-label'] || inputProps?.['aria-label'];
 
     return (
-      <div ref={this.root} onBlur={this.onBlur}>
+      <div ref={this.root} onBlur={this.onBlur} onFocus={this.onFocus}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
           {this.getSuggestionsAlert(classNames.screenReaderText)}
           <div className={classNames.text}>

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -193,7 +193,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   selectedItems?: T[];
 
   /**
-   * Aria label for the displayed selection. A good value would be something like "Selected Contacts"
+   * Aria label for the displayed selection. A good value would be something like "Selected Contacts".
    * @defaultvalue ''
    */
   selectionAriaLabel?: string;

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -193,6 +193,20 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   selectedItems?: T[];
 
   /**
+   * Aria label for the displayed selection. A good value would be something like "Selected Contacts"
+   * @defaultvalue ''
+   */
+  selectionAriaLabel?: string;
+
+  /**
+   * Override the role used for the element containing selected items.
+   * Update this if onRenderItem does not return elements with role="listitem".
+   * A good alternative would be 'group'.
+   * @defaultvalue 'list'
+   */
+  selectionRole?: string;
+
+  /**
    * A callback used to modify the input string.
    */
   onInputChange?: (input: string) => string;

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.tsx
@@ -42,23 +42,19 @@ export const PeoplePickerItemBase = (props: IPeoplePickerItemSelectedProps) => {
     : undefined;
 
   return (
-    <div
-      className={classNames.root}
-      data-is-focusable={!disabled}
-      data-is-sub-focuszone={true}
-      data-selection-index={index}
-      role={'listitem'}
-      aria-labelledby={'selectedItemPersona-' + itemId}
-    >
+    <div className={classNames.root} role={'listitem'}>
       <div className={classNames.itemContent} id={'selectedItemPersona-' + itemId}>
         <Persona size={PersonaSize.size24} styles={personaStyles} coinProps={{ styles: personaCoinStyles }} {...item} />
       </div>
       <IconButton
+        id={itemId}
         onClick={onRemoveItem}
         disabled={disabled}
         iconProps={{ iconName: 'Cancel', styles: { root: { fontSize: '12px' } } }}
         className={classNames.removeButton}
         ariaLabel={removeButtonAriaLabel}
+        aria-labelledby={`${itemId} selectedItemPersona-${itemId}`}
+        data-selection-index={index}
       />
     </div>
   );

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -4,101 +4,94 @@ exports[`PeoplePicker renders correctly 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
-    >
-      <div
-        className=
-            ms-BasePicker-text
-            {
-              align-items: center;
-              border-radius: 2px;
-              border: 1px solid #605e5c;
-              box-sizing: border-box;
-              display: flex;
-              flex-wrap: wrap;
-              min-height: 30px;
-              min-width: 180px;
-              position: relative;
-            }
-            &:hover {
-              border-color: #323130;
-            }
-      >
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-self: flex-end;
-                background-color: transparent;
-                border-radius: 2px;
-                border: none;
-                color: #323130;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 30px;
-                outline: none;
-                padding-bottom: 0;
-                padding-left: 6px;
-                padding-right: 6px;
-                padding-top: 0;
-              }
-              &::-ms-clear {
-                display: none;
-              }
-          data-lpignore={true}
-          id="combobox-id__0"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
-            }
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
           }
-          value=""
-        />
-      </div>
+          &:hover {
+            border-color: #323130;
+          }
+    >
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
+        value=""
+      />
     </div>
   </div>
 </div>
@@ -108,560 +101,553 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
     >
-      <div
+      <span
+        aria-labelledby="selected-items-id__0-label"
         className=
-            ms-BasePicker-text
+            ms-BasePicker-itemsWrapper
             {
-              align-items: center;
-              border-radius: 2px;
-              border: 1px solid #605e5c;
-              box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;
-              min-height: 30px;
-              min-width: 180px;
-              position: relative;
+              max-width: 100%;
             }
-            &:hover {
-              border-color: #323130;
-            }
+        id="selected-items-id__0"
+        role="list"
       >
-        <span
+        <div
           className=
-              ms-BasePicker-itemsWrapper
+              ms-PickerPersona-container
               {
-                display: flex;
-                flex-wrap: wrap;
-                max-width: 100%;
+                align-items: center;
+                background: #f3f2f1;
+                border-radius: 15px;
+                cursor: default;
+                display: inline-flex;
+                margin-bottom: 1px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 1px;
+                max-width: 300px;
+                min-width: 0px;
+                outline: transparent;
+                position: relative;
+                user-select: none;
+                vertical-align: middle;
               }
-          id="selected-items-id__0"
-          role="list"
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -1px;
+                content: "";
+                left: -1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: -1px;
+                top: -1px;
+                z-index: 1;
+              }
+              &:hover {
+                background: #edebe9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border: 1px solid WindowText;
+              }
+          role="listitem"
         >
           <div
-            aria-labelledby="selectedItemPersona-id__10"
             className=
-                ms-PickerPersona-container
+                ms-PickerItem-content
                 {
-                  align-items: center;
-                  background: #f3f2f1;
-                  border-radius: 15px;
-                  cursor: default;
-                  display: inline-flex;
-                  margin-bottom: 1px;
-                  margin-left: 2px;
-                  margin-right: 2px;
-                  margin-top: 1px;
-                  max-width: 300px;
+                  flex: 0 1 auto;
+                  max-width: 100%;
                   min-width: 0px;
-                  outline: transparent;
-                  position: relative;
-                  user-select: none;
-                  vertical-align: middle;
+                  overflow: hidden;
                 }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: -1px;
-                  content: "";
-                  left: -1px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: -1px;
-                  top: -1px;
-                  z-index: 1;
-                }
-                &:hover {
-                  background: #edebe9;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  border: 1px solid WindowText;
-                }
-            data-is-focusable={true}
-            data-is-sub-focuszone={true}
-            data-selection-index={0}
-            role="listitem"
+            id="selectedItemPersona-id__9"
           >
             <div
               className=
-                  ms-PickerItem-content
+                  ms-Persona
+                  ms-Persona--size24
+                  ms-Persona--online
                   {
-                    flex: 0 1 auto;
-                    max-width: 100%;
-                    min-width: 0px;
-                    overflow: hidden;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    align-items: center;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    display: flex;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    min-width: 24px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
                   }
-              id="selectedItemPersona-id__10"
+                  & .contextualHost {
+                    display: none;
+                  }
             >
               <div
                 className=
-                    ms-Persona
+                    ms-Persona-coin
                     ms-Persona--size24
-                    ms-Persona--online
                     {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
-                      align-items: center;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      color: #323130;
-                      display: flex;
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 14px;
                       font-weight: 400;
-                      height: 24px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      min-width: 24px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
                     }
-                    & .contextualHost {
-                      display: none;
-                    }
+                role="presentation"
               >
                 <div
                   className=
-                      ms-Persona-coin
-                      ms-Persona--size24
+                      ms-Persona-imageArea
                       {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
+                        flex: 0 0 auto;
+                        height: 24px;
+                        position: relative;
+                        text-align: center;
+                        width: 24px;
                       }
                   role="presentation"
                 >
                   <div
                     className=
-                        ms-Persona-imageArea
+                        ms-Image
+                        ms-Persona-image
                         {
-                          flex: 0 0 auto;
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          border-radius: 50%;
+                          border: 0px;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           height: 24px;
-                          position: relative;
-                          text-align: center;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
                           width: 24px;
                         }
-                    role="presentation"
-                  >
-                    <div
-                      className=
-                          ms-Image
-                          ms-Persona-image
-                          {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            border-radius: 50%;
-                            border: 0px;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            height: 24px;
-                            left: 0px;
-                            margin-right: 10px;
-                            overflow: hidden;
-                            perspective: 1px;
-                            position: absolute;
-                            top: 0px;
-                            width: 24px;
-                          }
-                      style={
-                        Object {
-                          "height": 24,
-                          "width": 24,
-                        }
+                    style={
+                      Object {
+                        "height": 24,
+                        "width": 24,
                       }
-                    >
-                      <img
-                        alt=""
-                        className=
-                            ms-Image-image
-                            ms-Image-image--cover
-                            ms-Image-image--portrait
-                            is-notLoaded
-                            is-fadeIn
-                            {
-                              display: block;
-                              height: 100%;
-                              object-fit: cover;
-                              opacity: 0;
-                              width: 100%;
-                            }
-                        onError={[Function]}
-                        onLoad={[Function]}
-                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                      />
-                    </div>
-                    <div
+                    }
+                  >
+                    <img
+                      alt=""
                       className=
-                          ms-Persona-presence
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
                           {
-                            -ms-high-contrast-adjust: none;
-                            background-clip: content-box;
-                            background-color: #6BB700;
-                            border-radius: 50%;
-                            border: 2px solid #ffffff;
-                            bottom: -2px;
-                            box-sizing: content-box;
-                            forced-color-adjust: none;
-                            height: 8px;
-                            position: absolute;
-                            right: -2px;
-                            text-align: center;
-                            top: auto;
-                            width: 8px;
+                            display: block;
+                            height: 100%;
+                            object-fit: cover;
+                            opacity: 0;
+                            width: 100%;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background-color: Highlight;
-                            border-color: Window;
-                          }
-                      role="presentation"
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
                     />
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-presence
+                        {
+                          -ms-high-contrast-adjust: none;
+                          background-clip: content-box;
+                          background-color: #6BB700;
+                          border-radius: 50%;
+                          border: 2px solid #ffffff;
+                          bottom: -2px;
+                          box-sizing: content-box;
+                          forced-color-adjust: none;
+                          height: 8px;
+                          position: absolute;
+                          right: -2px;
+                          text-align: center;
+                          top: auto;
+                          width: 8px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: Highlight;
+                          border-color: Window;
+                        }
+                    role="presentation"
+                  />
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-details
+                    {
+                      display: flex;
+                      flex-direction: column;
+                      justify-content: space-around;
+                      min-width: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-align: left;
+                      width: 100%;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-primaryText
+                      {
+                        color: #323130;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                      &:hover {
+                        color: #201f1e;
+                      }
+                  dir="auto"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Annie Lindqvist
                   </div>
                 </div>
                 <div
                   className=
-                      ms-Persona-details
+                      ms-Persona-secondaryText
                       {
-                        display: flex;
-                        flex-direction: column;
-                        justify-content: space-around;
-                        min-width: 0px;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        text-align: left;
-                        width: 100%;
+                        color: #605e5c;
+                        display: none;
+                        font-size: 12px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
                       }
+                  dir="auto"
                 >
                   <div
                     className=
-                        ms-Persona-primaryText
+                        ms-TooltipHost
                         {
-                          color: #323130;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
+                          display: inline;
                         }
-                        &:hover {
-                          color: #201f1e;
-                        }
-                    dir="auto"
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
-                    <div
-                      className=
-                          ms-TooltipHost
-                          {
-                            display: inline;
-                          }
-                      onBlurCapture={[Function]}
-                      onFocusCapture={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      Annie Lindqvist
-                    </div>
+                    Designer
                   </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-tertiaryText
+                      {
+                        color: #605e5c;
+                        display: none;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                  dir="auto"
+                >
                   <div
                     className=
-                        ms-Persona-secondaryText
+                        ms-TooltipHost
                         {
-                          color: #605e5c;
-                          display: none;
-                          font-size: 12px;
-                          font-weight: 400;
-                          overflow: hidden;
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
+                          display: inline;
                         }
-                    dir="auto"
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
-                    <div
-                      className=
-                          ms-TooltipHost
-                          {
-                            display: inline;
-                          }
-                      onBlurCapture={[Function]}
-                      onFocusCapture={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      Designer
-                    </div>
+                    In a meeting
                   </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-optionalText
+                      {
+                        color: #605e5c;
+                        display: none;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                  dir="auto"
+                >
                   <div
                     className=
-                        ms-Persona-tertiaryText
+                        ms-TooltipHost
                         {
-                          color: #605e5c;
-                          display: none;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
+                          display: inline;
                         }
-                    dir="auto"
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
-                    <div
-                      className=
-                          ms-TooltipHost
-                          {
-                            display: inline;
-                          }
-                      onBlurCapture={[Function]}
-                      onFocusCapture={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      In a meeting
-                    </div>
-                  </div>
-                  <div
-                    className=
-                        ms-Persona-optionalText
-                        {
-                          color: #605e5c;
-                          display: none;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
-                        }
-                    dir="auto"
-                  >
-                    <div
-                      className=
-                          ms-TooltipHost
-                          {
-                            display: inline;
-                          }
-                      onBlurCapture={[Function]}
-                      onFocusCapture={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      Available at 4:00pm
-                    </div>
+                    Available at 4:00pm
                   </div>
                 </div>
               </div>
             </div>
-            <button
-              className=
-                  ms-Button
-                  ms-Button--icon
-                  ms-PickerItem-removeButton
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    border-radius: 15px;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #323130;
-                    cursor: pointer;
-                    display: inline-block;
-                    flex: 0 0 auto;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 24px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    width: 24px;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 2px;
-                    content: "";
-                    left: 2px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 2px;
-                    top: 2px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    background: #c8c6c4;
-                    color: #201f1e;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    border-color: Highlight;
-                    color: Highlight;
-                  }
-                  &:active {
-                    background-color: #edebe9;
-                    color: #005a9e;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className=
-                    ms-Button-flexContainer
-                    {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
-                    }
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Button-icon
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        flex-shrink: 0;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        height: 16px;
-                        line-height: 16px;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                        speak: none;
-                        text-align: center;
-                      }
-                  data-icon-name="Cancel"
-                >
-                  
-                </i>
-              </span>
-            </button>
           </div>
-        </span>
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-describedby="selected-items-id__0"
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-self: flex-end;
-                background-color: transparent;
-                border-radius: 2px;
-                border: none;
-                color: #323130;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 30px;
-                outline: none;
-                padding-bottom: 0;
-                padding-left: 6px;
-                padding-right: 6px;
-                padding-top: 0;
-              }
-              &::-ms-clear {
-                display: none;
-              }
-          data-lpignore={true}
-          id="combobox-id__0"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
+          <button
+            aria-labelledby="id__9 selectedItemPersona-id__9"
+            className=
+                ms-Button
+                ms-Button--icon
+                ms-PickerItem-removeButton
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 15px;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  cursor: pointer;
+                  display: inline-block;
+                  flex: 0 0 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 24px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  width: 24px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  background: #c8c6c4;
+                  color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #edebe9;
+                  color: #005a9e;
+                }
+            data-is-focusable={true}
+            data-selection-index={0}
+            id="id__9"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                    }
+                data-icon-name="Cancel"
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </span>
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-describedby="selected-items-id__0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
             }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
           }
-          value=""
-        />
-      </div>
+        }
+        value=""
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import { getId, styled, classNamesFunction } from '../../../Utilities';
+import { styled, classNamesFunction } from '../../../Utilities';
 import { IconButton } from '../../../Button';
 
 import { ITagItemProps, ITagItemStyleProps, ITagItemStyles } from './TagPicker.types';
 import { getStyles } from './TagItem.styles';
+import { useId } from '@fluentui/react-hooks';
 
 const getClassNames = classNamesFunction<ITagItemStyleProps, ITagItemStyles>();
 
@@ -33,7 +34,7 @@ export const TagItemBase = (props: ITagItemProps) => {
     disabled,
   });
 
-  const itemId = getId();
+  const itemId = useId();
 
   const disabledAttrs = enableTagFocusInDisabledPicker
     ? {

--- a/packages/react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { styled, classNamesFunction } from '../../../Utilities';
+import { getId, styled, classNamesFunction } from '../../../Utilities';
 import { IconButton } from '../../../Button';
 
 import { ITagItemProps, ITagItemStyleProps, ITagItemStyles } from './TagPicker.types';
@@ -33,23 +33,31 @@ export const TagItemBase = (props: ITagItemProps) => {
     disabled,
   });
 
+  const itemId = getId();
+
+  const disabledAttrs = enableTagFocusInDisabledPicker
+    ? {
+        'aria-disabled': disabled,
+        tabindex: 0,
+      }
+    : {
+        disabled: disabled,
+      };
+
   return (
-    <div
-      className={classNames.root}
-      role={'listitem'}
-      key={index}
-      data-selection-index={index}
-      data-is-focusable={(enableTagFocusInDisabledPicker || !disabled) && true}
-    >
-      <span className={classNames.text} aria-label={title} title={title}>
+    <div className={classNames.root} role={'listitem'} key={index}>
+      <span className={classNames.text} title={title} id={`${itemId}-text`}>
         {children}
       </span>
       <IconButton
+        id={itemId}
         onClick={onRemoveItem}
-        disabled={disabled}
+        {...disabledAttrs}
         iconProps={{ iconName: 'Cancel', styles: { root: { fontSize: '12px' } } }}
         className={classNames.close}
         ariaLabel={removeButtonAriaLabel}
+        aria-labelledby={`${itemId} ${itemId}-text`}
+        data-selection-index={index}
       />
     </div>
   );

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -54,12 +54,9 @@ exports[`TagItem accepts title override 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
       }
-  data-is-focusable={true}
-  data-selection-index={0}
   role="listitem"
 >
   <span
-    aria-label="Red color"
     className=
         ms-TagItem-text
         {
@@ -72,11 +69,13 @@ exports[`TagItem accepts title override 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+    id="id__0-text"
     title="Red color"
   >
     Red
   </span>
   <button
+    aria-labelledby="id__0 id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -147,6 +146,8 @@ exports[`TagItem accepts title override 1`] = `
           color: #ffffff;
         }
     data-is-focusable={true}
+    data-selection-index={0}
+    id="id__0"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}
@@ -252,12 +253,9 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
       }
-  data-is-focusable={true}
-  data-selection-index={0}
   role="listitem"
 >
   <span
-    aria-label="Red"
     className=
         ms-TagItem-text
         {
@@ -270,6 +268,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+    id="id__0-text"
     title="Red"
   >
     <i
@@ -299,6 +298,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
     </i>
   </span>
   <button
+    aria-labelledby="id__0 id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -369,6 +369,8 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           color: #ffffff;
         }
     data-is-focusable={true}
+    data-selection-index={0}
+    id="id__0"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}
@@ -474,12 +476,9 @@ exports[`TagItem renders correctly 1`] = `
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
       }
-  data-is-focusable={true}
-  data-selection-index={0}
   role="listitem"
 >
   <span
-    aria-label="Red color"
     className=
         ms-TagItem-text
         {
@@ -492,11 +491,13 @@ exports[`TagItem renders correctly 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+    id="id__0-text"
     title="Red color"
   >
     Red color
   </span>
   <button
+    aria-labelledby="id__0 id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -567,6 +568,8 @@ exports[`TagItem renders correctly 1`] = `
           color: #ffffff;
         }
     data-is-focusable={true}
+    data-selection-index={0}
+    id="id__0"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -4,309 +4,304 @@ exports[`TagPicker renders correctly 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
     >
-      <div
+      <span
+        aria-labelledby="selected-items-id__0-label"
         className=
-            ms-BasePicker-text
+            ms-BasePicker-itemsWrapper
             {
-              align-items: center;
-              border-radius: 2px;
-              border: 1px solid #605e5c;
-              box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;
-              min-height: 30px;
-              min-width: 180px;
-              position: relative;
+              max-width: 100%;
             }
-            &:hover {
-              border-color: #323130;
-            }
+        id="selected-items-id__0"
+        role="list"
       >
-        <span
+        <div
           className=
-              ms-BasePicker-itemsWrapper
+              ms-TagItem
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #f3f2f1;
+                border-radius: 2px;
+                box-sizing: content-box;
+                color: #323130;
+                cursor: default;
                 display: flex;
-                flex-wrap: wrap;
-                max-width: 100%;
+                flex-shrink: 1;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 26px;
+                line-height: 26px;
+                margin-bottom: 2px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 2px;
+                max-width: 300px;
+                min-width: 0px;
+                outline: transparent;
+                position: relative;
+                user-select: none;
               }
-          id="selected-items-id__0"
-          role="list"
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:hover {
+                background: #edebe9;
+                color: #201f1e;
+              }
+              &:hover .ms-TagItem-close {
+                color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border: 1px solid WindowText;
+              }
+          role="listitem"
         >
-          <div
+          <span
             className=
-                ms-TagItem
+                ms-TagItem-text
+                {
+                  margin-bottom: 0;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 0;
+                  min-width: 30px;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+            id="id__1-text"
+            title="black"
+          >
+            black
+          </span>
+          <button
+            aria-labelledby="id__1 id__1-text"
+            className=
+                ms-Button
+                ms-Button--icon
+                ms-TagItem-close
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background: #f3f2f1;
-                  border-radius: 2px;
-                  box-sizing: content-box;
-                  color: #323130;
-                  cursor: default;
-                  display: flex;
-                  flex-shrink: 1;
-                  flex-wrap: nowrap;
+                  background-color: transparent;
+                  border-radius: 0 2px 2px 0;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #605e5c;
+                  cursor: pointer;
+                  display: inline-block;
+                  flex: 0 0 auto;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 26px;
-                  line-height: 26px;
-                  margin-bottom: 2px;
-                  margin-left: 2px;
-                  margin-right: 2px;
-                  margin-top: 2px;
-                  max-width: 300px;
-                  min-width: 0px;
+                  height: 100%;
                   outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
                   position: relative;
+                  text-align: center;
+                  text-decoration: none;
                   user-select: none;
+                  width: 30px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
+                  border: 1px solid transparent;
+                  bottom: 2px;
                   content: "";
-                  left: 1px;
+                  left: 2px;
                   outline: 1px solid #605e5c;
                   position: absolute;
-                  right: 1px;
-                  top: 1px;
+                  right: 2px;
+                  top: 2px;
                   z-index: 1;
                 }
-                &:hover {
-                  background: #edebe9;
-                  color: #201f1e;
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
                 }
-                &:hover .ms-TagItem-close {
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  background: #e1dfdd;
                   color: #323130;
                 }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  border: 1px solid WindowText;
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #005a9e;
+                  color: #ffffff;
                 }
             data-is-focusable={true}
             data-selection-index={0}
-            role="listitem"
+            id="id__1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
           >
             <span
-              aria-label="black"
               className=
-                  ms-TagItem-text
+                  ms-Button-flexContainer
                   {
-                    margin-bottom: 0;
-                    margin-left: 8px;
-                    margin-right: 8px;
-                    margin-top: 0;
-                    min-width: 30px;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                  }
-              title="black"
-            >
-              black
-            </span>
-            <button
-              className=
-                  ms-Button
-                  ms-Button--icon
-                  ms-TagItem-close
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    border-radius: 0 2px 2px 0;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #605e5c;
-                    cursor: pointer;
-                    display: inline-block;
-                    flex: 0 0 auto;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
                     height: 100%;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    width: 30px;
+                    justify-content: center;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 2px;
-                    content: "";
-                    left: 2px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 2px;
-                    top: 2px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    background: #e1dfdd;
-                    color: #323130;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    border-color: Highlight;
-                    color: Highlight;
-                  }
-                  &:active {
-                    background-color: #005a9e;
-                    color: #ffffff;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
+              data-automationid="splitbuttonprimary"
             >
-              <span
+              <i
+                aria-hidden={true}
                 className=
-                    ms-Button-flexContainer
+                    ms-Button-icon
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
                     }
-                data-automationid="splitbuttonprimary"
+                data-icon-name="Cancel"
               >
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Button-icon
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        flex-shrink: 0;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        height: 16px;
-                        line-height: 16px;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                        speak: none;
-                        text-align: center;
-                      }
-                  data-icon-name="Cancel"
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </span>
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-describedby="selected-items-id__0"
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-self: flex-end;
-                background-color: transparent;
-                border-radius: 2px;
-                border: none;
-                color: #323130;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 30px;
-                outline: none;
-                padding-bottom: 0;
-                padding-left: 6px;
-                padding-right: 6px;
-                padding-top: 0;
-              }
-              &::-ms-clear {
-                display: none;
-              }
-          data-lpignore={true}
-          id="combobox-id__0"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </span>
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-describedby="selected-items-id__0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
             }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
           }
-          value=""
-        />
-      </div>
+        }
+        value=""
+      />
     </div>
   </div>
 </div>
@@ -316,309 +311,304 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
     >
-      <div
+      <span
+        aria-labelledby="selected-items-id__0-label"
         className=
-            ms-BasePicker-text
+            ms-BasePicker-itemsWrapper
             {
-              align-items: center;
-              border-radius: 2px;
-              border: 1px solid #605e5c;
-              box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;
-              min-height: 30px;
-              min-width: 180px;
-              position: relative;
+              max-width: 100%;
             }
-            &:hover {
-              border-color: #323130;
-            }
+        id="selected-items-id__0"
+        role="list"
       >
-        <span
+        <div
           className=
-              ms-BasePicker-itemsWrapper
+              ms-TagItem
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #f3f2f1;
+                border-radius: 2px;
+                box-sizing: content-box;
+                color: #323130;
+                cursor: default;
                 display: flex;
-                flex-wrap: wrap;
-                max-width: 100%;
+                flex-shrink: 1;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 26px;
+                line-height: 26px;
+                margin-bottom: 2px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 2px;
+                max-width: 300px;
+                min-width: 0px;
+                outline: transparent;
+                position: relative;
+                user-select: none;
               }
-          id="selected-items-id__0"
-          role="list"
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:hover {
+                background: #edebe9;
+                color: #201f1e;
+              }
+              &:hover .ms-TagItem-close {
+                color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border: 1px solid WindowText;
+              }
+          role="listitem"
         >
-          <div
+          <span
             className=
-                ms-TagItem
+                ms-TagItem-text
+                {
+                  margin-bottom: 0;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 0;
+                  min-width: 30px;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+            id="id__1-text"
+            title="text"
+          >
+            text
+          </span>
+          <button
+            aria-labelledby="id__1 id__1-text"
+            className=
+                ms-Button
+                ms-Button--icon
+                ms-TagItem-close
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background: #f3f2f1;
-                  border-radius: 2px;
-                  box-sizing: content-box;
-                  color: #323130;
-                  cursor: default;
-                  display: flex;
-                  flex-shrink: 1;
-                  flex-wrap: nowrap;
+                  background-color: transparent;
+                  border-radius: 0 2px 2px 0;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #605e5c;
+                  cursor: pointer;
+                  display: inline-block;
+                  flex: 0 0 auto;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 26px;
-                  line-height: 26px;
-                  margin-bottom: 2px;
-                  margin-left: 2px;
-                  margin-right: 2px;
-                  margin-top: 2px;
-                  max-width: 300px;
-                  min-width: 0px;
+                  height: 100%;
                   outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
                   position: relative;
+                  text-align: center;
+                  text-decoration: none;
                   user-select: none;
+                  width: 30px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 1px;
+                  border: 1px solid transparent;
+                  bottom: 2px;
                   content: "";
-                  left: 1px;
+                  left: 2px;
                   outline: 1px solid #605e5c;
                   position: absolute;
-                  right: 1px;
-                  top: 1px;
+                  right: 2px;
+                  top: 2px;
                   z-index: 1;
                 }
-                &:hover {
-                  background: #edebe9;
-                  color: #201f1e;
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
                 }
-                &:hover .ms-TagItem-close {
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  background: #e1dfdd;
                   color: #323130;
                 }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  border: 1px solid WindowText;
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #005a9e;
+                  color: #ffffff;
                 }
             data-is-focusable={true}
             data-selection-index={0}
-            role="listitem"
+            id="id__1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
           >
             <span
-              aria-label="text"
               className=
-                  ms-TagItem-text
+                  ms-Button-flexContainer
                   {
-                    margin-bottom: 0;
-                    margin-left: 8px;
-                    margin-right: 8px;
-                    margin-top: 0;
-                    min-width: 30px;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                  }
-              title="text"
-            >
-              text
-            </span>
-            <button
-              className=
-                  ms-Button
-                  ms-Button--icon
-                  ms-TagItem-close
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    border-radius: 0 2px 2px 0;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #605e5c;
-                    cursor: pointer;
-                    display: inline-block;
-                    flex: 0 0 auto;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
                     height: 100%;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    width: 30px;
+                    justify-content: center;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 2px;
-                    content: "";
-                    left: 2px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 2px;
-                    top: 2px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    background: #e1dfdd;
-                    color: #323130;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    border-color: Highlight;
-                    color: Highlight;
-                  }
-                  &:active {
-                    background-color: #005a9e;
-                    color: #ffffff;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
+              data-automationid="splitbuttonprimary"
             >
-              <span
+              <i
+                aria-hidden={true}
                 className=
-                    ms-Button-flexContainer
+                    ms-Button-icon
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
                     }
-                data-automationid="splitbuttonprimary"
+                data-icon-name="Cancel"
               >
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Button-icon
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        flex-shrink: 0;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        height: 16px;
-                        line-height: 16px;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                        speak: none;
-                        text-align: center;
-                      }
-                  data-icon-name="Cancel"
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </span>
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-describedby="selected-items-id__0"
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-self: flex-end;
-                background-color: transparent;
-                border-radius: 2px;
-                border: none;
-                color: #323130;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 30px;
-                outline: none;
-                padding-bottom: 0;
-                padding-left: 6px;
-                padding-right: 6px;
-                padding-top: 0;
-              }
-              &::-ms-clear {
-                display: none;
-              }
-          data-lpignore={true}
-          id="combobox-id__0"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </span>
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-describedby="selected-items-id__0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
             }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
           }
-          value=""
-        />
-      </div>
+        }
+        value=""
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -4,63 +4,56 @@ exports[`BasePicker renders correctly 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
+      className="ms-BasePicker-text"
     >
-      <div
-        className="ms-BasePicker-text"
-      >
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className="ms-BasePicker-input"
-          data-lpignore={true}
-          id="combobox-id__0"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
-            }
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className="ms-BasePicker-input"
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
           }
-          value=""
-        />
-      </div>
+        }
+        value=""
+      />
     </div>
   </div>
 </div>
@@ -70,64 +63,57 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
 <div
   className="ms-BasePicker"
   onBlur={[Function]}
+  onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
     onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="presentation"
   >
     <div
-      className="ms-SelectionZone"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onFocusCapture={[Function]}
-      onKeyDown={[Function]}
-      onKeyDownCapture={[Function]}
-      onMouseDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
+      className="ms-BasePicker-text"
     >
-      <div
-        className="ms-BasePicker-text"
-      >
-        <input
-          aria-autocomplete="both"
-          aria-controls=""
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          autoCapitalize="off"
-          autoComplete="off"
-          className="ms-BasePicker-input testclass "
-          data-lpignore={true}
-          id="pckSelectedUser"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onCompositionEnd={[Function]}
-          onCompositionStart={[Function]}
-          onCompositionUpdate={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          placeholder="Bitte einen Benutzer angeben..."
-          role="combobox"
-          spellCheck={false}
-          style={
-            Object {
-              "fontFamily": "inherit",
-            }
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className="ms-BasePicker-input testclass "
+        data-lpignore={true}
+        id="pckSelectedUser"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Bitte einen Benutzer angeben..."
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
           }
-          value=""
-        />
-      </div>
+        }
+        value=""
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12406 and #14776
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Does a bunch of co-dependent updates on the picker's selected tags, since interaction is tied to roles, which is then tied to naming 😅. The changes are:

- FocusZone is removed by default, though the attributes and public methods are left in, so (hopefully) someone could wrap a picker in their own FocusZone if they wanted to
- The selected tag listitems are not focusable or interactive; only the remove buttons are interactive and focusable
- The remove buttons are named by the tag they remove
- The selection list has a property to give it a unique aria-label, and it falls back on the aria-label of the picker, if provided
- All the picker examples are updated to have good names passed in
