### PR TITLE
Darken TeachingBubble button text color to meet contrast minimum on hover/focus

### DIFF
--- a/change/@fluentui-react-65cd5bf3-bea6-4eeb-ab59-ec95a325b2b1.json
+++ b/change/@fluentui-react-65cd5bf3-bea6-4eeb-ab59-ec95a325b2b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "darken teaching bubble button text color to meet contrast minimum when hovered or focused",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -229,11 +229,12 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
           ':hover': {
             backgroundColor: palette.themeLighter,
             borderColor: palette.themeLighter,
-            color: palette.themePrimary,
+            color: palette.themeDark,
           },
           ':focus': {
             backgroundColor: palette.themeLighter,
             border: `1px solid ${palette.black}`,
+            color: palette.themeDark,
             outline: `1px solid ${palette.white}`,
             outlineOffset: '-2px',
           },

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   background-color: #deecf9;
                   border-color: #deecf9;
                   border: 1px solid #106ebe;
-                  color: #0078d4;
+                  color: #005a9e;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -371,6 +371,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 &:focus {
                   background-color: #deecf9;
                   border: 1px solid #000000;
+                  color: #005a9e;
                   outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -628,7 +628,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   background-color: #deecf9;
                   border-color: #deecf9;
                   border: 1px solid #106ebe;
-                  color: #0078d4;
+                  color: #005a9e;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
                   background-color: Highlight;
@@ -638,6 +638,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 &:focus {
                   background-color: #deecf9;
                   border: 1px solid #000000;
+                  color: #005a9e;
                   outline-offset: -2px;
                   outline: 1px solid #ffffff;
                 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Darkens text color of TeachingBubble's primary button to `themeDark` when hoevered or focused to meet text contrast requirements.
