### PR TITLE
feat(popper): autoSize modifier - add option to apply max sizes always

### DIFF
--- a/change/@fluentui-react-positioning-59761690-673f-4441-adc9-556691ec9289.json
+++ b/change/@fluentui-react-positioning-59761690-673f-4441-adc9-556691ec9289.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "AutoSize modifier - add options to apply max sizes always",
+  "packageName": "@fluentui/react-positioning",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `NotepadPersonIcon`. @TanelVari ([#17828](https://github.com/microsoft/fluentui/pull/17828))
 - Added `PhoneIcon`, `OutlookColorIcon`, `SkypeColorIcon`. Corrected `NotepadPersonIcon` properties. @TanelVari ([#17857](https://github.com/microsoft/fluentui/pull/17857))
 - Added `FilesOneNoteIcon`. @TanelVari ([#17982](https://github.com/microsoft/fluentui/pull/17982))
+- Add options on `Popper` `autoSize` modifier to apply max sizes always @yuanboxue-amber ([#17994](https://github.com/microsoft/fluentui/pull/17994))
 
 ### Performance
 

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -48,6 +48,8 @@ import {
   PositioningProps,
   PopperShorthandProps,
   partitionPopperPropsFromShorthand,
+  AutoSize,
+  AUTOSIZES,
 } from '../../utils/positioner';
 import { CloseIcon, ChevronDownIcon } from '@fluentui/react-icons-northstar';
 
@@ -1694,7 +1696,7 @@ Dropdown.propTypes = {
   triggerButton: customPropTypes.itemShorthand,
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
   value: PropTypes.oneOfType([customPropTypes.itemShorthand, customPropTypes.collectionShorthand]),
   'aria-labelledby': PropTypes.string,
   'aria-invalid': PropTypes.bool,

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -13,7 +13,7 @@ import { Popup, PopupProps, PopupEvents, PopupEventsArray } from '../Popup/Popup
 import { Menu, MenuProps } from '../Menu/Menu';
 import { MenuItemProps } from '../Menu/MenuItem';
 import { focusMenuItem } from './focusUtils';
-import { ALIGNMENTS, POSITIONS, PositioningProps } from '../../utils/positioner';
+import { ALIGNMENTS, POSITIONS, PositioningProps, AutoSize, AUTOSIZES } from '../../utils/positioner';
 import {
   ComponentWithAs,
   useAccessibility,
@@ -334,7 +334,7 @@ MenuButton.propTypes = {
   tabbableTrigger: PropTypes.bool,
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
   menu: PropTypes.oneOfType([
     customPropTypes.itemShorthandWithoutJSX,
     PropTypes.arrayOf(customPropTypes.itemShorthandWithoutJSX),

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -42,6 +42,8 @@ import {
   Popper,
   PositioningProps,
   PopperChildrenProps,
+  AutoSize,
+  AUTOSIZES,
 } from '../../utils/positioner';
 import { PopupContent, PopupContentProps } from './PopupContent';
 
@@ -641,7 +643,7 @@ Popup.propTypes = {
   tabbableTrigger: PropTypes.bool,
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
   content: customPropTypes.shorthandAllowingChildren,
   contentRef: customPropTypes.ref,
   trapFocus: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),

--- a/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
@@ -29,7 +29,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
 } from '../../utils';
-import { getBasePlacement, PopperChildrenProps } from '../../utils/positioner';
+import { getBasePlacement, PopperChildrenProps, AutoSize, AUTOSIZES } from '../../utils/positioner';
 
 export interface PopupContentSlotClassNames {
   content: string;
@@ -70,15 +70,16 @@ export interface PopupContentProps extends UIComponentProps, ChildrenComponentPr
 
   /**
    * Applies max-height and max-width on popper to fit it within the available space in viewport.
-   * true enables this for both width and height.
-   * 'height' applies only `max-height` and 'width' for `max-width`
+   * true enables this for both width and height when overflow happens. 'always' applies `max-height`/`max-width` regardless of overflow.
+   * 'height' applies `max-height` when overflow happens, and 'width' for `max-width`
+   * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
    */
-  autoSize?: 'height' | 'width' | boolean;
+  autoSize?: AutoSize;
 }
 
 export type PopupContentStylesProps = Required<Pick<PopupContentProps, 'pointing'>> & {
   basePlacement: PopperJs.BasePlacement;
-  autoSize?: 'height' | 'width' | boolean;
+  autoSize?: AutoSize;
 };
 
 export const popupContentClassName = 'ui-popup__content';
@@ -205,7 +206,7 @@ PopupContent.propTypes = {
   pointerRef: customPropTypes.ref,
   trapFocus: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   autoFocus: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
 };
 PopupContent.handledProps = Object.keys(PopupContent.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -3,7 +3,7 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ALIGNMENTS, POSITIONS } from '../../utils/positioner';
+import { ALIGNMENTS, POSITIONS, AUTOSIZES } from '../../utils/positioner';
 import { ComponentEventHandler, ShorthandValue, ShorthandCollection, FluentComponentStaticProps } from '../../types';
 import {
   UIComponentProps,
@@ -22,7 +22,7 @@ import { MenuProps } from '../Menu/Menu';
 import { MenuItemProps } from '../Menu/MenuItem';
 import { PopupProps } from '../Popup/Popup';
 import { Ref } from '@fluentui/react-component-ref';
-import { PositioningProps } from '../../utils/positioner/types';
+import { PositioningProps, AutoSize } from '../../utils/positioner/types';
 
 import {
   ComponentWithAs,
@@ -307,7 +307,7 @@ SplitButton.propTypes = {
   ]),
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
 };
 
 SplitButton.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -31,6 +31,8 @@ import {
   PopperChildrenProps,
   Alignment,
   Position,
+  AutoSize,
+  AUTOSIZES,
 } from '../../utils/positioner';
 import { PortalInner } from '../Portal/PortalInner';
 import { TooltipContent, TooltipContentProps } from './TooltipContent';
@@ -290,7 +292,7 @@ Tooltip.propTypes = {
   content: customPropTypes.shorthandAllowingChildren,
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf([true, false, 'height', 'width']),
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
   popperRef: customPropTypes.ref,
   flipBoundary: PropTypes.oneOfType([
     PropTypes.object as PropTypes.Requireable<HTMLElement>,

--- a/packages/fluentui/react-northstar/src/utils/positioner/types.internal.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/types.internal.ts
@@ -1,4 +1,5 @@
-import { Alignment, Position } from './types';
+import { Alignment, Position, AutoSize } from './types';
 
 export const ALIGNMENTS: Alignment[] = ['top', 'bottom', 'start', 'end', 'center'];
 export const POSITIONS: Position[] = ['above', 'below', 'before', 'after'];
+export const AUTOSIZES: AutoSize[] = ['height', 'height-always', 'width', 'width-always', 'always', true, false];

--- a/packages/fluentui/react-northstar/src/utils/positioner/types.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/types.ts
@@ -74,6 +74,8 @@ export type PopperModifiersFn = (
 export type Position = 'above' | 'below' | 'before' | 'after';
 export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center';
 
+export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;
+
 export type PopperChildrenFn = (props: PopperChildrenProps) => React.ReactElement;
 
 export type Boundary = PopperJs.Boundary | 'scrollParent' | 'window';
@@ -129,10 +131,11 @@ export interface PositioningProps {
 
   /**
    * Applies max-height and max-width on popper to fit it within the available space in viewport.
-   * true enables this for both width and height.
-   * 'height' applies only `max-height` and 'width' for `max-width`
+   * true enables this for both width and height when overflow happens. 'always' applies `max-height`/`max-width` regardless of overflow.
+   * 'height' applies `max-height` when overflow happens, and 'width' for `max-width`
+   * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
    */
-  autoSize?: 'height' | 'width' | boolean;
+  autoSize?: AutoSize;
 }
 
 export interface PopperProps extends PositioningProps {

--- a/packages/fluentui/react-northstar/src/utils/positioner/usePopper.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/usePopper.ts
@@ -181,7 +181,8 @@ function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: Rea
 
         autoSize && {
           // Similar code as popper-maxsize-modifier: https://github.com/atomiks/popper.js/blob/master/src/modifiers/maxSize.js
-          // popper-maxsize-modifier only calculates the max sizes. This modifier applies the max sizes when overflow is detected
+          // popper-maxsize-modifier only calculates the max sizes.
+          // This modifier can apply max sizes always, or apply the max sizes only when overflow is detected
           name: 'applyMaxSize',
           enabled: true,
           phase: 'beforeWrite' as PopperJs.ModifierPhases,
@@ -199,10 +200,19 @@ function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: Rea
             const widthProp: keyof PopperJs.SideObject = basePlacement === 'left' ? 'left' : 'right';
             const heightProp: keyof PopperJs.SideObject = basePlacement === 'top' ? 'top' : 'bottom';
 
-            if (overflow[widthProp] > 0 && (autoSize === true || autoSize === 'width')) {
+            const applyMaxWidth =
+              autoSize === 'always' ||
+              autoSize === 'width-always' ||
+              (overflow[widthProp] > 0 && (autoSize === true || autoSize === 'width'));
+            const applyMaxHeight =
+              autoSize === 'always' ||
+              autoSize === 'height-always' ||
+              (overflow[heightProp] > 0 && (autoSize === true || autoSize === 'height'));
+
+            if (applyMaxWidth) {
               state.styles.popper.maxWidth = `${width - overflow[widthProp] - x}px`;
             }
-            if (overflow[heightProp] > 0 && (autoSize === true || autoSize === 'height')) {
+            if (applyMaxHeight) {
               state.styles.popper.maxHeight = `${height - overflow[heightProp] - y}px`;
             }
           },

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -11,6 +11,9 @@ import * as React from 'react';
 export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center';
 
 // @public (undocumented)
+export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;
+
+// @public (undocumented)
 export type Boundary = PopperJs.Boundary | 'scrollParent' | 'window';
 
 // @public (undocumented)
@@ -46,7 +49,7 @@ export type Position = 'above' | 'below' | 'before' | 'after';
 export interface PositioningProps {
     align?: Alignment;
     arrowPadding?: number;
-    autoSize?: 'height' | 'width' | boolean;
+    autoSize?: AutoSize;
     containerRef?: React.Ref<PopperRefHandle>;
     flipBoundary?: Boundary;
     offset?: Offset;

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -14,6 +14,8 @@ export type Offset = OffsetFunction | [number | null | undefined, number | null 
 export type Position = 'above' | 'below' | 'before' | 'after';
 export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center';
 
+export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;
+
 export type Boundary = PopperJs.Boundary | 'scrollParent' | 'window';
 
 export type PopperRefHandle = { updatePosition: () => void };
@@ -76,10 +78,12 @@ export interface PositioningProps {
 
   /**
    * Applies max-height and max-width on popper to fit it within the available space in viewport.
-   * true enables this for both width and height.
-   * 'height' applies only `max-height` and 'width' for `max-width`
+   * true enables this for both width and height when overflow happens.
+   * 'always' applies `max-height`/`max-width` regardless of overflow.
+   * 'height' applies `max-height` when overflow happens, and 'width' for `max-width`
+   * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
    */
-  autoSize?: 'height' | 'width' | boolean;
+  autoSize?: AutoSize;
 }
 
 export interface PopperOptions extends PositioningProps {

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -174,7 +174,7 @@ function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: Rea
         autoSize && {
           // Similar code as popper-maxsize-modifier: https://github.com/atomiks/popper.js/blob/master/src/modifiers/maxSize.js
           // popper-maxsize-modifier only calculates the max sizes.
-          // This modifier applies the max sizes when overflow is detected
+          // This modifier can apply max sizes always, or apply the max sizes only when overflow is detected
           name: 'applyMaxSize',
           enabled: true,
           phase: 'beforeWrite' as PopperJs.ModifierPhases,
@@ -192,10 +192,19 @@ function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: Rea
             const widthProp: keyof PopperJs.SideObject = basePlacement === 'left' ? 'left' : 'right';
             const heightProp: keyof PopperJs.SideObject = basePlacement === 'top' ? 'top' : 'bottom';
 
-            if (overflow[widthProp] > 0 && (autoSize === true || autoSize === 'width')) {
+            const applyMaxWidth =
+              autoSize === 'always' ||
+              autoSize === 'width-always' ||
+              (overflow[widthProp] > 0 && (autoSize === true || autoSize === 'width'));
+            const applyMaxHeight =
+              autoSize === 'always' ||
+              autoSize === 'height-always' ||
+              (overflow[heightProp] > 0 && (autoSize === true || autoSize === 'height'));
+
+            if (applyMaxWidth) {
               state.styles.popper.maxWidth = `${width - overflow[widthProp] - x}px`;
             }
-            if (overflow[heightProp] > 0 && (autoSize === true || autoSize === 'height')) {
+            if (applyMaxHeight) {
               state.styles.popper.maxHeight = `${height - overflow[heightProp] - y}px`;
             }
           },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`usePopper` has autoSize modifier that applies max-height/max-width to popup content when there's overflow.
This PR adds option `'height-always' | 'width-always' | 'always'`, which applies max-height/max-width regardless of overflow

```ts
// this change is in typing files for popper, in both n* and react-positioning

type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;

interface PositioningProps {
  ...

  /**
   * Applies max-height and max-width on popper to fit it within the available space in viewport.
   * true enables this for both width and height when overflow happens.
   * 'always' applies `max-height`/`max-width` regardless of overflow.
   * 'height' applies `max-height` when overflow happens, and 'width' for `max-width`
   * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
   */
  autoSize?: AutoSize;
}
```

#### Focus areas to test

(optional)
