### PR TITLE
Button: Setting focus visibility to true in scenarios where it should be supported

### DIFF
--- a/change/office-ui-fabric-react-7c58862c-c0eb-4b51-82ac-a7786db0a992.json
+++ b/change/office-ui-fabric-react-7c58862c-c0eb-4b51-82ac-a7786db0a992.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Button: Setting focus visibility to true in scenarios where it should be supported.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 import {
-  IRenderFunction,
   anchorProperties,
   assign,
   buttonProperties,
+  createMergedRef,
+  css,
   getId,
   getNativeProps,
-  KeyCodes,
-  css,
-  mergeAriaAttributeValues,
-  portalContainsElement,
+  initializeComponentRef,
   memoizeFunction,
+  mergeAriaAttributeValues,
   nullRender,
+  portalContainsElement,
+  setFocusVisibility,
   warnConditionallyRequiredProps,
   warnDeprecations,
-  EventGroup,
-  initializeComponentRef,
   Async,
+  EventGroup,
   FocusRects,
+  IRenderFunction,
+  KeyCodes,
 } from '../../Utilities';
-import { createMergedRef } from '@uifabric/utilities';
 import { Icon, FontIcon, ImageIcon } from '../../Icon';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { ContextualMenu, IContextualMenuProps } from '../../ContextualMenu';
@@ -287,8 +288,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   public focus(): void {
     if (this._isSplitButton && this._splitButtonContainer.current) {
+      setFocusVisibility(true);
       this._splitButtonContainer.current.focus();
     } else if (this._buttonElement.current) {
+      setFocusVisibility(true);
       this._buttonElement.current.focus();
     }
   }
@@ -820,6 +823,13 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       this._onToggleMenu(false);
       ev.preventDefault();
       ev.stopPropagation();
+    }
+
+    if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
+      // We manually set the focus visibility to true if opening via Enter or Space to account for the scenario where
+      // a user clicks on the button, closes the menu and then opens it via keyboard. In this scenario our default logic
+      // for setting focus visibility is not triggered since there is no keyboard navigation present beforehand.
+      setFocusVisibility(true, ev.target as Element);
     }
 
     if (!(ev.altKey || ev.metaKey) && (isUp || isDown)) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11793, fixes #12291
- [x] Include a change request file using `$ yarn change`

#### Description of changes

__Cherry-pick of #17820__

This PR fixes 2 scenarios where keyboard focus should appear but wasn't when using the `Button` component in the `@fluentui/react` package.

The first scenario was that when programmatically focusing a `Button` the focus styling wouldn't be set.

__Before:__
![ButtonProgrammaticallyFocusBefore](https://user-images.githubusercontent.com/7798177/114792698-ae6ee080-9d3d-11eb-8905-dc1df85cb2e0.gif)

__After:__
![ButtonProgrammaticallyFocusAfter](https://user-images.githubusercontent.com/7798177/114792711-b595ee80-9d3d-11eb-9c63-2ad0c5cfb72c.gif)

The second scenario was that when clicking on a `Button` with a menu (so that the focus was already on the element), dismissing the menu and then opening it via pressing the `Enter` or `Space` keys, the focus indicator was not appearing:

__Before:__
![MenuButtonBefore](https://user-images.githubusercontent.com/7798177/114792876-04438880-9d3e-11eb-8cb2-09bfc20d3174.gif)

__After:__
![MenuButton](https://user-images.githubusercontent.com/7798177/114792815-e5dd8d00-9d3d-11eb-83f1-435ba8e4eace.gif)
