### PR TITLE
fix(react-components): Re-export react-theme-provider

### DIFF
--- a/change/@fluentui-react-components-7e8456da-70cd-4885-98c9-972af58c881f.json
+++ b/change/@fluentui-react-components-7e8456da-70cd-4885-98c9-972af58c881f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Re-export react-theme-provider",
+  "packageName": "@fluentui/react-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -14,6 +14,7 @@ export * from "@fluentui/react-make-styles";
 export * from "@fluentui/react-menu";
 export * from "@fluentui/react-provider";
 export * from "@fluentui/react-theme";
+export * from "@fluentui/react-theme-provider";
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -2,6 +2,7 @@
 export * from '@fluentui/react-make-styles';
 export * from '@fluentui/react-provider';
 export * from '@fluentui/react-theme';
+export * from '@fluentui/react-theme-provider';
 
 // Components
 export * from '@fluentui/react-avatar';


### PR DESCRIPTION
Re-export `react-theme-provider` in `react-components` to be able to

```js
import { useTheme } from '@fluentui/react-components'
```