### PR TITLE
Fix bug where adding an item from outside of UPP forces focus on the input

### DIFF
--- a/change/@fluentui-react-experiments-f26560d7-d431-4288-8d2e-557a581a5934.json
+++ b/change/@fluentui-react-experiments-f26560d7-d431-4288-8d2e-557a581a5934.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Put focus on the input only when suggestion is selected from UPP picker",
+  "packageName": "@fluentui/react-experiments",
+  "email": "angon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -591,6 +591,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     // to lose focus in the picker, so call focus again here in that case
     if (selectedItems.length === 1 && shouldForceFocusInput) {
       input.current?.focus();
+      shouldForceFocusInput.current = false;
     }
   }, [selectedItems.length]);
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -589,7 +589,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   React.useEffect(() => {
     // We add the selected items list in the UI once we have items, which causes us
     // to lose focus in the picker, so call focus again here in that case
-    if (selectedItems.length === 1 && shouldForceFocusInput) {
+    if (selectedItems.length === 1 && shouldForceFocusInput.current) {
       input.current?.focus();
       shouldForceFocusInput.current = false;
     }

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -291,6 +291,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDragEnd: _onDragEnd,
   };
 
+  const shouldForceFocusInput = React.useRef<boolean>(false);
   const _onSuggestionSelected = React.useCallback(
     (ev: any, item: IFloatingSuggestionItemProps<T>) => {
       addItems([item.item]);
@@ -299,6 +300,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         input.current.clear();
       }
       showPicker(false);
+      shouldForceFocusInput.current = true;
     },
     [addItems, onSuggestionSelected, showPicker],
   );
@@ -587,7 +589,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   React.useEffect(() => {
     // We add the selected items list in the UI once we have items, which causes us
     // to lose focus in the picker, so call focus again here in that case
-    if (selectedItems.length === 1) {
+    if (selectedItems.length === 1 && shouldForceFocusInput) {
       input.current?.focus();
     }
   }, [selectedItems.length]);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Setting variable shouldForceFocusInput to keep track of when we should force focus on the input (only when adding item from UPP picker).

#### Focus areas to test

(optional)
