### PR TITLE
Charting: Pentagon icon shape updated.

### DIFF
--- a/change/@fluentui-react-charting-e7f4af41-403d-4915-88f6-1b629e04f880.json
+++ b/change/@fluentui-react-charting-e7f4af41-403d-4915-88f6-1b629e04f880.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Charting: Pentagon size reverted to normal size",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-e7f4af41-403d-4915-88f6-1b629e04f880.json
+++ b/change/@fluentui-react-charting-e7f4af41-403d-4915-88f6-1b629e04f880.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Charting: Pentagon size reverted to normal size",
   "packageName": "@fluentui/react-charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -917,7 +917,7 @@ export const pointTypes: PointTypes = {
     widthRatio: 2,
   },
   [Points.pentagon]: {
-    widthRatio: 1.5,
+    widthRatio: 1.168,
   },
   [Points.octagon]: {
     widthRatio: 2.414,


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Charting: In multiline chart, 
While using different icons enabled, Pentagon size looks bigger when compared to other shapes.

To reduce size of pentagon, in previous PR, changed size of a line. Now reverting to the previous size of the line of pentagon.

@Raghurk , Jonah Lu

#### Focus areas to test

Multi line chart with different shapes