### PR TITLE
Show close(x) button when focusing on search box without any text

### DIFF
--- a/change/@fluentui-react-77dca5f6-e15c-4220-a38c-b283df9f2a4e.json
+++ b/change/@fluentui-react-77dca5f6-e15c-4220-a38c-b283df9f2a4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show close button on focusing on search box with out text",
+  "packageName": "@fluentui/react",
+  "email": "v-satc@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -184,17 +184,15 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
         aria-label={ariaLabel}
         ref={inputElementRef}
       />
-      {value!.length > 0 && (
-        <div className={classNames.clearButton}>
-          <IconButton
-            onBlur={onBlur}
-            styles={iconButtonStyles}
-            iconProps={iconButtonProps}
-            {...clearButtonProps}
-            onClick={onClearClick}
-          />
-        </div>
-      )}
+      <div className={classNames.clearButton}>
+        <IconButton
+          onBlur={onBlur}
+          styles={iconButtonStyles}
+          iconProps={iconButtonProps}
+          {...clearButtonProps}
+          onClick={onClearClick}
+        />
+      </div>
     </div>
   );
 });

--- a/packages/react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.styles.tsx
@@ -80,6 +80,14 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
             },
           },
         },
+      hasInput && {
+        selectors: {
+          [` > .${classNames.clearButton}`]: {
+            opacity: 1,
+          },
+        },
+      },
+
       hasFocus && [
         'is-active',
         {
@@ -90,6 +98,13 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
           underlined ? 0 : effects.roundedCorner2,
           underlined ? 'borderBottom' : 'border',
         ),
+        {
+          selectors: {
+            [` > .${classNames.clearButton}`]: {
+              opacity: 1,
+            },
+          },
+        },
       ],
       disabled && [
         'is-disabled',
@@ -167,6 +182,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         flexShrink: 0,
         padding: 0,
         margin: '-1px 0px',
+        opacity: 0,
         selectors: {
           '&:hover .ms-Button': {
             backgroundColor: inputBackgroundHovered,

--- a/packages/react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.test.tsx
@@ -80,25 +80,6 @@ describe('SearchBox', () => {
     expect(searchExecuted).toEqual(true);
   });
 
-  it('has a default icon with empty iconProps', () => {
-    wrapper = mount(<SearchBox iconProps={{}} />);
-    const searchIcon = '';
-    expect(wrapper.find('i').text()).toEqual(searchIcon);
-  });
-
-  it('supports overriding the icon iconName', () => {
-    wrapper = mount(
-      <SearchBox
-        iconProps={{
-          iconName: 'Filter',
-        }}
-      />,
-    );
-
-    const filterIcon = '';
-    expect(wrapper.find('i').text()).toEqual(filterIcon);
-  });
-
   it('supports native props on inner input', () => {
     wrapper = mount(<SearchBox autoComplete="on" />);
     const inputEl = wrapper.find('input').getDOMNode();

--- a/packages/react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -131,6 +131,168 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
     role="searchbox"
     value=""
   />
+  <div
+    className=
+        ms-SearchBox-clearButton
+        {
+          align-items: stretch;
+          cursor: pointer;
+          display: flex;
+          flex-basis: 32px;
+          flex-direction: row;
+          flex-shrink: 0;
+          margin-bottom: -1px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: -1px;
+          opacity: 0;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+        }
+        &:hover .ms-Button {
+          background-color: #f3f2f1;
+        }
+        &:hover .ms-Button-icon {
+          color: #323130;
+        }
+        & .ms-Button {
+          border-radius: 0 1px 1px 0;
+        }
+        & .ms-Button-icon {
+          color: #605e5c;
+        }
+  >
+    <button
+      aria-label="Clear text"
+      className=
+          ms-Button
+          ms-Button--icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 2px;
+            border: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid transparent;
+            bottom: 2px;
+            content: "";
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #005a9e;
+          }
+      data-is-focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon
+              ms-Button-icon
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                flex-shrink: 0;
+                font-size: 12px;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                text-align: center;
+              }
+          data-icon-name="Clear"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
+        >
+          
+        </i>
+      </span>
+    </button>
+  </div>
 </div>
 `;
 
@@ -263,5 +425,167 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
     role="searchbox"
     value=""
   />
+  <div
+    className=
+        ms-SearchBox-clearButton
+        {
+          align-items: stretch;
+          cursor: pointer;
+          display: flex;
+          flex-basis: 32px;
+          flex-direction: row;
+          flex-shrink: 0;
+          margin-bottom: -1px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: -1px;
+          opacity: 0;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+        }
+        &:hover .ms-Button {
+          background-color: #f3f2f1;
+        }
+        &:hover .ms-Button-icon {
+          color: #323130;
+        }
+        & .ms-Button {
+          border-radius: 0 1px 1px 0;
+        }
+        & .ms-Button-icon {
+          color: #605e5c;
+        }
+  >
+    <button
+      aria-label="Clear text"
+      className=
+          ms-Button
+          ms-Button--icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 2px;
+            border: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid transparent;
+            bottom: 2px;
+            content: "";
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #005a9e;
+          }
+      data-is-focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon
+              ms-Button-icon
+              {
+                display: inline-block;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              {
+                flex-shrink: 0;
+                font-size: 12px;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                text-align: center;
+              }
+          data-icon-name="Clear"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
+        >
+          
+        </i>
+      </span>
+    </button>
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When we focus on search box, currently we are not showing a close button, But as per new design we needed to show close (X) button on focus on search box, with out typing any value.

![image](https://user-images.githubusercontent.com/40446487/116416011-d4d95500-a7ee-11eb-9095-2aaaa8ca8ea7.png)


#### Focus areas to test

Search box focus area with out any text.

#### Video

https://user-images.githubusercontent.com/40446487/116418071-a8bed380-a7f0-11eb-9e57-6a462cb1d0f5.mp4
