### PR TITLE
Fix Hidden Panel bug where onDismiss is being fired on closed Panel

### DIFF
--- a/change/@fluentui-react-259aad7e-bfe3-4c49-b23b-a7b8199390a0.json
+++ b/change/@fluentui-react-259aad7e-bfe3-4c49-b23b-a7b8199390a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Hidden Panel bug where onDismiss is being fired while panel is closed",
+  "packageName": "@fluentui/react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -283,7 +283,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
   }
 
   public dismiss = (ev?: React.SyntheticEvent<HTMLElement> | KeyboardEvent): void => {
-    if (this.props.onDismiss) {
+    if (this.props.onDismiss && this.isActive) {
       this.props.onDismiss(ev);
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17931 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR is to fix an issue with the hidden Panel variant where `onDismiss` fires when esc is pressed even when the Panel is hidden

#### Focus areas to test

(optional)
