### PR TITLE
UnifiedPicker: Remove relayout after item is added

### DIFF
--- a/change/@fluentui-react-experiments-1be1f552-3d2f-4533-b02c-64c758f3b496.json
+++ b/change/@fluentui-react-experiments-1be1f552-3d2f-4533-b02c-64c758f3b496.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UnifiedPicker: Remove conditional layout to fix focus issues",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
                 flex-wrap: wrap;
                 flex: 1 1 auto;
               }
-          role="listbox"
+          role=""
         >
           <div
             aria-expanded={false}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -62,68 +62,82 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
           role="status"
         />
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
+          aria-multiselectable="true"
+          aria-orientation="horizontal"
           className=
-              ms-BasePicker-div
-              ms-UnifiedPicker-div
+              ms-UnifiedPicker-listDiv
+              ms-UnifiedPicker-listDiv
               {
-                display: flex;
+                display: inline-flex;
+                flex-wrap: wrap;
                 flex: 1 1 auto;
               }
-          onDragOver={[Function]}
-          onDrop={[Function]}
-          role="combobox"
+          role="listbox"
         >
-          <input
-            aria-autocomplete="list"
-            autoCapitalize="off"
-            autoComplete="off"
+          <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className=
-                ms-BasePicker-input
-                ms-UnifiedPicker-input
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border: none;
                   display: flex;
-                  flex-grow: 1;
                   flex: 1 1 auto;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 34px;
-                  margin-bottom: 1px;
-                  margin-left: 1px;
-                  margin-right: 1px;
-                  margin-top: 1px;
-                  outline: none;
-                  padding-bottom: 0px;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
                 }
-                &::-ms-clear {
-                  display: none;
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            role="combobox"
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="off"
+              autoComplete="off"
+              className=
+                  ms-BasePicker-input
+                  ms-UnifiedPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    display: flex;
+                    flex-grow: 1;
+                    flex: 1 1 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 34px;
+                    margin-bottom: 1px;
+                    margin-left: 1px;
+                    margin-right: 1px;
+                    margin-top: 1px;
+                    outline: none;
+                    padding-bottom: 0px;
+                    padding-left: 6px;
+                    padding-right: 6px;
+                    padding-top: 0;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
+              data-lpignore={true}
+              disabled={false}
+              onChange={[Function]}
+              onClick={[Function]}
+              onCompositionEnd={[Function]}
+              onCompositionStart={[Function]}
+              onCompositionUpdate={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              style={
+                Object {
+                  "fontFamily": "inherit",
                 }
-            data-lpignore={true}
-            disabled={false}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            style={
-              Object {
-                "fontFamily": "inherit",
               }
-            }
-            value=""
-          />
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -660,7 +660,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
             <Announced message={announcementText} />
             <div
               className={css('ms-UnifiedPicker-listDiv', classNames.listDiv)}
-              role={'listbox'}
+              role={selectedItems.length > 0 ? 'listbox' : ''}
               aria-orientation={'horizontal'}
               aria-multiselectable={'true'}
               aria-label={itemListAriaLabel}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -658,19 +658,17 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         >
           <div className={css('ms-BasePicker-text', classNames.pickerText)}>
             <Announced message={announcementText} />
-            {headerComponent}
-            {
-              <div
-                className={css('ms-UnifiedPicker-listDiv', classNames.listDiv)}
-                role={'listbox'}
-                aria-orientation={'horizontal'}
-                aria-multiselectable={'true'}
-                aria-label={itemListAriaLabel}
-              >
-                {_renderSelectedItemsList()}
-                {_canAddItems() && renderPickerInput()}
-              </div>
-            }
+            <div
+              className={css('ms-UnifiedPicker-listDiv', classNames.listDiv)}
+              role={'listbox'}
+              aria-orientation={'horizontal'}
+              aria-multiselectable={'true'}
+              aria-label={itemListAriaLabel}
+            >
+              {headerComponent}
+              {_renderSelectedItemsList()}
+              {_canAddItems() && renderPickerInput()}
+            </div>
           </div>
         </SelectionZone>
       </FocusZone>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -304,7 +304,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDragEnd: _onDragEnd,
   };
 
-  const shouldForceFocusInput = React.useRef<boolean>(false);
   const _onSuggestionSelected = React.useCallback(
     (ev: any, item: IFloatingSuggestionItemProps<T>) => {
       addItems([item.item]);
@@ -313,7 +312,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
         input.current.clear();
       }
       showPicker(false);
-      shouldForceFocusInput.current = true;
     },
     [addItems, onSuggestionSelected, showPicker],
   );
@@ -610,15 +608,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onRemoveSuggestion: _onFloatingSuggestionRemoved,
     });
 
-  React.useEffect(() => {
-    // We add the selected items list in the UI once we have items, which causes us
-    // to lose focus in the picker, so call focus again here in that case
-    if (selectedItems.length === 1 && shouldForceFocusInput.current) {
-      input.current?.focus();
-      shouldForceFocusInput.current = false;
-    }
-  }, [selectedItems.length]);
-
   const renderPickerInput = () => {
     return (
       <div
@@ -670,7 +659,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           <div className={css('ms-BasePicker-text', classNames.pickerText)}>
             <Announced message={announcementText} />
             {headerComponent}
-            {selectedItems.length > 0 && (
+            {
               <div
                 className={css('ms-UnifiedPicker-listDiv', classNames.listDiv)}
                 role={'listbox'}
@@ -681,8 +670,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                 {_renderSelectedItemsList()}
                 {_canAddItems() && renderPickerInput()}
               </div>
-            )}
-            {_canAddItems() && selectedItems.length === 0 && renderPickerInput()}
+            }
           </div>
         </SelectionZone>
       </FocusZone>

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -62,68 +62,82 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
           role="status"
         />
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
+          aria-multiselectable="true"
+          aria-orientation="horizontal"
           className=
-              ms-BasePicker-div
-              ms-UnifiedPicker-div
+              ms-UnifiedPicker-listDiv
+              ms-UnifiedPicker-listDiv
               {
-                display: flex;
+                display: inline-flex;
+                flex-wrap: wrap;
                 flex: 1 1 auto;
               }
-          onDragOver={[Function]}
-          onDrop={[Function]}
-          role="combobox"
+          role="listbox"
         >
-          <input
-            aria-autocomplete="list"
-            autoCapitalize="off"
-            autoComplete="off"
+          <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className=
-                ms-BasePicker-input
-                ms-UnifiedPicker-input
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border: none;
                   display: flex;
-                  flex-grow: 1;
                   flex: 1 1 auto;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 34px;
-                  margin-bottom: 1px;
-                  margin-left: 1px;
-                  margin-right: 1px;
-                  margin-top: 1px;
-                  outline: none;
-                  padding-bottom: 0px;
-                  padding-left: 6px;
-                  padding-right: 6px;
-                  padding-top: 0;
                 }
-                &::-ms-clear {
-                  display: none;
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            role="combobox"
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="off"
+              autoComplete="off"
+              className=
+                  ms-BasePicker-input
+                  ms-UnifiedPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    display: flex;
+                    flex-grow: 1;
+                    flex: 1 1 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 34px;
+                    margin-bottom: 1px;
+                    margin-left: 1px;
+                    margin-right: 1px;
+                    margin-top: 1px;
+                    outline: none;
+                    padding-bottom: 0px;
+                    padding-left: 6px;
+                    padding-right: 6px;
+                    padding-top: 0;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
+              data-lpignore={true}
+              disabled={false}
+              onChange={[Function]}
+              onClick={[Function]}
+              onCompositionEnd={[Function]}
+              onCompositionStart={[Function]}
+              onCompositionUpdate={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              onKeyDown={[Function]}
+              onPaste={[Function]}
+              style={
+                Object {
+                  "fontFamily": "inherit",
                 }
-            data-lpignore={true}
-            disabled={false}
-            onChange={[Function]}
-            onClick={[Function]}
-            onCompositionEnd={[Function]}
-            onCompositionStart={[Function]}
-            onCompositionUpdate={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onPaste={[Function]}
-            style={
-              Object {
-                "fontFamily": "inherit",
               }
-            }
-            value=""
-          />
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
                 flex-wrap: wrap;
                 flex: 1 1 auto;
               }
-          role="listbox"
+          role=""
         >
           <div
             aria-expanded={false}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [] Include a change request file using `$ yarn change`

#### Description of changes

- removed that code. It was causing focus issues.
- moved the header into the div so the flex layout works
- that relayout was originally to fix an accessibility failure, now I'm changing the role depending on if there are items in the list or not instead of the whole layout. All those tests pass.
- updated snapshots
