### PR TITLE
KeytipLayerBase remove unnecessary Array spread in ctor

### DIFF
--- a/change/@fluentui-react-eadbb7b4-bf06-4ad0-9687-c9a5739674e5.json
+++ b/change/@fluentui-react-eadbb7b4-bf06-4ad0-9687-c9a5739674e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary Array spread in KeytipLayerBase ctor",
+  "packageName": "@fluentui/react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -86,12 +86,12 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
     this._events = new EventGroup(this);
     this._async = new Async(this);
 
-    const managerKeytips = [...this._keytipManager.getKeytips()];
+    const keytips = this._keytipManager.getKeytips();
+
     this.state = {
       inKeytipMode: false,
-      // Get the initial set of keytips
-      keytips: managerKeytips,
-      visibleKeytips: this._getVisibleKeytips(managerKeytips),
+      keytips,
+      visibleKeytips: this._getVisibleKeytips(keytips),
     };
 
     this._buildTree();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The Array spread in `KeytipLayerBase`'s ctor is unnecessary.

<img width="1392" alt="Screen Shot 2021-04-28 at 5 06 04 PM" src="https://user-images.githubusercontent.com/706967/116487708-725f7380-a845-11eb-954a-f7731dc48cc6.png">

`KeytipManager.getKeytips` returns a new Array each call.

https://github.com/microsoft/fluentui/blob/8dab6a61ea83ec4f31b93ca60a965b5de4ad1b94/packages/react/src/utilities/keytips/KeytipManager.ts#L156

Can test with:

```js
var foo = { a: 0, b: 1, c: 2 };
Object.keys(foo).map(key => foo[key]) === Object.keys(foo).map(key => foo[key])
false
```

#### Focus areas to test

(optional)
