### PR TITLE
Rename `document` to `targetDocument`

### DIFF
--- a/change/@fluentui-react-make-styles-72844d9c-33f6-4b8a-b622-59b442158509.json
+++ b/change/@fluentui-react-make-styles-72844d9c-33f6-4b8a-b622-59b442158509.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename `document` to `targetDocument`",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-make-styles/src/__styles.ts
+++ b/packages/react-make-styles/src/__styles.ts
@@ -17,8 +17,8 @@ export function __styles<Slots extends string>(resolvedStyles: ResolvedStylesByS
   }
 
   return function useClasses(): Record<Slots, string> {
-    const { dir, document } = useFluent();
-    const renderer = useRenderer(document);
+    const { dir, targetDocument } = useFluent();
+    const renderer = useRenderer(targetDocument);
 
     return getStyles({ dir, renderer });
   };


### PR DESCRIPTION
Fixes a rename missed by #17827

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
