### PR TITLE
fix(Toolbar): correct ref to Toolbar overflowSentinel

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 
 ### Fixes
+- Correct ref to `Toolbar` overflowSentinel @yuanboxue-amber ([#17813](https://github.com/microsoft/fluentui/pull/17813))
 
 ### Features
 - Add default `backgroundActive2` and brand `backgroundPressed1` color slots @notandrew ([#17699](https://github.com/microsoft/fluentui/pull/17699))

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -515,7 +515,6 @@ export const Toolbar = compose<'div', ToolbarProps, ToolbarStylesProps, {}, {}>(
           defaultProps: () => ({
             id: 'sentinel',
             className: classes.overflowSentinel,
-            ref: overflowSentinel,
           }),
         })}
       </Ref>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Ref on Toolbar overflowSentinel is not set correctly. This causes TMP memory leak. This PR corrected it.

Regarding the memory leak:
I created a codesandbox to mount/unmount an overflow Toolbar on a button click: https://codesandbox.io/s/fluent-ui-example-forked-x8b7x?file=/example.js
When Toolbar unmounted, this codesandbox is not showing much difference in terms of detached DOM nodes for 0.53.0 and 0.54.0. So I'm not sure why this bug causes memory leak. We only know that the memory leak disappears when this bug was corrected in TMP

#### Focus areas to test

(optional)
