### PR TITLE
MenuButton context menu is not positioned correctly

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct ref to `Toolbar` overflowSentinel @yuanboxue-amber ([#17813](https://github.com/microsoft/fluentui/pull/17813))
 - Fix `Carousel` to allow click in element inside item @assuncaocharles ([#17814](https://github.com/microsoft/fluentui/pull/17814))
 - Fix `chatMessageStyles` to show reactions on mouse over when variable `showActionMenu` is present @assuncaocharles ([#17853](https://github.com/microsoft/fluentui/pull/17853))
+- Fix `MenuButton` context position by removing right click reference object in `Popup` @petr-duda ([#17976](https://github.com/microsoft/fluentui/pull/17976))
 
 ### Features
 - Add default `backgroundActive2` and brand `backgroundPressed1` color slots @notandrew ([#17699](https://github.com/microsoft/fluentui/pull/17699))

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -222,6 +222,7 @@ export const Popup: React.FC<PopupProps> &
   const handleDocumentClick = (getRefs: Function) => (e: MouseEvent) => {
     if (isOpenedByRightClick && isOutsidePopupElement(getRefs(), e)) {
       trySetOpen(false, e);
+      rightClickReferenceObject.current = null;
       return;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #17797
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Currently the behaviour of Fluent UI MenuButton for context menu is such that if you right click, it will open at the place wherever you right click. But if you have another triggering element and put it as a target prop (e.g. "..." button in the Codesandbox example), then clicking on the three dots would open at the last position opened.

Codesandbox repro - https://codesandbox.io/s/sontextmenubutton-positionbug-wjzyl?file=/example.js

This PR will remove the right click reference object when the popup is closed so the next time you click on the context menu, it will determine the position from scratch (either below the button for left-click or it will create new reference from the right-click event position).

#### Focus areas to test

(optional)
