### PR TITLE
Combobox: Fix ariaLabelAsText

### DIFF
--- a/change/@fluentui-react-d9f2a9e6-6e17-4c64-a29e-4026316ffda3.json
+++ b/change/@fluentui-react-d9f2a9e6-6e17-4c64-a29e-4026316ffda3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Combobox: Fix issue where ariaLabelAsText broken",
+  "comment": "Combobox: Fix issue where the ariaLabel was intended to be used as the preview text but it wasn't showing up.",
   "packageName": "@fluentui/react",
   "email": "joschect@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-d9f2a9e6-6e17-4c64-a29e-4026316ffda3.json
+++ b/change/@fluentui-react-d9f2a9e6-6e17-4c64-a29e-4026316ffda3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Fix issue where ariaLabelAsText broken",
+  "packageName": "@fluentui/react",
+  "email": "joschect@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -702,7 +702,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
             : normalizeToString(suggestedDisplayValue);
         } else {
           return indexWithinBounds(currentOptions, index)
-            ? currentOptions[index].text
+            ? getPreviewText(currentOptions[index])
             : normalizeToString(suggestedDisplayValue);
         }
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

ariaLabelAsText indicates that the aria-label should be used as the selected display value. This was broken during the migration to function components and this change fixes it.

#### Focus areas to test

(optional)
