### PR TITLE
fix(Button): Button uses menuProps.id as aria-controls value if passed

### DIFF
--- a/change/@fluentui-react-56830010-b9ac-4c74-b792-3cb556bf37aa.json
+++ b/change/@fluentui-react-56830010-b9ac-4c74-b792-3cb556bf37aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Button uses custom menuProps.id to set its aria-controls id if passed",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -249,9 +249,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     if (this._isSplitButton) {
       return this._onRenderSplitButtonContent(tag, buttonProps);
     } else if (this.props.menuProps) {
+      const { id = `${this._labelId}-menu` } = this.props.menuProps;
       assign(buttonProps, {
         'aria-expanded': !menuHidden,
-        'aria-controls': !menuHidden ? this._labelId + '-menu' : null,
+        'aria-controls': !menuHidden ? id : null,
         'aria-haspopup': true,
       });
     }

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -348,6 +348,23 @@ describe('Button', () => {
         expect(menuProps.hidden).toEqual(false);
       });
 
+      it('uses menuprops id in aria-controls when passed', () => {
+        const menuProps: IContextualMenuProps = {
+          id: 'custom-id',
+          items: [
+            {
+              key: 'menuItem',
+              text: 'Menu Item',
+            },
+          ],
+        };
+
+        const button = renderIntoDocument(<DefaultButton menuProps={menuProps}>Hello</DefaultButton>);
+        ReactTestUtils.Simulate.click(button);
+
+        expect(button.getAttribute('aria-controls')).toBe('custom-id');
+      });
+
       it('applies aria-pressed to a checked split button', () => {
         const button: any = render(
           <DefaultButton


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10892](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10892)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

BaseButton now checks for `menuProps.id`, and defaults to internal id if it isn't present. Includes a test as well.