### PR TITLE
chore: update packages for SizeAuditor

### DIFF
--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -20,11 +20,9 @@ if (package === '@fluentui/react-northstar') {
   entries = buildEntries('@fluentui/react-components');
 } else if (package === '@fluentui/react') {
   createFluentReactFixtures();
-  createEntry('@fluentui/react-compose');
   createEntry('@fluentui/keyboard-key');
 
   entries = buildEntries('@fluentui/react');
-  entries['react-compose'] = buildEntry('@fluentui/react-compose');
   entries['keyboard-key'] = buildEntry('@fluentui/keyboard-key');
 } else {
   process.exit(1);

--- a/apps/test-bundles/webpackUtils.js
+++ b/apps/test-bundles/webpackUtils.js
@@ -130,6 +130,7 @@ function createFluentConvergedFixtures() {
     // makeStyles
     'ax',
     'makeStyles',
+    'makeStaticStyles',
 
     // utils
     // 'usePopper',

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -21,7 +21,7 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: yarn build --to @fluentui/react @fluentui/react-button @fluentui/react-compose @fluentui/keyboard-key --no-cache
+      - script: yarn build --to @fluentui/react @fluentui/keyboard-key --no-cache
         displayName: yarn build to @fluentui/react
 
       - script: yarn workspace test-bundles bundle:size


### PR DESCRIPTION
#### Description of changes

This PR:
- removes `@fluentui/react-compose` from bundle size gates as we are not going to use this package in future
- adds `makeStaticStyles()` from `@fluentui/react-components` to bundle size gates
- removes `@fluentui/react-button` from v8 job as it's a part of the converged job
