### PR TITLE
usePopper: support `target` override

### DIFF
--- a/change/@fluentui-react-positioning-de71ed31-0b56-45af-9ff5-a1ede911e689.json
+++ b/change/@fluentui-react-positioning-de71ed31-0b56-45af-9ff5-a1ede911e689.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support popper target override",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -56,7 +56,6 @@ export interface PositioningProps {
     overflowBoundary?: Boundary;
     position?: Position;
     positionFixed?: boolean;
-    // (undocumented)
     target?: HTMLElement | null;
     unstable_disableTether?: boolean | 'all';
     unstable_pinned?: boolean;

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -56,6 +56,8 @@ export interface PositioningProps {
     overflowBoundary?: Boundary;
     position?: Position;
     positionFixed?: boolean;
+    // (undocumented)
+    target?: HTMLElement | null;
     unstable_disableTether?: boolean | 'all';
     unstable_pinned?: boolean;
 }

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -84,6 +84,11 @@ export interface PositioningProps {
    * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
    */
   autoSize?: AutoSize;
+
+  /**
+   * Manual override for popper target. Useful for scenarios where a component accepts user prop to override target
+   */
+  target?: HTMLElement | null;
 }
 
 export interface PopperOptions extends PositioningProps {

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -359,14 +359,14 @@ export function usePopper(
       popperInstanceRef.current?.destroy();
       popperInstanceRef.current = null;
     };
-  }, [options.enabled]);
+  }, [options.enabled, options.target]);
   useIsomorphicLayoutEffect(() => {
     if (!isFirstMount) {
       popperInstanceRef.current?.setOptions(
         resolvePopperOptions(options.target || targetRef.current, containerRef.current, arrowRef.current),
       );
     }
-  }, [resolvePopperOptions]);
+  }, [resolvePopperOptions, options.target]);
 
   if (process.env.NODE_ENV !== 'production') {
     // This checked should run only in development mode

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -1,7 +1,6 @@
-import { useEventCallback, useIsomorphicLayoutEffect, useFirstMount } from '@fluentui/react-utilities';
+import { useEventCallback, useIsomorphicLayoutEffect, useFirstMount, canUseDOM } from '@fluentui/react-utilities';
 import { useFluent } from '@fluentui/react-shared-contexts';
 import {
-  isBrowser,
   getScrollParent,
   applyRtlToOffset,
   getPlacement,
@@ -287,7 +286,7 @@ export function usePopper(
 
     let popperInstance: PopperInstance | null = null;
 
-    if (isBrowser() && enabled) {
+    if (canUseDOM() && enabled) {
       if (target && containerRef.current) {
         popperInstance = PopperJs.createPopper(
           target,

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -365,7 +365,7 @@ export function usePopper(
         resolvePopperOptions(options.target || targetRef.current, containerRef.current, arrowRef.current),
       );
     }
-  }, [resolvePopperOptions, options.target]);
+  }, [resolvePopperOptions]);
 
   if (process.env.NODE_ENV !== 'production') {
     // This checked should run only in development mode

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -283,14 +283,16 @@ export function usePopper(
     popperInstanceRef.current?.destroy();
     popperInstanceRef.current = null;
 
+    const target = options.target || targetRef.current;
+
     let popperInstance: PopperInstance | null = null;
 
     if (isBrowser() && enabled) {
-      if (targetRef.current && containerRef.current) {
+      if (target && containerRef.current) {
         popperInstance = PopperJs.createPopper(
-          targetRef.current,
+          target,
           containerRef.current,
-          resolvePopperOptions(targetRef.current, containerRef.current, arrowRef.current),
+          resolvePopperOptions(target, containerRef.current, arrowRef.current),
         );
       }
     }
@@ -361,7 +363,7 @@ export function usePopper(
   useIsomorphicLayoutEffect(() => {
     if (!isFirstMount) {
       popperInstanceRef.current?.setOptions(
-        resolvePopperOptions(targetRef.current, containerRef.current, arrowRef.current),
+        resolvePopperOptions(options.target || targetRef.current, containerRef.current, arrowRef.current),
       );
     }
   }, [resolvePopperOptions]);

--- a/packages/react-positioning/src/utils/index.ts
+++ b/packages/react-positioning/src/utils/index.ts
@@ -1,4 +1,3 @@
-export * from './isBrowser';
 export * from './positioningHelper';
 export * from './getBoundary';
 export * from './getScrollParent';

--- a/packages/react-positioning/src/utils/isBrowser.tsx
+++ b/packages/react-positioning/src/utils/isBrowser.tsx
@@ -1,4 +1,0 @@
-const hasDocument = typeof document === 'object' && document !== null;
-const hasWindow = typeof window === 'object' && window !== null && window.self === window;
-
-export const isBrowser = () => hasDocument && hasWindow;


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds a `target` option to `usePopper` to handle scenarios where user prop can override popper target where internal state can also assign the `targetRef` returned by the hook.