### PR TITLE
Pass all ThemeProvider classes to context

### DIFF
--- a/change/@fluentui-react-theme-provider-54ebae8c-c980-427c-8cfb-4f209b761c39.json
+++ b/change/@fluentui-react-theme-provider-54ebae8c-c980-427c-8cfb-4f209b761c39.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Pass all ThemeProvider classes to context",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme-provider/etc/react-theme-provider.api.md
+++ b/packages/react-theme-provider/etc/react-theme-provider.api.md
@@ -31,7 +31,6 @@ export interface ThemeProviderState extends ThemeProviderProps {
     ref: React.MutableRefObject<HTMLElement>;
     // (undocumented)
     theme: Theme;
-    themeClassName: string;
 }
 
 export { useTheme }

--- a/packages/react-theme-provider/src/components/ThemeProvider/ThemeProvider.types.ts
+++ b/packages/react-theme-provider/src/components/ThemeProvider/ThemeProvider.types.ts
@@ -16,8 +16,4 @@ export interface ThemeProviderState extends ThemeProviderProps {
    */
   ref: React.MutableRefObject<HTMLElement>;
   theme: Theme;
-  /**
-   * CSS class that will apply theme CSS variables
-   */
-  themeClassName: string;
 }

--- a/packages/react-theme-provider/src/components/ThemeProvider/renderThemeProvider.tsx
+++ b/packages/react-theme-provider/src/components/ThemeProvider/renderThemeProvider.tsx
@@ -9,7 +9,7 @@ export function renderThemeProvider(state: ThemeProviderState) {
   return (
     <slots.root {...slotProps.root}>
       <ThemeContext.Provider value={state.theme}>
-        <ThemeClassNameContext.Provider value={state.themeClassName}>{state.children}</ThemeClassNameContext.Provider>
+        <ThemeClassNameContext.Provider value={state.className ?? ''}>{state.children}</ThemeClassNameContext.Provider>
       </ThemeContext.Provider>
     </slots.root>
   );

--- a/packages/react-theme-provider/src/components/ThemeProvider/useThemeProvider.ts
+++ b/packages/react-theme-provider/src/components/ThemeProvider/useThemeProvider.ts
@@ -39,8 +39,7 @@ export const useThemeProvider = (
   const theme = mergeThemes(parentTheme, state.theme ?? {});
   const themeClassName = useThemeStyleTag({ theme, targetDocument: state.targetDocument });
 
-  state.themeClassName = themeClassName;
   // ax is not needed here because `themeClassName` is not from a `makeStyles` call
-  state.className = [state.className || '', state.themeClassName].filter(Boolean).join(' ');
+  state.className = [state.className || '', themeClassName].filter(Boolean).join(' ');
   return state;
 };


### PR DESCRIPTION
Since `ThemeProvider`now applies styles to children, add all applied
classes to context

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
