### PR TITLE
Fix empty NOTICE files

### DIFF
--- a/scripts/copy-notices.js
+++ b/scripts/copy-notices.js
@@ -19,14 +19,14 @@ async function copyNotices() {
     path.resolve(monorepo.findGitRoot(), 'packages', dependencyName.replace('@fluentui/', ''), 'NOTICE.txt'),
   );
 
+  console.log(`reading ${noticeFilePath}`);
+  const noticeFileContent = fs.readFileSync(noticeFilePath);
+
   copyLocations.forEach(copyLocation => {
-    // on node < 14 if the copy src and dest are the same path
-    // it results in the original file becoming an empty file
+    // on node < 14 copyFile has an issue with empty files, safer to read contents and write
     // https://github.com/nodejs/node/issues/34624
-    if (copyLocation !== noticeFilePath) {
-      console.log('copying NOTICE.txt to', copyLocation);
-      fs.copyFileSync(noticeFilePath, copyLocation);
-    }
+    console.log('writing NOTICE.txt to', copyLocation);
+    fs.writeFileSync(copyLocation, noticeFileContent);
   });
 }
 

--- a/scripts/copy-notices.js
+++ b/scripts/copy-notices.js
@@ -20,8 +20,13 @@ async function copyNotices() {
   );
 
   copyLocations.forEach(copyLocation => {
-    console.log('copying NOTICE.txt to', copyLocation);
-    fs.copyFileSync(noticeFilePath, copyLocation);
+    // on node < 14 if the copy src and dest are the same path
+    // it results in the original file becoming an empty file
+    // https://github.com/nodejs/node/issues/34624
+    if (copyLocation !== noticeFilePath) {
+      console.log('copying NOTICE.txt to', copyLocation);
+      fs.copyFileSync(noticeFilePath, copyLocation);
+    }
   });
 }
 


### PR DESCRIPTION
#### Pull request checklist

Works around node issue nodejs/node#34624 where `fs.copyFile` can result in empty files

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
