### PR TITLE
Fix border color of Textfield

### DIFF
--- a/change/@fluentui-azure-themes-cc09b6c0-5d4a-4ab7-b82d-2c8917cf4eec.json
+++ b/change/@fluentui-azure-themes-cc09b6c0-5d4a-4ab7-b82d-2c8917cf4eec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix border color of textfield",
+  "packageName": "@fluentui/azure-themes",
+  "email": "aidanmc95@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -13,6 +13,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         height: StyleConstants.inputControlHeight,
       },
       !hasErrorMessage && {
+        borderColor: semanticColors.inputPlaceholderText,
         selectors: {
           '::after': {
             borderColor: extendedSemanticColors.controlFocus,


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

### Description of changes

#### Rest
- Change
  - Border color
    - Dark: #A19F9D
    - Light: #8A8886

Before: 
<img width="217" alt="TextField_Dark_Rest" src="https://user-images.githubusercontent.com/35254365/114248663-18a61080-994d-11eb-87ae-b6cb67186141.PNG">
After: 
<img width="172" alt="TextField_Dark_Rest_Change" src="https://user-images.githubusercontent.com/35254365/114248670-1c399780-994d-11eb-9977-a18039bd61b2.PNG">

