### PR TITLE
shiche/range slider toggle transition fix

### DIFF
--- a/change/@fluentui-react-46dbd61f-f128-403e-925f-eb5cceeac059.json
+++ b/change/@fluentui-react-46dbd61f-f128-403e-925f-eb5cceeac059.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix rangeSlider toggleTransition double firing bug",
+  "packageName": "@fluentui/react",
+  "email": "shi.cheng@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -292,6 +292,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
       );
     }
     toggleUseShowTransitions();
+    console.log('295 toggled!');
     onMouseMoveOrTouchMove(event, true);
   };
 
@@ -300,6 +301,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
       props.onChanged(event, value as number);
     }
     toggleUseShowTransitions();
+    console.log('304toggled!');
     disposeListeners();
   };
 
@@ -385,13 +387,6 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
     style: getTrackStyles(bottomSectionWidth),
   };
 
-  const eventProps = {
-    ...onMouseDownProp,
-    ...onTouchStartProp,
-    ...onKeyDownProp,
-    ...divButtonProps,
-  };
-
   const sliderProps: React.HTMLAttributes<HTMLElement> = {
     'aria-disabled': disabled,
     role: 'slider',
@@ -402,7 +397,10 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
   const sliderBoxProps: React.HTMLAttributes<HTMLElement> = {
     id,
     className: css(classNames.slideBox, buttonProps!.className),
-    ...eventProps,
+    ...onMouseDownProp,
+    ...onTouchStartProp,
+    ...onKeyDownProp,
+    ...divButtonProps,
     ...(!ranged && {
       ...sliderProps,
       'aria-valuemin': min,
@@ -419,7 +417,6 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
     style: getPositionStyles(valuePercent),
     ...(ranged && {
       ...sliderProps,
-      ...eventProps,
       ...onFocusProp,
       id: `max-${id}`,
       'aria-valuemin': lowerValue,
@@ -438,7 +435,6 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
         className: classNames.thumb,
         style: getPositionStyles(lowerValuePercent),
         ...sliderProps,
-        ...eventProps,
         ...onFocusProp,
         id: `min-${id}`,
         'aria-valuemin': min,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
`ToggleTransition` hook is fired twice when clicking on thumbs of a range slider. This may cause different transition behavior between the two thumbs. The reason is that a couple of unneeded event props are given to the thumbs, specifically `onMouseDownOrTouchStart`. Removing the event props will solve the issue and not affect the other behavior of rangeSlider
