### PR TITLE
Donut chart: Legend container should not render when hideLegend is true issue resolved.

### DIFF
--- a/change/@fluentui-react-charting-c2029bde-0ae1-4dac-98d1-3ef9976e7295.json
+++ b/change/@fluentui-react-charting-c2029bde-0ae1-4dac-98d1-3ef9976e7295.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Donut chart - when hideLegend true, udpated legends container",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-c2029bde-0ae1-4dac-98d1-3ef9976e7295.json
+++ b/change/@fluentui-react-charting-c2029bde-0ae1-4dac-98d1-3ef9976e7295.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Donut chart - when hideLegend true, udpated legends container",
   "packageName": "@fluentui/react-charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -145,7 +145,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
             />
           )}
         </Callout>
-        <div className={this._classNames.legendContainer}>{!hideLegend && legendBars}</div>
+        {!hideLegend && <div className={this._classNames.legendContainer}>{legendBars}</div>}
       </div>
     );
   }

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -826,14 +826,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
   <span
     className="ms-layer"
   />
-  <div
-    className=
-
-        {
-          padding-top: 16px;
-          width: nullpx;
-        }
-  />
 </div>
 `;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/17545
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In Donut chart: legends bars container display condition updated

#### Focus areas to test

Donut chart.

