### PR TITLE
Fix component template files

### DIFF
--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/render{{componentName}}.tsx.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/render{{componentName}}.tsx.hbs
@@ -4,7 +4,6 @@ import { {{camelCase componentName}}ShorthandProps, {{componentName}}State } fro
 
 /**
  * Render the final JSX of {{componentName}}
- * {@docCategory {{componentName}} }
  */
 export const render{{componentName}} = (state: {{componentName}}State) => {
   const { slots, slotProps } = getSlots(state, {{camelCase componentName}}ShorthandProps);

--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}.ts.hbs
@@ -13,8 +13,6 @@ const mergeProps = makeMergeProps<{{componentName}}State>({ deepMerge: {{camelCa
  * @param props - props from this instance of {{componentName}}
  * @param ref - reference to root HTMLElement of {{componentName}}
  * @param defaultProps - (optional) default prop values provided by the implementing type
- *
- * {@docCategory {{componentName}} }
  */
 export const use{{componentName}} = (
   props: {{componentName}}Props,

--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -1,4 +1,4 @@
-import { makeStyles, ax} from '@fluentui/react-make-styles';
+import { makeStyles, ax } from '@fluentui/react-make-styles';
 import { {{componentName}}State } from './{{componentName}}.types';
 
 /**

--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -1,4 +1,4 @@
-import { makeStyles, useAx } from '@fluentui/react-make-styles';
+import { makeStyles, ax} from '@fluentui/react-make-styles';
 import { {{componentName}}State } from './{{componentName}}.types';
 
 /**
@@ -14,14 +14,13 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the {{componentName}} slots based on the state
- * {@docCategory {{componentName}} }
  */
 export const use{{componentName}}Styles = (state: {{componentName}}State): {{componentName}}State => {
   const styles = useStyles();
-  state.className = useAx(styles.root, state.className);
+  state.className = ax(styles.root, state.className);
 
   // TODO Add class names to slots, for example:
-  // state.mySlot.className = useAx(styles.mySlot, state.mySlot.className);
+  // state.mySlot.className = ax(styles.mySlot, state.mySlot.className);
 
   return state;
 };

--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/{{componentName}}.tsx.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/{{componentName}}.tsx.hbs
@@ -5,7 +5,7 @@ import { render{{componentName}} } from './render{{componentName}}';
 import { use{{componentName}}Styles } from './use{{componentName}}Styles';
 
 /**
- * {@docCategory {{componentName}} }
+ * {{componentName}} component
  */
 export const {{componentName}} = React.forwardRef<HTMLElement, {{componentName}}Props>((props, ref) => {
   const state = use{{componentName}}(props, ref);

--- a/scripts/create-component/plop-templates-component/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
+++ b/scripts/create-component/plop-templates-component/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 
 /**
- * {@docCategory {{componentName}} }
+ * {{componentName}} Props
  */
 export interface {{componentName}}Props extends ComponentProps, React.HTMLAttributes<HTMLElement> {
   /*
@@ -14,24 +14,21 @@ export interface {{componentName}}Props extends ComponentProps, React.HTMLAttrib
 
 /**
  * Names of the shorthand properties in {{componentName}}Props
- * {@docCategory {{componentName}} }
  */
 export const {{camelCase componentName}}ShorthandProps = [] as const; // TODO add shorthand property names
 
 /**
  * Names of the shorthand properties in {{componentName}}Props
- * {@docCategory {{componentName}} }
  */
 export type {{componentName}}ShorthandProps = typeof {{camelCase componentName}}ShorthandProps[number];
 
 /**
  * Names of {{componentName}}Props that have a default value in use{{componentName}}
- * {@docCategory {{componentName}} }
  */
 export type {{componentName}}DefaultedProps = never; // TODO add names of properties with default values
 
 /**
- * {@docCategory {{componentName}} }
+ * {{componentName}} State
  */
 export type {{componentName}}State = ComponentState<
   React.Ref<HTMLElement>,


### PR DESCRIPTION
* `useAx` was removed, use `ax` in component style template
* remove `docCategory` as suggested in #[17586](https://github.com/microsoft/fluentui/pull/17586#discussion_r602625738)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
