### PR TITLE
fix(DatePicker): Switch disabledAutoFocus to true by default for keyboard a11y

### DIFF
--- a/change/@fluentui-react-e1e5b762-32cf-499d-82e4-eeecdf0e4ef7.json
+++ b/change/@fluentui-react-e1e5b762-32cf-499d-82e4-eeecdf0e4ef7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DatePicker no longer opens on focus by default, but still opens on click",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3500,6 +3500,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
     minDate?: Date;
     onAfterMenuDismiss?: () => void;
     onSelectDate?: (date: Date | null | undefined) => void;
+    openOnClick?: boolean;
     parseDateFromString?: (dateStr: string) => Date | null;
     pickerAriaLabel?: string;
     placeholder?: string;

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -212,7 +212,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
     allFocusable,
     calendarAs: CalendarType = Calendar,
     tabIndex,
-    disableAutoFocus,
+    disableAutoFocus = true,
   } = props;
 
   const id = useId('DatePicker', props.id);
@@ -339,7 +339,9 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
   };
 
   const onTextFieldClick = (ev: React.MouseEvent<HTMLElement>): void => {
-    if (!props.disableAutoFocus && !isCalendarShown && !props.disabled) {
+    // default openOnClick to !props.disableAutoFocus for legacy support of disableAutoFocus behavior
+    const openOnClick = props.openOnClick || !props.disableAutoFocus;
+    if (openOnClick && !isCalendarShown && !props.disabled) {
       showDatePickerPopup();
       return;
     }
@@ -459,7 +461,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
           // eslint-disable-next-line react/jsx-no-bind
           onPositioned={onCalloutPositioned}
         >
-          <FocusTrapZone isClickableOutsideFocusTrap={true} disableFirstFocus={props.disableAutoFocus}>
+          <FocusTrapZone isClickableOutsideFocusTrap={true} disableFirstFocus={disableAutoFocus}>
             <CalendarType
               {...calendarProps}
               // eslint-disable-next-line react/jsx-no-bind

--- a/packages/react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react/src/components/DatePicker/DatePicker.types.ts
@@ -123,9 +123,16 @@ export interface IDatePickerProps
 
   /**
    * Whether the DatePicker should open automatically when the control is focused
-   * @defaultvalue false
+   * WARNING: setting this to false creates an accessibility violation and is not recommended
+   * @defaultvalue true
    */
   disableAutoFocus?: boolean;
+
+  /**
+   * Whether the DatePicker should open when the input is clicked
+   * @defaultvalue true
+   */
+  openOnClick?: boolean;
 
   /**
    * Placeholder text for the DatePicker


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [11636](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11636)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

DatePicker no longer opens on focus by default, since that behavior would violate [WCAG's On Focus](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html) (and create a not-wonderful keyboard experience).

I added an `openOnFocus` property that defaults to true, so the mouse experience still has the same default behavior. It also allows the open-on-click behavior to be controlled separately from the focus behavior.
