### PR TITLE
Add e2e scripts during package creation

### DIFF
--- a/scripts/create-package/plop-templates-react/e2e.js
+++ b/scripts/create-package/plop-templates-react/e2e.js
@@ -1,0 +1,3 @@
+const cypress = require('@fluentui/scripts/cypress');
+
+cypress();

--- a/scripts/create-package/plop-templates-react/e2e/tsconfig.json
+++ b/scripts/create-package/plop-templates-react/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+// Extend main tsconfig.json but include cypress types
+
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress", "../../scripts/cypress/support"]
+  },
+  "include": ["."]
+}

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -15,6 +15,7 @@
     "build": "just-scripts build",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "e2e": "echo \"{{{packageNpmName}}} E2E testing not enabled replace this command with 'node e2e.js'\"",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds all the necessary scripts to run e2e tests off the bat during package creation.

Does not enable the e2e command but instructions on how to do it are provided. This saves some overhead of starting up cypress and browsers for no reason

#### Focus areas to test

(optional)
