### PR TITLE
Persona color guidance in Best Practices docs

### DIFF
--- a/change/@fluentui-react-examples-8cf7ff59-2751-4e91-8693-5d9908114b0c.json
+++ b/change/@fluentui-react-examples-8cf7ff59-2751-4e91-8693-5d9908114b0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add guidance on avoiding color alone accessibility violations to the Persona docs and examples\"",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/Persona/Persona.Alternate.Example.tsx
+++ b/packages/react-examples/src/react/Persona/Persona.Alternate.Example.tsx
@@ -30,6 +30,7 @@ export const PersonaAlternateExample: React.FunctionComponent = () => {
       />
       <Persona
         {...examplePersona}
+        secondaryText="Designer (Available)"
         size={PersonaSize.size32}
         presence={PersonaPresence.online}
         imageAlt="Annie Ried, status is available at 4 PM"

--- a/packages/react-examples/src/react/Persona/Persona.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Persona/Persona.Basic.Example.tsx
@@ -47,6 +47,7 @@ export const PersonaBasicExample: React.FunctionComponent = () => {
       <Label>Size 24 Persona</Label>
       <Persona
         {...examplePersona}
+        text="Annie Lindqvist (Available)"
         size={PersonaSize.size24}
         presence={PersonaPresence.online}
         hidePersonaDetails={!renderDetails}
@@ -55,6 +56,7 @@ export const PersonaBasicExample: React.FunctionComponent = () => {
       <Label>Size 32 Persona</Label>
       <Persona
         {...examplePersona}
+        text="Annie Lindqvist (Available)"
         size={PersonaSize.size32}
         presence={PersonaPresence.online}
         hidePersonaDetails={!renderDetails}

--- a/packages/react-examples/src/react/Persona/docs/PersonaBestPractices.md
+++ b/packages/react-examples/src/react/Persona/docs/PersonaBestPractices.md
@@ -8,3 +8,7 @@
 ### Content
 
 - Change the values of the color swatches in high contrast mode.
+
+### Accessibility
+
+The presence indicator for small personas of size 32 or less only uses color to indicate the current status. This can result in poor accessibility for anyone who has trouble perceiving color. If you use the presence indicator on small personas, we recommend adding a text alternative as we do in our examples.

--- a/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -729,7 +729,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          Designer
+          Designer (Available)
         </div>
       </div>
       <div

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -882,7 +882,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          Annie Lindqvist
+          Annie Lindqvist (Available)
         </div>
       </div>
       <div
@@ -1177,7 +1177,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          Annie Lindqvist
+          Annie Lindqvist (Available)
         </div>
       </div>
       <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10296](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10296)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is a change to the Persona examples and docs alone, it doesn't include any component changes.

The issue is that our smallest personas have status/presence indicators that use color alone, while larger personas have icons as well. After discussing with design, it does make sense to continue providing those dots, and adding icons at that size isn't really feasible. The solution we came up with was to make sure authors are informed that they'll need some sort of text alternative in addition to the status dots, so I added the a11y section to Best Practices and updated our examples to demonstrate a text alternative at small sizes.
