### PR TITLE
Remove pointer-events: 'none' from BaseButton disabled styles

### DIFF
--- a/change/@fluentui-react-examples-ee42cce0-ef18-4a3a-9bf6-8568b27d01ef.json
+++ b/change/@fluentui-react-examples-ee42cce0-ef18-4a3a-9bf6-8568b27d01ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove pointerEvents: 'none' from BaseButton disabled styles",
+  "packageName": "@fluentui/react-examples",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-89676332-dbf8-41f6-8fbf-47186fde2c52.json
+++ b/change/@fluentui-react-experiments-89676332-dbf8-41f6-8fbf-47186fde2c52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove pointerEvents: 'none' from BaseButton disabled styles",
+  "packageName": "@fluentui/react-experiments",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-f99c9975-1ce0-409f-ab22-3b8fbe5a8d16.json
+++ b/change/@fluentui-react-f99c9975-1ce0-409f-ab22-3b8fbe5a8d16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove pointerEvents: 'none' from BaseButton disabled styles",
+  "packageName": "@fluentui/react",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
@@ -863,7 +863,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 padding-left: 16px;
                 padding-right: 16px;
                 padding-top: 0;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -1225,7 +1224,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 padding-left: 16px;
                 padding-right: 16px;
                 padding-top: 0;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -601,7 +601,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           padding-left: 4px;
                           padding-right: 4px;
                           padding-top: 0;
-                          pointer-events: none;
                           position: relative;
                           text-align: center;
                           text-decoration: none;
@@ -951,7 +950,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       padding-left: 4px;
                       padding-right: 4px;
                       padding-top: 0;
-                      pointer-events: none;
                       position: relative;
                       text-align: center;
                       text-decoration: none;
@@ -1146,7 +1144,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         padding-left: 4px;
                         padding-right: 4px;
                         padding-top: 0;
-                        pointer-events: none;
                         position: relative;
                         text-align: center;
                         text-decoration: none;

--- a/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
             padding-left: 16px;
             padding-right: 16px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;

--- a/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -513,7 +513,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           padding-left: 41px;
                           padding-right: 20px;
                           padding-top: 0;
-                          pointer-events: none;
                           position: relative;
                           text-align: center;
                           text-decoration: none;
@@ -974,7 +973,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       padding-left: 27px;
                       padding-right: 20px;
                       padding-top: 0;
-                      pointer-events: none;
                       position: relative;
                       text-align: center;
                       text-decoration: none;

--- a/packages/react-examples/src/react/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -1104,7 +1104,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -1248,7 +1247,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;

--- a/packages/react-examples/src/react/__snapshots__/SpinButton.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/SpinButton.Icon.Example.tsx.shot
@@ -708,7 +708,6 @@ exports[`Component Examples renders SpinButton.Icon.Example.tsx correctly 1`] = 
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -852,7 +851,6 @@ exports[`Component Examples renders SpinButton.Icon.Example.tsx correctly 1`] = 
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             padding-left: 4px;
             padding-right: 4px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;
@@ -169,7 +168,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             padding-left: 4px;
             padding-right: 4px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;
@@ -1116,7 +1114,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           padding-left: 4px;
           padding-right: 4px;
           padding-top: 0;
-          pointer-events: none;
           position: relative;
           text-align: center;
           text-decoration: none;
@@ -1246,7 +1243,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           padding-left: 4px;
           padding-right: 4px;
           padding-top: 0;
-          pointer-events: none;
           position: relative;
           text-align: center;
           text-decoration: none;

--- a/packages/react/src/components/Button/BaseButton.styles.ts
+++ b/packages/react/src/components/Button/BaseButton.styles.ts
@@ -70,7 +70,6 @@ export const getStyles = memoizeFunction(
           borderColor: disabledBackground,
           color: disabledText,
           cursor: 'default',
-          pointerEvents: 'none',
           selectors: {
             ':hover': noOutline,
             ':focus': noOutline,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17606
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Removes the `pointer-events: 'none'` styling that is applied to disabled buttons. This allows disabled buttons to have native `title` tooltips available (which is how native html buttons work in their disabled state).

#### Focus areas to test

Buttons
