### PR TITLE
chore(e2e): Run as a binary from @fluentui/scripts

### DIFF
--- a/change/@fluentui-react-menu-94da245a-d556-43e6-8ac4-880392e5a68a.json
+++ b/change/@fluentui-react-menu-94da245a-d556-43e6-8ac4-880392e5a68a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove custom script for e2e tests",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-menu/e2e.js
+++ b/packages/react-menu/e2e.js
@@ -1,6 +1,0 @@
-const cypress = require('@fluentui/scripts/cypress');
-
-return cypress().catch(err => {
-  console.error(err);
-  process.exit(1);
-});

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -17,7 +17,6 @@
     "build": "just-scripts build",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "e2e": "node e2e.js",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "echo \"This is DEPRECATED instead use 'storybook'\" && just-scripts dev:storybook",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -17,13 +17,13 @@
     "build": "just-scripts build",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "e2e": "e2e",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "echo \"This is DEPRECATED instead use 'storybook'\" && just-scripts dev:storybook",
     "storybook": "start-storybook",
     "start-test": "echo \"This is DEPRECATED instead use 'test --watch'\" && just-scripts jest-watch",
     "test": "jest",
-    "e2e": "e2e",
     "update-snapshots": "echo \"This is DEPRECATED instead use 'test -u'\" && just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -23,6 +23,7 @@
     "storybook": "start-storybook",
     "start-test": "echo \"This is DEPRECATED instead use 'test --watch'\" && just-scripts jest-watch",
     "test": "jest",
+    "e2e": "e2e",
     "update-snapshots": "echo \"This is DEPRECATED instead use 'test -u'\" && just-scripts jest -u"
   },
   "devDependencies": {

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const cypress = require('cypress');
 const path = require('path');
 
@@ -21,41 +22,42 @@ const baseConfig = {
     : 'http://localhost:3000',
 };
 
-const run = config => {
+const run = () => {
   return cypress.run({
     configFile: false,
     config: {
       ...baseConfig,
-      ...config,
     },
   });
 };
 
-const open = config => {
+const open = () => {
   cypress.open({
     configFile: false,
     config: {
       ...baseConfig,
-      ...config,
     },
   });
 };
 
-module.exports = config => {
-  const argv = require('yargs')
-    .option('mode', {
-      describe: 'Choose a mode to run cypress',
-      choices: ['run', 'open'],
-    })
-    .demandOption('mode').argv;
+const argv = require('yargs')
+  .option('mode', {
+    describe: 'Choose a mode to run cypress',
+    choices: ['run', 'open'],
+  })
+  .demandOption('mode').argv;
 
-  if (argv.mode === 'open') {
-    open(config);
-  } else {
-    return run(config).then(result => {
+if (argv.mode === 'open') {
+  open();
+} else {
+  return run()
+    .then(result => {
       if (result.totalFailed) {
         throw new Error(`${result.totalFailed} failing E2E tests`);
       }
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
     });
-  }
-};
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "./index.js",
   "bin": {
-    "just-scripts": "./just-scripts.js"
+    "just-scripts": "./just-scripts.js",
+    "e2e": "./cypress.js"
   },
   "scripts": {
     "build": "echo no-op",


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Since cypress does not support config extensions [cypressio/cypress#5674](https://github.com/cypress-io/cypress/issues/5674) this integration was done previously with a node script.

Moving this to be a binary as a part of `@fluentui/scripts` to remove the need for custom scripts in projects.

**⚠⚠ Windows users might have to delete node_modules and reinstall to generate cmd bin scripts**