### PR TITLE
Fix Slider to fire onChanged when Home and End are pressed

### DIFF
--- a/change/office-ui-fabric-react-47b90c33-a32e-451d-91d4-77cd5349df7d.json
+++ b/change/office-ui-fabric-react-47b90c33-a32e-451d-91d4-77cd5349df7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Slider to fire onChanged when Home and End are pressed",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -369,10 +369,18 @@ export class SliderBase extends React.Component<ISliderProps, ISliderState> impl
 
       case KeyCodes.home:
         value = min;
+
+        this._clearOnKeyDownTimer();
+        this._setOnKeyDownTimer(event);
+
         break;
 
       case KeyCodes.end:
         value = max;
+
+        this._clearOnKeyDownTimer();
+        this._setOnKeyDownTimer(event);
+
         break;
 
       default:


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17734 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

PR in master: #17966

This PR is to fix an issue where `onChanged` does not get triggered by the Home or End key, but can get triggered by the directional keys

#### Focus areas to test

(optional)
