### PR TITLE
Add pointer-events none for slotted svgs in button and anchors to prevent focus rect on click

### DIFF
--- a/change/@fluentui-web-components-bc432deb-1c1e-4c4d-9740-42e530893758.json
+++ b/change/@fluentui-web-components-bc432deb-1c1e-4c4d-9740-42e530893758.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add pointer-events none for slotted svgs in buttons and anchors to prevent focus rect on click",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -107,6 +107,7 @@ export const BaseButtonStyles: ElementStyles = css`
             replace when adaptive typography is figured out */ ''
     } width: 16px;
     height: 16px;
+    pointer-events: none;
   }
 
   .start {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Add pointer-events none for slotted svgs in button and anchors to prevent focus rect on click

#### Focus areas to test
Boot the test environment - click the icon button. No more focus rect!
