### PR TITLE
Legends missing accessible name issue resolved by adding aria-label

### DIFF
--- a/change/@fluentui-react-charting-fb11b55c-1ef8-4493-ba2f-efbca16247a5.json
+++ b/change/@fluentui-react-charting-fb11b55c-1ef8-4493-ba2f-efbca16247a5.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
-  "comment": "aria-lable added to legends and updated test cases",
+  "comment": "aria-label added to legends and updated test cases",
   "packageName": "@fluentui/react-charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-charting-fb11b55c-1ef8-4493-ba2f-efbca16247a5.json
+++ b/change/@fluentui-react-charting-fb11b55c-1ef8-4493-ba2f-efbca16247a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "aria-lable added to legends and updated test cases",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -215,6 +215,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -521,6 +522,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-OverflowSet
             {
@@ -1020,6 +1022,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1343,6 +1346,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1666,6 +1670,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1989,6 +1994,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -511,6 +512,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -986,6 +988,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1344,6 +1347,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -273,6 +273,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -815,6 +816,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-OverflowSet
             {
@@ -1608,6 +1610,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -2167,6 +2170,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -2726,6 +2730,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -3285,6 +3290,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -514,6 +515,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1081,6 +1083,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1392,6 +1395,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -123,7 +123,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps, allowFocusOnLegends = true } = this.props;
     return (
       <OverflowSet
-        {...(allowFocusOnLegends && { role: 'listbox' })}
+        {...(allowFocusOnLegends && { role: 'listbox', 'aria-label': 'Legends' })}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -204,6 +204,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -499,6 +500,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-OverflowSet
             {
@@ -976,6 +978,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1288,6 +1291,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1600,6 +1604,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1912,6 +1917,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -287,6 +287,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -587,6 +588,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1141,6 +1143,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1628,6 +1631,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1003,6 +1003,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -655,6 +656,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-OverflowSet
             {
@@ -1288,6 +1290,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1767,6 +1770,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -2246,6 +2250,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -2725,6 +2730,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -458,6 +459,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-OverflowSet
             {
@@ -894,6 +896,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1230,6 +1233,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1566,6 +1570,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -1902,6 +1907,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {
@@ -2238,6 +2244,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-OverflowSet
                   {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added aria-label to the legends, to resolve accessibility issue in Legends.

#### Focus areas to test

Legends

#### Before fix

![image](https://user-images.githubusercontent.com/20105532/116350085-f2b6b200-a80e-11eb-9bad-48c7dfb24326.png)

#### After fix

![image](https://user-images.githubusercontent.com/20105532/116350245-3f01f200-a80f-11eb-88f5-501edd1f18a7.png)
