### PR TITLE
Cherry-picking the changes from PR #17330

### DIFF
--- a/change/office-ui-fabric-react-5497f0ac-dae2-400c-b130-385c39f5750d.json
+++ b/change/office-ui-fabric-react-5497f0ac-dae2-400c-b130-385c39f5750d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Adding aupport for customized role for DetailsList",
+  "comment": "DetailsList: Adding support for customized role.",
   "packageName": "office-ui-fabric-react",
   "email": "vishgup@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/office-ui-fabric-react-5497f0ac-dae2-400c-b130-385c39f5750d.json
+++ b/change/office-ui-fabric-react-5497f0ac-dae2-400c-b130-385c39f5750d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding aupport for customized role for DetailsList",
+  "packageName": "office-ui-fabric-react",
+  "email": "vishgup@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3810,6 +3810,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     onRowDidMount?: (item?: any, index?: number) => void;
     onRowWillUnmount?: (item?: any, index?: number) => void;
     onShouldVirtualize?: (props: IListProps) => boolean;
+    role?: string;
     rowElementEventMap?: {
         eventName: string;
         callback: (context: IDragDropContext, event?: any) => void;
@@ -3899,6 +3900,7 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     onRenderCheck?: (props: IDetailsRowCheckProps) => JSX.Element;
     onRenderDetailsCheckbox?: IRenderFunction<IDetailsCheckboxProps>;
     onWillUnmount?: (row?: DetailsRowBase) => void;
+    role?: string;
     rowFieldsAs?: React.ComponentType<IDetailsRowFieldsProps>;
     styles?: IStyleFunctionOrObject<IDetailsRowStyleProps, IDetailsRowStyles>;
     theme?: ITheme;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -179,6 +179,9 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     selectionZoneRef,
   } = props;
 
+  const defaultRole = 'grid';
+  const role = props.role ? props.role : defaultRole;
+
   const rowId = getId('row');
 
   const groupNestingDepth = getGroupNestingDepth(groups);
@@ -406,11 +409,11 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const finalGroupProps = React.useMemo((): IGroupRenderProps | undefined => {
     return {
       ...groupProps,
-      role: 'rowgroup',
+      role: role === defaultRole ? 'rowgroup' : 'presentation',
       onRenderFooter: finalOnRenderDetailsGroupFooter,
       onRenderHeader: finalOnRenderDetailsGroupHeader,
     };
-  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader]);
+  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, role]);
 
   const sumColumnWidths = useConst(() =>
     memoizeFunction((columns: IColumn[]) => {
@@ -433,6 +436,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       const finalOnRenderRow = props.onRenderRow
         ? composeRenderFunction(props.onRenderRow, onRenderDefaultRow)
         : onRenderDefaultRow;
+
+      const rowRole = role === defaultRole ? undefined : 'presentation';
 
       const rowProps: IDetailsRowProps = {
         item: item,
@@ -464,6 +469,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         enableUpdateAnimations,
         rowWidth,
         useFastIcons,
+        role: rowRole,
       };
 
       if (!item) {
@@ -506,6 +512,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       onRenderMissingItem,
       props.onRenderRow,
       rowWidth,
+      role,
     ],
   );
 
@@ -613,7 +620,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     >
       <FocusRects />
       <div
-        role="grid"
+        role={role}
         aria-label={ariaLabelForGrid}
         aria-rowcount={isPlaceholderData ? -1 : rowCount}
         aria-colcount={colCount}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -322,6 +322,9 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    * @defaultvalue true
    */
   useFastIcons?: boolean;
+
+  /** Role for the list. */
+  role?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -264,6 +264,9 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       />
     );
 
+    const defaultRole = 'row';
+    const role = this.props.role ? this.props.role : defaultRole;
+
     return (
       <FocusZone
         data-is-focusable={true}
@@ -277,7 +280,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         direction={FocusZoneDirection.horizontal}
         elementRef={this._root}
         componentRef={this._focusZone}
-        role="row"
+        role={role}
         aria-label={ariaLabel}
         aria-describedby={ariaDescribedBy}
         className={this._classNames.root}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -198,6 +198,9 @@ export interface IDetailsRowBaseProps
    */
   useFastIcons?: boolean;
 
+  /** Role for the row. */
+  role?: string;
+
   /**
    * Id for row
    */


### PR DESCRIPTION
In DetailsList component, role="grid" is hard-coded. This PR contains changes to provide support for custom role of DetailsList.
If no role is provided in props, then "grid" is the default role.