### PR TITLE
Manually return theme from storybook knob

### DIFF
--- a/packages/storybook/src/knobs/useFluentTheme.ts
+++ b/packages/storybook/src/knobs/useFluentTheme.ts
@@ -20,7 +20,12 @@ const themeOptions = [
   { label: 'Teams High Contrast', theme: teamsHighContrastTheme },
 ];
 
-export const useFluentTheme = (): { label: string; theme: Theme } =>
+export const useFluentTheme = (): { label: string; theme: Theme } => {
   // Casting any here due to issue: https://github.com/storybookjs/storybook/issues/9751
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  select(themeSelectorLabel, themeOptions as any, themeOptions[0] as any);
+  const { label } = select(themeSelectorLabel, themeOptions as any, themeOptions[0] as any);
+
+  // Can't trust storybook not to HTML encode theme values
+  const { theme } = themeOptions.find(pair => pair.label === label) || { theme: webLightTheme };
+  return { label, theme };
+};


### PR DESCRIPTION
Storybook `select` knob seems to serialize the theme object in some way
between story switches in the main dashboard that results in HTML
encoded URLs in the theme. Example below:

> --global-type-fontFamilies-base: \&#39;Segoe UI&#39;, \&#39;Segoe UI Web (West European)\&#39;, -apple-system, BlinkMacSystemFont, Roboto, \&#39;Helvetica Neue\&#39;, sans-serif;

This PR still retains the storybook knob but selects the theme object
manually

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
