### PR TITLE
[v7.0] ContextualMenu: focused div when menu is opened now has role = "menu"

### DIFF
--- a/change/office-ui-fabric-react-35889863-356d-47b9-9d1b-654dcca510aa.json
+++ b/change/office-ui-fabric-react-35889863-356d-47b9-9d1b-654dcca510aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: focused div when menu is opened now has role = menu",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -361,6 +361,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
           <div
             aria-label={ariaLabel}
             aria-labelledby={labelElementId}
+            role={'menu'}
             style={contextMenuStyle}
             ref={(host: HTMLDivElement) => (this._host = host)}
             id={id}
@@ -491,9 +492,9 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
     defaultRender?: IRenderFunction<IContextualMenuListProps>,
   ): JSX.Element => {
     let indexCorrection = 0;
-    const { items, totalItemCount, hasCheckmarks, hasIcons, role } = menuListProps;
+    const { items, totalItemCount, hasCheckmarks, hasIcons } = menuListProps;
     return (
-      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role={role ?? 'menu'}>
+      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role={'presentation'}>
         {items.map((item, index) => {
           const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
           if (item.itemType !== ContextualMenuItemType.Divider && item.itemType !== ContextualMenuItemType.Header) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
-import { KeyCodes, IRenderFunction } from '../../Utilities';
+import { KeyCodes } from '../../Utilities';
 import { FocusZoneDirection } from '../../FocusZone';
 import * as renderer from 'react-test-renderer';
 // Have to import this separately for mock purposes
@@ -9,7 +9,7 @@ import * as Utilities from '../../Utilities';
 import { IContextualMenuProps, IContextualMenuStyles, IContextualMenu } from './ContextualMenu.types';
 import { ContextualMenu } from './ContextualMenu';
 import { canAnyMenuItemsCheck } from './ContextualMenu.base';
-import { IContextualMenuItem, ContextualMenuItemType, IContextualMenuListProps } from './ContextualMenu.types';
+import { IContextualMenuItem, ContextualMenuItemType } from './ContextualMenu.types';
 import { IContextualMenuRenderItem, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import { DefaultButton, IButton } from '../../Button';
 
@@ -1271,7 +1271,7 @@ describe('ContextualMenu', () => {
   });
 
   describe('onRenderMenuList function tests', () => {
-    it('List has default role as menu.', () => {
+    it('List has default role as presentation.', () => {
       const items: IContextualMenuItem[] = [
         {
           text: 'TestText 1',
@@ -1284,32 +1284,7 @@ describe('ContextualMenu', () => {
       const internalList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
 
       expect(internalList).toBeTruthy();
-      expect(internalList.getAttribute('role')).toEqual('menu');
-    });
-
-    it('List applies role that is set by custom onRenderMenuList function.', () => {
-      const items: IContextualMenuItem[] = [
-        {
-          text: 'TestText 1',
-          key: 'TestKey1',
-        },
-      ];
-
-      const onRenderMenuList: IRenderFunction<IContextualMenuListProps> = (props, defaultRender) => {
-        if (props) {
-          props.role = 'grid';
-        }
-        return defaultRender?.(props) ?? null;
-      };
-
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onRenderMenuList={onRenderMenuList} />,
-      );
-
-      const internalList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-
-      expect(internalList).toBeTruthy();
-      expect(internalList.getAttribute('role')).toEqual('grid');
+      expect(internalList.getAttribute('role')).toEqual('presentation');
     });
   });
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1271,7 +1271,7 @@ describe('ContextualMenu', () => {
   });
 
   describe('onRenderMenuList function tests', () => {
-    it('List has default role as presentation.', () => {
+    it('List has default role as presentation', () => {
       const items: IContextualMenuItem[] = [
         {
           text: 'TestText 1',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -265,6 +265,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                role="menu"
                 tabIndex={-1}
               >
                 <div
@@ -307,7 +308,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                         }
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
-                    role="menu"
+                    role="presentation"
                   >
                     <li
                       className=


### PR DESCRIPTION
cherry-pick of #17683 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17628 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ContextualMenu: element that's focused when menu is opened now has role = "menu"

- Moved `role = menu`  attribute to container div which is the element that gains focus when menu is opened.
- Updated elements in between container div and first menu item to have `role = presentation`.
- Removed 1 `onRenderMenuList` unit test from `ContextualMenu` since `role` will be static as `"presentation"` moving forward.
