### PR TITLE
chore: use constants instead of magic numbers in makeStyles()

### DIFF
--- a/change/@fluentui-make-styles-fd511602-b4f9-4495-807f-673bd04f51c4.json
+++ b/change/@fluentui-make-styles-fd511602-b4f9-4495-807f-673bd04f51c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: use constans instead of magic numbers in makeStyles()",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/ax.ts
+++ b/packages/make-styles/src/ax.ts
@@ -1,4 +1,11 @@
-import { DEFINITION_LOOKUP_TABLE, HASH_LENGTH, RTL_PREFIX, SEQUENCE_PREFIX } from './constants';
+import {
+  DEFINITION_LOOKUP_TABLE,
+  HASH_LENGTH,
+  RTL_PREFIX,
+  RULE_CLASSNAME_INDEX,
+  RULE_RTL_CSS_INDEX,
+  SEQUENCE_PREFIX,
+} from './constants';
 import { hashString } from './runtime/utils/hashString';
 import { MakeStylesReducedDefinitions } from './types';
 
@@ -127,11 +134,11 @@ export function ax(): string {
     const resultDefinition = resultDefinitions[property];
 
     if (isRtl) {
-      const rtlPrefix = isRtl && resultDefinition[3] ? RTL_PREFIX : '';
+      const rtlPrefix = isRtl && resultDefinition[RULE_RTL_CSS_INDEX] ? RTL_PREFIX : '';
 
-      atomicClassNames += rtlPrefix + resultDefinition[1] + ' ';
+      atomicClassNames += rtlPrefix + resultDefinition[RULE_CLASSNAME_INDEX] + ' ';
     } else {
-      atomicClassNames += resultDefinition[1] + ' ';
+      atomicClassNames += resultDefinition[RULE_CLASSNAME_INDEX] + ' ';
     }
   }
 

--- a/packages/make-styles/src/constants.ts
+++ b/packages/make-styles/src/constants.ts
@@ -9,3 +9,9 @@ export const RTL_PREFIX = 'r';
 export const SEQUENCE_PREFIX = '__';
 
 export const DEFINITION_LOOKUP_TABLE: Record<string, [MakeStylesReducedDefinitions, boolean /* isRTL */]> = {};
+
+/* indexes for values in MakeStylesResolvedRule tuple */
+export const RULE_STYLE_BUCKET_INDEX = 0;
+export const RULE_CLASSNAME_INDEX = 1;
+export const RULE_CSS_INDEX = 2;
+export const RULE_RTL_CSS_INDEX = 3;

--- a/packages/make-styles/src/renderer/createDOMRenderer.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer.ts
@@ -1,5 +1,11 @@
+import {
+  RTL_PREFIX,
+  RULE_CLASSNAME_INDEX,
+  RULE_CSS_INDEX,
+  RULE_RTL_CSS_INDEX,
+  RULE_STYLE_BUCKET_INDEX,
+} from '../constants';
 import { MakeStylesRenderer, StyleBucketName } from '../types';
-import { RTL_PREFIX } from '../constants';
 
 export interface MakeStylesDOMRenderer extends MakeStylesRenderer {
   insertionCache: Record<string, true>;
@@ -89,8 +95,8 @@ export function createDOMRenderer(target: Document = document): MakeStylesDOMRen
         const definition = definitions[propName];
         // 👆 [bucketName, className, css, rtlCSS?]
 
-        const className = definition[1];
-        const rtlCSS = definition[3];
+        const className = definition[RULE_CLASSNAME_INDEX];
+        const rtlCSS = definition[RULE_RTL_CSS_INDEX];
 
         const ruleClassName = className && (dir === 'rtl' && rtlCSS ? RTL_PREFIX + className : className);
 
@@ -104,8 +110,8 @@ export function createDOMRenderer(target: Document = document): MakeStylesDOMRen
           continue;
         }
 
-        const bucketName = definition[0];
-        const css = definition[2];
+        const bucketName = definition[RULE_STYLE_BUCKET_INDEX];
+        const css = definition[RULE_CSS_INDEX];
         const ruleCSS = dir === 'rtl' ? rtlCSS || css : css;
 
         const sheet = getStyleSheetForBucket(bucketName, target, renderer);

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -1,11 +1,12 @@
-import { resolveStyleRules } from './resolveStyleRules';
+import { RULE_CLASSNAME_INDEX } from '../constants';
 import { MakeStylesResolvedRule } from '../types';
 import { makeStylesRulesSerializer } from '../utils/test/snapshotSerializer';
+import { resolveStyleRules } from './resolveStyleRules';
 
 expect.addSnapshotSerializer(makeStylesRulesSerializer);
 
 function getFirstClassName(resolvedStyles: Record<string, MakeStylesResolvedRule>): string {
-  return resolvedStyles[Object.keys(resolvedStyles)[0]][1] as string;
+  return resolvedStyles[Object.keys(resolvedStyles)[0]][RULE_CLASSNAME_INDEX] as string;
 }
 
 describe('resolveStyleRules', () => {

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -45,7 +45,7 @@ export function resolveStyleRules(
       const rtlDefinition = (rtlValue && { key: property, value: rtlValue }) || convertProperty(property, value);
       const flippedInRtl = rtlDefinition.key !== property || rtlDefinition.value !== value;
 
-      const cssRules = compileCSS({
+      const [ltrCSS, rtlCSS] = compileCSS({
         className,
         media,
         pseudo,
@@ -58,7 +58,7 @@ export function resolveStyleRules(
         rtlValue: flippedInRtl ? rtlDefinition.value : undefined,
       });
 
-      result[key] = [getStyleBucketName(pseudo, media, support), className, cssRules[0], cssRules[1]];
+      result[key] = [getStyleBucketName(pseudo, media, support), className, ltrCSS, rtlCSS];
     } else if (property === 'animationName') {
       const animationNames = Array.isArray(value) ? value : [value];
       let keyframeCSS = '';

--- a/packages/make-styles/src/utils/test/snapshotSerializer.ts
+++ b/packages/make-styles/src/utils/test/snapshotSerializer.ts
@@ -1,5 +1,6 @@
 import * as prettier from 'prettier';
 
+import { RULE_CSS_INDEX, RULE_RTL_CSS_INDEX } from '../../constants';
 import { MakeStylesDOMRenderer } from '../../renderer/createDOMRenderer';
 import { isObject } from '../../runtime/utils/isObject';
 import { MakeStylesResolvedRule, StyleBucketName } from '../../types';
@@ -37,7 +38,7 @@ export const makeStylesRulesSerializer: jest.SnapshotSerializerPlugin = {
     return Object.keys(value).reduce((acc, property) => {
       const rule: MakeStylesResolvedRule = value[property];
 
-      return prettier.format(acc + rule[2] + (rule[3] || ''), { parser: 'css' }).trim();
+      return prettier.format(acc + rule[RULE_CSS_INDEX] + (rule[RULE_RTL_CSS_INDEX] || ''), { parser: 'css' }).trim();
     }, '');
   },
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR is based on a suggestion from https://github.com/microsoft/fluentui/pull/17669#discussion_r607848929 @miroslavstastny to use constants as magic numbers are hard to read & understand. 
