### PR TITLE
Deprecate Fluent UI N* `Portal` component

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Documentation
 
 ### Deprecations
+- Set as deprecated `Portal` component @petr-duda ([#17983](https://github.com/microsoft/fluentui/pull/17983))
 
 <!--------------------------------[ v0.54.0 ]------------------------------- -->
 ## [v0.54.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.54.0) (2021-04-06)

--- a/packages/fluentui/react-northstar/src/components/Portal/Portal.tsx
+++ b/packages/fluentui/react-northstar/src/components/Portal/Portal.tsx
@@ -79,7 +79,9 @@ export interface PortalProps extends ChildrenComponentProps, ContentComponentPro
 }
 
 /**
- * A Portal allows to render children outside of their parent.
+ * (DEPRECATED) A Portal allows to render children outside of their parent.
+ *
+ * @deprecated Please use "Popup" component instead.
  */
 export const Portal: React.FC<PortalProps> & FluentComponentStaticProps<PortalProps> = props => {
   const context = useFluentContext();

--- a/packages/fluentui/react-northstar/src/components/Portal/Portal.tsx
+++ b/packages/fluentui/react-northstar/src/components/Portal/Portal.tsx
@@ -81,7 +81,7 @@ export interface PortalProps extends ChildrenComponentProps, ContentComponentPro
 /**
  * (DEPRECATED) A Portal allows to render children outside of their parent.
  *
- * @deprecated Please use "Popup" component instead.
+ * @deprecated Please use "Popup" or "Dialog" components instead.
  */
 export const Portal: React.FC<PortalProps> & FluentComponentStaticProps<PortalProps> = props => {
   const context = useFluentContext();


### PR DESCRIPTION
## Description of changes

This PR deprecates `Portal` component in `@fluentui/react-northstar`.

## Why?

This component came from Semantic UI React and was indented to be used as a base component for all components that are rendered out of DOM. In reality, it's used only in `Dialog` and even there `Dialog` component declares some overrides to behavior.

Currently `Portal` handles too much for a component that should render elements out of DOM order, but not enough to be useful like a separate component. As `Portal` renders elements out of DOM it also adds a lot of responsibilities to customers to handle accessibility properly.

## Moving forward

There is no direct replacement for `Portal` component, but please consider to use `Popup` or `Dialog` components instead.
