### PR TITLE
Fix website references section

### DIFF
--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -228,7 +228,7 @@ function generateCategories() {
   }
 
   // Add reference pages
-  pagesByCategory.References = { ...pagesByCategory.References, ..._loadReferences() };
+  pagesByCategory.References = [...pagesByCategory.References, ..._loadReferences()];
 
   // Convert the categories to an array (filter out empty categories)
   return categoryNames

--- a/change/@fluentui-public-docsite-f2485731-28cc-4ef4-b82c-fca7d7b03054.json
+++ b/change/@fluentui-public-docsite-f2485731-28cc-4ef4-b82c-fca7d7b03054.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix website references section",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17995
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The controls "References" section wasn't being shown on the website because of incorrectly spreading arrays into an object rather than an array (and the object was filtered out later because it doesn't have a `length` property). Not sure why the compiler didn't catch this...