### PR TITLE
Remove allowDisabledFocus attribute from example splitbutton

### DIFF
--- a/change/@fluentui-react-examples-74627050-fa72-4756-aa91-4a20cde0f75a.json
+++ b/change/@fluentui-react-examples-74627050-fa72-4756-aa91-4a20cde0f75a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove allowDisabledFocus from disabled standalone splitbutton",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/Button/Button.Split.Example.tsx
+++ b/packages/react-examples/src/react/Button/Button.Split.Example.tsx
@@ -65,7 +65,6 @@ export const ButtonSplitExample: React.FunctionComponent<IButtonExampleProps> = 
       <DefaultButton
         text="Disabled"
         disabled
-        allowDisabledFocus
         split
         splitButtonAriaLabel="See 2 options"
         aria-roledescription="split button"

--- a/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.Split.Example.tsx.shot
@@ -1186,7 +1186,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex={0}
     >
       <span
         style={
@@ -1267,7 +1266,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 color: GrayText;
               }
           data-is-focusable={false}
-          disabled={false}
+          disabled={true}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           onKeyUp={[Function]}
@@ -1372,7 +1371,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 color: GrayText;
               }
           data-is-focusable={false}
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [11037](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11037)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Examples change only:

Our examples page includes a disabled standalone splitbutton, and it has `allowDisabledFocus` set on it. That makes sense to add on a splitbutton or button within a menu or command bar, but shouldn't be modeled on a standalone button. I've removed the attribute from the example.
