### PR TITLE
(5.0) Fix website production build

### DIFF
--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@uifabric/fabric-website",
   "version": "5.8.8",
-  "private": true,
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = function (argv) {
   const { BUNDLE_NAME: entryPointName } = require('@fluentui/public-docsite-setup');
 
   const version = require('./package.json').version;
-  const isProductionArg = !!argv && argv.production;
+  const isProductionArg = argv.indexOf('--production') > -1;
 
   const now = Date.now();
 

--- a/common/changes/@uifabric/fabric-website/2021-04-14-20-48.json
+++ b/common/changes/@uifabric/fabric-website/2021-04-14-20-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Update website to use shared setup for loading",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
Apparently the way #17634 changed the check for the `--production` arg in webpack doesn't work in that webpack version. Revert to the old way (verified locally).

(related to #14691)