### PR TITLE
[v7.0] Dropdown: no longer automatically selects the first option when dropdown receives keyboard focus

### DIFF
--- a/change/office-ui-fabric-react-b93681c2-e5ef-4115-8266-4ecc13467243.json
+++ b/change/office-ui-fabric-react-b93681c2-e5ef-4115-8266-4ecc13467243.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: no longer automatically selects the first option when dropdown receives keyboard focus",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -1172,16 +1172,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   };
 
   private _onFocus = (ev: React.FocusEvent<HTMLDivElement>): void => {
-    const { isOpen, selectedIndices } = this.state;
-    const { multiSelect } = this.props;
-
     const disabled = this._isDisabled();
 
     if (!disabled) {
-      if (!this._isFocusedByClick && !isOpen && selectedIndices.length === 0 && !multiSelect) {
-        // Per aria: https://www.w3.org/TR/wai-aria-practices-1.1/#listbox_kbd_interaction
-        this._moveIndex(ev, 1, 0, -1);
-      }
       if (this.props.onFocus) {
         this.props.onFocus(ev);
       }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -300,16 +300,16 @@ describe('Dropdown', () => {
       expect(titleElement.text()).toEqual('2');
     });
 
-    it('selects the first valid item on focus', () => {
+    it('does not select any item on focus', () => {
       wrapper = mount(<Dropdown label="testgroup" options={DEFAULT_OPTIONS} />);
 
       wrapper.find('.ms-Dropdown').simulate('focus');
 
       const titleElement = wrapper.find('.ms-Dropdown-title');
-      expect(titleElement.text()).toEqual('1');
+      expect(titleElement.text()).toEqual('');
     });
 
-    it('can be programmatically focused when tabIndex=-1, and will select the first valid item', () => {
+    it('can be programmatically focused when tabIndex=-1, and will not automatically select an item', () => {
       const dropdown = React.createRef<IDropdown>();
 
       const container = document.createElement('div');
@@ -326,10 +326,10 @@ describe('Dropdown', () => {
 
       const titleElement = container.querySelector('.ms-Dropdown-title') as HTMLElement;
       // for some reason, JSDOM does not return innerText of 1 so we have to use innerHTML instead.
-      expect(titleElement.innerHTML).toEqual('1');
+      expect(titleElement.innerHTML).toEqual('');
     });
 
-    it('opens and focuses/selects first selectable option when focus(true) is called', () => {
+    it('opens and does not automatically select an item when focus(true) is called', () => {
       const dropdown = React.createRef<IDropdown>();
 
       const container = document.createElement('div');
@@ -338,9 +338,8 @@ describe('Dropdown', () => {
 
       expect(document.body.querySelector('.ms-Dropdown-item')).toBeNull();
       dropdown.current!.focus(true);
-      const firstDropdownItem = document.body.querySelector('.ms-Dropdown-item');
-      expect(firstDropdownItem).not.toBeNull();
-      expect(firstDropdownItem!.getAttribute('aria-selected')).toBe('true');
+      const titleElement = container.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.innerHTML).toEqual('');
     });
 
     it('selects the first valid item on Home keypress', () => {


### PR DESCRIPTION
cherry-pick of #17739

#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug-[11604](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11604)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- removed conditional which selected the first option whenever dropdown receives keyboard focus.
- updated 3 tests to assert that no selection should be made when dropdown receives focus.

**New Behavior:** 

![dropdown-focus-1](https://user-images.githubusercontent.com/8649804/113944991-53c40a80-97ba-11eb-8e6b-74763d5c1345.JPG)
