### PR TITLE
DocumentCardTitleBase: avoid React setState lifecycles in rAF

### DIFF
--- a/change/@fluentui-react-ff79c167-b8c9-41d9-9568-6b8bdf3e12e9.json
+++ b/change/@fluentui-react-ff79c167-b8c9-41d9-9568-6b8bdf3e12e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rAF setState in DocumentCardTitleBase",
+  "packageName": "@fluentui/react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -151,6 +151,8 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
           (parseInt(style.height, 10) + TRUNCATION_VERTICAL_OVERFLOW_THRESHOLD) / parseInt(style.lineHeight, 10),
         );
 
+        element.style.whiteSpace = '';
+
         // Use overflow to predict truncated length.
         // Take an example.The text is: A text with A very long text that need to be truncated.ppt
         // if container is like

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -24,11 +24,8 @@ const TRUNCATION_VERTICAL_OVERFLOW_THRESHOLD = 5;
  */
 export class DocumentCardTitleBase extends React.Component<IDocumentCardTitleProps, IDocumentCardTitleState> {
   private _titleElement = React.createRef<HTMLDivElement>();
-  private _measureTitleElement = React.createRef<HTMLDivElement>();
-
   private _titleTruncationTimer: number;
   private _classNames: IProcessedStyleSet<IDocumentCardTitleStyles>;
-
   private _async: Async;
   private _events: EventGroup;
   private _clientWidth: number | undefined;
@@ -88,20 +85,8 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
       showAsSecondaryTitle,
     });
 
-    let documentCardTitle;
-    if (this._needMeasurement) {
-      documentCardTitle = (
-        <div
-          className={this._classNames.root}
-          ref={this._measureTitleElement}
-          title={title}
-          style={{ whiteSpace: 'nowrap' }}
-        >
-          {title}
-        </div>
-      );
-    } else if (shouldTruncate && truncatedTitleFirstPiece && truncatedTitleSecondPiece) {
-      documentCardTitle = (
+    if (shouldTruncate && truncatedTitleFirstPiece && truncatedTitleSecondPiece) {
+      return (
         <div className={this._classNames.root} ref={this._titleElement} title={title}>
           {truncatedTitleFirstPiece}
           &hellip;
@@ -109,13 +94,17 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
         </div>
       );
     } else {
-      documentCardTitle = (
-        <div className={this._classNames.root} ref={this._titleElement} title={title}>
+      return (
+        <div
+          className={this._classNames.root}
+          ref={this._titleElement}
+          title={title}
+          style={{ whiteSpace: this._needMeasurement ? 'nowrap' : undefined }}
+        >
           {title}
         </div>
       );
     }
-    return documentCardTitle;
   }
 
   /**
@@ -138,7 +127,7 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
 
   private _truncateWhenInAnimation: () => void = () => {
     const originalTitle = this.props.title;
-    const element: HTMLDivElement | null = this._measureTitleElement.current;
+    const element: HTMLDivElement | null = this._titleElement.current;
 
     if (element) {
       const style: CSSStyleDeclaration = getComputedStyle(element);

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -103,7 +103,7 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
           className={this._classNames.root}
           ref={this._titleElement}
           title={title}
-          style={{ whiteSpace: this._needMeasurement ? 'nowrap' : undefined }}
+          style={this._needMeasurement ? { whiteSpace: 'nowrap' } : undefined}
         >
           {title}
         </div>

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -59,7 +59,7 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
       } else {
         this._events.off(window, 'resize', this._updateTruncation);
       }
-    } else if (this._clientWidth === undefined && this.props.shouldTruncate) {
+    } else if (this._needMeasurement) {
       this._async.requestAnimationFrame(() => {
         this._truncateWhenInAnimation();
         this._shrinkTitle();

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -58,7 +58,7 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
 
     if (this.props.shouldTruncate) {
       this._truncateTitle();
-      requestAnimationFrame(this._shrinkTitle);
+      this._async.requestAnimationFrame(this._shrinkTitle);
       this._events.on(window, 'resize', this._updateTruncation);
     }
   }

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx
@@ -207,7 +207,7 @@ export class DocumentCardTitleBase extends React.Component<IDocumentCardTitlePro
         clearTimeout(this._titleTruncationTimer);
         if (this._clientWidth !== clientWidth) {
           this._titleTruncationTimer = this._async.setTimeout(() => {
-            this._clientWidth = clientWidth;
+            this._clientWidth = undefined;
             this.setState({
               truncatedTitleFirstPiece: undefined,
               truncatedTitleSecondPiece: undefined,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes `DocumentCardTitleBase` render perf
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`DocumentCardTitleBase` toggles a `needMeasurement: boolean` state parameter even when content is not overflowing `(s < 1)` causing unnecessary `setState` CPU work after initial render and on window `resize`. 

https://github.com/microsoft/fluentui/blob/7d2a0ee3af7ab8a13f4cf007bfed6aeebde35b23/packages/react/src/components/DocumentCard/DocumentCardTitle.base.tsx#L176

We noticed this while profiling SharePoint Online:

![image](https://user-images.githubusercontent.com/706967/116149813-7057b200-a697-11eb-8ab1-7591f7d2ab5d.png)

This pull-request removes the need for related state parameters to avoid unnecessary React lifecycle work.

### Before changes

Initial render rAFs on https://fluentuipr.z22.web.core.windows.net/pull/17963/react/storybook/iframe.html?id=components-documentcard--document-card-compact-example&viewMode=story

<img width="1440" alt="Screen Shot 2021-04-26 at 5 55 46 PM" src="https://user-images.githubusercontent.com/706967/116169178-f506f800-a6b8-11eb-9555-9513f02a23f6.png">

### After changes

Initial render rAFs on https://fluentuipr.z22.web.core.windows.net/pull/17963/react/storybook/iframe.html?id=components-documentcard--document-card-compact-example&viewMode=story

<img width="1152" alt="Screen Shot 2021-04-26 at 10 54 52 PM" src="https://user-images.githubusercontent.com/706967/116192375-9d7d8200-a6e2-11eb-99bd-f66e41559fe0.png">

#### Focus areas to test

- DocumentCardTitle with & without overflow & on 'resize' event
