### PR TITLE
feat(useOnClickOutside): can be disabled

### DIFF
--- a/change/@fluentui-react-examples-1dfb52b6-1e13-4aa3-9f3b-b6b35a1b5e61.json
+++ b/change/@fluentui-react-examples-1dfb52b6-1e13-4aa3-9f3b-b6b35a1b5e61.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add custom menu trigger story",
+  "packageName": "@fluentui/react-examples",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-4933064e-1106-4919-a000-8f743ca01b47.json
+++ b/change/@fluentui-react-menu-4933064e-1106-4919-a000-8f743ca01b47.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable outside click listener when menu is closed",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-42828487-1a15-401e-badb-24601f306a49.json
+++ b/change/@fluentui-react-utilities-42828487-1a15-401e-badb-24601f306a49.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "useOnClickOutside can be disabled",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
+++ b/packages/react-examples/src/react-menu/Menu/Menu.stories.tsx
@@ -81,6 +81,31 @@ export const ControlledPopup = () => {
   );
 };
 
+export const CustomTrigger = () => {
+  const [open, setOpen] = React.useState(false);
+  const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
+    setOpen(data.open);
+  };
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Custom Trigger</button>
+      <Menu open={open} onOpenChange={onOpenChange}>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuList>
+          <MenuItem>New </MenuItem>
+          <MenuItem>New Window</MenuItem>
+          <MenuItem disabled>Open File</MenuItem>
+          <MenuItem>Open Folder</MenuItem>
+        </MenuList>
+      </Menu>
+    </>
+  );
+};
+
 export const MenuTriggerInteractions = () => {
   const context = boolean('context', false);
   const hover = boolean('hover', false);

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -25,6 +25,26 @@ describe('MenuTrigger', () => {
   });
 });
 
+describe('Custom Trigger', () => {
+  it('should open menu when clicked', () => {
+    cy.visitStory('Menu', 'CustomTrigger')
+      .contains('Custom Trigger')
+      .click()
+      .get(menuSelector)
+      .should('be.visible');
+  });
+
+  it('should dismiss the menu when click outside', () => {
+    cy.visitStory('Menu', 'CustomTrigger')
+      .contains('Custom Trigger')
+      .click()
+      .get('body')
+      .click('bottomRight')
+      .get(menuSelector)
+      .should('not.exist');
+  });
+});
+
 describe('MenuItem', () => {
   it('should close the menu when clicked', () => {
     cy.visitStory('Menu', 'TextOnly')

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -43,11 +43,6 @@ describe('Custom Trigger', () => {
       .get(menuSelector)
       .should('not.exist');
   });
-
-  // TODO just testing
-  it('should fail', () => {
-    expect(true).equals(false);
-  });
 });
 
 describe('MenuItem', () => {

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -45,7 +45,7 @@ describe('Custom Trigger', () => {
   });
 
   // TODO just testing
-  it.only('should fail', () => {
+  it('should fail', () => {
     expect(true).equals(false);
   });
 });

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -43,6 +43,11 @@ describe('Custom Trigger', () => {
       .get(menuSelector)
       .should('not.exist');
   });
+
+  // TODO just testing
+  it.only('should fail', () => {
+    expect(true).equals(false);
+  });
 });
 
 describe('MenuItem', () => {

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -97,6 +97,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   useMenuSelectableState(state);
   useMenuPopup(state);
   useOnClickOutside({
+    disabled: state.open,
     element: targetDocument,
     refs: [state.menuPopupRef, triggerRef],
     callback: e => state.setOpen(e, false),

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -302,6 +302,7 @@ export type UseOnClickOutsideOptions = {
     element: Document | undefined;
     refs: React_2.MutableRefObject<HTMLElement | undefined | null>[];
     callback: (ev: MouseEvent | TouchEvent) => void;
+    disabled?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -26,4 +26,15 @@ describe('useOnClickOutside', () => {
     expect(element.removeEventListener).toHaveBeenCalledTimes(2);
     expect(element.removeEventListener).toHaveBeenCalledWith(event, expect.anything());
   });
+
+  it('should not add event listeners when disabled', () => {
+    // Arrange
+    const element = ({ addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown) as Document;
+
+    // Act
+    renderHook(() => useOnClickOutside({ disabled: true, element, callback: jest.fn(), refs: [] }));
+
+    // Assert
+    expect(element.addEventListener).toHaveBeenCalledTimes(0);
+  });
 });

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -14,28 +14,35 @@ export type UseOnClickOutsideOptions = {
    * Called if the click is outside the element refs
    */
   callback: (ev: MouseEvent | TouchEvent) => void;
+
+  /**
+   * Disables event listeners
+   */
+  disabled?: boolean;
 };
 
 /**
  * Utility to perform checks where a click/touch event was made outside a compoent
  */
 export const useOnClickOutside = (options: UseOnClickOutsideOptions) => {
-  const { refs, callback, element } = options;
+  const { refs, callback, element, disabled } = options;
 
   const listener = useEventCallback((ev: MouseEvent | TouchEvent) => {
     const isOutside = refs.every(ref => !ref.current?.contains(ev.target as HTMLElement));
-    if (isOutside) {
+    if (isOutside && !disabled) {
       callback(ev);
     }
   });
 
   React.useEffect(() => {
-    element?.addEventListener('click', listener);
-    element?.addEventListener('touchstart', listener);
+    if (!disabled) {
+      element?.addEventListener('click', listener);
+      element?.addEventListener('touchstart', listener);
+    }
 
     return () => {
       element?.removeEventListener('click', listener);
       element?.removeEventListener('touchstart', listener);
     };
-  }, [listener, element]);
+  }, [listener, element, disabled]);
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Allows `useOnClickOutside` hook to be disabled, without it, a window listener would always be created.

Also fixes a bug when controlling the menu with custom triggers, since clicking on the custom trigger would always be an outside click

#### Focus areas to test

(optional)
