### PR TITLE
Fixing versions of packages used when exporting examples to codepen from v8 website

### DIFF
--- a/change/@fluentui-react-docsite-components-a7bfd7ac-4c53-42d0-a488-2d9188b0d911.json
+++ b/change/@fluentui-react-docsite-components-a7bfd7ac-4c53-42d0-a488-2d9188b0d911.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing versions of packages used when exporting examples to codepen from v8 website.",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/CodepenComponent/CodepenComponent.tsx
+++ b/packages/react-docsite-components/src/components/CodepenComponent/CodepenComponent.tsx
@@ -42,11 +42,11 @@ const CodepenComponentBase: React.FunctionComponent<ICodepenProps> = props => {
     // boilerplate for codepen API
     const htmlContent = [
       // load core Fabric bundle and hooks bundle
-      script('@fluentui/react@7/dist/fluentui-react.js'),
-      script('@fluentui/react-hooks@7/dist/react-hooks.js'),
+      script('@fluentui/react@8/dist/fluentui-react.js'),
+      script('@fluentui/react-hooks@8/dist/react-hooks.js'),
       // load example data bundle only if used
       jsContentStr.indexOf('window.FluentUIExampleData') !== -1
-        ? script('@fluentui/example-data@7/dist/example-data.js')
+        ? script('@fluentui/example-data@8/dist/example-data.js')
         : '',
       `<div id="${CONTENT_ID}"></div>`,
     ]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue when exporting an example to a codepen via the website when viewing the v8 version where the codepen exported wasn't working because the versions of the packages used in it referred to v7 instead of v8.
