### PR TITLE
Prevent website chunks from overwriting each other

### DIFF
--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -21,12 +21,38 @@ module.exports = function(env, argv) {
     argv.mode === 'production' ||
     argv.production === true;
 
-  const now = Date.now();
-
   // Must be kept in sync with the value in apps/public-docsite/bin/create-site-manifests.js
   // (just referencing the type, not the actual constant, in case the package hasn't been built yet)
   /** @type {typeof import('@fluentui/public-docsite-setup').BUNDLE_NAME} */
   const entryPointName = 'fabric-site';
+
+  /**
+   * @param {boolean} isProductionConfig - Whether this particular config is for dev or production mode
+   * @returns {webpack.Configuration}
+   */
+  function getConfig(isProductionConfig) {
+    const chunkSuffix = isProductionConfig ? '.min.js' : '.js';
+    const chunkId = isProductionConfig ? '[id]' : 'dev-[id]';
+
+    return addMonacoWebpackConfig({
+      entry: {
+        [entryPointName]: './lib/root.js',
+      },
+
+      output: {
+        // Note that dev and production mode chunks MUST HAVE DIFFERENT NAMES (handled above).
+        // Otherwise they'll overwrite each other and cause hard-to-debug errors at runtime.
+        chunkFilename: `${entryPointName}-${version}-${chunkId}${chunkSuffix}`,
+      },
+
+      // The website config intentionally doesn't have React as an external because we bundle it
+      // to ensure we get a consistent version.
+
+      resolve: {
+        alias: getResolveAlias(true /*useLib*/),
+      },
+    });
+  }
 
   return [
     // Copy index.html and generate bootstrap script
@@ -37,28 +63,11 @@ module.exports = function(env, argv) {
       CopyWebpackPlugin,
       webpack,
     }),
-    // Rest of the site
-    ...resources.createConfig(
-      entryPointName,
-      isProductionArg,
-      addMonacoWebpackConfig({
-        entry: {
-          [entryPointName]: './lib/root.js',
-        },
-
-        output: {
-          chunkFilename: `${entryPointName}-${version}-[name]-${now}${isProductionArg ? '.min' : ''}.js`,
-        },
-
-        // The website config intentionally doesn't have React as an external because we bundle it
-        // to ensure we get a consistent version.
-
-        resolve: {
-          alias: getResolveAlias(true /*useLib*/),
-        },
-      }),
-      // always build the dev bundle too
-      /* only production */ false,
-    ),
+    // Rest of the site.
+    // Set up dev/production configs separately because they need different chunkFilename settings.
+    ...resources.createConfig(entryPointName, false /*isProduction*/, getConfig(false)),
+    ...(isProductionArg
+      ? resources.createConfig(entryPointName, true /*isProduction*/, getConfig(true), true /*onlyProduction*/)
+      : []),
   ];
 };

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -15,16 +15,26 @@ const entryPointName = 'fabric-site';
 
 const outDir = 'dist';
 
+/** @type {webpack.Configuration[]} */
 module.exports = [
   // Copy index.html and generate bootstrap script
-  getLoadSiteConfig({
-    libraryPath: path.dirname(require.resolve('@fluentui/react/package.json')),
-    outDir: path.join(__dirname, outDir),
-    isProduction: false,
-    CopyWebpackPlugin,
-    webpack,
-  }),
-  // Rest of site
+  {
+    ...getLoadSiteConfig({
+      libraryPath: path.dirname(require.resolve('@fluentui/react/package.json')),
+      outDir: path.join(__dirname, outDir),
+      isProduction: false,
+      CopyWebpackPlugin,
+      webpack,
+    }),
+    // Uncomment this block to serve previously built files under dist (for example from running
+    // yarn bundle --production) -- this is for debugging purposes in special cases only
+    // devServer: {
+    //   host: 'localhost',
+    //   port: 4322,
+    //   static: path.join(__dirname, outDir),
+    // },
+  },
+  // Rest of site (comment out if serving previously built files)
   resources.createServeConfig(
     addMonacoWebpackConfig({
       entry: {

--- a/change/@fluentui-public-docsite-5d92f512-d76e-4c8a-933f-d18b1628b5d6.json
+++ b/change/@fluentui-public-docsite-5d92f512-d76e-4c8a-933f-d18b1628b5d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent website chunks from overwriting each other",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #14691
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Some of the pages on the version 8 website are broken in production builds only. I'm pretty sure this is because the website's webpack config includes both development and production mode configs, and certain chunks were overwriting each other due to using the same `chunkFilename` value. Fix is to define the configs entirely separately and use different filenames.