### PR TITLE
fix(Datepicker): accessibility update to error handling when the date value is auto-reset

### DIFF
--- a/change/@fluentui-react-0bb7417e-2d02-4cb5-8c38-1ddba32f35ed.json
+++ b/change/@fluentui-react-0bb7417e-2d02-4cb5-8c38-1ddba32f35ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Datepicker accessibility fix: the input is no longer marked invalid when the date is reset",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3524,6 +3524,7 @@ export interface IDatePickerStrings extends ICalendarStrings {
     invalidInputErrorMessage?: string;
     isOutOfBoundsErrorMessage?: string;
     isRequiredErrorMessage?: string;
+    isResetStatusMessage?: string;
 }
 
 // @public (undocumented)
@@ -3545,6 +3546,8 @@ export interface IDatePickerStyles {
     // (undocumented)
     icon: IStyle;
     root: IStyle;
+    // (undocumented)
+    statusMessage?: IStyle;
     // (undocumented)
     textField: IStyle;
     // (undocumented)

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -133,7 +133,6 @@ function useErrorMessage(
         // Check if date is null, or date is Invalid Date
         if (!date || isNaN(date.getTime())) {
           // Reset invalid input field, if formatting is available
-          console.log('resetting invalid input field to past selected date', strings);
           setSelectedDate(selectedDate);
           // default the newer isResetStatusMessage string to invalidInputErrorMessage for legacy support
           const selectedText = formatDate ? formatDate(selectedDate) : '';

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -460,6 +460,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
             className: css(classNames.icon, iconProps && iconProps.className),
             onClick: onIconClick,
           }}
+          // eslint-disable-next-line react/jsx-no-bind
           onRenderDescription={renderTextfieldDescription}
           // eslint-disable-next-line react/jsx-no-bind
           onKeyDown={onTextFieldKeyDown}

--- a/packages/react/src/components/DatePicker/DatePicker.styles.ts
+++ b/packages/react/src/components/DatePicker/DatePicker.styles.ts
@@ -67,5 +67,8 @@ export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
         cursor: 'default',
       },
     ],
+    statusMessage: {
+      color: 'red',
+    },
   };
 };

--- a/packages/react/src/components/DatePicker/DatePicker.styles.ts
+++ b/packages/react/src/components/DatePicker/DatePicker.styles.ts
@@ -11,7 +11,7 @@ const GlobalClassNames = {
 
 export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
   const { className, theme, disabled, label, isDatePickerShown } = props;
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const DatePickerIcon: IStyle = {
@@ -67,8 +67,12 @@ export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
         cursor: 'default',
       },
     ],
-    statusMessage: {
-      color: 'red',
-    },
+    statusMessage: [
+      fonts.small,
+      {
+        color: semanticColors.errorText,
+        paddingTop: 5,
+      },
+    ],
   };
 };

--- a/packages/react/src/components/DatePicker/DatePicker.styles.ts
+++ b/packages/react/src/components/DatePicker/DatePicker.styles.ts
@@ -71,7 +71,7 @@ export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
       fonts.small,
       {
         color: semanticColors.errorText,
-        paddingTop: 5,
+        marginTop: 5,
       },
     ],
   };

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -194,6 +194,60 @@ describe('DatePicker', () => {
     );
   });
 
+  it('should show status message and reset value when allowTextInput is true and invalid string is entered', () => {
+    safeCreate(<DatePickerBase allowTextInput={true} />, datePicker => {
+      const input = datePicker.root.findByType('input');
+      const status = datePicker.root.findByProps({ 'aria-live': 'assertive' });
+
+      expect(status.children[0]).toBeUndefined();
+
+      // input invalid string "test", then blur
+      const fakeInputEvent = { target: { value: 'test' } };
+      renderer.act(() => {
+        input.props.onInput(fakeInputEvent);
+      });
+      renderer.act(() => {
+        input.props.onBlur();
+      });
+
+      expect(typeof status.children[0]).toBe('string');
+      expect((status.children[0] as string).length).toBeGreaterThan(0);
+      expect(input.props.value).toBe('');
+    });
+  });
+
+  it('should reset status message after selecting a valid date', () => {
+    // See https://github.com/facebook/react/issues/11565
+    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+
+    safeCreate(<DatePickerBase allowTextInput={true} initialPickerDate={new Date('2021-04-15')} />, datePicker => {
+      const input = datePicker.root.findByType('input');
+      const status = datePicker.root.findByProps({ 'aria-live': 'assertive' });
+
+      // input invalid string "test", then blur
+      const fakeInputEvent = { target: { value: 'test' } };
+      renderer.act(() => {
+        input.props.onInput(fakeInputEvent);
+      });
+      renderer.act(() => {
+        input.props.onBlur();
+      });
+
+      expect(typeof status.children[0]).toBe('string');
+
+      // pick valid date
+      renderer.act(() => {
+        input.props.onClick();
+      });
+      renderer.act(() => {
+        const date = new Date('2021-04-10');
+        datePicker.root.findByType(CalendarDayGridBase).props.onSelectDate(date, [date]);
+      });
+
+      expect(status.children[0]).toBeUndefined();
+    });
+  });
+
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
   it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     // See https://github.com/facebook/react/issues/11565

--- a/packages/react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react/src/components/DatePicker/DatePicker.types.ts
@@ -273,6 +273,13 @@ export interface IDatePickerStrings extends ICalendarStrings {
    * Error message to render for TextField if date boundary (minDate, maxDate) validation fails.
    */
   isOutOfBoundsErrorMessage?: string;
+
+  /**
+   * Status message to render for TextField the input date parsing fails,
+   * and the typed value is cleared and reset to the previous value.
+   *  e.g. "Invalid entry `{0}`, date reset to `{1}`"
+   */
+  isResetStatusMessage?: string;
 }
 
 /**
@@ -306,5 +313,6 @@ export interface IDatePickerStyles {
   textField: IStyle;
   callout: IStyle;
   icon: IStyle;
+  statusMessage?: IStyle;
   wrapper?: IStyle;
 }

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 12px;
                 font-weight: 400;
-                padding-top: 5px;
+                margin-top: 5px;
               }
         />
         

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -226,7 +226,13 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           className=
 
               {
-                color: red;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #a4262c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                padding-top: 5px;
               }
         />
         

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
               }
         >
           <input
+            aria-describedby="TextFieldDescription3"
             aria-expanded={false}
             aria-invalid={false}
             className=
@@ -217,6 +218,19 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           </i>
         </div>
       </div>
+      <span
+        id="TextFieldDescription3"
+      >
+        <div
+          aria-live="assertive"
+          className=
+
+              {
+                color: red;
+              }
+        />
+        
+      </span>
     </div>
   </div>
 </div>

--- a/packages/react/src/components/DatePicker/defaults.ts
+++ b/packages/react/src/components/DatePicker/defaults.ts
@@ -10,4 +10,5 @@ export const defaultDatePickerStrings: IDatePickerStrings = {
   closeButtonAriaLabel: 'Close date picker',
   isRequiredErrorMessage: 'Field is required',
   invalidInputErrorMessage: 'Invalid date format',
+  isResetStatusMessage: 'Invalid entry "{0}", date reset to "{1}"',
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10835](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10835)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously, when a DatePicker with text input got an input string that couldn't be parsed into a date, it would both reset the date and mark the input as invalid, which results in an input with a valid entry (the prior string) also presenting itself as invalid, both visually and semantically.

To fix this, I made the following changes:
- Rather than use the TextField's errorMessage (which also adds aria-invalid), I added an internal DatePicker statusMessage that uses the TextField's description (custom descriptions are still rendered as well)
- The new statusMessage is a live region, but not an alert
- The internal statusMessage can be customized through `strings.isResetStatusMessage`, though it defaults to `invalidInputErrorMessage` so it doesn't break existing implementations.
- The new `isResetStatusMessage` can be formatted with both the invalid text entry and the reset value for a more informative message

#### Focus areas to test

Datepicker w/ text input
