### PR TITLE
Clean up react-app-polyfill usage

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -21,7 +21,6 @@
     "puppeteer": "^1.13.0",
     "tslib": "^1.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "devDependencies": {

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.1.0",
     "@fluentui/scripts": "^1.0.0",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/apps/public-docsite-resources/webpack.serve.config.js
+++ b/apps/public-docsite-resources/webpack.serve.config.js
@@ -7,7 +7,7 @@ const BUNDLE_NAME = 'demo-app';
 module.exports = resources.createServeConfig(
   addMonacoWebpackConfig({
     entry: {
-      [BUNDLE_NAME]: './src/index.tsx',
+      [BUNDLE_NAME]: ['react-app-polyfill/ie11', './src/index.tsx'],
     },
 
     externals: {

--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -26,7 +26,6 @@
     "@fluentui/eslint-plugin": "^1.1.0",
     "@fluentui/react-monaco-editor": "^1.0.29",
     "@fluentui/scripts": "^1.0.0",
-    "react-app-polyfill": "~1.0.1",
     "write-file-webpack-plugin": "^4.1.0"
   },
   "dependencies": {

--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = function(env, argv) {
 
     return addMonacoWebpackConfig({
       entry: {
-        [entryPointName]: './lib/root.js',
+        [entryPointName]: ['react-app-polyfill/ie11', './lib/root.js'],
       },
 
       output: {

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -38,7 +38,7 @@ module.exports = [
   resources.createServeConfig(
     addMonacoWebpackConfig({
       entry: {
-        [entryPointName]: './src/root.tsx',
+        [entryPointName]: ['react-app-polyfill/ie11', './src/root.tsx'],
       },
 
       output: {

--- a/apps/server-rendered-app/package.json
+++ b/apps/server-rendered-app/package.json
@@ -27,7 +27,6 @@
     "@fluentui/react": "^8.11.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "tslib": "^1.10.0"
   }

--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -29,7 +29,6 @@
     "@fluentui/font-icons-mdl2": "^8.0.4",
     "@microsoft/load-themed-styles": "^1.10.26",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "tslib": "^1.10.0"
   }

--- a/apps/theming-designer/webpack.config.js
+++ b/apps/theming-designer/webpack.config.js
@@ -6,7 +6,7 @@ const IS_PRODUCTION = process.argv.indexOf('--production') > -1;
 
 module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
   entry: {
-    [BUNDLE_NAME]: './lib/index.js',
+    [BUNDLE_NAME]: ['react-app-polyfill/ie11', './lib/index.js'],
   },
 
   output: {

--- a/apps/theming-designer/webpack.serve.config.js
+++ b/apps/theming-designer/webpack.serve.config.js
@@ -3,7 +3,7 @@ const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
 
 module.exports = resources.createServeConfig(
   {
-    entry: './src/index.tsx',
+    entry: ['react-app-polyfill/ie11', './src/index.tsx'],
     output: {
       filename: 'theming-designer.js',
     },

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -24,7 +24,6 @@
     "es6-promise": "^4.1.0",
     "immutability-helper": "~2.8.1",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "tslib": "^1.10.0"
   }

--- a/apps/todo-app/webpack.serve.config.js
+++ b/apps/todo-app/webpack.serve.config.js
@@ -2,7 +2,7 @@ const resources = require('../../scripts/webpack/webpack-resources');
 
 module.exports = resources.createServeConfig(
   {
-    entry: './src/index.tsx',
+    entry: ['react-app-polyfill/ie11', './src/index.tsx'],
     output: {
       filename: 'todo-app.js',
     },

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -48,7 +48,6 @@
     "postcss-loader": "4.1.0",
     "raw-loader": "4.0.2",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "screener-storybook": "0.21.2",
     "style-loader": "2.0.0",

--- a/change/@fluentui-foundation-legacy-db74b529-a0b7-44d7-8ad9-3235d188f6d4.json
+++ b/change/@fluentui-foundation-legacy-db74b529-a0b7-44d7-8ad9-3235d188f6d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-public-docsite-ba9b6632-7d75-45dd-9023-1aa5d3edc1ab.json
+++ b/change/@fluentui-public-docsite-ba9b6632-7d75-45dd-9023-1aa5d3edc1ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make inclusion of react-app-polyfill explicit",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-resources-e06c2100-a017-4e47-be6f-644f3d48c47e.json
+++ b/change/@fluentui-public-docsite-resources-e06c2100-a017-4e47-be6f-644f3d48c47e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make inclusion of react-app-polyfill explicit",
+  "packageName": "@fluentui/public-docsite-resources",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-a6a85e29-538a-41f0-b153-f4a12c1675ec.json
+++ b/change/@fluentui-react-a6a85e29-538a-41f0-b153-f4a12c1675ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-6f60dc43-b443-4775-bfb8-7a00d1a0685e.json
+++ b/change/@fluentui-react-accordion-6f60dc43-b443-4775-bfb8-7a00d1a0685e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-accordion",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-ffa8ea25-2f64-4e87-abc9-dbb260a37b17.json
+++ b/change/@fluentui-react-avatar-ffa8ea25-2f64-4e87-abc9-dbb260a37b17.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-e74d24ad-278a-49a6-b826-48e7ea7e560b.json
+++ b/change/@fluentui-react-badge-e74d24ad-278a-49a6-b826-48e7ea7e560b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-831cdfe9-e868-426d-a5d9-c1606675f0ba.json
+++ b/change/@fluentui-react-button-831cdfe9-e868-426d-a5d9-c1606675f0ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-63731a69-d8ea-460f-af83-b52d28d34ce6.json
+++ b/change/@fluentui-react-cards-63731a69-d8ea-460f-af83-b52d28d34ce6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-86ba8d3b-57f2-4e53-9a5a-9713235d41a2.json
+++ b/change/@fluentui-react-charting-86ba8d3b-57f2-4e53-9a5a-9713235d41a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-8a729a63-26a1-41c8-a5c3-35c2a2b5fcb8.json
+++ b/change/@fluentui-react-checkbox-8a729a63-26a1-41c8-a5c3-35c2a2b5fcb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-9188e619-d040-4436-8910-cbf028835f21.json
+++ b/change/@fluentui-react-conformance-9188e619-d040-4436-8910-cbf028835f21.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-9c6e76de-18e2-4302-b2f9-63d3bb6c3952.json
+++ b/change/@fluentui-react-context-selector-9c6e76de-18e2-4302-b2f9-63d3bb6c3952.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-aff59473-7efa-4360-8af6-11459e83d470.json
+++ b/change/@fluentui-react-divider-aff59473-7efa-4360-8af6-11459e83d470.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-divider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-8649b15b-a1bc-4a56-801c-71e2914f517e.json
+++ b/change/@fluentui-react-docsite-components-8649b15b-a1bc-4a56-801c-71e2914f517e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Make inclusion of react-app-polyfill in webpack serve config explicit",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-examples-2945ef70-6b7f-48e1-9b7d-0cdf539fb53c.json
+++ b/change/@fluentui-react-examples-2945ef70-6b7f-48e1-9b7d-0cdf539fb53c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-a828d19f-ca14-40d2-8f9d-ad1f50d02443.json
+++ b/change/@fluentui-react-experiments-a828d19f-ca14-40d2-8f9d-ad1f50d02443.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-314e9fe1-5a82-4089-8c5f-b30a6cf5d797.json
+++ b/change/@fluentui-react-file-type-icons-314e9fe1-5a82-4089-8c5f-b30a6cf5d797.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-flex-3c217eec-753f-4229-ba6f-71d70b9322b9.json
+++ b/change/@fluentui-react-flex-3c217eec-753f-4229-ba6f-71d70b9322b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-flex",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-f13c513c-f335-4435-8d25-68cf73c42f5d.json
+++ b/change/@fluentui-react-focus-f13c513c-f335-4435-8d25-68cf73c42f5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-854ef976-c7ed-4692-a0d2-4db93a339df5.json
+++ b/change/@fluentui-react-icon-provider-854ef976-c7ed-4692-a0d2-4db93a339df5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-5a4924e5-f3a7-4d94-91d8-b9151593e14c.json
+++ b/change/@fluentui-react-icons-mdl2-5a4924e5-f3a7-4d94-91d8-b9151593e14c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-5bb0f043-505c-4583-80e8-64fc0f24f017.json
+++ b/change/@fluentui-react-icons-mdl2-branded-5bb0f043-505c-4583-80e8-64fc0f24f017.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-d4dd9d4e-a57a-4d99-b110-6485540b3fd7.json
+++ b/change/@fluentui-react-image-d4dd9d4e-a57a-4d99-b110-6485540b3fd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-e2600c65-45aa-44b8-bea9-cea83158d293.json
+++ b/change/@fluentui-react-link-e2600c65-45aa-44b8-bea9-cea83158d293.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-cbaba370-3f86-4187-8bc1-682cf034bc32.json
+++ b/change/@fluentui-react-make-styles-cbaba370-3f86-4187-8bc1-682cf034bc32.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-152d7053-181a-4b3a-8729-48a92248d4c7.json
+++ b/change/@fluentui-react-menu-152d7053-181a-4b3a-8729-48a92248d4c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-ffdbbab5-1a02-46e7-948a-91c17c2315e6.json
+++ b/change/@fluentui-react-monaco-editor-ffdbbab5-1a02-46e7-948a-91c17c2315e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-0fcc7bd6-8844-4def-8d18-305e5ca349ce.json
+++ b/change/@fluentui-react-provider-0fcc7bd6-8844-4def-8d18-305e5ca349ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-5a9cc9a9-6ced-451c-8b5e-90f357af104c.json
+++ b/change/@fluentui-react-slider-5a9cc9a9-6ced-451c-8b5e-90f357af104c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-slider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-919a86af-3e73-419c-ac62-5ea4a8907eb2.json
+++ b/change/@fluentui-react-tabs-919a86af-3e73-419c-ac62-5ea4a8907eb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-efd7e72f-b2e6-45c5-9fed-cef79e44ccf1.json
+++ b/change/@fluentui-react-tabster-efd7e72f-b2e6-45c5-9fed-cef79e44ccf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-tabster",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-b7273460-015f-4345-bdf8-8245438b9a8d.json
+++ b/change/@fluentui-react-text-b7273460-015f-4345-bdf8-8245438b9a8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-b4cb57c4-622b-4794-8a33-4ffaf58a8a88.json
+++ b/change/@fluentui-react-theme-b4cb57c4-622b-4794-8a33-4ffaf58a8a88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toggle-afeb94e8-843e-4cc1-8e25-9a1af08813c8.json
+++ b/change/@fluentui-react-toggle-afeb94e8-843e-4cc1-8e25-9a1af08813c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-toggle",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-fe1598f3-8cb9-4fa5-bb3e-1c18e45fac98.json
+++ b/change/@fluentui-react-tooltip-fe1598f3-8cb9-4fa5-bb3e-1c18e45fac98.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-7c108c9c-aa31-4bc6-a7ca-cc3660f6902a.json
+++ b/change/@fluentui-react-utilities-7c108c9c-aa31-4bc6-a7ca-cc3660f6902a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-041c4654-d94c-47f6-a7ec-219b1f77aa30.json
+++ b/change/@fluentui-react-window-provider-041c4654-d94c-47f6-a7ec-219b1f77aa30.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-bc2316c7-6777-4c43-8d64-15f51fe8310a.json
+++ b/change/@fluentui-test-utilities-bc2316c7-6777-4c43-8d64-15f51fe8310a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-71fcc292-994e-44bd-9d61-18e72a0d134a.json
+++ b/change/@fluentui-theme-71fcc292-994e-44bd-9d61-18e72a0d134a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-b47a8ea8-9455-4d69-975a-38a5fcdd0f12.json
+++ b/change/@fluentui-utilities-b47a8ea8-9455-4d69-975a-38a5fcdd0f12.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unneeded react-app-polyfill devDependency",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "postcss-modules": "2.0.0",
     "prettier": "1.19.1",
     "raw-loader": "4.0.2",
+    "react-app-polyfill": "2.0.0",
     "sass-loader": "10.1.1",
     "satisfied": "^1.1.1",
     "storybook-addon-performance": "0.14.0",

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-hooks-testing-library": "^0.5.0",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -35,7 +35,6 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "es6-weak-map": "^2.0.2",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -33,7 +33,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -40,7 +40,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -30,7 +30,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-context-selector/package.json
+++ b/packages/react-context-selector/package.json
@@ -28,7 +28,6 @@
     "@types/react-dom": "16.9.10",
     "@types/react-test-renderer": "^16.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-is": "^16.6.3",
     "react-test-renderer": "^16.3.0"

--- a/packages/react-divider/package.json
+++ b/packages/react-divider/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-docsite-components/package.json
+++ b/packages/react-docsite-components/package.json
@@ -29,7 +29,6 @@
     "@types/react-custom-scrollbars": "^4.0.5",
     "@types/react-dom": "16.9.10",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "peerDependencies": {

--- a/packages/react-docsite-components/webpack.serve.config.js
+++ b/packages/react-docsite-components/webpack.serve.config.js
@@ -1,7 +1,7 @@
 const resources = require('../../scripts/webpack/webpack-resources');
 
 module.exports = resources.createServeConfig({
-  entry: './src/index.demo.tsx',
+  entry: ['react-app-polyfill/ie11', './src/index.demo.tsx'],
 
   output: {
     filename: 'demo-app.js',

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -33,7 +33,6 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "glob": "^7.1.2",
     "jest-snapshot": "~24.9.0",
-    "react-app-polyfill": "~1.0.1",
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {

--- a/packages/react-experiments/package.json
+++ b/packages/react-experiments/package.json
@@ -42,7 +42,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-hooks-testing-library": "^0.5.0",
     "react-test-renderer": "^16.3.0"

--- a/packages/react-file-type-icons/package.json
+++ b/packages/react-file-type-icons/package.json
@@ -25,8 +25,7 @@
     "@fluentui/eslint-plugin": "^1.1.0",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
-    "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1"
+    "react": "16.8.6"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.0.2",

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -38,7 +38,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-icon-provider/package.json
+++ b/packages/react-icon-provider/package.json
@@ -29,7 +29,6 @@
     "@fluentui/scripts": "^1.0.0",
     "enzyme": "~3.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-icons-mdl2-branded/package.json
+++ b/packages/react-icons-mdl2-branded/package.json
@@ -26,7 +26,6 @@
     "@types/react-dom": "16.9.10",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-is": "^16.6.3",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-make-styles/package.json
+++ b/packages/react-make-styles/package.json
@@ -25,7 +25,6 @@
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-monaco-editor/package.json
+++ b/packages/react-monaco-editor/package.json
@@ -29,7 +29,6 @@
     "@types/react-syntax-highlighter": "^10.2.1",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "webpack-bundle-analyzer": "^4.4.0"
   },

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -35,7 +35,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -31,7 +31,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -33,7 +33,6 @@
     "@types/react-test-renderer": "^16.0.0",
     "enzyme": "~3.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -28,7 +28,6 @@
     "@types/react-dom": "16.9.10",
     "@types/react-test-renderer": "^16.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-theme/package.json
+++ b/packages/react-theme/package.json
@@ -27,7 +27,6 @@
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-toggle/package.json
+++ b/packages/react-toggle/package.json
@@ -32,7 +32,6 @@
     "@types/react-dom": "16.9.10",
     "enzyme": "~3.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6"
   },
   "dependencies": {

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -34,7 +34,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -31,7 +31,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -28,8 +28,7 @@
     "@fluentui/test-utilities": "^8.0.2",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
-    "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1"
+    "react": "16.8.6"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,6 @@
     "jest-snapshot": "~24.9.0",
     "office-ui-fabric-core": "^11.0.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -25,7 +25,6 @@
     "@types/react-test-renderer": "^16.0.0",
     "enzyme": "~3.10.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-test-renderer": "^16.3.0",
     "@fluentui/scripts": "^1.0.0"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -31,8 +31,7 @@
     "@fluentui/scripts": "^1.0.0",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
-    "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1"
+    "react": "16.8.6"
   },
   "dependencies": {
     "@fluentui/merge-styles": "^8.0.3",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -36,7 +36,6 @@
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
-    "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
     "react-test-renderer": "^16.3.0"
   },

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -34,7 +34,6 @@
     "enzyme": "",
     "enzyme-adapter-react-16": "",
     "react": "",
-    "react-app-polyfill": "",
     "react-dom": "",
     "react-test-renderer": ""
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9660,10 +9660,10 @@ core-js-pure@^3.0.0, core-js-pure@^3.0.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
-core-js@3, core-js@^3.0.1, core-js@^3.0.4, core-js@^3.3.2, core-js@^3.5.0:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+core-js@3, core-js@^3.0.1, core-js@^3.0.4, core-js@^3.3.2, core-js@^3.6.5:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
+  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -9674,11 +9674,6 @@ core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
-
-core-js@^3.6.5:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
-  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -21736,7 +21731,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promise@^8.0.3:
+promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
   integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
@@ -22109,17 +22104,17 @@ react-addons-shallow-compare@^15.6.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-app-polyfill@~1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz#890f8d7f2842ce6073f030b117de9130a5f385f0"
-  integrity sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==
+react-app-polyfill@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"
+  integrity sha512-0sF4ny9v/B7s6aoehwze9vJNWcmCemAUYBVasscVr92+UYiEqDXOxfKjXN685mDaMRNF3WdhHQs76oTODMocFA==
   dependencies:
-    core-js "^3.5.0"
+    core-js "^3.6.5"
     object-assign "^4.1.1"
-    promise "^8.0.3"
+    promise "^8.1.0"
     raf "^3.4.1"
-    regenerator-runtime "^0.13.3"
-    whatwg-fetch "^3.0.0"
+    regenerator-runtime "^0.13.7"
+    whatwg-fetch "^3.4.1"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"
@@ -27852,10 +27847,10 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Instead of implicitly including `react-app-polyfill/ie11` in webpack bundles (see #9622), make the inclusion explicit, *only* where it's needed: in browser-targeted apps such as the website, legacy demo apps, and theme designer.

Move the `react-app-polyfill` dev dep to the root and update the version. (It's okay for this to be a dev dep because it's only used either for local development via `yarn start`, or when bundling.)