### PR TITLE
Legends missing accessible name issue resolved by adding aria-label - cherryPick #17978

### DIFF
--- a/change/@uifabric-charting-b744c8ef-ad3d-4e26-901c-f774734364ce.json
+++ b/change/@uifabric-charting-b744c8ef-ad3d-4e26-901c-f774734364ce.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "cherry-pick of #17978 - added aria-label to the legends",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@uifabric-charting-b744c8ef-ad3d-4e26-901c-f774734364ce.json
+++ b/change/@uifabric-charting-b744c8ef-ad3d-4e26-901c-f774734364ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "cherry-pick of #17978 - added aria-label to the legends",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -215,6 +215,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -529,6 +530,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-FocusZone
             ms-OverflowSet
@@ -1036,6 +1038,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1367,6 +1370,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1698,6 +1702,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2029,6 +2034,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -519,6 +520,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1002,6 +1004,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1368,6 +1371,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -273,6 +273,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -823,6 +824,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-FocusZone
             ms-OverflowSet
@@ -1624,6 +1626,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2191,6 +2194,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2758,6 +2762,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -3325,6 +3330,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -522,6 +523,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1097,6 +1099,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1416,6 +1419,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -123,7 +123,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps, allowFocusOnLegends = true } = this.props;
     return (
       <OverflowSet
-        {...(allowFocusOnLegends && { role: 'listbox' })}
+        {...(allowFocusOnLegends && { role: 'listbox', 'aria-label': 'Legends' })}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -204,6 +204,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -507,6 +508,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-FocusZone
             ms-OverflowSet
@@ -992,6 +994,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1312,6 +1315,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1632,6 +1636,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1952,6 +1957,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -287,6 +287,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -595,6 +596,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1157,6 +1159,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1652,6 +1655,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1003,6 +1003,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -663,6 +664,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-FocusZone
             ms-OverflowSet
@@ -1304,6 +1306,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1791,6 +1794,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2278,6 +2282,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2765,6 +2770,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -466,6 +467,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
           }
     >
       <div
+        aria-label="Legends"
         className=
             ms-FocusZone
             ms-OverflowSet
@@ -910,6 +912,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1254,6 +1257,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1598,6 +1602,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -1942,6 +1947,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet
@@ -2286,6 +2292,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
             }
           >
             <div
+              aria-label="Legends"
               className=
                   ms-FocusZone
                   ms-OverflowSet


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #https://github.com/microsoft/fluentui/pull/17978/files

## Original Description

#### Description of changes

Added aria-label to the legends, to resolve accessibility issue in Legends.

#### Focus areas to test

Legends

#### Before fix

![image](https://user-images.githubusercontent.com/20105532/116350085-f2b6b200-a80e-11eb-9bad-48c7dfb24326.png)

#### After fix

![image](https://user-images.githubusercontent.com/20105532/116350245-3f01f200-a80f-11eb-88f5-501edd1f18a7.png)

