### PR TITLE
fix(Datepicker): prev/next buttons use aria-disabled instead of disabled to prevent focus being lost

### DIFF
--- a/change/@fluentui-react-15bc4db2-766c-4367-8db5-cca4e969137c.json
+++ b/change/@fluentui-react-15bc4db2-766c-4367-8db5-cca4e969137c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Calendar prev/next buttons to use aria-disabled instead of disabled so they do not lose focus",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -132,13 +132,15 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
   const prevMonthInBounds = minDate ? compareDatePart(minDate, getMonthStart(navigatedDate)) < 0 : true;
   const nextMonthInBounds = maxDate ? compareDatePart(getMonthEnd(navigatedDate), maxDate) < 0 : true;
 
+  // use aria-disabled instead of disabled so focus is not lost
+  // when a prev/next button becomes disabled after being clicked
   return (
     <div className={classNames.monthComponents}>
       <button
         className={css(classNames.headerIconButton, {
           [classNames.disabledStyle]: !prevMonthInBounds,
         })}
-        disabled={!allFocusable && !prevMonthInBounds}
+        tabIndex={prevMonthInBounds ? undefined : allFocusable ? 0 : -1}
         aria-disabled={!prevMonthInBounds}
         onClick={prevMonthInBounds ? onSelectPrevMonth : undefined}
         onKeyDown={prevMonthInBounds ? onButtonKeyDown(onSelectPrevMonth) : undefined}
@@ -156,7 +158,7 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
         className={css(classNames.headerIconButton, {
           [classNames.disabledStyle]: !nextMonthInBounds,
         })}
-        disabled={!allFocusable && !nextMonthInBounds}
+        tabIndex={nextMonthInBounds ? undefined : allFocusable ? 0 : -1}
         aria-disabled={!nextMonthInBounds}
         onClick={nextMonthInBounds ? onSelectNextMonth : undefined}
         onKeyDown={nextMonthInBounds ? onButtonKeyDown(onSelectNextMonth) : undefined}

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -226,7 +226,8 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
             className={css(classNames.navigationButton, {
               [classNames.disabled]: !isPrevYearInBounds,
             })}
-            disabled={!allFocusable && !isPrevYearInBounds}
+            aria-disabled={!isPrevYearInBounds}
+            tabIndex={isPrevYearInBounds ? undefined : allFocusable ? 0 : -1}
             onClick={isPrevYearInBounds ? onSelectPrevYear : undefined}
             onKeyDown={isPrevYearInBounds ? onButtonKeyDown(onSelectPrevYear) : undefined}
             title={
@@ -242,7 +243,8 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
             className={css(classNames.navigationButton, {
               [classNames.disabled]: !isNextYearInBounds,
             })}
-            disabled={!allFocusable && !isNextYearInBounds}
+            aria-disabled={!isNextYearInBounds}
+            tabIndex={isNextYearInBounds ? undefined : allFocusable ? 0 : -1}
             onClick={isNextYearInBounds ? onSelectNextYear : undefined}
             onKeyDown={isNextYearInBounds ? onButtonKeyDown(onSelectNextYear) : undefined}
             title={


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [11642](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11642)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When using the prev/next month, or prev/next year buttons within a bounded date range, they currently cause focus to be lost (and therefore also virtual cursor) when they have focus then become disabled. To prevent that, I switched those buttons to use `aria-disabled="true" tabindex="-1"` for the disabled state, so they don't kick focus back up to `<body>`.

#### Focus areas to test

Datepicker with bounded dates
