### PR TITLE
Dropdown: no longer automatically selects the first option when dropdown receives keyboard focus

### DIFF
--- a/change/@fluentui-react-11dcb542-e793-481e-8b08-f108e49ec730.json
+++ b/change/@fluentui-react-11dcb542-e793-481e-8b08-f108e49ec730.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: no longer automatically selects the first option when dropdown receives keyboard focus",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -1201,19 +1201,9 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   };
 
   private _onFocus = (ev: React.FocusEvent<HTMLDivElement>): void => {
-    const { isOpen } = this.state;
-    const {
-      multiSelect,
-      hoisted: { selectedIndices },
-    } = this.props;
-
     const disabled = this._isDisabled();
 
     if (!disabled) {
-      if (!this._isFocusedByClick && !isOpen && selectedIndices.length === 0 && !multiSelect) {
-        // Per aria: https://www.w3.org/TR/wai-aria-practices-1.1/#listbox_kbd_interaction
-        this._moveIndex(ev, 1, 0, -1);
-      }
       if (this.props.onFocus) {
         this.props.onFocus(ev);
       }

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -343,7 +343,7 @@ describe('Dropdown', () => {
       expect(titleElement.text()).toEqual('');
     });
 
-    it('can be programmatically focused when tabIndex=-1, and will not select an item', () => {
+    it('can be programmatically focused when tabIndex=-1, and will not automatically select an item', () => {
       const dropdown = React.createRef<IDropdown>();
 
       const container = document.createElement('div');
@@ -360,6 +360,25 @@ describe('Dropdown', () => {
 
       const titleElement = container.querySelector('.ms-Dropdown-title') as HTMLElement;
       // for some reason, JSDOM does not return innerText of 1 so we have to use innerHTML instead.
+      expect(titleElement.innerHTML).toEqual('');
+    });
+
+    it('opens and does not automatically select an item when focus(true) is called', () => {
+      const dropdown = React.createRef<IDropdown>();
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      ReactTestUtils.act(() => {
+        ReactDOM.render(<Dropdown componentRef={dropdown} label="testgroup" options={DEFAULT_OPTIONS} />, container);
+      });
+
+      expect(document.body.querySelector('.ms-Dropdown-item')).toBeNull();
+
+      ReactTestUtils.act(() => {
+        dropdown.current!.focus(true);
+      });
+      const titleElement = container.querySelector('.ms-Dropdown-title') as HTMLElement;
       expect(titleElement.innerHTML).toEqual('');
     });
 

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -334,16 +334,16 @@ describe('Dropdown', () => {
       expect(titleElement.text()).toEqual('2');
     });
 
-    it('selects the first valid item on focus', () => {
+    it('does not select any item on focus', () => {
       wrapper = mount(<Dropdown label="testgroup" options={DEFAULT_OPTIONS} />);
 
       wrapper.find('.ms-Dropdown').simulate('focus');
 
       const titleElement = wrapper.find('.ms-Dropdown-title');
-      expect(titleElement.text()).toEqual('1');
+      expect(titleElement.text()).toEqual('');
     });
 
-    it('can be programmatically focused when tabIndex=-1, and will select the first valid item', () => {
+    it('can be programmatically focused when tabIndex=-1, and will not select an item', () => {
       const dropdown = React.createRef<IDropdown>();
 
       const container = document.createElement('div');
@@ -360,27 +360,7 @@ describe('Dropdown', () => {
 
       const titleElement = container.querySelector('.ms-Dropdown-title') as HTMLElement;
       // for some reason, JSDOM does not return innerText of 1 so we have to use innerHTML instead.
-      expect(titleElement.innerHTML).toEqual('1');
-    });
-
-    it('opens and focuses/selects first selectable option when focus(true) is called', () => {
-      const dropdown = React.createRef<IDropdown>();
-
-      const container = document.createElement('div');
-      document.body.appendChild(container);
-
-      ReactTestUtils.act(() => {
-        ReactDOM.render(<Dropdown componentRef={dropdown} label="testgroup" options={DEFAULT_OPTIONS} />, container);
-      });
-
-      expect(document.body.querySelector('.ms-Dropdown-item')).toBeNull();
-
-      ReactTestUtils.act(() => {
-        dropdown.current!.focus(true);
-      });
-      const firstDropdownItem = document.body.querySelector('.ms-Dropdown-item');
-      expect(firstDropdownItem).not.toBeNull();
-      expect(firstDropdownItem!.getAttribute('aria-selected')).toBe('true');
+      expect(titleElement.innerHTML).toEqual('');
     });
 
     it('selects the first valid item on Home keypress', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug-[11604](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11604)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- removed conditional which selected the first option whenever dropdown receives keyboard focus.
- updated 3 tests to assert that no selection should be made when dropdown receives focus.

**New Behavior:** 

![dropdown-focus-1](https://user-images.githubusercontent.com/8649804/113944991-53c40a80-97ba-11eb-8e6b-74763d5c1345.JPG)
