### PR TITLE
Pass MouseEvent to Toggle onChange callback

### DIFF
--- a/change/@fluentui-react-04f6e4ed-219b-4630-9a88-c977c492e191.json
+++ b/change/@fluentui-react-04f6e4ed-219b-4630-9a88-c977c492e191.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass MouseEvent to Toggle onChange callback",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -98,7 +98,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
 
     const onClick = (ev: React.MouseEvent<HTMLElement>) => {
       if (!disabled) {
-        setChecked(!checked);
+        setChecked(!checked, ev);
         if (onToggleClick) {
           onToggleClick(ev);
         }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Toggle was not previously passing its MouseEvent to the `onChange` callback. This change fixes that error.

#### Focus areas to test

(optional)
