### PR TITLE
fix(makeStyles): DOM renderer should not throw in SSR

### DIFF
--- a/apps/perf-test/src/scenarios/MakeStyles.tsx
+++ b/apps/perf-test/src/scenarios/MakeStyles.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses, makeStyles, createDOMRenderer } from '@fluentui/make-styles';
 import * as React from 'react';
 
-const renderer = createDOMRenderer();
+const renderer = createDOMRenderer(document);
 
 const useStyles = makeStyles({
   view: {

--- a/change/@fluentui-make-styles-e78e8913-4ef7-4a39-a0af-0c9bc5725353.json
+++ b/change/@fluentui-make-styles-e78e8913-4ef7-4a39-a0af-0c9bc5725353.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(makeStyles): DOM renderer should not throw in SSR",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/etc/make-styles.api.md
+++ b/packages/make-styles/etc/make-styles.api.md
@@ -17,7 +17,7 @@ export function createCSSVariablesProxy(prefix?: string): unknown;
 // Warning: (ae-forgotten-export) The symbol "MakeStylesDOMRenderer" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function createDOMRenderer(target?: Document): MakeStylesDOMRenderer;
+export function createDOMRenderer(target: Document | undefined): MakeStylesDOMRenderer;
 
 // @public (undocumented)
 export type MakeStaticStyles = ({

--- a/packages/make-styles/src/makeStaticStyles.test.ts
+++ b/packages/make-styles/src/makeStaticStyles.test.ts
@@ -8,7 +8,7 @@ expect.addSnapshotSerializer(makeStylesRendererSerializer);
 describe('makeStaticStyles', () => {
   let renderer: MakeStylesDOMRenderer;
   beforeEach(() => {
-    renderer = createDOMRenderer();
+    renderer = createDOMRenderer(document);
   });
 
   afterEach(() => {

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -15,7 +15,7 @@ describe('makeStyles', () => {
   let renderer: MakeStylesDOMRenderer;
 
   beforeEach(() => {
-    renderer = createDOMRenderer();
+    renderer = createDOMRenderer(document);
   });
 
   afterEach(() => {
@@ -172,15 +172,12 @@ describe('makeStyles', () => {
     `);
   });
   it('handles tokens', () => {
-    const rendererA = createDOMRenderer(createFakeDocument());
-
     const computeClasses = makeStyles<'root', { display: string }>({
       root: tokens => ({ display: tokens.display }),
     });
+    computeClasses({ dir: 'rtl', renderer });
 
-    computeClasses({ dir: 'rtl', renderer: rendererA });
-
-    expect(rendererA).toMatchInlineSnapshot(`
+    expect(renderer).toMatchInlineSnapshot(`
       .fl81ese0 {
         display: var(--display);
       }

--- a/packages/make-styles/src/mergeClasses.test.ts
+++ b/packages/make-styles/src/mergeClasses.test.ts
@@ -6,7 +6,7 @@ import { SEQUENCE_PREFIX } from './constants';
 
 const options: MakeStylesOptions = {
   dir: 'ltr',
-  renderer: createDOMRenderer(),
+  renderer: createDOMRenderer(document),
 };
 
 describe('mergeClasses', () => {

--- a/packages/make-styles/src/renderer/createDOMRenderer-node.test.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer-node.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+
+// 👆 this is intentionally to test in SSR like environment
+
+import { MakeStylesReducedDefinitions } from '../types';
+import { createDOMRenderer } from './createDOMRenderer';
+
+describe('createDOMRenderer', () => {
+  it('"document" should not be defined', () => {
+    expect(typeof document).toBe('undefined');
+  });
+
+  it('should return classes even without a document', () => {
+    const renderer = createDOMRenderer(undefined);
+    const definitions: MakeStylesReducedDefinitions = {
+      color: ['', 'foo', '.foo { color: red }'],
+    };
+
+    expect(renderer.insertDefinitions('ltr', definitions)).toBe('foo');
+  });
+});

--- a/packages/make-styles/src/renderer/createDOMRenderer.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer.ts
@@ -70,13 +70,20 @@ function getStyleSheetForBucket(
   return renderer.styleElements[bucketName]!.sheet as CSSStyleSheet;
 }
 
-const renderers = new WeakMap<Document, MakeStylesDOMRenderer>();
+// To avoid errors related to SSR as `document` can be undefined, to workaround this we are using a fake object
+// `fakeDocument`. When a value matches `fakeDocument`, we will create a noop renderer.
+//
+// It's an edge case, we should provide an SSR renderer for these use cases.
+const fakeDocumentForSSR = {
+  ...(process.env.NODE_ENV && { fakeDocumentForSSR: true }),
+};
+
+const renderers = new WeakMap<Document | typeof fakeDocumentForSSR, MakeStylesDOMRenderer>();
+
 let lastIndex = 0;
 
-/* eslint-disable guard-for-in */
-
-export function createDOMRenderer(target: Document = document): MakeStylesDOMRenderer {
-  const value: MakeStylesDOMRenderer | undefined = renderers.get(target);
+export function createDOMRenderer(target: Document | undefined): MakeStylesDOMRenderer {
+  const value: MakeStylesDOMRenderer | undefined = renderers.get(target || fakeDocumentForSSR);
 
   if (value) {
     return value;
@@ -91,6 +98,7 @@ export function createDOMRenderer(target: Document = document): MakeStylesDOMRen
     insertDefinitions: function insertStyles(dir, definitions): string {
       let classes = '';
 
+      // eslint-disable-next-line guard-for-in
       for (const propName in definitions) {
         const definition = definitions[propName];
         // 👆 [bucketName, className, css, rtlCSS?]
@@ -114,15 +122,17 @@ export function createDOMRenderer(target: Document = document): MakeStylesDOMRen
         const css = definition[RULE_CSS_INDEX];
         const ruleCSS = dir === 'rtl' ? rtlCSS || css : css;
 
-        const sheet = getStyleSheetForBucket(bucketName, target, renderer);
+        if (target) {
+          const sheet = getStyleSheetForBucket(bucketName, target, renderer);
 
-        try {
-          sheet.insertRule(ruleCSS, sheet.cssRules.length);
-        } catch (e) {
-          // We've disabled these warnings due to false-positive errors with browser prefixes
-          if (process.env.NODE_ENV !== 'production' && !ignoreSuffixesRegex.test(ruleCSS)) {
-            // eslint-disable-next-line no-console
-            console.error(`There was a problem inserting the following rule: "${ruleCSS}"`, e);
+          try {
+            sheet.insertRule(ruleCSS, sheet.cssRules.length);
+          } catch (e) {
+            // We've disabled these warnings due to false-positive errors with browser prefixes
+            if (process.env.NODE_ENV !== 'production' && !ignoreSuffixesRegex.test(ruleCSS)) {
+              // eslint-disable-next-line no-console
+              console.error(`There was a problem inserting the following rule: "${ruleCSS}"`, e);
+            }
           }
         }
 
@@ -133,7 +143,7 @@ export function createDOMRenderer(target: Document = document): MakeStylesDOMRen
     },
   };
 
-  renderers.set(target, renderer);
+  renderers.set(target || fakeDocumentForSSR, renderer);
 
   return renderer;
 }

--- a/packages/make-styles/src/renderer/createDOMRenderer.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer.ts
@@ -75,7 +75,7 @@ function getStyleSheetForBucket(
 //
 // It's an edge case, we should provide an SSR renderer for these use cases.
 const fakeDocumentForSSR = {
-  ...(process.env.NODE_ENV && { fakeDocumentForSSR: true }),
+  ...(process.env.NODE_ENV !== 'production' && { fakeDocumentForSSR: true }),
 };
 
 const renderers = new WeakMap<Document | typeof fakeDocumentForSSR, MakeStylesDOMRenderer>();


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17902
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes existing renderer compatible with SSR apps. We still need to introduce a renderer/an approach for generating styles on server, but at least it will not throw after this PR.
