### PR TITLE
delete recipients based on index, not value

### DIFF
--- a/change/@fluentui-react-experiments-b7dde1f0-1a92-4e28-8a54-6d8fa4eaaae9.json
+++ b/change/@fluentui-react-experiments-b7dde1f0-1a92-4e28-8a54-6d8fa4eaaae9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "delete recipients based on index, not value",
+  "packageName": "@fluentui/react-experiments",
+  "email": "jaredi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -21,7 +21,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
     }
   }, [selectedItems]);
 
-  const removeItems = (itemsToRemove: TItem[]): void => {
+  const removeItems = (itemsToRemove: TItem[], indicesToRemove: number[]): void => {
     // Intentionally not using .filter here as we want to only remove a specific
     // item in case of duplicates of same item.
     const updatedItems: TItem[] = [...items];
@@ -30,7 +30,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
       updatedItems.splice(index, 1);
     });
     setItems(updatedItems);
-    props.onItemsRemoved?.(itemsToRemove);
+    props.onItemsRemoved?.(itemsToRemove, indicesToRemove);
   };
 
   const _replaceItem = React.useCallback(
@@ -51,7 +51,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
     () =>
       // create callbacks ahead of time with memo.
       // (hooks have to be called in the same order)
-      items.map((item: TItem) => () => removeItems([item])),
+      items.map((item: TItem, index: number) => () => removeItems([item], [index])),
     // TODO: consider whether dependency on removeItems should be added
     // (removeItems would likely need to be wrapped in useCallback)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -105,7 +105,7 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
   /**
    * A callback when an item or items are removed
    */
-  onItemsRemoved?: (removedItems: T[]) => void;
+  onItemsRemoved?: (removedItems: T[], removedIndices: number[]) => void;
 
   /**
    * A callback on whether this item can be removed

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -284,7 +284,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         const itemsToRemove = focusedItemIndices.includes(draggedIndex)
           ? (getSelectedItems() as T[])
           : [selectedItems[draggedIndex]];
-        _onRemoveSelectedItems(itemsToRemove);
+        const indicesToRemove = focusedItemIndices.includes(draggedIndex) ? focusedItemIndices : [draggedIndex];
+        _onRemoveSelectedItems(itemsToRemove, indicesToRemove);
       }
       // Clear any remaining drag data
       const dataList = event?.dataTransfer?.items;
@@ -367,24 +368,25 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           input.current.inputElement === document.activeElement &&
           (input.current as Autofill).cursorLocation === 0
         ) {
-          const item = selectedItems[selectedItems.length - 1];
+          const indexToRemove = selectedItems.length - 1;
+          const item = selectedItems[indexToRemove];
           showPicker(false);
           ev.preventDefault();
           setDeleteAnnouncementText([item]);
-          selectedItemsListOnItemsRemoved?.([item]);
+          selectedItemsListOnItemsRemoved?.([item], [indexToRemove]);
           removeItemAt(selectedItems.length - 1);
         } else if (focusedItemIndices.length > 0) {
           showPicker(false);
           ev.preventDefault();
           setDeleteAnnouncementText(getSelectedItems());
-          selectedItemsListOnItemsRemoved?.(getSelectedItems());
+          selectedItemsListOnItemsRemoved?.(getSelectedItems(), focusedItemIndices);
           removeSelectedItems();
           input.current?.focus();
         }
       }
     },
     [
-      focusedItemIndices.length,
+      focusedItemIndices,
       getSelectedItems,
       onKeyDown,
       removeItemAt,
@@ -576,10 +578,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   );
 
   const _onRemoveSelectedItems = React.useCallback(
-    (itemsToRemove: T[]) => {
+    (itemsToRemove: T[], indicesToRemove: number[]) => {
       setDeleteAnnouncementText(itemsToRemove);
-      removeItems(itemsToRemove);
-      selectedItemsListOnItemsRemoved?.(itemsToRemove);
+      removeItems(itemsToRemove, indicesToRemove);
+      selectedItemsListOnItemsRemoved?.(itemsToRemove, indicesToRemove);
     },
     [selectedItemsListOnItemsRemoved, removeItems, setDeleteAnnouncementText],
   );

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -9,7 +9,7 @@ export interface IUseSelectedItemsResponse<T> {
   removeItemAt: (index: number) => void;
   removeItem: (item: T) => void;
   replaceItem: (itemToReplace: T, itemsToReplaceWith: T[]) => void;
-  removeItems: (itemsToRemove: T[]) => void;
+  removeItems: (itemsToRemove: T[], indicesToRemove: number[]) => void;
   removeSelectedItems: () => void;
   getSelectedItems: () => T[];
   hasSelectedItems: () => boolean;
@@ -113,14 +113,10 @@ export const useSelectedItems = <T extends {}>(
   );
 
   const removeItems = React.useCallback(
-    (itemsToRemove: any[]): void => {
-      const currentItems: T[] = [...items];
-      const updatedItems: T[] = currentItems;
-      // Intentionally not using .filter here as we want to only remove a specific
-      // item in case of duplicates of same item.
-      itemsToRemove.forEach(item => {
-        const index: number = updatedItems.indexOf(item);
-        updatedItems.splice(index, 1);
+    (itemsToRemove: any[], indicesToRemove: number[]): void => {
+      // we want to only remove specific items in case of duplicates of same item.
+      const updatedItems: T[] = items.filter((item: T, index: number) => {
+        return !indicesToRemove.includes(index);
       });
       setSelectedItems(updatedItems);
       selection.setItems(updatedItems);
@@ -144,9 +140,17 @@ export const useSelectedItems = <T extends {}>(
     }
   }, [hasSelectedItems, selection]);
 
+  const getSelectedIndices = React.useCallback((): number[] => {
+    if (hasSelectedItems()) {
+      return selection.getSelectedIndices();
+    } else {
+      return [];
+    }
+  }, [hasSelectedItems, selection]);
+
   const removeSelectedItems = React.useCallback((): void => {
-    removeItems(getSelectedItems());
-  }, [getSelectedItems, removeItems]);
+    removeItems(getSelectedItems(), getSelectedIndices());
+  }, [getSelectedItems, removeItems, getSelectedIndices]);
 
   const unselectAll = React.useCallback((): void => {
     if (hasSelectedItems()) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Dragging 2nd recipient changed it to a copy of the 1st

Repro:
1) Add two recipients to the TO recipient well
2) Drag the first recipient to the CC well.
3) Drag the second recipient to the CC well

Result:
The first recipient appears twice in the CC well, the second recipient APPEARS to have disappeared.

If you now SEND the message, the second recipient reappears in the TO well and receives the message. (potential information disclosure if the user decides that removing the recipient was what they really wanted)

Expected:
Move the second recipient to the CC well.


PROBLEM:
`updatedItems.indexOf(item)` fails to find a match, so returns -1 to indicate failure.

So we pass -1 as the `index` to `updatedItems.splice(index, 1);`

Here -1 means "index from the end" so we remove the LAST item in the array.


FIX:
Use indices to delete, instead of comparing item values.

#### Focus areas to test

TESTING:
Verify that single delete, multiple delete work.
Verify that moving recipients between wells works, regardless of the order.
Verify multi select drag-n-drop works to move a set of recipients from the middle/beginning/end of the list