### PR TITLE
Rename Fabric component usage in export to codepen

### DIFF
--- a/change/@uifabric-tsx-editor-3bca7fdc-72fa-4afb-a7d5-86e30ab24ed2.json
+++ b/change/@uifabric-tsx-editor-3bca7fdc-72fa-4afb-a7d5-86e30ab24ed2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rename Fabric component usage in export to codepen",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -22,7 +22,7 @@ module.exports = {
 
   '**/package.json': 'node ./scripts/lint-staged/no-tslint-deps',
 
-  'packages/!(react-examples)/**/(docs|examples)/*': 'node ./scripts/lint-staged/no-old-example-paths',
+  'packages/!(react-examples)/**/(docs|examples)/!(*.txt)': 'node ./scripts/lint-staged/no-old-example-paths',
   'packages/!(react-examples)/**/*.doc.ts*': 'node ./scripts/lint-staged/no-old-example-paths',
   'packages/{office-ui-fabric-react,react-cards,react-focus}/src/components/__snapshots__/*':
     'node ./scripts/lint-staged/no-old-snapshot-paths',

--- a/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -41,6 +41,26 @@ return LabelBasicExampleWrapper;
 }
 `;
 
+exports[`example transform handles examples using <Fabric> 1`] = `
+Object {
+  "output": "const { Fabric: FabricComponent, Label, initializeIcons } = window.Fabric;
+
+// Initialize icons in case this example uses them
+initializeIcons();
+
+const LabelBasicExample = () => {
+  return (
+    <FabricComponent>
+      <Label>I'm a Label</Label>
+    </FabricComponent>
+  );
+};
+
+const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
+ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
+}
+`;
+
 exports[`example transform handles examples with class components 1`] = `
 Object {
   "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;

--- a/packages/tsx-editor/src/transpiler/exampleTransform.test.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.test.ts
@@ -39,6 +39,14 @@ describe('example transform', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('handles examples using <Fabric>', () => {
+    const result = transformFile('functionFabric.txt');
+    expect(result.output).toBeTruthy();
+    expect(result.output).toContain('<FabricComponent>');
+    expect(result.output).not.toContain('<Fabric>');
+    expect(result).toMatchSnapshot();
+  });
+
   it('handles examples with class components', () => {
     const result = transformFile('class.txt');
     expect(result.output).toBeTruthy();

--- a/packages/tsx-editor/src/transpiler/exampleTransform.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.ts
@@ -96,6 +96,9 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
     // rename to avoid conflict with window.Fabric
     const renamedFabricComponent = 'FabricComponent';
 
+    // Replace <Fabric> with <FabricComponent>
+    lines[0] = lines[0].replace(new RegExp('<(/)?Fabric\\b', 'g'), `<$1${renamedFabricComponent}`);
+
     // If eval-ing the code, the component can't use JSX format
     const wrapperCode = returnFunction
       ? `React.createElement(${renamedFabricComponent}, null, React.createElement(${component}, null))`

--- a/packages/tsx-editor/src/transpiler/examples/functionFabric.txt
+++ b/packages/tsx-editor/src/transpiler/examples/functionFabric.txt
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { Fabric, Label } from 'office-ui-fabric-react/lib/Label';
+
+export const LabelBasicExample = () => {
+  return (
+    <Fabric>
+      <Label>I'm a Label</Label>
+    </Fabric>
+  );
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, examples which use the `<Fabric>` component fail to render when exported to CodePen. This is because we'd previously made a fix for a naming conflict (`window.Fabric` UMD global vs. `Fabric` component) but forgot to apply the fix to usage of the component within the example. Fix is to rename usage of the component as well.

(Not relevant for master because the UMD global is renamed to `FluentUIReact`.)