### PR TITLE
fix(DetailsList): add accessible name to group header checkboxes

### DIFF
--- a/change/@fluentui-react-935f309c-e864-42ac-ae2a-333f049a1f63.json
+++ b/change/@fluentui-react-935f309c-e864-42ac-ae2a-333f049a1f63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add DetailsList prop to name group header checkbox, and tie checkbox name to associated group name",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-420447c8-af08-49e6-b0fc-9a284a1041ee.json
+++ b/change/@fluentui-react-examples-420447c8-af08-49e6-b0fc-9a284a1041ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add aria-label string to DetailsList group header checkbox",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -106,6 +106,7 @@ export class DetailsListGroupedExample extends React.Component<{}, IDetailsListG
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
           checkButtonAriaLabel="select row"
+          checkButtonGroupAriaLabel="select section"
           onRenderDetailsHeader={this._onRenderDetailsHeader}
           groupProps={{
             showEmptyGroups: true,

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Large.Example.tsx
@@ -50,6 +50,7 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         ariaLabelForSelectionColumn="Toggle selection"
         checkButtonAriaLabel="select row"
+        checkButtonGroupAriaLabel="select section"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1312,6 +1312,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader10-check GroupHeader10"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -1352,6 +1354,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader10-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"
@@ -2714,6 +2717,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader12-check GroupHeader12"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -2754,6 +2759,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader12-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"
@@ -3134,6 +3140,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader14-check GroupHeader14"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -3174,6 +3182,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader14-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -967,6 +967,8 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                           >
                             <button
                               aria-checked={false}
+                              aria-label="select section"
+                              aria-labelledby="GroupHeader5-check GroupHeader5"
                               className=
                                   ms-GroupHeader-check
                                   {
@@ -1007,6 +1009,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   }
                               data-is-focusable={false}
                               data-selection-toggle={true}
+                              id="GroupHeader5-check"
                               onClick={[Function]}
                               role="checkbox"
                               type="button"

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -153,6 +153,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader3-check GroupHeader3"
                           className=
                               ms-GroupHeader-check
                               {
@@ -193,6 +194,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader3-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"
@@ -2151,6 +2153,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader6-check GroupHeader6"
                           className=
                               ms-GroupHeader-check
                               {
@@ -2191,6 +2194,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader6-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"
@@ -4149,6 +4153,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader9-check GroupHeader9"
                           className=
                               ms-GroupHeader-check
                               {
@@ -4189,6 +4194,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader9-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3788,6 +3788,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     checkboxCellClassName?: string;
     checkboxVisibility?: CheckboxVisibility;
     checkButtonAriaLabel?: string;
+    checkButtonGroupAriaLabel?: string;
     className?: string;
     columnReorderOptions?: IColumnReorderOptions;
     columns?: IColumn[];

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -420,7 +420,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         },
       },
     };
-  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, role]);
+  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, checkButtonGroupAriaLabel, role]);
 
   const sumColumnWidths = useConst(() =>
     memoizeFunction((columns: IColumn[]) => {

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -171,6 +171,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     getRowAriaLabel,
     getRowAriaDescribedBy,
     checkButtonAriaLabel,
+    checkButtonGroupAriaLabel,
     checkboxCellClassName,
     useReducedRowRenderer,
     enableUpdateAnimations,
@@ -412,6 +413,12 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       role: role === defaultRole ? 'rowgroup' : 'presentation',
       onRenderFooter: finalOnRenderDetailsGroupFooter,
       onRenderHeader: finalOnRenderDetailsGroupHeader,
+      // pass through custom group header checkbox label
+      headerProps: {
+        selectAllButtonProps: {
+          'aria-label': checkButtonGroupAriaLabel,
+        },
+      },
     };
   }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, role]);
 

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -904,3 +904,34 @@ describe('DetailsList', () => {
     expect(checkboxId).toEqual(detailsRowCheckSource[`aria-labelledby`].split(' ')[0]);
   });
 });
+
+it('names group header checkboxes based on checkButtonGroupAriaLabel', () => {
+  const container = document.createElement('div');
+  ReactDOM.render(
+    <DetailsList
+      items={mockData(5)}
+      groups={[
+        {
+          key: 'group0',
+          name: 'Group 0',
+          startIndex: 0,
+          count: 2,
+        },
+        {
+          key: 'group1',
+          name: 'Group 1',
+          startIndex: 2,
+          count: 3,
+        },
+      ]}
+      checkButtonGroupAriaLabel="select section"
+    />,
+    container,
+  );
+
+  const checkbox = container.querySelector('[role="checkbox"][aria-label="select section"]') as HTMLElement;
+  expect(checkbox).not.toBeNull();
+
+  const groupNameId = checkbox.getAttribute('aria-labelledby')?.split(' ')[1];
+  expect(container.querySelector(`#${groupNameId} span`)!.textContent).toEqual('Group 0');
+});

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -245,8 +245,11 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Accessible label describing or summarizing the list. */
   ariaLabel?: string;
 
-  /** Accessible label for the check button. */
+  /** Accessible label for the row check button, e.g. "select row". */
   checkButtonAriaLabel?: string;
+
+  /** Accessible label for the group header check button, e.g. "select section". */
+  checkButtonGroupAriaLabel?: string;
 
   /** Accessible label for the grid within the list. */
   ariaLabelForGrid?: string;

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -137,7 +137,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
                 type="button"
                 className={this._classNames.check}
                 role="checkbox"
+                id={`${this._id}-check`}
                 aria-checked={currentlySelected}
+                aria-labelledby={`${this._id}-check ${this._id}`}
                 data-selection-toggle={true}
                 onClick={this._onToggleSelectGroupClick}
                 {...selectAllButtonProps}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13385
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds an accessible name to Grouped DetailsList group header checkboxes, following the same pattern that was used to name row checkboxes in #17245:
- A prop was added to DetailsList to customize the checkbox name (e.g. "select section")
- The checkbox uses both that custom prop and the group header text as its accessible name

