### PR TITLE
ContextualMenu: Making IMenuItemStyles and IContextualMenuItemStyles optional instead of required

### DIFF
--- a/change/office-ui-fabric-react-53867022-e23d-482b-8736-1d179d753855.json
+++ b/change/office-ui-fabric-react-53867022-e23d-482b-8736-1d179d753855.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "ContextualMenu: Making IMenuItemStyles and IContextualMenuItemStyles optional instead of required.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3166,17 +3166,17 @@ export interface IContextualMenu {
 // @public @deprecated (undocumented)
 export interface IContextualMenuClassNames {
     // (undocumented)
-    container: string;
+    container?: string;
     // (undocumented)
-    header: string;
+    header?: string;
     // (undocumented)
-    list: string;
+    list?: string;
     // (undocumented)
-    root: string;
+    root?: string;
     // (undocumented)
     subComponentStyles?: IContextualMenuSubComponentStyles;
     // (undocumented)
-    title: string;
+    title?: string;
 }
 
 // @public (undocumented)
@@ -3285,22 +3285,22 @@ export interface IContextualMenuItemStyleProps {
 
 // @public (undocumented)
 export interface IContextualMenuItemStyles extends IButtonStyles {
-    anchorLink: IStyle;
-    checkmarkIcon: IStyle;
-    divider: IStyle;
-    icon: IStyle;
-    iconColor: IStyle;
-    item: IStyle;
-    label: IStyle;
-    linkContent: IStyle;
-    linkContentMenu: IStyle;
-    root: IStyle;
-    screenReaderText: IStyle;
-    secondaryText: IStyle;
-    splitContainer: IStyle;
-    splitMenu: IStyle;
-    splitPrimary: IStyle;
-    subMenuIcon: IStyle;
+    anchorLink?: IStyle;
+    checkmarkIcon?: IStyle;
+    divider?: IStyle;
+    icon?: IStyle;
+    iconColor?: IStyle;
+    item?: IStyle;
+    label?: IStyle;
+    linkContent?: IStyle;
+    linkContentMenu?: IStyle;
+    root?: IStyle;
+    screenReaderText?: IStyle;
+    secondaryText?: IStyle;
+    splitContainer?: IStyle;
+    splitMenu?: IStyle;
+    splitPrimary?: IStyle;
+    subMenuIcon?: IStyle;
 }
 
 // @public (undocumented)
@@ -5904,44 +5904,44 @@ export interface IMaskedTextFieldState {
 // @public @deprecated (undocumented)
 export interface IMenuItemClassNames {
     // (undocumented)
-    checkmarkIcon: string;
+    checkmarkIcon?: string;
     // (undocumented)
-    divider: string;
+    divider?: string;
     // (undocumented)
-    icon: string;
+    icon?: string;
     // (undocumented)
-    item: string;
+    item?: string;
     // (undocumented)
-    label: string;
+    label?: string;
     // (undocumented)
-    linkContent: string;
+    linkContent?: string;
     // (undocumented)
-    linkContentMenu: string;
+    linkContentMenu?: string;
     // (undocumented)
-    root: string;
+    root?: string;
     // (undocumented)
-    screenReaderText: string;
+    screenReaderText?: string;
     // (undocumented)
-    secondaryText: string;
+    secondaryText?: string;
     // (undocumented)
-    splitContainer: string;
+    splitContainer?: string;
     // (undocumented)
-    splitMenu: string;
+    splitMenu?: string;
     // (undocumented)
-    splitPrimary: string;
+    splitPrimary?: string;
     // (undocumented)
-    subMenuIcon: string;
+    subMenuIcon?: string;
 }
 
 // @public (undocumented)
 export interface IMenuItemStyles extends IButtonStyles {
-    anchorLink: IStyle;
-    checkmarkIcon: IStyle;
-    divider: IStyle;
-    iconColor: IStyle;
-    item: IStyle;
-    linkContent: IStyle;
-    subMenuIcon: IStyle;
+    anchorLink?: IStyle;
+    checkmarkIcon?: IStyle;
+    divider?: IStyle;
+    iconColor?: IStyle;
+    item?: IStyle;
+    linkContent?: IStyle;
+    subMenuIcon?: IStyle;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -17,11 +17,11 @@ import { IContextualMenuSubComponentStyles } from './ContextualMenu.types';
  * @deprecated in favor of mergeStyles API.
  */
 export interface IContextualMenuClassNames {
-  container: string;
-  root: string;
-  list: string;
-  header: string;
-  title: string;
+  container?: string;
+  root?: string;
+  list?: string;
+  header?: string;
+  title?: string;
   subComponentStyles?: IContextualMenuSubComponentStyles;
 }
 
@@ -29,20 +29,20 @@ export interface IContextualMenuClassNames {
  * @deprecated in favor of mergeStyles API.
  */
 export interface IMenuItemClassNames {
-  item: string;
-  divider: string;
-  root: string;
-  linkContent: string;
-  icon: string;
-  checkmarkIcon: string;
-  subMenuIcon: string;
-  label: string;
-  secondaryText: string;
-  splitContainer: string;
-  splitPrimary: string;
-  splitMenu: string;
-  linkContentMenu: string;
-  screenReaderText: string;
+  item?: string;
+  divider?: string;
+  root?: string;
+  linkContent?: string;
+  icon?: string;
+  checkmarkIcon?: string;
+  subMenuIcon?: string;
+  label?: string;
+  secondaryText?: string;
+  splitContainer?: string;
+  splitPrimary?: string;
+  splitMenu?: string;
+  linkContentMenu?: string;
+  screenReaderText?: string;
 }
 
 const CONTEXTUAL_SPLIT_MENU_MINWIDTH = '28px';

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -589,37 +589,37 @@ export interface IMenuItemStyles extends IButtonStyles {
   /**
    * Styles for a menu item that is an anchor link.
    */
-  item: IStyle;
+  item?: IStyle;
 
   /**
    * Styles for the content inside the button/link of the menuItem.
    */
-  linkContent: IStyle;
+  linkContent?: IStyle;
 
   /**
    * Styles for a menu item that is an anchor link.
    */
-  anchorLink: IStyle;
+  anchorLink?: IStyle;
 
   /**
    * Default icon color style for known icons.
    */
-  iconColor: IStyle;
+  iconColor?: IStyle;
 
   /**
    * Default style for checkmark icons.
    */
-  checkmarkIcon: IStyle;
+  checkmarkIcon?: IStyle;
 
   /**
    * Styles for the submenu icon of a menu item.
    */
-  subMenuIcon: IStyle;
+  subMenuIcon?: IStyle;
 
   /**
    * Styles for a divider item of a ConextualMenu.
    */
-  divider: IStyle;
+  divider?: IStyle;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
@@ -172,82 +172,82 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
   /**
    * Style for the root element.
    */
-  root: IStyle;
+  root?: IStyle;
 
   /**
    * Styles for a menu item that is an anchor link.
    */
-  item: IStyle;
+  item?: IStyle;
 
   /**
    * Styles for a divider item of a ContextualMenu.
    */
-  divider: IStyle;
+  divider?: IStyle;
 
   /**
    * Styles for the content inside the button/link of the menuItem.
    */
-  linkContent: IStyle;
+  linkContent?: IStyle;
 
   /**
    * Styles for a menu item that is an anchor link.
    */
-  anchorLink: IStyle;
+  anchorLink?: IStyle;
 
   /**
    * Styles for the icon element of a menu item.
    */
-  icon: IStyle;
+  icon?: IStyle;
 
   /**
    * Default icon color style for known icons.
    */
-  iconColor: IStyle;
+  iconColor?: IStyle;
 
   /**
    * Default style for checkmark icons.
    */
-  checkmarkIcon: IStyle;
+  checkmarkIcon?: IStyle;
 
   /**
    * Styles for the submenu icon of a menu item.
    */
-  subMenuIcon: IStyle;
+  subMenuIcon?: IStyle;
 
   /**
    * Styles for the label of a menu item.
    */
-  label: IStyle;
+  label?: IStyle;
 
   /**
    * Styles for the secondary text of a menu item.
    */
-  secondaryText: IStyle;
+  secondaryText?: IStyle;
 
   /**
    * Styles for the container of a split menu item.
    */
-  splitContainer: IStyle;
+  splitContainer?: IStyle;
 
   /**
    * Styles for the primary portion of a split menu item.
    */
-  splitPrimary: IStyle;
+  splitPrimary?: IStyle;
 
   /**
    * Styles for the menu portion of a split menu item.
    */
-  splitMenu: IStyle;
+  splitMenu?: IStyle;
 
   /**
    * Styles for a menu item that is a link.
    */
-  linkContentMenu: IStyle;
+  linkContentMenu?: IStyle;
 
   /**
    * Styles for hidden screen reader text.
    */
-  screenReaderText: IStyle;
+  screenReaderText?: IStyle;
 }
 
 export interface IContextualMenuItemRenderFunctions {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

__Cherry-pick of #17831__

This PR makes all the style sections in `IMenuItemStyles` and `IContextualMenuItemStyles` optional instead of required to allow for partial definitions of the `styles` object.