### PR TITLE
fix(Nav): add a Nav example with text wrapping and no tooltips to demo better a11y practices

### DIFF
--- a/change/@fluentui-react-examples-583178b2-dbbd-4bc6-b09e-2c324391cfd6.json
+++ b/change/@fluentui-react-examples-583178b2-dbbd-4bc6-b09e-2c324391cfd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add a Nav example with no tooltips to demonstrate better accessibility",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-examples-583178b2-dbbd-4bc6-b09e-2c324391cfd6.json
+++ b/change/@fluentui-react-examples-583178b2-dbbd-4bc6-b09e-2c324391cfd6.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add a Nav example with no tooltips to demonstrate better accessibility",
-  "packageName": "@fluentui/react-examples",
-  "email": "sarah.higley@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-react-examples-ca978538-891f-42fc-b30c-939a2cfe7350.json
+++ b/change/@fluentui-react-examples-ca978538-891f-42fc-b30c-939a2cfe7350.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add a Nav example with no tooltips to demonstrate better accessibility",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
@@ -9,12 +9,15 @@ const navStyles: Partial<INavStyles> = {
     border: '1px solid #eee',
     overflowY: 'auto',
   },
+  // these link styles override the default truncation behavior
   link: {
     whiteSpace: 'normal',
     lineHeight: 'inherit',
   },
 };
 
+// adding an empty title string to each link removes the tooltip;
+// it's unnecessary now that the text wraps, and will not truncate
 const navLinkGroups: INavLinkGroup[] = [
   {
     links: [
@@ -47,7 +50,6 @@ const navLinkGroups: INavLinkGroup[] = [
         name: 'Shared Documents and Files',
         url: 'http://example.com',
         key: 'key3',
-        isExpanded: true,
         target: '_blank',
         title: '',
       },

--- a/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { Nav, INavStyles, INavLinkGroup } from '@fluentui/react/lib/Nav';
+
+const navStyles: Partial<INavStyles> = {
+  root: {
+    width: 208,
+    height: 350,
+    boxSizing: 'border-box',
+    border: '1px solid #eee',
+    overflowY: 'auto',
+  },
+  link: {
+    whiteSpace: 'normal',
+    lineHeight: 'inherit',
+  },
+};
+
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    links: [
+      {
+        name: 'Home',
+        url: 'http://example.com',
+        expandAriaLabel: 'Expand Home section',
+        collapseAriaLabel: 'Collapse Home section',
+        title: '',
+        links: [
+          {
+            name: 'Activity',
+            url: 'http://msn.com',
+            key: 'key1',
+            target: '_blank',
+            title: '',
+          },
+          {
+            name: 'MSN',
+            url: 'http://msn.com',
+            disabled: true,
+            key: 'key2',
+            target: '_blank',
+            title: '',
+          },
+        ],
+        isExpanded: true,
+      },
+      {
+        name: 'Shared Documents and Files',
+        url: 'http://example.com',
+        key: 'key3',
+        isExpanded: true,
+        target: '_blank',
+        title: '',
+      },
+      {
+        name: 'Pages',
+        url: 'http://msn.com',
+        key: 'key4',
+        target: '_blank',
+        title: '',
+      },
+      {
+        name: 'Notebook',
+        url: 'http://msn.com',
+        key: 'key5',
+        disabled: true,
+        title: '',
+      },
+      {
+        name: 'Communication and Media',
+        url: 'http://msn.com',
+        key: 'key6',
+        target: '_blank',
+        title: '',
+      },
+      {
+        name: 'News',
+        url: 'http://cnn.com',
+        icon: 'News',
+        key: 'key7',
+        target: '_blank',
+        title: '',
+      },
+    ],
+  },
+];
+
+export const NavWrappedExample: React.FunctionComponent = () => {
+  return (
+    <Nav selectedKey="key6" ariaLabel="Nav example with wrapped link text" styles={navStyles} groups={navLinkGroups} />
+  );
+};

--- a/packages/react-examples/src/react/Nav/Nav.doc.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.doc.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { NavBasicExample } from './Nav.Basic.Example';
+import { NavWrappedExample } from './Nav.Wrapped.Example';
 import { IDocPageProps } from '@fluentui/react/lib/common/DocPage.types';
 import { NavFabricDemoAppExample } from './Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './Nav.Nested.Example';
 import { NavCustomGroupHeadersExample } from './Nav.CustomGroupHeaders.Example';
 
 const NavBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Basic.Example.tsx') as string;
+const NavWrappedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx') as string;
 const NavFabricDemoAppExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx') as string;
 const NavNestedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Nested.Example.tsx') as string;
 const NavCustomGroupHeadersExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.CustomGroupHeaders.Example.tsx') as string;
@@ -19,6 +21,11 @@ export const NavPageProps: IDocPageProps = {
       title: 'Basic nav with sample links',
       code: NavBasicExampleCode,
       view: <NavBasicExample />,
+    },
+    {
+      title: 'Nav with wrapped link text and no tooltips',
+      code: NavWrappedExampleCode,
+      view: <NavWrappedExample />,
     },
     {
       title: 'Nav similar to the one in this demo app',

--- a/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
+++ b/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
@@ -13,3 +13,5 @@
 ### Accessibility
 
 If your Nav items lose meaning by being truncated, they might benefit from being styled to wrap their text instead. Although the full text is exposed in a tooltip, that tooltip is not accessible through the keyboard, touch, voice control, or other assistive tech without hover functionality.
+
+The second Nav example, "Nav with wrapped link text and no tooltips", shows how to override the default Nav styles to remove text truncation and tooltips.

--- a/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
+++ b/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
@@ -14,4 +14,4 @@
 
 If your Nav items lose meaning by being truncated, they might benefit from being styled to wrap their text instead. Although the full text is exposed in a tooltip, that tooltip is not accessible through the keyboard, touch, voice control, or other assistive tech without hover functionality.
 
-The second Nav example, "Nav with wrapped link text and no tooltips", shows how to override the default Nav styles to remove text truncation and tooltips.
+The Nav example "Nav with wrapped link text and no tooltips" shows how to override the default Nav styles to remove text truncation and tooltips.

--- a/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
+++ b/packages/react-examples/src/react/Nav/docs/NavBestPractices.md
@@ -9,3 +9,7 @@
 - Use the word that feels right for the navigation. For example, some items may make more sense as nouns (e.g. “Files”), others as adjectives (“Shared”). Use what makes sense for customers, and keep it short!
 - Try to keep your app’s nav in a consistent order across platforms. This sort of consistency increases predictability which drives customer confidence, thus retaining and engaging them.
 - If using a menu button to expand and collapse the `Nav`, use the tooltip “Expand navigation” or “Collapse navigation”.
+
+### Accessibility
+
+If your Nav items lose meaning by being truncated, they might benefit from being styled to wrap their text instead. Although the full text is exposed in a tooltip, that tooltip is not accessible through the keyboard, touch, voice control, or other assistive tech without hover functionality.

--- a/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
@@ -1,0 +1,1419 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Nav.Wrapped.Example.tsx correctly 1`] = `
+<div
+  className=
+      ms-FocusZone
+      &:focus {
+        outline: none;
+      }
+  data-focuszone-id="FocusZone0"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+>
+  <nav
+    aria-label="Nav example with wrapped link text"
+    className=
+        ms-Nav
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          border: 1px solid #eee;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 350px;
+          overflow-y: auto;
+          user-select: none;
+          width: 208px;
+        }
+    role="navigation"
+  >
+    <div
+      className="ms-Nav-group is-expanded"
+    >
+      <div
+        className=
+            ms-Nav-groupContent
+            {
+              animation-duration: 0.367s;
+              animation-fill-mode: both;
+              animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);pointer-events:none;}to{transform:translate3d(0,0,0);pointer-events:auto;};
+              animation-timing-function: cubic-bezier(.1,.9,.2,1);
+              display: block;
+              margin-bottom: 40px;
+            }
+      >
+        <ul
+          className=
+              ms-Nav-navItems
+              {
+                list-style-type: none;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
+          role="list"
+        >
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  is-expanded
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="Home"
+              title=""
+            >
+              <button
+                aria-expanded="true"
+                aria-label="Collapse Home section"
+                className=
+                    ms-Nav-chevronButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border: none;
+                      color: #323130;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      left: 1px;
+                      line-height: 44px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: absolute;
+                      text-align: left;
+                      text-overflow: ellipsis;
+                      top: 1px;
+                      white-space: nowrap;
+                      width: 26px;
+                      z-index: 1;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:visited {
+                      color: #323130;
+                    }
+                onClick={[Function]}
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Nav-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 44px;
+                        left: 8px;
+                        line-height: 44px;
+                        position: absolute;
+                        speak: none;
+                        top: 0px;
+                        transform: rotate(-180deg);
+                        transition: transform .1s linear;
+                      }
+                  data-icon-name="ChevronDown"
+                >
+                  
+                </i>
+              </button>
+              <a
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 27px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f3f2f1;
+                    }
+                data-is-focusable={true}
+                href="http://example.com"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                title=""
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    Home
+                  </div>
+                </span>
+              </a>
+            </div>
+            <ul
+              className=
+                  ms-Nav-navItems
+                  {
+                    list-style-type: none;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
+              role="list"
+            >
+              <li
+                className=
+                    ms-Nav-navItem
+                    {
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                    }
+                role="listitem"
+              >
+                <div
+                  className=
+                      ms-Nav-compositeLink
+                      {
+                        color: #323130;
+                        display: block;
+                        position: relative;
+                      }
+                  name="Activity"
+                  title=""
+                >
+                  <a
+                    className=
+                        ms-Button
+                        ms-Button--action
+                        ms-Button--command
+                        ms-Nav-link
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-radius: 2px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #323130;
+                          cursor: pointer;
+                          display: block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 44px;
+                          line-height: inherit;
+                          outline: transparent;
+                          overflow: hidden;
+                          padding-bottom: 0;
+                          padding-left: 41px;
+                          padding-right: 20px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: center;
+                          text-decoration: none;
+                          text-overflow: ellipsis;
+                          user-select: none;
+                          white-space: normal;
+                          width: 100%;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid #ffffff;
+                          bottom: 1px;
+                          content: "";
+                          left: 1px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 1px;
+                          top: 1px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          border-color: Window;
+                          border: 0px;
+                        }
+                        &:hover {
+                          color: #0078d4;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          color: Highlight;
+                        }
+                        &:hover .ms-Button-icon {
+                          color: #0078d4;
+                        }
+                        &:active {
+                          color: #000000;
+                        }
+                        &:active .ms-Button-icon {
+                          color: #004578;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                          border: 1px solid WindowText;
+                        }
+                        .ms-Nav-compositeLink:hover & {
+                          background-color: #f3f2f1;
+                        }
+                    data-is-focusable={true}
+                    href="http://msn.com"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title=""
+                  >
+                    <span
+                      className=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: flex-start;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <div
+                        className=
+                            ms-Nav-linkText
+                            {
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              overflow: hidden;
+                              text-align: left;
+                              text-overflow: ellipsis;
+                              vertical-align: middle;
+                            }
+                      >
+                        Activity
+                      </div>
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                className=
+                    ms-Nav-navItem
+                    {
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                    }
+                role="listitem"
+              >
+                <div
+                  className=
+                      ms-Nav-compositeLink
+                      is-disabled
+                      {
+                        color: #a19f9d;
+                        display: block;
+                        position: relative;
+                      }
+                  name="MSN"
+                  title=""
+                >
+                  <button
+                    aria-disabled={true}
+                    className=
+                        ms-Button
+                        ms-Button--action
+                        ms-Button--command
+                        is-disabled
+                        ms-Nav-link
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-color: transparent;
+                          border-radius: 2px;
+                          border: 1px solid transparent;
+                          box-sizing: border-box;
+                          color: #a19f9d;
+                          cursor: pointer;
+                          display: block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 44px;
+                          line-height: inherit;
+                          outline: transparent;
+                          overflow: hidden;
+                          padding-bottom: 0;
+                          padding-left: 41px;
+                          padding-right: 20px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: center;
+                          text-decoration: none;
+                          text-overflow: ellipsis;
+                          user-select: none;
+                          white-space: normal;
+                          width: 100%;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid #ffffff;
+                          bottom: 1px;
+                          content: "";
+                          left: 1px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 1px;
+                          top: 1px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          border-color: Window;
+                          border: 0px;
+                          color: GrayText;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                          border: 1px solid WindowText;
+                        }
+                    data-is-focusable={false}
+                    disabled={true}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    title=""
+                    type="button"
+                  >
+                    <span
+                      className=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: flex-start;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <div
+                        className=
+                            ms-Nav-linkText
+                            {
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              overflow: hidden;
+                              text-align: left;
+                              text-overflow: ellipsis;
+                              vertical-align: middle;
+                            }
+                      >
+                        MSN
+                      </div>
+                    </span>
+                  </button>
+                </div>
+              </li>
+            </ul>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  is-expanded
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="Shared Documents and Files"
+              title=""
+            >
+              <a
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 27px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f3f2f1;
+                    }
+                data-is-focusable={true}
+                href="http://example.com"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+                title=""
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    Shared Documents and Files
+                  </div>
+                </span>
+              </a>
+            </div>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="Pages"
+              title=""
+            >
+              <a
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 27px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f3f2f1;
+                    }
+                data-is-focusable={true}
+                href="http://msn.com"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+                title=""
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    Pages
+                  </div>
+                </span>
+              </a>
+            </div>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  is-disabled
+                  {
+                    color: #a19f9d;
+                    display: block;
+                    position: relative;
+                  }
+              name="Notebook"
+              title=""
+            >
+              <button
+                aria-disabled={true}
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    is-disabled
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-color: transparent;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #a19f9d;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 27px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                      color: GrayText;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                data-is-focusable={false}
+                disabled={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                title=""
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    Notebook
+                  </div>
+                </span>
+              </button>
+            </div>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  is-selected
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="Communication and Media"
+              title=""
+            >
+              <a
+                aria-current="page"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #edebe9;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #000000;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 600;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 27px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f3f2f1;
+                    }
+                    &:after {
+                      border-left: 2px solid #0078d4;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      pointer-events: none;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                    }
+                data-is-focusable={true}
+                href="http://msn.com"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+                title=""
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    Communication and Media
+                  </div>
+                </span>
+              </a>
+            </div>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="News"
+              title=""
+            >
+              <a
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: inherit;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      white-space: normal;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
+                      border: 0px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+                      border: 1px solid WindowText;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f3f2f1;
+                    }
+                data-is-focusable={true}
+                href="http://cnn.com"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+                title=""
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons-2";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #106ebe;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                        }
+                    data-icon-name="News"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <div
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-align: left;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
+                  >
+                    News
+                  </div>
+                </span>
+              </a>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
@@ -623,7 +623,6 @@ exports[`Component Examples renders Nav.Wrapped.Example.tsx correctly 1`] = `
             <div
               className=
                   ms-Nav-compositeLink
-                  is-expanded
                   {
                     color: #323130;
                     display: block;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10281](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10281)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The default Nav styles with text truncation and tooltips have accessibility issues b/c they don't work with keyboard, voice control, or touch (and by extension switch, eye gaze, etc.).

It doesn't seem prudent to change that default behavior in v8, so I added an example showing how to override those styles, and added accessibility info for authors under Best Practices.
