### PR TITLE
Cherry-pick changes from PR #17802

### DIFF
--- a/change/@fluentui-react-3b98d60e-b005-4de8-bc22-8fe61dbe20b7.json
+++ b/change/@fluentui-react-3b98d60e-b005-4de8-bc22-8fe61dbe20b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-58144ccf-d3b9-41d8-addd-f2af487144ba.json
+++ b/change/@fluentui-react-58144ccf-d3b9-41d8-addd-f2af487144ba.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-f258e3b5-628f-4451-b1bd-a6650dd7bc61.json
+++ b/change/@fluentui-react-examples-f258e3b5-628f-4451-b1bd-a6650dd7bc61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react-examples",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-4fc31aca-789b-4454-a745-ffe444a93f39.json
+++ b/change/@fluentui-react-experiments-4fc31aca-789b-4454-a745-ffe444a93f39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persona presence indicator background clipping is changed so there is never any space between the border and the content regardless of the browser zoom level used.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "b.sjursen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -78,7 +78,7 @@ exports[`PersonaPresence renders available 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #6BB700;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -131,7 +131,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -204,7 +204,7 @@ exports[`PersonaPresence renders away 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #FFAA44;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -259,7 +259,7 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -329,7 +329,7 @@ exports[`PersonaPresence renders blocked 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -399,7 +399,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -465,7 +465,7 @@ exports[`PersonaPresence renders busy 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #C43148;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -512,7 +512,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -584,7 +584,7 @@ exports[`PersonaPresence renders do not disturb 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #C50F1F;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -641,7 +641,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;
@@ -713,7 +713,7 @@ exports[`PersonaPresence renders offline 1`] = `
       ms-Persona-presence
       {
         -ms-high-contrast-adjust: none;
-        background-clip: content-box;
+        background-clip: border-box;
         background-color: #ffffff;
         border-radius: 50%;
         border: 2px solid #ffffff;

--- a/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1,0 +1,1297 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
+<div
+  className=
+
+      {
+        max-width: 300px;
+      }
+>
+  <div
+    className=
+        ms-Facepile
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          width: auto;
+        }
+  >
+    <span
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            width: 1px;
+          }
+      id="id__0"
+    >
+      To move through the items use left and right arrow keys.
+    </span>
+    <div
+      className=
+          ms-Facepile-itemContainer
+          {
+            display: flex;
+          }
+    >
+      <ul
+        aria-label="Example list of Facepile personas"
+        className=
+            ms-Facepile-members
+            {
+              display: flex;
+              list-style-type: none;
+              margin-bottom: -2px;
+              margin-left: -2px;
+              margin-right: -2px;
+              margin-top: -2px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+            }
+      >
+        <li
+          className=
+              ms-Facepile-member
+              {
+                display: inline-flex;
+                flex: 0 0 auto;
+                margin-bottom: 2px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 2px;
+              }
+        >
+          <button
+            className=
+                ms-Button
+                ms-Facepile-itemButton
+                ms-Facepile-person
+                ms-Button--facepile
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 50%;
+                  border: none;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseMove={[Function]}
+            onMouseOut={[Function]}
+            onMouseUp={[Function]}
+            title="Annie Lindqvist"
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size32
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 32px;
+                        position: relative;
+                        text-align: center;
+                        width: 32px;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Image
+                        ms-Persona-image
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          border-radius: 50%;
+                          border: 0px;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
+                          width: 32px;
+                        }
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            object-fit: cover;
+                            opacity: 0;
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-presence
+                        {
+                          -ms-high-contrast-adjust: none;
+                          background-clip: border-box;
+                          background-color: #FFAA44;
+                          border-radius: 50%;
+                          border: 2px solid #ffffff;
+                          bottom: -2px;
+                          box-sizing: content-box;
+                          forced-color-adjust: none;
+                          height: 8px;
+                          position: absolute;
+                          right: -2px;
+                          text-align: center;
+                          top: auto;
+                          width: 8px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: WindowText;
+                          border-color: Window;
+                        }
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </span>
+          </button>
+        </li>
+        <li
+          className=
+              ms-Facepile-member
+              {
+                display: inline-flex;
+                flex: 0 0 auto;
+                margin-bottom: 2px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 2px;
+              }
+        >
+          <div
+            className=
+                ms-Facepile-itemButton
+                ms-Facepile-person
+                {
+                  background-color: transparent;
+                  border-radius: 50%;
+                  border: none;
+                  display: inline;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  text-align: center;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            data-is-focusable={true}
+            onMouseMove={[Function]}
+            onMouseOut={[Function]}
+            title="Aaron Reid"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #6BB700;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 8px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 8px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: Highlight;
+                        border-color: Window;
+                      }
+                  role="presentation"
+                />
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className=
+              ms-Facepile-member
+              {
+                display: inline-flex;
+                flex: 0 0 auto;
+                margin-bottom: 2px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 2px;
+              }
+        >
+          <button
+            className=
+                ms-Button
+                ms-Facepile-itemButton
+                ms-Facepile-person
+                ms-Button--facepile
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 50%;
+                  border: none;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseMove={[Function]}
+            onMouseOut={[Function]}
+            onMouseUp={[Function]}
+            title="Alex Lundberg"
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size32
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 32px;
+                        position: relative;
+                        text-align: center;
+                        width: 32px;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    aria-hidden="true"
+                    className=
+                        ms-Persona-initials
+                        {
+                          background-color: #8E562E;
+                          border-radius: 50%;
+                          color: #ffffff;
+                          font-size: 14px;
+                          font-weight: 600;
+                          height: 32px;
+                          line-height: 32px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          background-color: Window !important;
+                          border: 1px solid WindowText;
+                          box-sizing: border-box;
+                          color: WindowText;
+                          forced-color-adjust: none;
+                        }
+                        & i {
+                          font-weight: 600;
+                        }
+                  >
+                    <span>
+                      AL
+                    </span>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-presence
+                        {
+                          -ms-high-contrast-adjust: none;
+                          background-clip: border-box;
+                          background-color: #ffffff;
+                          border-radius: 50%;
+                          border: 2px solid #ffffff;
+                          bottom: -2px;
+                          box-sizing: content-box;
+                          forced-color-adjust: none;
+                          height: 8px;
+                          position: absolute;
+                          right: -2px;
+                          text-align: center;
+                          top: auto;
+                          width: 8px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: WindowText;
+                          border-color: Window;
+                        }
+                        &:before {
+                          border-radius: 50%;
+                          border: 1px solid #8A8886;
+                          box-sizing: border-box;
+                          content: "";
+                          height: 100%;
+                          left: 0px;
+                          position: absolute;
+                          top: 0px;
+                          width: 100%;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                          border-color: Window;
+                          height: calc(100% - 2px);
+                          left: 1px;
+                          top: 1px;
+                          width: calc(100% - 2px);
+                        }
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className=
+
+        {
+          padding-top: 20px;
+        }
+  >
+    <div
+      className=
+          ms-Slider
+          ms-Slider-enabled
+          ms-Slider-row
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 10px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 10px;
+            user-select: none;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              word-wrap: break-word;
+            }
+        htmlFor="Slider7"
+      >
+        Number of Personas:
+      </label>
+      <div
+        className=
+            ms-Slider-container
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
+      >
+        <div
+          aria-disabled={false}
+          aria-label="Number of Personas:"
+          aria-valuemax={5}
+          aria-valuemin={1}
+          aria-valuenow={3}
+          aria-valuetext="3"
+          className=
+              ms-Slider-slideBox
+              ms-Slider-showValue
+              ms-Slider-showTransitions
+              {
+                align-items: center;
+                background: transparent;
+                border: none;
+                display: flex;
+                flex-grow: 1;
+                height: 28px;
+                line-height: 28px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                position: relative;
+                width: auto;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active .ms-Slider-active {
+                background-color: #005a9e;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-active {
+                background-color: Highlight;
+              }
+              &:hover .ms-Slider-active {
+                background-color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-active {
+                background-color: Highlight;
+              }
+              &:active .ms-Slider-inactive {
+                background-color: #deecf9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
+                border-color: Highlight;
+              }
+              &:hover .ms-Slider-inactive {
+                background-color: #deecf9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
+                border-color: Highlight;
+              }
+              &:active .ms-Slider-thumb {
+                border: 2px solid #005a9e;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-thumb {
+                border-color: Highlight;
+              }
+              &:hover .ms-Slider-thumb {
+                border: 2px solid #005a9e;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-thumb {
+                border-color: Highlight;
+              }
+              &:active .ms-Slider-zeroTick {
+                background-color: #deecf9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-zeroTick {
+                background-color: Highlight;
+              }
+              &:hover .ms-Slider-zeroTick {
+                background-color: #deecf9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
+                background-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
+          data-is-focusable={true}
+          id="Slider7"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className=
+                ms-Slider-line
+                {
+                  display: flex;
+                  position: relative;
+                  width: 100%;
+                }
+          >
+            <span
+              className=
+                  ms-Slider-thumb
+                  {
+                    background: #ffffff;
+                    border-color: #605e5c;
+                    border-radius: 10px;
+                    border-style: solid;
+                    border-width: 2px;
+                    box-sizing: border-box;
+                    display: block;
+                    height: 16px;
+                    position: absolute;
+                    top: -6px;
+                    transform: translateX(-50%);
+                    transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+                    width: 16px;
+                  }
+              style={
+                Object {
+                  "left": "50%",
+                }
+              }
+            />
+            <span
+              className=
+                  ms-Slider-inactive
+                  {
+                    border-radius: 4px;
+                    box-sizing: border-box;
+                    height: 4px;
+                    width: 100%;
+                  }
+                  {
+                    background: #c8c6c4;
+                    transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    border: 1px solid WindowText;
+                  }
+              style={
+                Object {
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className=
+                  ms-Slider-active
+                  {
+                    border-radius: 4px;
+                    box-sizing: border-box;
+                    height: 4px;
+                    width: 100%;
+                  }
+                  {
+                    background: #605e5c;
+                    transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                  }
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
+            />
+            <span
+              className=
+                  ms-Slider-inactive
+                  {
+                    border-radius: 4px;
+                    box-sizing: border-box;
+                    height: 4px;
+                    width: 100%;
+                  }
+                  {
+                    background: #c8c6c4;
+                    transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    border: 1px solid WindowText;
+                  }
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
+            />
+          </div>
+        </div>
+        <label
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                flex-shrink: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                line-height: 1;
+                margin-bottom: 0;
+                margin-left: 8px;
+                margin-right: 8px;
+                margin-top: 0;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                white-space: nowrap;
+                width: 40px;
+                word-wrap: break-word;
+              }
+        >
+          3
+        </label>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Dropdown-container
+          {
+            margin-bottom: 10px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 10px;
+            padding-top: 0px;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        id="Dropdown8-label"
+      >
+        Persona Size:
+      </label>
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="Dropdown8-label Dropdown8-option"
+        className=
+            ms-Dropdown
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-color: #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              user-select: none;
+            }
+            &:hover .ms-Dropdown-title {
+              border-color: #323130;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:focus .ms-Dropdown-title {
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-title {
+              color: Highlight;
+            }
+            &:focus:after {
+              border-radius: 2px;
+              border: 2px solid #0078d4;
+              box-sizing: border-box;
+              content: '';
+              height: 100%;
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+              color: Highlight;
+            }
+            &:active .ms-Dropdown-title {
+              border-color: #0078d4;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:hover .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            &:focus .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+              color: Highlight;
+            }
+            &:active .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            &:hover .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:focus .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:active .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:hover .ms-Dropdown-title--hasError {
+              border-color: #a4262c;
+            }
+            &:active .ms-Dropdown-title--hasError {
+              border-color: #a4262c;
+            }
+        data-is-focusable={true}
+        data-ktp-target={true}
+        id="Dropdown8"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
+      >
+        <span
+          aria-atomic={true}
+          aria-invalid={false}
+          aria-live="polite"
+          className=
+              ms-Dropdown-title
+              {
+                background-color: #ffffff;
+                border-color: #605e5c;
+                border-radius: 2px;
+                border-style: solid;
+                border-width: 1px;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: block;
+                height: 32px;
+                line-height: 30px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow: hidden;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 28px;
+                padding-top: 0;
+                position: relative;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          id="Dropdown8-option"
+        >
+          size32
+        </span>
+        <span
+          className=
+              ms-Dropdown-caretDownWrapper
+              {
+                cursor: pointer;
+                height: 32px;
+                line-height: 30px;
+                position: absolute;
+                right: 8px;
+                top: 1px;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  pointer-events: none;
+                  speak: none;
+                }
+            data-icon-name="ChevronDown"
+          >
+            
+          </i>
+        </span>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Checkbox
+          is-checked
+          is-enabled
+          {
+            display: flex;
+            margin-bottom: 10px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 10px;
+            padding-top: 15px;
+            position: relative;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            background: #005a9e;
+            border-color: #005a9e;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #005a9e;
+            border-color: #005a9e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+            background: Highlight;
+            border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+            color: Window;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+            color: Window;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
+          }
+    >
+      <input
+        aria-checked="true"
+        aria-label="Fade In"
+        checked={true}
+        className=
+
+            {
+              background: none;
+              opacity: 0;
+              position: absolute;
+            }
+            .ms-Fabric--isFocusVisible &:focus + label::before {
+              outline-offset: 2px;
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+              outline: 1px solid WindowText;
+            }
+        data-ktp-execute-target={true}
+        id="checkbox-9"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      <label
+        className=
+            ms-Checkbox-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: flex-start;
+              cursor: pointer;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              position: relative;
+              user-select: none;
+            }
+            &::before {
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+        htmlFor="checkbox-9"
+      >
+        <div
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                background: #0078d4;
+                border-color: #0078d4;
+                border-radius: 2px;
+                border: 1px solid #323130;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-right: 4px;
+                overflow: hidden;
+                position: relative;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                background: Highlight;
+                border-color: Highlight;
+                forced-color-adjust: none;
+              }
+          data-ktp-target={true}
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 1;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                  forced-color-adjust: none;
+                }
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className=
+              ms-Checkbox-text
+              {
+                color: #323130;
+                font-size: 14px;
+                line-height: 20px;
+                margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: WindowText;
+                forced-color-adjust: none;
+              }
+        >
+          Fade In
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -1,0 +1,2354 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctly 1`] = `
+<div>
+  <div>
+    <div
+      className="ms-BasePicker ms-PeoplePicker"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+    >
+      <span
+        hidden={true}
+        id="selected-items-id__0-label"
+      >
+        Selected contacts
+      </span>
+      <div
+        className="ms-SelectionZone"
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onDoubleClick={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onKeyDownCapture={[Function]}
+        onMouseDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-BasePicker-text
+              {
+                align-items: center;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-sizing: border-box;
+                display: flex;
+                flex-wrap: wrap;
+                min-height: 30px;
+                min-width: 180px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+        >
+          <input
+            aria-autocomplete="both"
+            aria-controls=""
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-label="Contacts"
+            autoCapitalize="off"
+            autoComplete="off"
+            className=
+                ms-BasePicker-input
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-self: flex-end;
+                  background-color: transparent;
+                  border-radius: 2px;
+                  border: none;
+                  color: #323130;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 30px;
+                  outline: none;
+                  padding-bottom: 0;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+            data-lpignore={true}
+            disabled={false}
+            id="combobox-id__0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onCompositionEnd={[Function]}
+            onCompositionStart={[Function]}
+            onCompositionUpdate={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            role="combobox"
+            spellCheck={false}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <label>
+       Click to Add a person 
+    </label>
+    <div>
+      <button
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #8a8886;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <div
+            className=
+                ms-Persona
+                ms-Persona--size48
+                ms-Persona--online
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 48px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                }
+                & .contextualHost {
+                  display: none;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size48
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 48px;
+                      position: relative;
+                      text-align: center;
+                      width: 48px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 48px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 48px;
+                      }
+                  style={
+                    Object {
+                      "height": 48,
+                      "width": 48,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #6BB700;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 12px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 12px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: Highlight;
+                        border-color: Window;
+                      }
+                  role="presentation"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Persona-presenceIcon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #ffffff;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 6px;
+                          font-style: normal;
+                          font-weight: normal;
+                          line-height: 12px;
+                          speak: none;
+                          vertical-align: top;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: Window;
+                        }
+                    data-icon-name="SkypeCheck"
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-Persona-details
+                  {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
+                    min-width: 0px;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-align: left;
+                    width: 100%;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-primaryText
+                    {
+                      color: #323130;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &:hover {
+                      color: #201f1e;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Annie Lindqvist
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-secondaryText
+                    {
+                      color: #605e5c;
+                      font-size: 12px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Designer
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-tertiaryText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  In a meeting
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-optionalText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Available at 4:00pm
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </button>
+    </div>
+    <div>
+      <button
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #8a8886;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <div
+            className=
+                ms-Persona
+                ms-Persona--size48
+                ms-Persona--busy
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 48px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                }
+                & .contextualHost {
+                  display: none;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size48
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 48px;
+                      position: relative;
+                      text-align: center;
+                      width: 48px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 48px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 48px;
+                      }
+                  style={
+                    Object {
+                      "height": 48,
+                      "width": 48,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #C43148;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 12px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 12px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: WindowText;
+                        border-color: Window;
+                      }
+                  role="presentation"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Persona-presenceIcon
+                        {
+                          color: #ffffff;
+                          display: inline-block;
+                          font-size: 6px;
+                          line-height: 12px;
+                          vertical-align: top;
+                          width: 1em;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: Window;
+                        }
+                    data-icon-name=""
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-Persona-details
+                  {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
+                    min-width: 0px;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-align: left;
+                    width: 100%;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-primaryText
+                    {
+                      color: #323130;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &:hover {
+                      color: #201f1e;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Aaron Reid
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-secondaryText
+                    {
+                      color: #605e5c;
+                      font-size: 12px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Designer
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-tertiaryText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  In a meeting
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-optionalText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Available at 4:00pm
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </button>
+    </div>
+    <div>
+      <button
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #8a8886;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <div
+            className=
+                ms-Persona
+                ms-Persona--size48
+                ms-Persona--donotdisturb
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 48px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                }
+                & .contextualHost {
+                  display: none;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size48
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 48px;
+                      position: relative;
+                      text-align: center;
+                      width: 48px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 48px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 48px;
+                      }
+                  style={
+                    Object {
+                      "height": 48,
+                      "width": 48,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #C50F1F;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 12px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 12px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: WindowText;
+                        border-color: Window;
+                      }
+                  role="presentation"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Persona-presenceIcon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #ffffff;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 6px;
+                          font-style: normal;
+                          font-weight: normal;
+                          line-height: 12px;
+                          speak: none;
+                          vertical-align: top;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: Window;
+                        }
+                    data-icon-name="SkypeMinus"
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-Persona-details
+                  {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
+                    min-width: 0px;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-align: left;
+                    width: 100%;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-primaryText
+                    {
+                      color: #323130;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &:hover {
+                      color: #201f1e;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Alex Lundberg
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-secondaryText
+                    {
+                      color: #605e5c;
+                      font-size: 12px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Software Developer
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-tertiaryText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  In a meeting
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-optionalText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Available at 4:00pm
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </button>
+    </div>
+    <div>
+      <button
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #8a8886;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <div
+            className=
+                ms-Persona
+                ms-Persona--size48
+                ms-Persona--offline
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 48px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                }
+                & .contextualHost {
+                  display: none;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size48
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 48px;
+                      position: relative;
+                      text-align: center;
+                      width: 48px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 48px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 48px;
+                      }
+                  style={
+                    Object {
+                      "height": 48,
+                      "width": 48,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #ffffff;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 12px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 12px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: WindowText;
+                        border-color: Window;
+                      }
+                      &:before {
+                        border-radius: 50%;
+                        border: 1px solid #8A8886;
+                        box-sizing: border-box;
+                        content: "";
+                        height: 100%;
+                        left: 0px;
+                        position: absolute;
+                        top: 0px;
+                        width: 100%;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                        border-color: Window;
+                        height: calc(100% - 2px);
+                        left: 1px;
+                        top: 1px;
+                        width: calc(100% - 2px);
+                      }
+                  role="presentation"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Persona-presenceIcon
+                        {
+                          border-color: #8A8886;
+                          color: #8A8886;
+                          display: inline-block;
+                          font-size: 6px;
+                          line-height: 12px;
+                          vertical-align: top;
+                          width: 1em;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: Window;
+                        }
+                    data-icon-name=""
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-Persona-details
+                  {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
+                    min-width: 0px;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-align: left;
+                    width: 100%;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-primaryText
+                    {
+                      color: #323130;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &:hover {
+                      color: #201f1e;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Roko Kolar
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-secondaryText
+                    {
+                      color: #605e5c;
+                      font-size: 12px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Financial Analyst
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-tertiaryText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  In a meeting
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-optionalText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Available at 4:00pm
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </button>
+    </div>
+    <div>
+      <button
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #8a8886;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <div
+            className=
+                ms-Persona
+                ms-Persona--size48
+                ms-Persona--online
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 48px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                }
+                & .contextualHost {
+                  display: none;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size48
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 48px;
+                      position: relative;
+                      text-align: center;
+                      width: 48px;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-radius: 50%;
+                        border: 0px;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 48px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 48px;
+                      }
+                  style={
+                    Object {
+                      "height": 48,
+                      "width": 48,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          object-fit: cover;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                  />
+                </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: border-box;
+                        background-color: #6BB700;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        forced-color-adjust: none;
+                        height: 12px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 12px;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        background-color: Highlight;
+                        border-color: Window;
+                      }
+                  role="presentation"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Persona-presenceIcon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #ffffff;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 6px;
+                          font-style: normal;
+                          font-weight: normal;
+                          line-height: 12px;
+                          speak: none;
+                          vertical-align: top;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: Window;
+                        }
+                    data-icon-name="SkypeCheck"
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-Persona-details
+                  {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
+                    min-width: 0px;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-align: left;
+                    width: 100%;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-primaryText
+                    {
+                      color: #323130;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &:hover {
+                      color: #201f1e;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Christian Bergqvist
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-secondaryText
+                    {
+                      color: #605e5c;
+                      font-size: 12px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Sr. Designer
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-tertiaryText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  In a meeting
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-optionalText
+                    {
+                      color: #605e5c;
+                      display: none;
+                      font-size: 14px;
+                      font-weight: 400;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                dir="auto"
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  Available at 4:00pm
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          margin-top: 10px;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="Disable People Picker"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-36"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-36"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Disable People Picker
+      </span>
+    </label>
+  </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          margin-top: 10px;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="Delay Suggestion Results"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-37"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-37"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Delay Suggestion Results
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1,0 +1,1774 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx correctly 1`] = `
+<div>
+  <div
+    className="ms-BasePicker ms-PeoplePicker"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <span
+      hidden={true}
+      id="selected-items-id__0-label"
+    >
+      Selected contacts
+    </span>
+    <div
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
+      onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="presentation"
+    >
+      <div
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+              position: relative;
+            }
+            &:hover {
+              border-color: #323130;
+            }
+      >
+        <span
+          aria-labelledby="selected-items-id__0-label"
+          className=
+              ms-BasePicker-itemsWrapper
+              {
+                display: flex;
+                flex-wrap: wrap;
+                max-width: 100%;
+              }
+          id="selected-items-id__0"
+          role="list"
+        >
+          <div
+            className=
+                ms-PickerPersona-container
+                {
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-PickerItem-content
+                  {
+                    flex: 0 1 auto;
+                    max-width: 100%;
+                    min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__27"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--online
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: border-box;
+                            background-color: #6BB700;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: Highlight;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Annie Lindqvist
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Designer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__27 selectedItemPersona-id__27"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
+                  }
+              data-is-focusable={true}
+              data-selection-index={0}
+              id="id__27"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+          <div
+            className=
+                ms-PickerPersona-container
+                {
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-PickerItem-content
+                  {
+                    flex: 0 1 auto;
+                    max-width: 100%;
+                    min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__28"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--busy
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: border-box;
+                            background-color: #C43148;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: WindowText;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Aaron Reid
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Designer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__28 selectedItemPersona-id__28"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
+                  }
+              data-is-focusable={true}
+              data-selection-index={1}
+              id="id__28"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+          <div
+            className=
+                ms-PickerPersona-container
+                {
+                  align-items: center;
+                  background: #f3f2f1;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 1px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 1px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -1px;
+                  content: "";
+                  left: -1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -1px;
+                  top: -1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-PickerItem-content
+                  {
+                    flex: 0 1 auto;
+                    max-width: 100%;
+                    min-width: 0px;
+                    overflow: hidden;
+                  }
+              id="selectedItemPersona-id__29"
+            >
+              <div
+                className=
+                    ms-Persona
+                    ms-Persona--size24
+                    ms-Persona--donotdisturb
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 24px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                    }
+                    & .contextualHost {
+                      display: none;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-coin
+                      ms-Persona--size24
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Persona-imageArea
+                        {
+                          flex: 0 0 auto;
+                          height: 24px;
+                          position: relative;
+                          text-align: center;
+                          width: 24px;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Image
+                          ms-Persona-image
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            border-radius: 50%;
+                            border: 0px;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 24px;
+                            left: 0px;
+                            margin-right: 10px;
+                            overflow: hidden;
+                            perspective: 1px;
+                            position: absolute;
+                            top: 0px;
+                            width: 24px;
+                          }
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        className=
+                            ms-Image-image
+                            ms-Image-image--cover
+                            ms-Image-image--portrait
+                            is-notLoaded
+                            is-fadeIn
+                            {
+                              display: block;
+                              height: 100%;
+                              object-fit: cover;
+                              opacity: 0;
+                              width: 100%;
+                            }
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+                      />
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-presence
+                          {
+                            -ms-high-contrast-adjust: none;
+                            background-clip: border-box;
+                            background-color: #C50F1F;
+                            border-radius: 50%;
+                            border: 2px solid #ffffff;
+                            bottom: -2px;
+                            box-sizing: content-box;
+                            forced-color-adjust: none;
+                            height: 8px;
+                            position: absolute;
+                            right: -2px;
+                            text-align: center;
+                            top: auto;
+                            width: 8px;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background-color: WindowText;
+                            border-color: Window;
+                          }
+                      role="presentation"
+                    />
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-details
+                      {
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: space-around;
+                        min-width: 0px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        text-align: left;
+                        width: 100%;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-primaryText
+                        {
+                          color: #323130;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                        &:hover {
+                          color: #201f1e;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Alex Lundberg
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-secondaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 12px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Software Developer
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-tertiaryText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      In a meeting
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-optionalText
+                        {
+                          color: #605e5c;
+                          display: none;
+                          font-size: 14px;
+                          font-weight: 400;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
+                        }
+                    dir="auto"
+                  >
+                    <div
+                      className=
+                          ms-TooltipHost
+                          {
+                            display: inline;
+                          }
+                      onBlurCapture={[Function]}
+                      onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      Available at 4:00pm
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-label="Remove"
+              aria-labelledby="id__29 selectedItemPersona-id__29"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-PickerItem-removeButton
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 15px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #c8c6c4;
+                    color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #005a9e;
+                  }
+              data-is-focusable={true}
+              data-selection-index={2}
+              id="id__29"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </span>
+        <input
+          aria-autocomplete="both"
+          aria-controls=""
+          aria-describedby="selected-items-id__0"
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="People Picker"
+          autoCapitalize="off"
+          autoComplete="off"
+          className=
+              ms-BasePicker-input
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: flex-end;
+                background-color: transparent;
+                border-radius: 2px;
+                border: none;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 30px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+          data-lpignore={true}
+          disabled={false}
+          id="combobox-id__0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onCompositionUpdate={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          role="combobox"
+          spellCheck={false}
+          style={
+            Object {
+              "fontFamily": "inherit",
+            }
+          }
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          margin-top: 10px;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="Disable People Picker"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-25"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-25"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Disable People Picker
+      </span>
+    </label>
+  </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          margin-top: 10px;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="Delay Suggestion Results"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-26"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-26"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Delay Suggestion Results
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -1,0 +1,796 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] = `
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 10px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
+>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size24
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 36px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 24px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size24
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 24px;
+              position: relative;
+              text-align: center;
+              width: 24px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 24px;
+              }
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
+            }
+          }
+        >
+          <img
+            alt="Annie Ried, status is unknown"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Reid
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Designer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size32
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 32px;
+              }
+          style={
+            Object {
+              "height": 32,
+              "width": 32,
+            }
+          }
+        >
+          <img
+            alt="Annie Ried, status is unknown"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Reid
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Designer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size32
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 32px;
+              }
+          style={
+            Object {
+              "height": 32,
+              "width": 32,
+            }
+          }
+        >
+          <img
+            alt="Annie Ried, status is available at 4 PM"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #6BB700;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
+          role="presentation"
+        />
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Reid
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Designer (Available)
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -1,0 +1,3212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 10px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
+>
+  <div
+    className=
+        ms-Checkbox
+        is-checked
+        is-enabled
+        {
+          display: flex;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          background: #005a9e;
+          border-color: #005a9e;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          background: #005a9e;
+          border-color: #005a9e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          background: Highlight;
+          border-color: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+          background: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+          background: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+          color: Window;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Window;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      aria-checked="true"
+      aria-label="Include persona details"
+      checked={true}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-0"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-0"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: #0078d4;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background: Highlight;
+              border-color: Highlight;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Include persona details
+      </span>
+    </label>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 8 Persona, with no presence
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size8
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 20px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 20px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size8
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <i
+        aria-hidden={true}
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 10px;
+              font-style: normal;
+              font-weight: normal;
+              left: 0px;
+              position: absolute;
+              right: auto;
+              speak: none;
+              top: 5px;
+            }
+        data-icon-name="Contact"
+      >
+        
+      </i>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 17px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 12px;
+              font-weight: 400;
+              line-height: 20px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 8 Persona, with presence
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size8
+        ms-Persona--offline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 20px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 20px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size8
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: border-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 0px;
+              bottom: -2px;
+              box-sizing: content-box;
+              forced-color-adjust: none;
+              height: 8px;
+              left: 0px;
+              position: absolute;
+              right: auto;
+              text-align: center;
+              top: 7px;
+              width: 8px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              background-color: WindowText;
+              border-color: Window;
+              border: 1px solid WindowText;
+              top: 9px;
+            }
+            &:before {
+              border-radius: 50%;
+              border: 1px solid #8A8886;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+        role="presentation"
+      />
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 17px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 12px;
+              font-weight: 400;
+              line-height: 20px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 24 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size24
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 24px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 24px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size24
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 24px;
+              position: relative;
+              text-align: center;
+              width: 24px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 24px;
+              }
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is online"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #6BB700;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
+          role="presentation"
+        />
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist (Available)
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 32 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size32
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 32px;
+              }
+          style={
+            Object {
+              "height": 32,
+              "width": 32,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is online"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #6BB700;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
+          role="presentation"
+        />
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist (Available)
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 40 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size40
+        ms-Persona--away
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 40px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 40px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size40
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 40px;
+              position: relative;
+              text-align: center;
+              width: 40px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 40px;
+              }
+          style={
+            Object {
+              "height": 40,
+              "width": 40,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is away"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #FFAA44;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 12px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 12px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 6px;
+                  font-style: normal;
+                  font-weight: normal;
+                  left: 1px;
+                  line-height: 12px;
+                  position: relative;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name="SkypeClock"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 48 Persona (default) 
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size48
+        ms-Persona--busy
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 48px;
+              }
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is busy"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #C43148;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 12px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 12px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #ffffff;
+                  display: inline-block;
+                  font-size: 6px;
+                  line-height: 12px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 56 Persona (default) 
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size56
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 56px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 56px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size56
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 56px;
+              position: relative;
+              text-align: center;
+              width: 56px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 56px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 56px;
+              }
+          style={
+            Object {
+              "height": 56,
+              "width": 56,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is online"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #6BB700;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 16px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 16px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 8px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 16px;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name="SkypeCheck"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 20px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 72 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size72
+        ms-Persona--donotdisturb
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
+              }
+          style={
+            Object {
+              "height": 72,
+              "width": 72,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is dnd"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #C50F1F;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 20px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 20px;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name="SkypeMinus"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 20px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: none;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 100 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size100
+        ms-Persona--blocked
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 100px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size100
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 100px;
+              position: relative;
+              text-align: center;
+              width: 100px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 100px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100px;
+              }
+          style={
+            Object {
+              "height": 100,
+              "width": 100,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is blocked"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #ffffff;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 28px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 28px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+              &:after {
+                background-color: #C43148;
+                content: "";
+                height: 2px;
+                left: 0px;
+                position: absolute;
+                top: 50%;
+                transform: translateY(-50%) rotate(-45deg);
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                background-color: Window;
+                left: 2px;
+                width: calc(100% - 4px);
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #C43148;
+                box-sizing: border-box;
+                content: "";
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                border-color: Window;
+                height: calc(100% - 2px);
+                left: 1px;
+                top: 1px;
+                width: calc(100% - 2px);
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #ffffff;
+                  display: inline-block;
+                  font-size: 14px;
+                  line-height: 28px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 20px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Size 120 Persona
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size120
+        ms-Persona--away
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 120px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 120px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size120
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 120px;
+              position: relative;
+              text-align: center;
+              width: 120px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 120px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 120px;
+              }
+          style={
+            Object {
+              "height": 120,
+              "width": 120,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is away"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #FFAA44;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 32px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 32px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 14px;
+                  font-style: normal;
+                  font-weight: normal;
+                  left: 1px;
+                  line-height: 32px;
+                  position: relative;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name="SkypeClock"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-Persona-primaryText
+            {
+              color: #323130;
+              font-size: 20px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            &:hover {
+              color: #201f1e;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Annie Lindqvist
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #605e5c;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          In a meeting
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-optionalText
+            {
+              color: #605e5c;
+              display: block;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div
+          className=
+              ms-TooltipHost
+              {
+                display: inline;
+              }
+          onBlurCapture={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          Available at 4:00pm
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1`] = `
 <div
   className=
       ms-Stack
@@ -23,13 +23,13 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
       }
 >
   <div>
-    Custom render function in place of persona coin's image
+    Custom icon in secondary text
   </div>
   <div
     className=
         ms-Persona
         ms-Persona--size72
-        ms-Persona--online
+        ms-Persona--offline
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
@@ -42,10 +42,10 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           font-size: 14px;
           font-weight: 400;
           height: 72px;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
           min-width: 72px;
           padding-bottom: 0px;
           padding-left: 0px;
@@ -56,12 +56,6 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         & .contextualHost {
           display: none;
         }
-    style={
-      Object {
-        "height": 72,
-        "minWidth": 72,
-      }
-    }
   >
     <div
       className=
@@ -87,32 +81,62 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               width: 72px;
             }
         role="presentation"
-        style={
-          Object {
-            "height": 72,
-            "width": 72,
-          }
-        }
       >
-        <img
-          alt="Ted Randall, status is available at 4 PM"
+        <div
           className=
-
+              ms-Image
+              ms-Persona-image
               {
-                border-radius: 20px;
-                display: block;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
               }
-          height={72}
-          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
-          width={72}
-        />
+          style={
+            Object {
+              "height": 72,
+              "width": 72,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is offline."
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
         <div
           className=
               ms-Persona-presence
               {
                 -ms-high-contrast-adjust: none;
                 background-clip: border-box;
-                background-color: #6BB700;
+                background-color: #ffffff;
                 border-radius: 50%;
                 border: 2px solid #ffffff;
                 bottom: -2px;
@@ -126,47 +150,48 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
                 width: 20px;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                background-color: Highlight;
+                background-color: WindowText;
                 border-color: Window;
               }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #8A8886;
+                box-sizing: border-box;
+                content: "";
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                border-color: Window;
+                height: calc(100% - 2px);
+                left: 1px;
+                top: 1px;
+                width: calc(100% - 2px);
+              }
           role="presentation"
-          style={
-            Object {
-              "height": "24px",
-              "width": "24px",
-            }
-          }
         >
           <i
             aria-hidden={true}
             className=
+                ms-Icon-placeHolder
                 ms-Persona-presenceIcon
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #ffffff;
+                  border-color: #8A8886;
+                  color: #8A8886;
                   display: inline-block;
-                  font-family: "FabricMDL2Icons";
                   font-size: 12px;
-                  font-style: normal;
-                  font-weight: normal;
                   line-height: 20px;
-                  speak: none;
                   vertical-align: top;
+                  width: 1em;
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                   color: Window;
                 }
-            data-icon-name="SkypeCheck"
-            style={
-              Object {
-                "fontSize": "12px",
-                "lineHeight": "24px",
-              }
-            }
-          >
-            
-          </i>
+            data-icon-name=""
+          />
         </div>
       </div>
     </div>
@@ -214,7 +239,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          Ted Randall
+          Annie Lindqvist
         </div>
       </div>
       <div
@@ -222,6 +247,42 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
             ms-Persona-secondaryText
             {
               color: #605e5c;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        dir="auto"
+      >
+        <div>
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-6";
+                  font-style: normal;
+                  font-weight: normal;
+                  margin-right: 5px;
+                  speak: none;
+                }
+            data-icon-name="Suitcase"
+          >
+            
+          </i>
+          Software Engineer
+        </div>
+      </div>
+      <div
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #605e5c;
+              display: block;
               font-size: 14px;
               font-weight: 400;
               overflow: hidden;
@@ -242,23 +303,9 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          Project Manager
+          In a meeting
         </div>
       </div>
-      <div
-        className=
-            ms-Persona-tertiaryText
-            {
-              color: #605e5c;
-              display: block;
-              font-size: 14px;
-              font-weight: 400;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-        dir="auto"
-      />
       <div
         className=
             ms-Persona-optionalText

--- a/packages/react-examples/src/react/__snapshots__/Persona.Presence.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Presence.Example.tsx.shot
@@ -1,0 +1,7998 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] = `
+<div
+  className=
+
+      & .ms-Persona {
+        margin-bottom: 20px;
+        margin-left: 0;
+        margin-right: 20px;
+        margin-top: 0;
+      }
+>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Online
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #6BB700;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: Highlight;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #6BB700;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: Highlight;
+                      border-color: Window;
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #6BB700;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: Highlight;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeCheck"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #6BB700;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: Highlight;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeCheck"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Online + Out of Office
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #6BB700;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #6BB700;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #6BB700;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #6BB700;
+                        color: #6BB700;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeCheck"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--online
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is online and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #6BB700;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #6BB700;
+                        color: #6BB700;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeCheck"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Away
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #FFAA44;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #FFAA44;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #FFAA44;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        left: 1px;
+                        line-height: 12px;
+                        position: relative;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeClock"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #FFAA44;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        left: 1px;
+                        line-height: 20px;
+                        position: relative;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeClock"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Away + Out of Office
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #B4009E;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #B4009E;
+                        color: #B4009E;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-16";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        position: relative;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeArrow"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--away
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is away and out of office."
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #B4009E;
+                        color: #B4009E;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-16";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        position: relative;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeArrow"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Busy
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #C43148;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C43148;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C43148;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        color: #ffffff;
+                        display: inline-block;
+                        font-size: 6px;
+                        line-height: 12px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C43148;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        color: #ffffff;
+                        display: inline-block;
+                        font-size: 12px;
+                        line-height: 20px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Busy + Out of Office
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #C43148;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #C43148;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #C43148;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        border-color: #C43148;
+                        color: #C43148;
+                        display: inline-block;
+                        font-size: 6px;
+                        line-height: 12px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--busy
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is busy and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #C43148;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        border-color: #C43148;
+                        color: #C43148;
+                        display: inline-block;
+                        font-size: 12px;
+                        line-height: 20px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Do not Disturb
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #C50F1F;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C50F1F;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C50F1F;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeMinus"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #C50F1F;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #ffffff;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeMinus"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Do not Disturb + Out of Office
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #C50F1F;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #C50F1F;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #C50F1F;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #C50F1F;
+                        color: #C50F1F;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeMinus"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--donotdisturb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #C50F1F;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #C50F1F;
+                        color: #C50F1F;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeMinus"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Blocked
+  </label>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Persona
+          ms-Persona--size8
+          ms-Persona--blocked
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: center;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 20px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            min-width: 20px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          & .contextualHost {
+            display: none;
+          }
+    >
+      <div
+        className=
+            ms-Persona-coin
+            ms-Persona--size8
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #ffffff;
+                border-radius: 50%;
+                border: 0px;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 8px;
+                left: 0px;
+                position: absolute;
+                right: auto;
+                text-align: center;
+                top: 7px;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+                border: 1px solid WindowText;
+                top: 9px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                background-color: Window;
+                left: 2px;
+                width: calc(100% - 4px);
+              }
+              &:before {
+                border-radius: 50%;
+                border: 1px solid #C43148;
+                box-sizing: border-box;
+                content: "";
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                border-color: Window;
+                height: calc(100% - 2px);
+                left: 1px;
+                top: 1px;
+                width: calc(100% - 2px);
+              }
+          role="presentation"
+        />
+      </div>
+      <div
+        className=
+            ms-Persona-details
+            {
+              display: flex;
+              flex-direction: column;
+              justify-content: space-around;
+              min-width: 0px;
+              padding-bottom: 0;
+              padding-left: 17px;
+              padding-right: 24px;
+              padding-top: 0;
+              text-align: left;
+              width: 100%;
+            }
+      >
+        <div
+          className=
+              ms-Persona-primaryText
+              {
+                color: #323130;
+                font-size: 12px;
+                font-weight: 400;
+                line-height: 20px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+              &:hover {
+                color: #201f1e;
+              }
+          dir="auto"
+        />
+        <div
+          className=
+              ms-Persona-secondaryText
+              {
+                color: #605e5c;
+                display: none;
+                font-size: 12px;
+                font-weight: 400;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          dir="auto"
+        />
+        <div
+          className=
+              ms-Persona-tertiaryText
+              {
+                color: #605e5c;
+                display: none;
+                font-size: 14px;
+                font-weight: 400;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          dir="auto"
+        />
+        <div
+          className=
+              ms-Persona-optionalText
+              {
+                color: #605e5c;
+                display: none;
+                font-size: 14px;
+                font-weight: 400;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          dir="auto"
+        />
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona
+          ms-Persona--size24
+          ms-Persona--blocked
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: center;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 24px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            min-width: 24px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          & .contextualHost {
+            display: none;
+          }
+    >
+      <div
+        className=
+            ms-Persona-coin
+            ms-Persona--size24
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Persona-imageArea
+              {
+                flex: 0 0 auto;
+                height: 24px;
+                position: relative;
+                text-align: center;
+                width: 24px;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Image
+                ms-Persona-image
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-radius: 50%;
+                  border: 0px;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 24px;
+                  left: 0px;
+                  margin-right: 10px;
+                  overflow: hidden;
+                  perspective: 1px;
+                  position: absolute;
+                  top: 0px;
+                  width: 24px;
+                }
+            style={
+              Object {
+                "height": 24,
+                "width": 24,
+              }
+            }
+          >
+            <img
+              alt="Annie Lindqvist, status is blocked"
+              className=
+                  ms-Image-image
+                  ms-Image-image--cover
+                  ms-Image-image--portrait
+                  is-notLoaded
+                  is-fadeIn
+                  {
+                    display: block;
+                    height: 100%;
+                    object-fit: cover;
+                    opacity: 0;
+                    width: 100%;
+                  }
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-presence
+                {
+                  -ms-high-contrast-adjust: none;
+                  background-clip: border-box;
+                  background-color: #ffffff;
+                  border-radius: 50%;
+                  border: 2px solid #ffffff;
+                  bottom: -2px;
+                  box-sizing: content-box;
+                  forced-color-adjust: none;
+                  height: 8px;
+                  position: absolute;
+                  right: -2px;
+                  text-align: center;
+                  top: auto;
+                  width: 8px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: WindowText;
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                  background-color: Window;
+                  left: 2px;
+                  width: calc(100% - 4px);
+                }
+                &:before {
+                  border-radius: 50%;
+                  border: 1px solid #C43148;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 100%;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  border-color: Window;
+                  height: calc(100% - 2px);
+                  left: 1px;
+                  top: 1px;
+                  width: calc(100% - 2px);
+                }
+            role="presentation"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona
+          ms-Persona--size48
+          ms-Persona--blocked
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: center;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 48px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            min-width: 48px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          & .contextualHost {
+            display: none;
+          }
+    >
+      <div
+        className=
+            ms-Persona-coin
+            ms-Persona--size48
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Persona-imageArea
+              {
+                flex: 0 0 auto;
+                height: 48px;
+                position: relative;
+                text-align: center;
+                width: 48px;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Image
+                ms-Persona-image
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-radius: 50%;
+                  border: 0px;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 48px;
+                  left: 0px;
+                  margin-right: 10px;
+                  overflow: hidden;
+                  perspective: 1px;
+                  position: absolute;
+                  top: 0px;
+                  width: 48px;
+                }
+            style={
+              Object {
+                "height": 48,
+                "width": 48,
+              }
+            }
+          >
+            <img
+              alt="Annie Lindqvist, status is blocked"
+              className=
+                  ms-Image-image
+                  ms-Image-image--cover
+                  ms-Image-image--portrait
+                  is-notLoaded
+                  is-fadeIn
+                  {
+                    display: block;
+                    height: 100%;
+                    object-fit: cover;
+                    opacity: 0;
+                    width: 100%;
+                  }
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-presence
+                {
+                  -ms-high-contrast-adjust: none;
+                  background-clip: border-box;
+                  background-color: #ffffff;
+                  border-radius: 50%;
+                  border: 2px solid #ffffff;
+                  bottom: -2px;
+                  box-sizing: content-box;
+                  forced-color-adjust: none;
+                  height: 12px;
+                  position: absolute;
+                  right: -2px;
+                  text-align: center;
+                  top: auto;
+                  width: 12px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: WindowText;
+                  border-color: Window;
+                }
+                &:after {
+                  background-color: #C43148;
+                  content: "";
+                  height: 1px;
+                  left: 0px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translateY(-50%) rotate(-45deg);
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                  background-color: Window;
+                  left: 2px;
+                  width: calc(100% - 4px);
+                }
+                &:before {
+                  border-radius: 50%;
+                  border: 1px solid #C43148;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 100%;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  border-color: Window;
+                  height: calc(100% - 2px);
+                  left: 1px;
+                  top: 1px;
+                  width: calc(100% - 2px);
+                }
+            role="presentation"
+          >
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Icon-placeHolder
+                  ms-Persona-presenceIcon
+                  {
+                    color: #ffffff;
+                    display: inline-block;
+                    font-size: 6px;
+                    line-height: 12px;
+                    vertical-align: top;
+                    width: 1em;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    color: Window;
+                  }
+              data-icon-name=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona
+          ms-Persona--size72
+          ms-Persona--blocked
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: center;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 72px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            min-width: 72px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          & .contextualHost {
+            display: none;
+          }
+    >
+      <div
+        className=
+            ms-Persona-coin
+            ms-Persona--size72
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Persona-imageArea
+              {
+                flex: 0 0 auto;
+                height: 72px;
+                position: relative;
+                text-align: center;
+                width: 72px;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Image
+                ms-Persona-image
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-radius: 50%;
+                  border: 0px;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 72px;
+                  left: 0px;
+                  margin-right: 10px;
+                  overflow: hidden;
+                  perspective: 1px;
+                  position: absolute;
+                  top: 0px;
+                  width: 72px;
+                }
+            style={
+              Object {
+                "height": 72,
+                "width": 72,
+              }
+            }
+          >
+            <img
+              alt="Annie Lindqvist, status is blocked"
+              className=
+                  ms-Image-image
+                  ms-Image-image--cover
+                  ms-Image-image--portrait
+                  is-notLoaded
+                  is-fadeIn
+                  {
+                    display: block;
+                    height: 100%;
+                    object-fit: cover;
+                    opacity: 0;
+                    width: 100%;
+                  }
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-presence
+                {
+                  -ms-high-contrast-adjust: none;
+                  background-clip: border-box;
+                  background-color: #ffffff;
+                  border-radius: 50%;
+                  border: 2px solid #ffffff;
+                  bottom: -2px;
+                  box-sizing: content-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  position: absolute;
+                  right: -2px;
+                  text-align: center;
+                  top: auto;
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: WindowText;
+                  border-color: Window;
+                }
+                &:after {
+                  background-color: #C43148;
+                  content: "";
+                  height: 2px;
+                  left: 0px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translateY(-50%) rotate(-45deg);
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                  background-color: Window;
+                  left: 2px;
+                  width: calc(100% - 4px);
+                }
+                &:before {
+                  border-radius: 50%;
+                  border: 2px solid #C43148;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 100%;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                  border-color: Window;
+                  height: calc(100% - 2px);
+                  left: 1px;
+                  top: 1px;
+                  width: calc(100% - 2px);
+                }
+            role="presentation"
+          >
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Icon-placeHolder
+                  ms-Persona-presenceIcon
+                  {
+                    color: #ffffff;
+                    display: inline-block;
+                    font-size: 12px;
+                    line-height: 20px;
+                    vertical-align: top;
+                    width: 1em;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    color: Window;
+                  }
+              data-icon-name=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Offline
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #8A8886;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #8A8886;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #8A8886;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        border-color: #8A8886;
+                        color: #8A8886;
+                        display: inline-block;
+                        font-size: 6px;
+                        line-height: 12px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #8A8886;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon-placeHolder
+                      ms-Persona-presenceIcon
+                      {
+                        border-color: #8A8886;
+                        color: #8A8886;
+                        display: inline-block;
+                        font-size: 12px;
+                        line-height: 20px;
+                        vertical-align: top;
+                        width: 1em;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Offline + Out of Office
+      </label>
+      <div
+        className=
+            ms-Stack
+            {
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: auto;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+      >
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size8
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 20px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 20px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size8
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #ffffff;
+                    border-radius: 50%;
+                    border: 0px;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 8px;
+                    left: 0px;
+                    position: absolute;
+                    right: auto;
+                    text-align: center;
+                    top: 7px;
+                    width: 8px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                    border: 1px solid WindowText;
+                    top: 9px;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 1px solid #B4009E;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            />
+          </div>
+          <div
+            className=
+                ms-Persona-details
+                {
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: space-around;
+                  min-width: 0px;
+                  padding-bottom: 0;
+                  padding-left: 17px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-align: left;
+                  width: 100%;
+                }
+          >
+            <div
+              className=
+                  ms-Persona-primaryText
+                  {
+                    color: #323130;
+                    font-size: 12px;
+                    font-weight: 400;
+                    line-height: 20px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  &:hover {
+                    color: #201f1e;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-secondaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 12px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-tertiaryText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+            <div
+              className=
+                  ms-Persona-optionalText
+                  {
+                    color: #605e5c;
+                    display: none;
+                    font-size: 14px;
+                    font-weight: 400;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+              dir="auto"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size24
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 24px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 24px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size24
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 24px;
+                    position: relative;
+                    text-align: center;
+                    width: 24px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 24px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 24px;
+                    }
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 8px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 8px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size48
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 48px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 48px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size48
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 48px;
+                    position: relative;
+                    text-align: center;
+                    width: 48px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 48px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 48px;
+                    }
+                style={
+                  Object {
+                    "height": 48,
+                    "width": 48,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 12px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 12px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 1px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #B4009E;
+                        color: #B4009E;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-16";
+                        font-size: 6px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 12px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeArrow"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona
+              ms-Persona--size72
+              ms-Persona--offline
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 72px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              & .contextualHost {
+                display: none;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size72
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 72px;
+                    position: relative;
+                    text-align: center;
+                    width: 72px;
+                  }
+              role="presentation"
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 72px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 72px;
+                    }
+                style={
+                  Object {
+                    "height": 72,
+                    "width": 72,
+                  }
+                }
+              >
+                <img
+                  alt="Annie Lindqvist, status is offline and out of office"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        object-fit: cover;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+              <div
+                className=
+                    ms-Persona-presence
+                    {
+                      -ms-high-contrast-adjust: none;
+                      background-clip: border-box;
+                      background-color: #ffffff;
+                      border-radius: 50%;
+                      border: 2px solid #ffffff;
+                      bottom: -2px;
+                      box-sizing: content-box;
+                      forced-color-adjust: none;
+                      height: 20px;
+                      position: absolute;
+                      right: -2px;
+                      text-align: center;
+                      top: auto;
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: WindowText;
+                      border-color: Window;
+                    }
+                    &:before {
+                      border-radius: 50%;
+                      border: 2px solid #B4009E;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 100%;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                      border-color: Window;
+                      height: calc(100% - 2px);
+                      left: 1px;
+                      top: 1px;
+                      width: calc(100% - 2px);
+                    }
+                role="presentation"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Persona-presenceIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border-color: #B4009E;
+                        color: #B4009E;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-16";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        line-height: 20px;
+                        speak: none;
+                        vertical-align: top;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        color: Window;
+                      }
+                  data-icon-name="SkypeArrow"
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Persona.PresenceColor.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.PresenceColor.Example.tsx.shot
@@ -1,0 +1,2506 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Persona.PresenceColor.Example.tsx correctly 1`] = `
+<div
+  className=
+
+      & .ms-Persona {
+        margin-bottom: 20px;
+        margin-left: 0;
+        margin-right: 20px;
+        margin-top: 0;
+      }
+>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Online
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--online
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is online."
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #fff;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: Highlight;
+                    border-color: Window;
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #000;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeCheck"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Online + Out of Office
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--online
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is online and out of office."
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #fff;
+                      color: #fff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeCheck"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Away
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--away
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is away."
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #fff;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #000;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      left: 1px;
+                      line-height: 20px;
+                      position: relative;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeClock"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Away + Out of Office
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--away
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is away and out of office."
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #fff;
+                      color: #fff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-16";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      position: relative;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeArrow"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Busy
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--busy
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is busy"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #fff;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Icon-placeHolder
+                    ms-Persona-presenceIcon
+                    {
+                      color: #000;
+                      display: inline-block;
+                      font-size: 12px;
+                      line-height: 20px;
+                      vertical-align: top;
+                      width: 1em;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Busy + Out of Office
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--busy
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is busy and out of office"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Icon-placeHolder
+                    ms-Persona-presenceIcon
+                    {
+                      border-color: #fff;
+                      color: #fff;
+                      display: inline-block;
+                      font-size: 12px;
+                      line-height: 20px;
+                      vertical-align: top;
+                      width: 1em;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        DnD
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--donotdisturb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is do not disturb"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #fff;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #000;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeMinus"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        DnD + Out of Office
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--donotdisturb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is do not disturb and out of office"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #fff;
+                      color: #fff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeMinus"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    Blocked
+  </label>
+  <div
+    className=
+        ms-Persona
+        ms-Persona--size72
+        ms-Persona--blocked
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+  >
+    <div
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
+        role="presentation"
+      >
+        <div
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 50%;
+                border: 0px;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
+              }
+          style={
+            Object {
+              "height": 72,
+              "width": 72,
+            }
+          }
+        >
+          <img
+            alt="Annie Lindqvist, status is blocked"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: 100%;
+                  object-fit: cover;
+                  opacity: 0;
+                  width: 100%;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: border-box;
+                background-color: #000;
+                border-radius: 50%;
+                border: 2px solid #000;
+                bottom: -2px;
+                box-sizing: content-box;
+                forced-color-adjust: none;
+                height: 20px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+              &:after {
+                background-color: #fff;
+                content: "";
+                height: 2px;
+                left: 0px;
+                position: absolute;
+                top: 50%;
+                transform: translateY(-50%) rotate(-45deg);
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+                background-color: Window;
+                left: 2px;
+                width: calc(100% - 4px);
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #fff;
+                box-sizing: border-box;
+                content: "";
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                border-color: Window;
+                height: calc(100% - 2px);
+                left: 1px;
+                top: 1px;
+                width: calc(100% - 2px);
+              }
+          role="presentation"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #000;
+                  display: inline-block;
+                  font-size: 12px;
+                  line-height: 20px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  color: Window;
+                }
+            data-icon-name=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Stack
+        {
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Offline
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--offline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is offline"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #8A8886;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Icon-placeHolder
+                    ms-Persona-presenceIcon
+                    {
+                      border-color: #8A8886;
+                      color: #8A8886;
+                      display: inline-block;
+                      font-size: 12px;
+                      line-height: 20px;
+                      vertical-align: top;
+                      width: 1em;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Stack
+          {
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-top: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+      >
+        Offline + Out of Office
+      </label>
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size72
+            ms-Persona--offline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 72px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 72px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size72
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 72px;
+                  position: relative;
+                  text-align: center;
+                  width: 72px;
+                }
+            role="presentation"
+          >
+            <div
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-radius: 50%;
+                    border: 0px;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 72px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 72px;
+                  }
+              style={
+                Object {
+                  "height": 72,
+                  "width": 72,
+                }
+              }
+            >
+              <img
+                alt="Annie Lindqvist, status is offline and out of office"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      object-fit: cover;
+                      opacity: 0;
+                      width: 100%;
+                    }
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+              />
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #000;
+                    border-radius: 50%;
+                    border: 2px solid #000;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 20px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+                  &:before {
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 100%;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    width: 100%;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+                    border-color: Window;
+                    height: calc(100% - 2px);
+                    left: 1px;
+                    top: 1px;
+                    width: calc(100% - 2px);
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #fff;
+                      color: #fff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-16";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 20px;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeArrow"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -1,0 +1,1187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] = `
+<div
+  className=
+
+      {
+        padding-bottom: 2px;
+        padding-left: 2px;
+        padding-right: 2px;
+        padding-top: 2px;
+      }
+      & > .ms-Shimmer-container {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
+>
+  <div
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={false}
+        aria-labelledby="Toggle0-stateText"
+        checked={false}
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 20px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #323130;
+            }
+            &:hover .ms-Toggle-thumb {
+              background-color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+            }
+        data-is-focusable={true}
+        data-ktp-target={true}
+        id="Toggle0"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <span
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #605e5c;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: 6px;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
+              }
+        />
+      </button>
+      <label
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              font-weight: 400;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
+      >
+        Toggle to load content
+      </label>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Shimmer-container
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
+            transform: translateZ(0);
+            transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+            forced-color-adjust: none;
+          }
+      style={
+        Object {
+          "width": "100%",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translateX(-100%);
+              width: 100%;
+            }
+      />
+      <div
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              position: relative;
+            }
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-ShimmerLine-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
+                fill: Window;
+              }
+          style={
+            Object {
+              "minWidth": "auto",
+              "width": "100%",
+            }
+          }
+        >
+          <svg
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
+            height="2"
+            width="2"
+          >
+            <path
+              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+            />
+          </svg>
+          <svg
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
+            height="2"
+            width="2"
+          >
+            <path
+              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+            />
+          </svg>
+          <svg
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
+            height="2"
+            width="2"
+          >
+            <path
+              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+            />
+          </svg>
+          <svg
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
+            height="2"
+            width="2"
+          >
+            <path
+              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-dataWrapper
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            transition: opacity 200ms;
+          }
+    >
+      <div
+        style={
+          Object {
+            "lineHeight": "1",
+            "minHeight": "16px",
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        
+        
+        
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      role="status"
+    />
+  </div>
+  <div
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={false}
+        aria-labelledby="Toggle1-stateText"
+        checked={false}
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 20px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #323130;
+            }
+            &:hover .ms-Toggle-thumb {
+              background-color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              border-color: Highlight;
+            }
+        data-is-focusable={true}
+        data-ktp-target={true}
+        id="Toggle1"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <span
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #605e5c;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: 6px;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
+              }
+        />
+      </button>
+      <label
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              font-weight: 400;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+        htmlFor="Toggle1"
+        id="Toggle1-stateText"
+      >
+        Toggle to load content
+      </label>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Shimmer-container
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
+            transform: translateZ(0);
+            transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+            forced-color-adjust: none;
+          }
+      style={
+        Object {
+          "width": "300",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translateX(-100%);
+              width: 100%;
+            }
+      />
+      <div
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
+      >
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerCircle-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 40px;
+                  min-width: 40px;
+                  width: 40px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border-color: Window;
+                }
+          >
+            <svg
+              className=
+                  ms-ShimmerCircle-svg
+                  {
+                    display: block;
+                    fill: #ffffff;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    fill: Window;
+                  }
+              height={40}
+              viewBox="0 0 10 10"
+              width={40}
+            >
+              <path
+                d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+              />
+            </svg>
+          </div>
+          <div
+            className=
+                ms-ShimmerGap-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 40px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "16px",
+                "width": 16,
+              }
+            }
+          />
+        </div>
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: wrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 10px;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 6px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 6px;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 8px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "90%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+          <div
+            className=
+                ms-ShimmerGap-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 20px;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "10%",
+              }
+            }
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-dataWrapper
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            transition: opacity 200ms;
+          }
+    >
+      <div
+        className=
+            ms-Persona
+            ms-Persona--size40
+            ms-Persona--away
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 40px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 40px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+      >
+        <div
+          className=
+              ms-Persona-coin
+              ms-Persona--size40
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 40px;
+                  position: relative;
+                  text-align: center;
+                  width: 40px;
+                }
+            role="presentation"
+          >
+            <div
+              aria-hidden="true"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #0078D4;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 16px;
+                    font-weight: 600;
+                    height: 40px;
+                    line-height: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                    forced-color-adjust: none;
+                  }
+                  & i {
+                    font-weight: 600;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-0";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                data-icon-name="Contact"
+              >
+                
+              </i>
+            </div>
+            <div
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: border-box;
+                    background-color: #FFAA44;
+                    border-radius: 50%;
+                    border: 2px solid #ffffff;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    forced-color-adjust: none;
+                    height: 12px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
+              role="presentation"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #ffffff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 6px;
+                      font-style: normal;
+                      font-weight: normal;
+                      left: 1px;
+                      line-height: 12px;
+                      position: relative;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      color: Window;
+                    }
+                data-icon-name="SkypeClock"
+              >
+                
+              </i>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-Persona-details
+              {
+                display: flex;
+                flex-direction: column;
+                justify-content: space-around;
+                min-width: 0px;
+                padding-bottom: 0;
+                padding-left: 12px;
+                padding-right: 12px;
+                padding-top: 0;
+                text-align: left;
+                width: 100%;
+              }
+        >
+          <div
+            className=
+                ms-Persona-primaryText
+                {
+                  color: #323130;
+                  font-size: 14px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+                &:hover {
+                  color: #201f1e;
+                }
+            dir="auto"
+          />
+          <div
+            className=
+                ms-Persona-secondaryText
+                {
+                  color: #605e5c;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+            dir="auto"
+          />
+          <div
+            className=
+                ms-Persona-tertiaryText
+                {
+                  color: #605e5c;
+                  display: none;
+                  font-size: 14px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+            dir="auto"
+          />
+          <div
+            className=
+                ms-Persona-optionalText
+                {
+                  color: #605e5c;
+                  display: none;
+                  font-size: 14px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
+            dir="auto"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -1,0 +1,462 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PersonaCoin renders a coin with a contact icon 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #0078D4;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-0";
+          font-size: 19.2px;
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Contact"
+  >
+    
+  </i>
+</div>
+`;
+
+exports[`PersonaCoin renders a coin with a contact icon for a Chinese name 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #69797E;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-0";
+          font-size: 19.2px;
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Contact"
+  >
+    
+  </i>
+</div>
+`;
+
+exports[`PersonaCoin renders a coin with the initials JB 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #0078D4;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <span
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          display: inline;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 19.2px;
+          font-weight: 400;
+          moz-osx-font-smoothing: grayscale;
+          webkit-font-smoothing: antialiased;
+        }
+  >
+    JB
+  </span>
+</div>
+`;
+
+exports[`PersonaCoin renders a correct persona 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #A4262C;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <span
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          display: inline;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 19.2px;
+          font-weight: 400;
+          moz-osx-font-smoothing: grayscale;
+          webkit-font-smoothing: antialiased;
+        }
+  >
+    JB
+  </span>
+</div>
+`;
+
+exports[`PersonaCoin renders a red coin 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: red;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <span
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          display: inline;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 19.2px;
+          font-weight: 400;
+          moz-osx-font-smoothing: grayscale;
+          webkit-font-smoothing: antialiased;
+        }
+  >
+    JB
+  </span>
+</div>
+`;
+
+exports[`PersonaCoin renders presence correctly when a very large coin is rendered 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #69797E;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 100px;
+        justify-content: center;
+        position: relative;
+        width: 100px;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-0";
+          font-size: 40px;
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Contact"
+  >
+    
+  </i>
+  <div
+    className=
+        ms-Persona-presence
+        {
+          -ms-high-contrast-adjust: none;
+          background-clip: border-box;
+          background-color: #C50F1F;
+          border-radius: 50%;
+          border: 2px solid #ffffff;
+          bottom: -2px;
+          box-sizing: content-box;
+          forced-color-adjust: none;
+          height: 12px;
+          position: absolute;
+          right: -2px;
+          text-align: center;
+          top: auto;
+          width: 12px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          background-color: WindowText;
+          border-color: Window;
+        }
+    role="presentation"
+    style={
+      Object {
+        "height": "33.333333333333336px",
+        "width": "33.333333333333336px",
+      }
+    }
+  >
+    <i
+      aria-hidden={true}
+      className=
+          ms-Persona-presenceIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #ffffff;
+            display: inline-block;
+            font-family: "FabricMDL2Icons";
+            font-size: 6px;
+            font-style: normal;
+            font-weight: normal;
+            line-height: 12px;
+            speak: none;
+            vertical-align: top;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            color: Window;
+          }
+      data-icon-name="SkypeMinus"
+      style={
+        Object {
+          "fontSize": "16.666666666666668px",
+          "lineHeight": "33.333333333333336px",
+        }
+      }
+    >
+      
+    </i>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders presence when it is passed 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #69797E;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-0";
+          font-size: 19.2px;
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Contact"
+  >
+    
+  </i>
+  <div
+    className=
+        ms-Persona-presence
+        {
+          -ms-high-contrast-adjust: none;
+          background-clip: border-box;
+          background-color: #C50F1F;
+          border-radius: 50%;
+          border: 2px solid #ffffff;
+          bottom: -2px;
+          box-sizing: content-box;
+          forced-color-adjust: none;
+          height: 12px;
+          position: absolute;
+          right: -2px;
+          text-align: center;
+          top: auto;
+          width: 12px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          background-color: WindowText;
+          border-color: Window;
+        }
+    role="presentation"
+    style={
+      Object {
+        "height": "16px",
+        "width": "16px",
+      }
+    }
+  >
+    <i
+      aria-hidden={true}
+      className=
+          ms-Persona-presenceIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #ffffff;
+            display: inline-block;
+            font-family: "FabricMDL2Icons";
+            font-size: 6px;
+            font-style: normal;
+            font-weight: normal;
+            line-height: 12px;
+            speak: none;
+            vertical-align: top;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            color: Window;
+          }
+      data-icon-name="SkypeMinus"
+      style={
+        Object {
+          "fontSize": "8px",
+          "lineHeight": "16px",
+        }
+      }
+    >
+      
+    </i>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders the coin with the provided image 1`] = `
+<div
+  className=
+      test-cn-root
+      {
+        align-items: center;
+        background-color: #69797E;
+        border-radius: 50%;
+        color: white;
+        display: flex;
+        height: 48px;
+        justify-content: center;
+        position: relative;
+        width: 48px;
+      }
+>
+  <span
+    className=
+        test-cn-initials
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          display: inline;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 19.2px;
+          font-weight: 400;
+          moz-osx-font-smoothing: grayscale;
+          webkit-font-smoothing: antialiased;
+        }
+  >
+    EG
+  </span>
+  <div
+    className=
+        ms-Image
+        test-cn-image
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border-radius: 50%;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          left: 0px;
+          overflow: hidden;
+          position: absolute;
+          top: 0px;
+          width: 48px;
+        }
+    style={
+      Object {
+        "height": 48,
+        "width": 48,
+      }
+    }
+  >
+    <img
+      alt=""
+      className=
+          ms-Image-image
+          ms-Image-image--cover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            object-fit: cover;
+            opacity: 0;
+            width: 100%;
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets//persona-male.png"
+    />
+  </div>
+</div>
+`;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -1,0 +1,907 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
+<div
+  className="ms-BasePicker ms-BaseExtendedPicker"
+  onCopy={[Function]}
+  onKeyDown={[Function]}
+>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+    data-focuszone-id="FocusZone0"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+  >
+    <div
+      className=
+          ms-SelectionZone
+          ms-UnifiedPicker-selectionZone
+          ms-UnifiedPicker-selectionZone
+          {
+            display: flex;
+            flex: 1 1 auto;
+          }
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
+      onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="presentation"
+    >
+      <div
+        className=
+            ms-BasePicker-text
+            ms-UnifiedPicker-text
+            {
+              border: 1px solid #a19f9d;
+              box-sizing: border-box;
+              display: flex;
+              flex: 1 1 auto;
+              min-height: 32px;
+              min-width: 180px;
+              padding-bottom: 1px;
+              padding-left: 1px;
+              padding-right: 1px;
+              padding-top: 1px;
+            }
+            &:hover {
+              border-color: #c7e0f4;
+            }
+      >
+        <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          className=
+              ms-BasePicker-div
+              ms-UnifiedPicker-div
+              {
+                display: flex;
+                flex: 1 1 auto;
+              }
+          onDragOver={[Function]}
+          onDrop={[Function]}
+          role="combobox"
+        >
+          <input
+            aria-autocomplete="list"
+            autoCapitalize="off"
+            autoComplete="off"
+            className=
+                ms-BasePicker-input
+                ms-UnifiedPicker-input
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border: none;
+                  display: flex;
+                  flex-grow: 1;
+                  flex: 1 1 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 34px;
+                  margin-bottom: 1px;
+                  margin-left: 1px;
+                  margin-right: 1px;
+                  margin-top: 1px;
+                  outline: none;
+                  padding-bottom: 0px;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+            data-lpignore={true}
+            disabled={false}
+            onChange={[Function]}
+            onClick={[Function]}
+            onCompositionEnd={[Function]}
+            onCompositionStart={[Function]}
+            onCompositionUpdate={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            style={
+              Object {
+                "fontFamily": "inherit",
+              }
+            }
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-BasePicker
+        ms-BaseFloatingPicker
+        ms-FloatingSuggestions
+
+  />
+</div>
+`;
+
+exports[`UnifiedPeoplePicker renders correctly with selected and suggested items 1`] = `
+<div
+  className="ms-BasePicker ms-BaseExtendedPicker"
+  onCopy={[Function]}
+  onKeyDown={[Function]}
+>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+  >
+    <div
+      className=
+          ms-SelectionZone
+          ms-UnifiedPicker-selectionZone
+          ms-UnifiedPicker-selectionZone
+          {
+            display: flex;
+            flex: 1 1 auto;
+          }
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
+      onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="presentation"
+    >
+      <div
+        className=
+            ms-BasePicker-text
+            ms-UnifiedPicker-text
+            {
+              border: 1px solid #a19f9d;
+              box-sizing: border-box;
+              display: flex;
+              flex: 1 1 auto;
+              min-height: 32px;
+              min-width: 180px;
+              padding-bottom: 1px;
+              padding-left: 1px;
+              padding-right: 1px;
+              padding-top: 1px;
+            }
+            &:hover {
+              border-color: #c7e0f4;
+            }
+      >
+        <div
+          aria-multiselectable="true"
+          aria-orientation="horizontal"
+          className=
+              ms-UnifiedPicker-listDiv
+              ms-UnifiedPicker-listDiv
+              {
+                display: inline-flex;
+                flex-wrap: wrap;
+                flex: 1 1 auto;
+              }
+          role="listbox"
+        >
+          <div
+            aria-labelledby="selectedItemPersona-id__2"
+            aria-selected={false}
+            className=
+                ms-PickerPersona-container
+                {
+                  align-items: center;
+                  background: #eff6fc;
+                  border-radius: 15px;
+                  cursor: default;
+                  display: inline-flex;
+                  margin-bottom: 4px;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 4px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: middle;
+                }
+                &:hover {
+                  background: #deecf9;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  background: Highlight;
+                  border: 1px solid ButtonText;
+                  color: HighlightText;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-PickerItem-content {
+                  color: HighlightText;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+                  color: HighlightText;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background: ButtonFace;
+                  border: 1px solid ButtonText;
+                  color: ButtonText;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& .ms-PickerItem-removeButton {
+                  color: ButtonText;
+                }
+            data-is-draggable={true}
+            data-is-focusable={true}
+            data-is-sub-focuszone={true}
+            data-selection-index={0}
+            draggable={true}
+            role="option"
+          >
+            <div
+              hidden={true}
+            >
+              <button
+                aria-label="Remove"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-PickerItem-removeButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 15px 0px 0px 15px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #005a9e;
+                      cursor: pointer;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      margin-right: -17px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: inherit;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      width: 44px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 2px;
+                      content: "";
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: inherit;
+                      color: inherit;
+                    }
+                    &:hover {
+                      background-color: #c7e0f4;
+                      color: #005a9e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      background: inherit;
+                      border-color: Highlight;
+                      color: inherit;
+                    }
+                    &:active {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                      background: inherit;
+                      color: inherit;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                        }
+                    data-icon-name="Add"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                        "fontSize": "14px",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+
+                  {
+                    display: inherit;
+                    position: relative;
+                  }
+            >
+              <div
+                className=
+                    ms-PickerItem-content
+                    {
+                      flex: 0 1 auto;
+                      max-width: 100%;
+                      min-width: 0px;
+                    }
+                id="selectedItemPersona-id__2"
+              >
+                <div
+                  className=
+                      ms-Persona
+                      ms-Persona--size32
+                      ms-Persona--online
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        align-items: center;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        color: inherit;
+                        display: flex;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        min-width: 32px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      & .contextualHost {
+                        display: none;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Persona-coin
+                        ms-Persona--size32
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                        }
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-Persona-imageArea
+                          {
+                            flex: 0 0 auto;
+                            height: 32px;
+                            position: relative;
+                            text-align: center;
+                            width: 32px;
+                          }
+                      role="presentation"
+                    >
+                      <div
+                        className=
+                            ms-Image
+                            ms-Persona-image
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              border-radius: 50%;
+                              border: 0px;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              height: 32px;
+                              left: 0px;
+                              margin-right: 10px;
+                              overflow: hidden;
+                              perspective: 1px;
+                              position: absolute;
+                              top: 0px;
+                              width: 32px;
+                            }
+                        style={
+                          Object {
+                            "height": 32,
+                            "width": 32,
+                          }
+                        }
+                      >
+                        <img
+                          alt=""
+                          className=
+                              ms-Image-image
+                              ms-Image-image--cover
+                              ms-Image-image--portrait
+                              is-notLoaded
+                              is-fadeIn
+                              {
+                                display: block;
+                                height: 100%;
+                                object-fit: cover;
+                                opacity: 0;
+                                width: 100%;
+                              }
+                          onError={[Function]}
+                          onLoad={[Function]}
+                          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                        />
+                      </div>
+                      <div
+                        className=
+                            ms-Persona-presence
+                            {
+                              -ms-high-contrast-adjust: none;
+                              background-clip: border-box;
+                              background-color: #6BB700;
+                              border-radius: 50%;
+                              border: 2px solid #ffffff;
+                              bottom: -2px;
+                              box-sizing: content-box;
+                              forced-color-adjust: none;
+                              height: 8px;
+                              position: absolute;
+                              right: -2px;
+                              text-align: center;
+                              top: auto;
+                              width: 8px;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background-color: Highlight;
+                              border-color: Window;
+                            }
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-details
+                        {
+                          display: flex;
+                          flex-direction: column;
+                          justify-content: space-around;
+                          min-width: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-align: left;
+                          width: 100%;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Persona-primaryText
+                          {
+                            color: #005a9e;
+                            font-size: 14px;
+                            font-weight: 400;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                          }
+                          &:hover {
+                            color: #005a9e;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            color: inherit;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            color: inherit;
+                          }
+                      dir="auto"
+                    >
+                      <div
+                        className=
+                            ms-TooltipHost
+                            {
+                              display: inline;
+                            }
+                        onBlurCapture={[Function]}
+                        onFocusCapture={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Annie Lindqvist
+                      </div>
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-secondaryText
+                          {
+                            color: #605e5c;
+                            display: none;
+                            font-size: 12px;
+                            font-weight: 400;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                          }
+                      dir="auto"
+                    >
+                      <div
+                        className=
+                            ms-TooltipHost
+                            {
+                              display: inline;
+                            }
+                        onBlurCapture={[Function]}
+                        onFocusCapture={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Designer
+                      </div>
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-tertiaryText
+                          {
+                            color: #605e5c;
+                            display: none;
+                            font-size: 14px;
+                            font-weight: 400;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                          }
+                      dir="auto"
+                    >
+                      <div
+                        className=
+                            ms-TooltipHost
+                            {
+                              display: inline;
+                            }
+                        onBlurCapture={[Function]}
+                        onFocusCapture={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        In a meeting
+                      </div>
+                    </div>
+                    <div
+                      className=
+                          ms-Persona-optionalText
+                          {
+                            color: #605e5c;
+                            display: none;
+                            font-size: 14px;
+                            font-weight: 400;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                          }
+                      dir="auto"
+                    >
+                      <div
+                        className=
+                            ms-TooltipHost
+                            {
+                              display: inline;
+                            }
+                        onBlurCapture={[Function]}
+                        onFocusCapture={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Available at 4:00pm
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <button
+                aria-label="Remove"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-PickerItem-removeButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 15px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #005a9e;
+                      cursor: pointer;
+                      display: inline-block;
+                      flex: 0 0 auto;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      width: 32px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 2px;
+                      content: "";
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: inherit;
+                      color: inherit;
+                    }
+                    &:hover {
+                      background-color: #c7e0f4;
+                      color: #005a9e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      background: inherit;
+                      border-color: Highlight;
+                      color: inherit;
+                    }
+                    &:active {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+                      background: inherit;
+                      color: inherit;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                        }
+                    data-icon-name="Cancel"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                        "fontSize": "14px",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            className=
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
+                {
+                  display: flex;
+                  flex: 1 1 auto;
+                }
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            role="combobox"
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="off"
+              autoComplete="off"
+              className=
+                  ms-BasePicker-input
+                  ms-UnifiedPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    display: flex;
+                    flex-grow: 1;
+                    flex: 1 1 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 34px;
+                    margin-bottom: 1px;
+                    margin-left: 1px;
+                    margin-right: 1px;
+                    margin-top: 1px;
+                    outline: none;
+                    padding-bottom: 0px;
+                    padding-left: 6px;
+                    padding-right: 6px;
+                    padding-top: 0;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
+              data-lpignore={true}
+              disabled={false}
+              onChange={[Function]}
+              onClick={[Function]}
+              onCompositionEnd={[Function]}
+              onCompositionStart={[Function]}
+              onCompositionUpdate={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              style={
+                Object {
+                  "fontFamily": "inherit",
+                }
+              }
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-BasePicker
+        ms-BaseFloatingPicker
+        ms-FloatingSuggestions
+
+  />
+</div>
+`;

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -1,0 +1,2264 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Persona renders Persona children correctly 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #498205;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          KL
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <span>
+      Persona Children
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: rgb(234, 234, 234);
+              border-radius: 50%;
+              color: rgb(168, 0, 0);
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-1";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="Help"
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with image 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Image
+            ms-Persona-image
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-radius: 50%;
+              border: 0px;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 48px;
+              left: 0px;
+              margin-right: 10px;
+              overflow: hidden;
+              perspective: 1px;
+              position: absolute;
+              top: 0px;
+              width: 48px;
+            }
+        style={
+          Object {
+            "height": 48,
+            "width": 48,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: 100%;
+                object-fit: cover;
+                opacity: 0;
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with initials 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #498205;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          KL
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with no props 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #0078D4;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-0";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="Contact"
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona which calls onRenderCoin callback without imageUrl 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #8E562E;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 42px;
+              font-weight: 600;
+              height: 100px;
+              line-height: 100px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          SV
+        </span>
+      </div>
+      <span
+        id="persona-coin-container"
+      />
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: border-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              forced-color-adjust: none;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:after {
+              background-color: #C43148;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #C43148;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+        role="presentation"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona which calls onRenderPersonaCoin callback with custom render 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-1";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Dictionary"
+  >
+    
+  </i>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Persona renders correctly with onRender callback 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Image
+            ms-Persona-image
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-radius: 50%;
+              border: 0px;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 100px;
+              left: 0px;
+              margin-right: 10px;
+              overflow: hidden;
+              perspective: 1px;
+              position: absolute;
+              top: 0px;
+              width: 100px;
+            }
+        style={
+          Object {
+            "height": 100,
+            "width": 100,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: 100%;
+                object-fit: cover;
+                opacity: 0;
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+        />
+      </div>
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: border-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              forced-color-adjust: none;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:after {
+              background-color: #C43148;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #C43148;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+        role="presentation"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin does not render the initials when showInitialsUntilImageLoads is false 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Image
+          ms-Persona-image
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-radius: 50%;
+            border: 0px;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 48px;
+            left: 0px;
+            margin-right: 10px;
+            overflow: hidden;
+            perspective: 1px;
+            position: absolute;
+            top: 0px;
+            width: 48px;
+          }
+      style={
+        Object {
+          "height": 48,
+          "width": 48,
+        }
+      }
+    >
+      <img
+        alt=""
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              object-fit: cover;
+              opacity: 0;
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders correctly 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #0078D4;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 16px;
+            font-weight: 600;
+            height: 48px;
+            line-height: 46px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          & i {
+            font-weight: 600;
+          }
+    >
+      <i
+        aria-hidden={true}
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
+        data-icon-name="Contact"
+      >
+        
+      </i>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders correctly with image 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Image
+          ms-Persona-image
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-radius: 50%;
+            border: 0px;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 48px;
+            left: 0px;
+            margin-right: 10px;
+            overflow: hidden;
+            perspective: 1px;
+            position: absolute;
+            top: 0px;
+            width: 48px;
+          }
+      style={
+        Object {
+          "height": 48,
+          "width": 48,
+        }
+      }
+    >
+      <img
+        alt=""
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              object-fit: cover;
+              opacity: 0;
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders correctly with onRender callback 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size100
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 100px;
+          position: relative;
+          text-align: center;
+          width: 100px;
+        }
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #8E562E;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 42px;
+            font-weight: 600;
+            height: 100px;
+            line-height: 100px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          & i {
+            font-weight: 600;
+          }
+    >
+      <span>
+        SV
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders correctly with provided initials 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #0078D4;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 16px;
+            font-weight: 600;
+            height: 48px;
+            line-height: 46px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          & i {
+            font-weight: 600;
+          }
+    >
+      <span>
+        JG
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders correctly with text 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #498205;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 16px;
+            font-weight: 600;
+            height: 48px;
+            line-height: 46px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          & i {
+            font-weight: 600;
+          }
+    >
+      <span>
+        KL
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  role="presentation"
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #498205;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 16px;
+            font-weight: 600;
+            height: 48px;
+            line-height: 46px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          & i {
+            font-weight: 600;
+          }
+    >
+      <span>
+        KL
+      </span>
+    </div>
+    <div
+      className=
+          ms-Image
+          ms-Persona-image
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-radius: 50%;
+            border: 0px;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 48px;
+            left: 0px;
+            margin-right: 10px;
+            overflow: hidden;
+            perspective: 1px;
+            position: absolute;
+            top: 0px;
+            width: 48px;
+          }
+      style={
+        Object {
+          "height": 48,
+          "width": 48,
+        }
+      }
+    >
+      <img
+        alt=""
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              object-fit: cover;
+              opacity: 0;
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
+++ b/packages/react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
@@ -1,0 +1,272 @@
+import { IPersonaPresenceStyleProps, IPersonaPresenceStyles, PersonaPresence, PersonaSize } from '../Persona.types';
+import { HighContrastSelector, getGlobalClassNames, IRawStyle, getHighContrastNoAdjustStyle } from '../../../Styling';
+import { personaPresenceSize, presenceBoolean, sizeBoolean } from '../PersonaConsts';
+
+const GlobalClassNames = {
+  presence: 'ms-Persona-presence',
+  presenceIcon: 'ms-Persona-presenceIcon',
+};
+
+export const getStyles = (props: IPersonaPresenceStyleProps): IPersonaPresenceStyles => {
+  const { theme, presenceColors } = props;
+  const { semanticColors, fonts } = theme;
+
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  const size = sizeBoolean(props.size as PersonaSize);
+  const presence = presenceBoolean(props.presence as PersonaPresence);
+
+  // Presence colors
+  const presenceColorAvailable = (presenceColors && presenceColors.available) || '#6BB700';
+  const presenceColorAway = (presenceColors && presenceColors.away) || '#FFAA44';
+  const presenceColorBusy = (presenceColors && presenceColors.busy) || '#C43148';
+  const presenceColorDnd = (presenceColors && presenceColors.dnd) || '#C50F1F';
+  const presenceColorOffline = (presenceColors && presenceColors.offline) || '#8A8886';
+  const presenceColorOof = (presenceColors && presenceColors.oof) || '#B4009E';
+  const presenceColorBackground = (presenceColors && presenceColors.background) || semanticColors.bodyBackground;
+
+  const isOpenCirclePresence =
+    presence.isOffline ||
+    (props.isOutOfOffice && (presence.isAvailable || presence.isBusy || presence.isAway || presence.isDoNotDisturb));
+
+  const borderSizeForSmallPersonas = '1px';
+  const borderSizeForLargePersonas = '2px';
+
+  const borderSize = size.isSize72 || size.isSize100 ? borderSizeForLargePersonas : borderSizeForSmallPersonas;
+
+  return {
+    presence: [
+      classNames.presence,
+      {
+        position: 'absolute',
+        height: personaPresenceSize.size12,
+        width: personaPresenceSize.size12,
+        borderRadius: '50%',
+        top: 'auto',
+        right: '-2px',
+        bottom: '-2px',
+        border: `2px solid ${presenceColorBackground}`,
+        textAlign: 'center',
+        boxSizing: 'content-box',
+        backgroundClip: 'border-box',
+        ...getHighContrastNoAdjustStyle(),
+
+        selectors: {
+          [HighContrastSelector]: {
+            borderColor: 'Window',
+            backgroundColor: 'WindowText',
+          },
+        },
+      },
+
+      (size.isSize8 || size.isSize10) && {
+        right: 'auto',
+        top: '7px',
+        left: 0,
+        border: 0,
+
+        selectors: {
+          [HighContrastSelector]: {
+            top: '9px',
+            border: '1px solid WindowText',
+          },
+        },
+      },
+
+      (size.isSize8 || size.isSize10 || size.isSize24 || size.isSize28 || size.isSize32) &&
+        makeSizeStyle(personaPresenceSize.size8),
+
+      (size.isSize40 || size.isSize48) && makeSizeStyle(personaPresenceSize.size12),
+
+      size.isSize16 && {
+        height: personaPresenceSize.size6,
+        width: personaPresenceSize.size6,
+        borderWidth: '1.5px',
+      },
+
+      size.isSize56 && makeSizeStyle(personaPresenceSize.size16),
+
+      size.isSize72 && makeSizeStyle(personaPresenceSize.size20),
+
+      size.isSize100 && makeSizeStyle(personaPresenceSize.size28),
+
+      size.isSize120 && makeSizeStyle(personaPresenceSize.size32),
+
+      presence.isAvailable && {
+        backgroundColor: presenceColorAvailable,
+
+        selectors: {
+          [HighContrastSelector]: backgroundColor('Highlight'),
+        },
+      },
+
+      presence.isAway && backgroundColor(presenceColorAway),
+
+      presence.isBlocked && [
+        {
+          selectors: {
+            // Only show :after at larger sizes
+            ':after':
+              size.isSize40 || size.isSize48 || size.isSize72 || size.isSize100
+                ? {
+                    content: '""',
+                    width: '100%',
+                    height: borderSize,
+                    backgroundColor: presenceColorBusy,
+                    transform: 'translateY(-50%) rotate(-45deg)',
+                    position: 'absolute',
+                    top: '50%',
+                    left: 0,
+                  }
+                : undefined,
+
+            [HighContrastSelector]: {
+              selectors: {
+                ':after': {
+                  width: `calc(100% - 4px)`,
+                  left: '2px',
+                  backgroundColor: 'Window',
+                },
+              },
+            },
+          },
+        },
+      ],
+
+      presence.isBusy && backgroundColor(presenceColorBusy),
+
+      presence.isDoNotDisturb && backgroundColor(presenceColorDnd),
+
+      presence.isOffline && backgroundColor(presenceColorOffline),
+
+      (isOpenCirclePresence || presence.isBlocked) && [
+        {
+          backgroundColor: presenceColorBackground,
+
+          selectors: {
+            ':before': {
+              content: '""',
+              width: '100%',
+              height: '100%',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              border: `${borderSize} solid ${presenceColorBusy}`,
+              borderRadius: '50%',
+              boxSizing: 'border-box',
+            },
+            [HighContrastSelector]: {
+              backgroundColor: 'WindowText',
+
+              selectors: {
+                ':before': {
+                  width: `calc(100% - 2px)`,
+                  height: `calc(100% - 2px)`,
+                  top: '1px',
+                  left: '1px',
+                  borderColor: 'Window',
+                },
+              },
+            },
+          },
+        },
+      ],
+
+      isOpenCirclePresence && presence.isAvailable && makeBeforeBorderStyle(borderSize, presenceColorAvailable),
+
+      isOpenCirclePresence && presence.isBusy && makeBeforeBorderStyle(borderSize, presenceColorBusy),
+
+      isOpenCirclePresence && presence.isAway && makeBeforeBorderStyle(borderSize, presenceColorOof),
+
+      isOpenCirclePresence && presence.isDoNotDisturb && makeBeforeBorderStyle(borderSize, presenceColorDnd),
+
+      isOpenCirclePresence && presence.isOffline && makeBeforeBorderStyle(borderSize, presenceColorOffline),
+
+      isOpenCirclePresence &&
+        presence.isOffline &&
+        props.isOutOfOffice &&
+        makeBeforeBorderStyle(borderSize, presenceColorOof),
+    ],
+
+    presenceIcon: [
+      classNames.presenceIcon,
+      {
+        color: presenceColorBackground,
+        fontSize: '6px', // exception case where we don't have an available theme.fonts variable to match it.
+        lineHeight: personaPresenceSize.size12,
+        verticalAlign: 'top',
+
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'Window',
+          },
+        },
+      },
+
+      size.isSize56 && {
+        fontSize: '8px', // exception case where we don't have an available theme.fonts variable to match it.
+        lineHeight: personaPresenceSize.size16,
+      },
+
+      size.isSize72 && {
+        fontSize: fonts.small.fontSize,
+        lineHeight: personaPresenceSize.size20,
+      },
+
+      size.isSize100 && {
+        fontSize: fonts.medium.fontSize,
+        lineHeight: personaPresenceSize.size28,
+      },
+
+      size.isSize120 && {
+        fontSize: fonts.medium.fontSize,
+        lineHeight: personaPresenceSize.size32,
+      },
+
+      presence.isAway && {
+        position: 'relative',
+        left: isOpenCirclePresence ? undefined : '1px',
+      },
+
+      isOpenCirclePresence && presence.isAvailable && makeOpenCircleIconStyle(presenceColorAvailable),
+
+      isOpenCirclePresence && presence.isBusy && makeOpenCircleIconStyle(presenceColorBusy),
+
+      isOpenCirclePresence && presence.isAway && makeOpenCircleIconStyle(presenceColorOof),
+
+      isOpenCirclePresence && presence.isDoNotDisturb && makeOpenCircleIconStyle(presenceColorDnd),
+
+      isOpenCirclePresence && presence.isOffline && makeOpenCircleIconStyle(presenceColorOffline),
+
+      isOpenCirclePresence && presence.isOffline && props.isOutOfOffice && makeOpenCircleIconStyle(presenceColorOof),
+    ],
+  };
+};
+
+function makeOpenCircleIconStyle(color: string): IRawStyle {
+  return {
+    color,
+    borderColor: color,
+  };
+}
+
+function makeBeforeBorderStyle(borderSize: string, color: string): IRawStyle {
+  return {
+    selectors: {
+      ':before': {
+        border: `${borderSize} solid ${color}`,
+      },
+    },
+  };
+}
+
+function makeSizeStyle(size: string): IRawStyle {
+  return {
+    height: size,
+    width: size,
+  };
+}
+
+function backgroundColor(color: string): IRawStyle {
+  return { backgroundColor: color };
+}

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -1,0 +1,1751 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Persona renders Persona children correctly 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #498205;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          KL
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <span>
+      Persona Children
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: rgb(234, 234, 234);
+              border-radius: 50%;
+              color: rgb(168, 0, 0);
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-1";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="Help"
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with image 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Image
+            ms-Persona-image
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-radius: 50%;
+              border: 0px;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 48px;
+              left: 0px;
+              margin-right: 10px;
+              overflow: hidden;
+              perspective: 1px;
+              position: absolute;
+              top: 0px;
+              width: 48px;
+            }
+        style={
+          Object {
+            "height": 48,
+            "width": 48,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: 100%;
+                object-fit: cover;
+                opacity: 0;
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with initials 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #498205;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          KL
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Kat Larrson
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona correctly with no props 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 48px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 48px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 48px;
+            position: relative;
+            text-align: center;
+            width: 48px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #0078D4;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 16px;
+              font-weight: 600;
+              height: 48px;
+              line-height: 46px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-0";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="Contact"
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: none;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona which calls onRenderCoin callback without imageUrl 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      role="presentation"
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color: #8E562E;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 42px;
+              font-weight: 600;
+              height: 100px;
+              line-height: 100px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+            & i {
+              font-weight: 600;
+            }
+      >
+        <span>
+          SV
+        </span>
+      </div>
+      <span
+        id="persona-coin-container"
+      />
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: border-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              forced-color-adjust: none;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:after {
+              background-color: #C43148;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #C43148;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+        role="presentation"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona which calls onRenderPersonaCoin callback with custom render 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <i
+    aria-hidden={true}
+    className=
+
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-1";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
+    data-icon-name="Dictionary"
+  >
+    
+  </i>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Persona renders correctly with onRender callback 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #323130;
+        display: flex;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      role="presentation"
+    >
+      <div
+        className=
+            ms-Image
+            ms-Persona-image
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-radius: 50%;
+              border: 0px;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 100px;
+              left: 0px;
+              margin-right: 10px;
+              overflow: hidden;
+              perspective: 1px;
+              position: absolute;
+              top: 0px;
+              width: 100px;
+            }
+        style={
+          Object {
+            "height": 100,
+            "width": 100,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: 100%;
+                object-fit: cover;
+                opacity: 0;
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+        />
+      </div>
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: border-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              forced-color-adjust: none;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:after {
+              background-color: #C43148;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #C43148;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+        role="presentation"
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #323130;
+            font-size: 20px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          &:hover {
+            color: #201f1e;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #605e5c;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #605e5c;
+            display: block;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+      dir="auto"
+    >
+      <div
+        className=
+            ms-TooltipHost
+            {
+              display: inline;
+            }
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -1,0 +1,654 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PeoplePicker renders correctly 1`] = `
+<div
+  className="ms-BasePicker"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
+  <div
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
+    onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
+    onMouseDownCapture={[Function]}
+    role="presentation"
+  >
+    <div
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+    >
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PeoplePicker renders correctly with preselected items 1`] = `
+<div
+  className="ms-BasePicker"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <span
+    hidden={true}
+    id="selected-items-id__0-label"
+  />
+  <div
+    className="ms-SelectionZone"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onFocusCapture={[Function]}
+    onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
+    onMouseDownCapture={[Function]}
+    role="presentation"
+  >
+    <div
+      className=
+          ms-BasePicker-text
+          {
+            align-items: center;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-sizing: border-box;
+            display: flex;
+            flex-wrap: wrap;
+            min-height: 30px;
+            min-width: 180px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+    >
+      <span
+        aria-labelledby="selected-items-id__0-label"
+        className=
+            ms-BasePicker-itemsWrapper
+            {
+              display: flex;
+              flex-wrap: wrap;
+              max-width: 100%;
+            }
+        id="selected-items-id__0"
+        role="list"
+      >
+        <div
+          className=
+              ms-PickerPersona-container
+              {
+                align-items: center;
+                background: #f3f2f1;
+                border-radius: 15px;
+                cursor: default;
+                display: inline-flex;
+                margin-bottom: 1px;
+                margin-left: 2px;
+                margin-right: 2px;
+                margin-top: 1px;
+                max-width: 300px;
+                min-width: 0px;
+                outline: transparent;
+                position: relative;
+                user-select: none;
+                vertical-align: middle;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -1px;
+                content: "";
+                left: -1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: -1px;
+                top: -1px;
+                z-index: 1;
+              }
+              &:hover {
+                background: #edebe9;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                border: 1px solid WindowText;
+              }
+          role="listitem"
+        >
+          <div
+            className=
+                ms-PickerItem-content
+                {
+                  flex: 0 1 auto;
+                  max-width: 100%;
+                  min-width: 0px;
+                  overflow: hidden;
+                }
+            id="selectedItemPersona-id__9"
+          >
+            <div
+              className=
+                  ms-Persona
+                  ms-Persona--size24
+                  ms-Persona--online
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    align-items: center;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #323130;
+                    display: flex;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 24px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    min-width: 24px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  & .contextualHost {
+                    display: none;
+                  }
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size24
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="presentation"
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 24px;
+                        position: relative;
+                        text-align: center;
+                        width: 24px;
+                      }
+                  role="presentation"
+                >
+                  <div
+                    className=
+                        ms-Image
+                        ms-Persona-image
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          border-radius: 50%;
+                          border: 0px;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          height: 24px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
+                          width: 24px;
+                        }
+                    style={
+                      Object {
+                        "height": 24,
+                        "width": 24,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            object-fit: cover;
+                            opacity: 0;
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
+                  <div
+                    className=
+                        ms-Persona-presence
+                        {
+                          -ms-high-contrast-adjust: none;
+                          background-clip: border-box;
+                          background-color: #6BB700;
+                          border-radius: 50%;
+                          border: 2px solid #ffffff;
+                          bottom: -2px;
+                          box-sizing: content-box;
+                          forced-color-adjust: none;
+                          height: 8px;
+                          position: absolute;
+                          right: -2px;
+                          text-align: center;
+                          top: auto;
+                          width: 8px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          background-color: Highlight;
+                          border-color: Window;
+                        }
+                    role="presentation"
+                  />
+                </div>
+              </div>
+              <div
+                className=
+                    ms-Persona-details
+                    {
+                      display: flex;
+                      flex-direction: column;
+                      justify-content: space-around;
+                      min-width: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-align: left;
+                      width: 100%;
+                    }
+              >
+                <div
+                  className=
+                      ms-Persona-primaryText
+                      {
+                        color: #323130;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                      &:hover {
+                        color: #201f1e;
+                      }
+                  dir="auto"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Annie Lindqvist
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-secondaryText
+                      {
+                        color: #605e5c;
+                        display: none;
+                        font-size: 12px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                  dir="auto"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Designer
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-tertiaryText
+                      {
+                        color: #605e5c;
+                        display: none;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                  dir="auto"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    In a meeting
+                  </div>
+                </div>
+                <div
+                  className=
+                      ms-Persona-optionalText
+                      {
+                        color: #605e5c;
+                        display: none;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                  dir="auto"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Available at 4:00pm
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            aria-labelledby="id__9 selectedItemPersona-id__9"
+            className=
+                ms-Button
+                ms-Button--icon
+                ms-PickerItem-removeButton
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 15px;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  cursor: pointer;
+                  display: inline-block;
+                  flex: 0 0 auto;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 24px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  width: 24px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  background: #c8c6c4;
+                  color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #edebe9;
+                  color: #005a9e;
+                }
+            data-is-focusable={true}
+            data-selection-index={0}
+            id="id__9"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                    }
+                data-icon-name="Cancel"
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </span>
+      <input
+        aria-autocomplete="both"
+        aria-controls=""
+        aria-describedby="selected-items-id__0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-BasePicker-input
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-self: flex-end;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 0;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+        data-lpignore={true}
+        id="combobox-id__0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
To avoid the clipping issue mentioned in issue #17801 we updated the CSS property background-clip from
content-box to border-box in the PersonaCoin styles file inside the react package. This makes the content stretch not just to the border, but also underneath to the edge of the border.

Further info of the older PR are [here](https://github.com/microsoft/fluentui/pull/17802).