### PR TITLE
make-styles - Bugfix - Adds direction as part of sequence hash

### DIFF
--- a/change/@fluentui-jest-serializer-make-styles-2e535215-7dff-40e8-b13c-e2ebced78f7f.json
+++ b/change/@fluentui-jest-serializer-make-styles-2e535215-7dff-40e8-b13c-e2ebced78f7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adds Unit Tests for direction collision",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-1679cfcb-966a-49d4-b9df-6f997bba463f.json
+++ b/change/@fluentui-make-styles-1679cfcb-966a-49d4-b9df-6f997bba463f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add quick fix to bug on direction collision",
+  "packageName": "@fluentui/make-styles",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-serializer-make-styles/src/index.test.tsx
+++ b/packages/jest-serializer-make-styles/src/index.test.tsx
@@ -24,46 +24,45 @@ const useStyles3 = makeStyles({
   },
 });
 
-const Test = () => {
+const Test = ({ id }: { id?: string }) => {
   const styles1 = useStyles1();
   const styles2 = useStyles2();
   const styles3 = useStyles3();
   return (
     <div
-      data-testid="test"
+      data-testid={id}
       className={mergeClasses('static-class', styles1.root, styles1.paddingLeft, styles2.paddingRight, styles3.display)}
     />
   );
 };
 
 const rtlWrapper: React.FC = ({ children }) => (
-  <ProviderContext.Provider value={{ dir: 'rtl' }}>{children}</ProviderContext.Provider>
+  <ProviderContext.Provider value={{ dir: 'rtl', targetDocument: document }}>{children}</ProviderContext.Provider>
 );
 
 describe('jest-serializer-make-styles', () => {
   it('should check styles', () => {
-    expect(render(<Test />).getByTestId('test')).toHaveStyle({
+    expect(render(<Test id="test" />).getByTestId('test')).toHaveStyle({
       display: 'none',
       paddingLeft: '10px',
       paddingRight: '20px',
     });
+    expect(render(<Test id="rtl-test" />, { wrapper: rtlWrapper }).getByTestId('rtl-test')).toHaveStyle({
+      display: 'none',
+      paddingLeft: '20px',
+      paddingRight: '10px',
+    });
   });
 
   it('renders without generated classes', () => {
-    const { container } = render(<Test />);
-    expect(container.firstChild).toMatchInlineSnapshot(`
+    expect(render(<Test />).container.firstChild).toMatchInlineSnapshot(`
       <div
         class="static-class"
-        data-testid="test"
       />
     `);
-  });
-  it('renders without generated classes rtl', () => {
-    const { container } = render(<Test />, { wrapper: rtlWrapper });
-    expect(container.firstChild).toMatchInlineSnapshot(`
+    expect(render(<Test />, { wrapper: rtlWrapper }).container.firstChild).toMatchInlineSnapshot(`
       <div
         class="static-class"
-        data-testid="test"
       />
     `);
   });

--- a/packages/make-styles/src/makeStaticStyles.test.ts
+++ b/packages/make-styles/src/makeStaticStyles.test.ts
@@ -124,7 +124,7 @@ describe('makeStaticStyles', () => {
     });
 
     useStaticStyles({ renderer });
-    expect(useStyles({ dir: 'ltr', renderer }).root).toBe('__xgtdzt0 fy9yzz70 f4ybsrx0');
+    expect(useStyles({ dir: 'ltr', renderer }).root).toBe('__xfubl30 fy9yzz70 f4ybsrx0');
 
     expect(renderer).toMatchInlineSnapshot(`
       @font-face {

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -28,7 +28,7 @@ describe('makeStyles', () => {
         color: 'red',
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__ncdyee0 fe3e8s90');
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__1ygo3xd fe3e8s90');
 
     expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s90 {
@@ -44,7 +44,7 @@ describe('makeStyles', () => {
         position: 'absolute',
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__1fslksb fe3e8s90 f1euv43f');
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__1e7fyny fe3e8s90 f1euv43f');
 
     expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s90 {
@@ -67,8 +67,8 @@ describe('makeStyles', () => {
     const ltrClasses = computeClasses({ dir: 'ltr', renderer }).root;
     const rtlClasses = computeClasses({ dir: 'rtl', renderer }).root;
 
-    expect(ltrClasses).toEqual('__947mlk0 frdkuqy0 f1c8chgj');
-    expect(rtlClasses).toEqual('__hcjvlo0 rfrdkuqy0 rf1c8chgj');
+    expect(ltrClasses).toEqual('__1170bue frdkuqy0 f1c8chgj');
+    expect(rtlClasses).toEqual('__4v2rxd0 rfrdkuqy0 rf1c8chgj');
 
     expect(renderer).toMatchInlineSnapshot(`
       .frdkuqy0 {
@@ -101,7 +101,7 @@ describe('makeStyles', () => {
         animationDuration: '5s',
       },
     });
-    expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('__194gjlt rf1g6ul6r f1cpbl36 f1t9cprh');
+    expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('__1kjcdwm rf1g6ul6r f1cpbl36 f1t9cprh');
 
     expect(renderer).toMatchInlineSnapshot(`
       @-webkit-keyframes rf1q8eu9e {

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -1,6 +1,7 @@
 import { createDOMRenderer, MakeStylesDOMRenderer, resetDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStyles } from './makeStyles';
 import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
+import { mergeClasses } from './mergeClasses';
 
 expect.addSnapshotSerializer(makeStylesRendererSerializer);
 
@@ -171,6 +172,7 @@ describe('makeStyles', () => {
       }
     `);
   });
+
   it('handles tokens', () => {
     const computeClasses = makeStyles<'root', { display: string }>({
       root: tokens => ({ display: tokens.display }),
@@ -182,5 +184,22 @@ describe('makeStyles', () => {
         display: var(--display);
       }
     `);
+  });
+
+  it('test', () => {
+    const computeClasses = makeStyles({
+      root: {
+        display: 'none',
+        marginLeft: '10px',
+      },
+    });
+
+    const styles = computeClasses({ dir: 'ltr', renderer });
+    const rtlStyles = computeClasses({ dir: 'rtl', renderer });
+
+    expect(styles.root).toBe('__bdp41n0 fjseox00 f1oou7ox');
+    expect(rtlStyles.root).toBe('__1wo0rp3 fjseox00 rf1oou7ox');
+
+    mergeClasses(styles.root, rtlStyles.root);
   });
 });

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -1,7 +1,6 @@
 import { createDOMRenderer, MakeStylesDOMRenderer, resetDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStyles } from './makeStyles';
 import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
-import { mergeClasses } from './mergeClasses';
 
 expect.addSnapshotSerializer(makeStylesRendererSerializer);
 
@@ -184,22 +183,5 @@ describe('makeStyles', () => {
         display: var(--display);
       }
     `);
-  });
-
-  it('test', () => {
-    const computeClasses = makeStyles({
-      root: {
-        display: 'none',
-        marginLeft: '10px',
-      },
-    });
-
-    const styles = computeClasses({ dir: 'ltr', renderer });
-    const rtlStyles = computeClasses({ dir: 'rtl', renderer });
-
-    expect(styles.root).toBe('__bdp41n0 fjseox00 f1oou7ox');
-    expect(rtlStyles.root).toBe('__1wo0rp3 fjseox00 rf1oou7ox');
-
-    mergeClasses(styles.root, rtlStyles.root);
   });
 });

--- a/packages/make-styles/src/mergeClasses.test.ts
+++ b/packages/make-styles/src/mergeClasses.test.ts
@@ -68,8 +68,8 @@ describe('mergeClasses', () => {
     const sequence3 = mergeClasses(sequence1, sequence2, className5);
 
     expect(sequence1).toBe(`ui-button ${className2}`);
-    expect(sequence2).toBe('ui-flex __9a122w0 f13qh94s f1sbtcvk fwiuce90 fdghr900 f15vdbe4');
-    expect(sequence3).toBe('ui-button ui-flex __xzc3aa0 f13qh94s f1sbtcvk fwiuce90 fdghr900 f15vdbe4 f1rqyxcv');
+    expect(sequence2).toBe('ui-flex __1en6qsd f13qh94s f1sbtcvk fwiuce90 fdghr900 f15vdbe4');
+    expect(sequence3).toBe('ui-button ui-flex __1pgz2r0 f13qh94s f1sbtcvk fwiuce90 fdghr900 f15vdbe4 f1rqyxcv');
   });
 
   it('warns if an unregistered sequence was passed', () => {
@@ -120,7 +120,7 @@ describe('mergeClasses', () => {
       expect(mergeClasses(rtlClasses1.start, rtlClasses2.start)).toBe(rtlClasses2.start);
 
       expect(mergeClasses(rtlClasses1.start, rtlClasses2.start, rtlClasses1.end, rtlClasses2.end)).toBe(
-        '__1lxk7b0 rfo2qazs0 rf93e62u0',
+        '__1xsx5rm rfo2qazs0 rf93e62u0',
       );
     });
 
@@ -134,6 +134,22 @@ describe('mergeClasses', () => {
       const sequence2 = mergeClasses(sequence1, classes.grid);
 
       expect(sequence2).toBe(`ui-button ${classes.grid}`);
+    });
+
+    it('classes for different text directions should not collide', () => {
+      // TODO: add a link to the issue
+
+      const computeClasses1 = makeStyles({ root: { color: 'red' } });
+      const computeClasses2 = makeStyles({ root: { paddingLeft: '10px' } });
+
+      const ltrClassName1 = computeClasses1(options).root;
+      const ltrClassName2 = computeClasses2(options).root;
+
+      const rtlClassName1 = computeClasses1({ ...options, dir: 'rtl' }).root;
+      const rtlClassName2 = computeClasses2({ ...options, dir: 'rtl' }).root;
+
+      expect(mergeClasses(ltrClassName1, ltrClassName2)).toBe('__17yj912 fe3e8s90 frdkuqy0');
+      expect(mergeClasses(rtlClassName1, rtlClassName2)).toBe('__1ss2kwo fe3e8s90 rfrdkuqy0');
     });
   });
 

--- a/packages/make-styles/src/mergeClasses.ts
+++ b/packages/make-styles/src/mergeClasses.ts
@@ -8,8 +8,8 @@ import {
   RULE_RTL_CSS_INDEX,
   SEQUENCE_PREFIX,
 } from './constants';
-import { hashString } from './runtime/utils/hashString';
 import { MakeStylesReducedDefinitions } from './types';
+import { hashSequence } from './runtime/utils/hashSequence';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
 const mergeClassesCachedResults: Record<string, string> = {};
@@ -147,7 +147,7 @@ export function mergeClasses(): string {
   atomicClassNames = atomicClassNames.slice(0, -1);
 
   // Each merge of classes generates a new sequence of atomic classes that needs to be registered
-  const newSequenceHash = SEQUENCE_PREFIX + hashString(atomicClassNames);
+  const newSequenceHash = hashSequence(atomicClassNames, dir!);
   atomicClassNames = newSequenceHash + ' ' + atomicClassNames;
 
   mergeClassesCachedResults[sequenceMatch] = atomicClassNames;

--- a/packages/make-styles/src/runtime/resolveClassesBySlots.ts
+++ b/packages/make-styles/src/runtime/resolveClassesBySlots.ts
@@ -12,7 +12,7 @@ export function resolveClassesBySlots<Slots extends string>(
   // eslint-disable-next-line guard-for-in
   for (const slotName in resolvedStyles) {
     const slotClasses = renderer.insertDefinitions(dir, resolvedStyles[slotName]);
-    const sequenceHash = SEQUENCE_PREFIX + hashString(slotClasses);
+    const sequenceHash = SEQUENCE_PREFIX + hashString(slotClasses + dir);
 
     const resultSlotClasses = sequenceHash + ' ' + slotClasses;
 

--- a/packages/make-styles/src/runtime/resolveClassesBySlots.ts
+++ b/packages/make-styles/src/runtime/resolveClassesBySlots.ts
@@ -1,6 +1,6 @@
+import { DEFINITION_LOOKUP_TABLE } from '../constants';
 import { MakeStylesRenderer, ResolvedStylesBySlots } from '../types';
-import { DEFINITION_LOOKUP_TABLE, SEQUENCE_PREFIX } from '../constants';
-import { hashString } from './utils/hashString';
+import { hashSequence } from './utils/hashSequence';
 
 export function resolveClassesBySlots<Slots extends string>(
   resolvedStyles: ResolvedStylesBySlots<Slots>,
@@ -12,7 +12,7 @@ export function resolveClassesBySlots<Slots extends string>(
   // eslint-disable-next-line guard-for-in
   for (const slotName in resolvedStyles) {
     const slotClasses = renderer.insertDefinitions(dir, resolvedStyles[slotName]);
-    const sequenceHash = SEQUENCE_PREFIX + hashString(slotClasses + dir);
+    const sequenceHash = hashSequence(slotClasses, dir);
 
     const resultSlotClasses = sequenceHash + ' ' + slotClasses;
 

--- a/packages/make-styles/src/runtime/utils/hashSequence.ts
+++ b/packages/make-styles/src/runtime/utils/hashSequence.ts
@@ -1,0 +1,6 @@
+import { SEQUENCE_PREFIX } from '../../constants';
+import { hashString } from './hashString';
+
+export function hashSequence(classes: string, dir: 'ltr' | 'rtl') {
+  return SEQUENCE_PREFIX + hashString(classes + dir);
+}


### PR DESCRIPTION
Quick bugfix (not definitive solution) for a bug 🐛  on make-styles, where classes for different text directions  are colliding
