### PR TITLE
Publish docs pipeline artifact after azure upload

### DIFF
--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -184,12 +184,6 @@ jobs:
             echo deployBasePath $(deployBasePath) docsiteVersion $(docsiteVersion) nightlyReleaseDate $(nightlyReleaseDate)
             NODE_ENV=production yarn build:fluentui:docs
 
-      - task: PublishPipelineArtifact@1
-        displayName: Publish Docsite as Pipeline Artifact
-        inputs:
-          path: packages/fluentui/docs/dist
-          artifactName: docsite_v$(docsiteVersion)
-
       - task: AzureUpload@2
         displayName: Upload to Azure
         inputs:
@@ -199,5 +193,11 @@ jobs:
           ContainerName: $web
           BlobPrefix: $(deployBasePath)
           Gzip: true
+
+      - task: PublishPipelineArtifact@1
+        displayName: Publish Docsite as Pipeline Artifact
+        inputs:
+          path: packages/fluentui/docs/dist
+          artifactName: docsite_v$(docsiteVersion)
 
       - template: .devops/templates/cleanup.yml


### PR DESCRIPTION
Due to MicrosoftDocs/azure-devops-docs#10543, if azure upload fails then
the failed job cannot be retried and a new pipeline run must be queued.

Adds the artifact publish to the end of the pipeline so the run can be
retried if azure upload fails

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
