### PR TITLE
Persona presence border zoom level bug

### DIFF
--- a/change/@fluentui-react-3b98d60e-b005-4de8-bc22-8fe61dbe20b7.json
+++ b/change/@fluentui-react-3b98d60e-b005-4de8-bc22-8fe61dbe20b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-58144ccf-d3b9-41d8-addd-f2af487144ba.json
+++ b/change/@fluentui-react-58144ccf-d3b9-41d8-addd-f2af487144ba.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-f258e3b5-628f-4451-b1bd-a6650dd7bc61.json
+++ b/change/@fluentui-react-examples-f258e3b5-628f-4451-b1bd-a6650dd7bc61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react-examples",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-4fc31aca-789b-4454-a745-ffe444a93f39.json
+++ b/change/@fluentui-react-experiments-4fc31aca-789b-4454-a745-ffe444a93f39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -240,7 +240,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         ms-Persona-presence
                         {
                           -ms-high-contrast-adjust: none;
-                          background-clip: content-box;
+                          background-clip: border-box;
                           background-color: #FFAA44;
                           border-radius: 50%;
                           border: 2px solid #ffffff;
@@ -383,7 +383,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #6BB700;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
@@ -561,7 +561,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         ms-Persona-presence
                         {
                           -ms-high-contrast-adjust: none;
-                          background-clip: content-box;
+                          background-clip: border-box;
                           background-color: #ffffff;
                           border-radius: 50%;
                           border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -303,7 +303,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #6BB700;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
@@ -687,7 +687,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #C43148;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
@@ -1065,7 +1065,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #C50F1F;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
@@ -1449,7 +1449,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #ffffff;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
@@ -1846,7 +1846,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                       ms-Persona-presence
                       {
                         -ms-high-contrast-adjust: none;
-                        background-clip: content-box;
+                        background-clip: border-box;
                         background-color: #6BB700;
                         border-radius: 50%;
                         border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -219,7 +219,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           ms-Persona-presence
                           {
                             -ms-high-contrast-adjust: none;
-                            background-clip: content-box;
+                            background-clip: border-box;
                             background-color: #6BB700;
                             border-radius: 50%;
                             border: 2px solid #ffffff;
@@ -665,7 +665,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           ms-Persona-presence
                           {
                             -ms-high-contrast-adjust: none;
-                            background-clip: content-box;
+                            background-clip: border-box;
                             background-color: #C43148;
                             border-radius: 50%;
                             border: 2px solid #ffffff;
@@ -1111,7 +1111,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           ms-Persona-presence
                           {
                             -ms-high-contrast-adjust: none;
-                            background-clip: content-box;
+                            background-clip: border-box;
                             background-color: #C50F1F;
                             border-radius: 50%;
                             border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -628,7 +628,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #6BB700;
                 border-radius: 50%;
                 border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -500,7 +500,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             ms-Persona-presence
             {
               -ms-high-contrast-adjust: none;
-              background-clip: content-box;
+              background-clip: border-box;
               background-color: #ffffff;
               border-radius: 50%;
               border: 0px;
@@ -816,7 +816,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #6BB700;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -1111,7 +1111,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #6BB700;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -1406,7 +1406,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #FFAA44;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -1727,7 +1727,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #C43148;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -2040,7 +2040,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #6BB700;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -2359,7 +2359,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #C50F1F;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -2678,7 +2678,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #ffffff;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
@@ -3024,7 +3024,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #FFAA44;
                 border-radius: 50%;
                 border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -111,7 +111,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #6BB700;
                 border-radius: 50%;
                 border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -135,7 +135,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #ffffff;
                 border-radius: 50%;
                 border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.Presence.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Presence.Example.tsx.shot
@@ -151,7 +151,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #6BB700;
                     border-radius: 50%;
                     border: 0px;
@@ -362,7 +362,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #6BB700;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -495,7 +495,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #6BB700;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -653,7 +653,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #6BB700;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -822,7 +822,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -1051,7 +1051,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -1202,7 +1202,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -1379,7 +1379,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -1589,7 +1589,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #FFAA44;
                     border-radius: 50%;
                     border: 0px;
@@ -1800,7 +1800,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #FFAA44;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -1933,7 +1933,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #FFAA44;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -2093,7 +2093,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #FFAA44;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -2264,7 +2264,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -2493,7 +2493,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -2644,7 +2644,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -2822,7 +2822,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -3033,7 +3033,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #C43148;
                     border-radius: 50%;
                     border: 0px;
@@ -3244,7 +3244,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C43148;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -3377,7 +3377,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C43148;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -3529,7 +3529,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C43148;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -3692,7 +3692,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -3921,7 +3921,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -4072,7 +4072,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -4243,7 +4243,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -4447,7 +4447,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #C50F1F;
                     border-radius: 50%;
                     border: 0px;
@@ -4658,7 +4658,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C50F1F;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -4791,7 +4791,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C50F1F;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -4949,7 +4949,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #C50F1F;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -5118,7 +5118,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -5347,7 +5347,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -5498,7 +5498,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -5675,7 +5675,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -5843,7 +5843,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #ffffff;
                 border-radius: 50%;
                 border: 0px;
@@ -6077,7 +6077,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 ms-Persona-presence
                 {
                   -ms-high-contrast-adjust: none;
-                  background-clip: content-box;
+                  background-clip: border-box;
                   background-color: #ffffff;
                   border-radius: 50%;
                   border: 2px solid #ffffff;
@@ -6233,7 +6233,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 ms-Persona-presence
                 {
                   -ms-high-contrast-adjust: none;
-                  background-clip: content-box;
+                  background-clip: border-box;
                   background-color: #ffffff;
                   border-radius: 50%;
                   border: 2px solid #ffffff;
@@ -6418,7 +6418,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 ms-Persona-presence
                 {
                   -ms-high-contrast-adjust: none;
-                  background-clip: content-box;
+                  background-clip: border-box;
                   background-color: #ffffff;
                   border-radius: 50%;
                   border: 2px solid #ffffff;
@@ -6634,7 +6634,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -6863,7 +6863,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -7014,7 +7014,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -7185,7 +7185,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -7367,7 +7367,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #ffffff;
                     border-radius: 50%;
                     border: 0px;
@@ -7596,7 +7596,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -7747,7 +7747,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;
@@ -7924,7 +7924,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     ms-Persona-presence
                     {
                       -ms-high-contrast-adjust: none;
-                      background-clip: content-box;
+                      background-clip: border-box;
                       background-color: #ffffff;
                       border-radius: 50%;
                       border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Persona.PresenceColor.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.PresenceColor.Example.tsx.shot
@@ -190,7 +190,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #fff;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -397,7 +397,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -645,7 +645,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #fff;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -854,7 +854,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -1103,7 +1103,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #fff;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -1304,7 +1304,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -1546,7 +1546,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #fff;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -1753,7 +1753,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -1959,7 +1959,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
-                background-clip: content-box;
+                background-clip: border-box;
                 background-color: #000;
                 border-radius: 50%;
                 border: 2px solid #000;
@@ -2213,7 +2213,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;
@@ -2433,7 +2433,7 @@ exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #000;
                     border-radius: 50%;
                     border: 2px solid #000;

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -1057,7 +1057,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   ms-Persona-presence
                   {
                     -ms-high-contrast-adjust: none;
-                    background-clip: content-box;
+                    background-clip: border-box;
                     background-color: #FFAA44;
                     border-radius: 50%;
                     border: 2px solid #ffffff;

--- a/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
         ms-Persona-presence
         {
           -ms-high-contrast-adjust: none;
-          background-clip: content-box;
+          background-clip: border-box;
           background-color: #C50F1F;
           border-radius: 50%;
           border: 2px solid #ffffff;
@@ -320,7 +320,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
         ms-Persona-presence
         {
           -ms-high-contrast-adjust: none;
-          background-clip: content-box;
+          background-clip: border-box;
           background-color: #C50F1F;
           border-radius: 50%;
           border: 2px solid #ffffff;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -522,7 +522,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                             ms-Persona-presence
                             {
                               -ms-high-contrast-adjust: none;
-                              background-clip: content-box;
+                              background-clip: border-box;
                               background-color: #6BB700;
                               border-radius: 50%;
                               border: 2px solid #ffffff;

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -1030,7 +1030,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             ms-Persona-presence
             {
               -ms-high-contrast-adjust: none;
-              background-clip: content-box;
+              background-clip: border-box;
               background-color: #ffffff;
               border-radius: 50%;
               border: 2px solid #ffffff;
@@ -1539,7 +1539,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             ms-Persona-presence
             {
               -ms-high-contrast-adjust: none;
-              background-clip: content-box;
+              background-clip: border-box;
               background-color: #ffffff;
               border-radius: 50%;
               border: 2px solid #ffffff;

--- a/packages/react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
+++ b/packages/react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
@@ -48,7 +48,7 @@ export const getStyles = (props: IPersonaPresenceStyleProps): IPersonaPresenceSt
         border: `2px solid ${presenceColorBackground}`,
         textAlign: 'center',
         boxSizing: 'content-box',
-        backgroundClip: 'content-box',
+        backgroundClip: 'border-box',
         ...getHighContrastNoAdjustStyle(),
 
         selectors: {

--- a/packages/react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -78,7 +78,7 @@ exports[`PersonaPresence renders available 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #6BB700;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -131,7 +131,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -204,7 +204,7 @@ exports[`PersonaPresence renders away 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #FFAA44;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -259,7 +259,7 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -329,7 +329,7 @@ exports[`PersonaPresence renders blocked 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -399,7 +399,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -465,7 +465,7 @@ exports[`PersonaPresence renders busy 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #C43148;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -512,7 +512,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -584,7 +584,7 @@ exports[`PersonaPresence renders do not disturb 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #C50F1F;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -641,7 +641,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -713,7 +713,7 @@ exports[`PersonaPresence renders offline 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -1030,7 +1030,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             ms-Persona-presence
             {
               -ms-high-contrast-adjust: none;
-              background-clip: content-box;
+              background-clip: border-box;
               background-color: #ffffff;
               border-radius: 50%;
               border: 2px solid #ffffff;
@@ -1539,7 +1539,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             ms-Persona-presence
             {
               -ms-high-contrast-adjust: none;
-              background-clip: content-box;
+              background-clip: border-box;
               background-color: #ffffff;
               border-radius: 50%;
               border: 2px solid #ffffff;

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                         ms-Persona-presence
                         {
                           -ms-high-contrast-adjust: none;
-                          background-clip: content-box;
+                          background-clip: border-box;
                           background-color: #6BB700;
                           border-radius: 50%;
                           border: 2px solid #ffffff;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17801
- [x] Include a change request file using `$ yarn change`

#### Description of changes

To avoid the clipping issue mentioned in issue #17801 we updated the CSS property `background-clip` from 
`content-box` to `border-box` in the PersonaCoin styles file inside the react package. This makes the content stretch not just _to_ the border, but also _underneath to the edge_ of the border.

An explanation of the CSS property can be seen [here](https://www.w3schools.com/cssref/css3_pr_background-clip.asp) for reference.

**Before change:**
![Screenshot 2021-04-13 at 16 36 41](https://user-images.githubusercontent.com/9829147/114570823-705ab980-9c76-11eb-9ca0-835b15a5fe85.png)

**After change:**
![Screenshot 2021-04-13 at 16 36 08](https://user-images.githubusercontent.com/9829147/114570884-7e103f00-9c76-11eb-8224-afe72a09739f.png)

