### PR TITLE
Update eslint deps for compatibility with new TS version

### DIFF
--- a/apps/codesandbox-react-template/src/index.tsx
+++ b/apps/codesandbox-react-template/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {
-  Fabric,
+  ThemeProvider,
   Checkbox,
   ChoiceGroup,
   Dropdown,
@@ -42,7 +42,7 @@ function start(): void {
   }
 
   ReactDOM.render(
-    <Fabric>
+    <ThemeProvider>
       <Stack gap={8}>
         <Checkbox label="Unchecked checkbox (uncontrolled)" />
         <ChoiceGroup defaultSelectedKey="B" options={choicegroupOptions} label="Pick One" required />
@@ -56,7 +56,7 @@ function start(): void {
           styles={dropdownStyles}
         />
       </Stack>
-    </Fabric>,
+    </ThemeProvider>,
     _rootDiv,
   );
 }

--- a/apps/pr-deploy-site/.eslintrc.json
+++ b/apps/pr-deploy-site/.eslintrc.json
@@ -1,6 +1,13 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/node"],
   "root": true,
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": "../../tsconfig.json"
+      }
+    }
+  },
   "overrides": [
     {
       // pr-deploy-site.js is run without transpiling in all browsers, which means it must use

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "just-scripts clean",
     "generate:site": "just-scripts generate:site",
-    "lint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .js,.ts --cache ."
   },
   "license": "MIT",
   "devDependencies": {

--- a/apps/test-bundles/.eslintrc.json
+++ b/apps/test-bundles/.eslintrc.json
@@ -1,4 +1,11 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/node"],
-  "root": true
+  "root": true,
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": "../../tsconfig.json"
+      }
+    }
+  }
 }

--- a/change/@fluentui-babel-make-styles-2ef10ec4-234c-42f4-b437-453bc28bea93.json
+++ b/change/@fluentui-babel-make-styles-2ef10ec4-234c-42f4-b437-453bc28bea93.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unused eslint-disables",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-cra-template-6911be48-4884-4ebe-be08-b16768692212.json
+++ b/change/@fluentui-cra-template-6911be48-4884-4ebe-be08-b16768692212.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update eslint config",
+  "packageName": "@fluentui/cra-template",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-9cd92621-624a-4360-a184-5c6acc542fa2.json
+++ b/change/@fluentui-eslint-plugin-9cd92621-624a-4360-a184-5c6acc542fa2.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Update dependencies and remove eslint@6 from peer deps",
+  "comment": "Update dependencies, remove eslint@6 from peer deps, and remove usage of process.cwd()",
   "packageName": "@fluentui/eslint-plugin",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-eslint-plugin-9cd92621-624a-4360-a184-5c6acc542fa2.json
+++ b/change/@fluentui-eslint-plugin-9cd92621-624a-4360-a184-5c6acc542fa2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update dependencies and remove eslint@6 from peer deps",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-7575028c-16c0-40d9-adf8-a20401e679ca.json
+++ b/change/@fluentui-foundation-legacy-7575028c-16c0-40d9-adf8-a20401e679ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark old ThemeProvider as deprecated to avoid confusion",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-69e887fa-7196-4231-8a45-a673a0a5798e.json
+++ b/change/@fluentui-react-69e887fa-7196-4231-8a45-a673a0a5798e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update eslint-disables and rename a type param to avoid shadowing (does not affect consumers)",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-examples-3814d184-6fa6-4370-b783-8bfa8b0a4bd4.json
+++ b/change/@fluentui-react-examples-3814d184-6fa6-4370-b783-8bfa8b0a4bd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update eslint overrides in examples; replace some Fabric and Customizer usage with ThemeProvider",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-monaco-editor-d8b0f947-e58a-4398-b408-b4d2f62c447a.json
+++ b/change/@fluentui-react-monaco-editor-d8b0f947-e58a-4398-b408-b4d2f62c447a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update demo page to use ThemeProvider not Fabric",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-c9e5b414-7605-494f-bffc-da67de90434f.json
+++ b/change/@fluentui-react-positioning-c9e5b414-7605-494f-bffc-da67de90434f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unused eslint-disable",
+  "packageName": "@fluentui/react-positioning",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-edc73cc6-4a60-44f5-9572-20839cf8f04f.json
+++ b/change/@fluentui-react-utilities-edc73cc6-4a60-44f5-9572-20839cf8f04f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ComponentState: fix shadowing and doc syntax for type params",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-3f648248-f47c-4f53-937e-bad736868c1c.json
+++ b/change/@fluentui-utilities-3f648248-f47c-4f53-937e-bad736868c1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update eslint-disables in tests",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-7e5e411d-c0e3-4394-8cc0-1e1b4d9ba7c9.json
+++ b/change/@fluentui-web-components-7e5e411d-c0e3-4394-8cc0-1e1b4d9ba7c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unused import",
+  "packageName": "@fluentui/web-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,15 +1,11 @@
 // @ts-check
 
-const { configHelpers } = require('./packages/eslint-plugin/src/index');
-
-const eslintGlob = `*.{${configHelpers.extensions.join(',')}}`;
-
 // https://www.npmjs.com/package/lint-staged
 module.exports = {
-  // Run eslint in fix mode followed by prettier (must be done in sequence, separate from other
-  // prettier formatting, since both commands can modify files)
-  [eslintGlob]: ['node ./scripts/lint-staged/eslint', 'prettier --write'],
-
-  // Run prettier on non-eslintable files (ignores handled by .prettierignore)
-  [`!(${eslintGlob})`]: 'prettier --write',
+  // Run eslint in fix mode for applicable files followed by prettier.
+  // - The eslint wrapper handles filtering which files should be linted, since we need to both:
+  //   - respect ignore files (which eslint doesn't do by default when passed a specific file path)
+  //   - match the set of files that are linted by the package's normal `lint` command
+  // - Prettier must be run in sequence after eslint since both of them can modify files
+  '*': ['node ./scripts/lint-staged/eslint', 'prettier --write'],
 };

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
       "packages/*",
       "packages/fluentui/*",
       "scripts",
-      "tools/"
+      "tools"
     ],
     "nohoist": [
       "@fluentui/make-styles/@types/stylis",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "cypress": "6.6.0",
     "cypress-real-events": "1.2.0",
     "danger": "^6.0.5",
+    "eslint": "7.25.0",
     "eslint-plugin-es": "4.1.0",
     "file-loader": "6.2.0",
     "gulp": "^4.0.2",
@@ -178,6 +179,9 @@
   "resolutions": {
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
+    "@typescript-eslint/eslint-plugin": "4.22.0",
+    "@typescript-eslint/experimental-utils": "4.22.0",
+    "@typescript-eslint/parser": "4.22.0",
     "eslint": "^7.1.0",
     "//": "pretty-format contains typing only supported by TS 3.8+ remove when support in this repo is available",
     "@testing-library/dom": "7.22.3",

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -440,7 +440,6 @@ export const plugin = declare<never, PluginObj<BabelPluginState>>(api => {
             const nodePath = styleNode.nodePath;
 
             if (styleNode.kind === 'SPREAD') {
-              // eslint-disable-next-line no-shadow
               const evaluationResult = (nodePath.get('argument') as NodePath<t.Expression>).evaluate();
 
               if (!evaluationResult.confident) {
@@ -450,7 +449,6 @@ export const plugin = declare<never, PluginObj<BabelPluginState>>(api => {
               }
 
               const stylesBySlots: Record<string, MakeStyles> = evaluationResult.value;
-              // eslint-disable-next-line no-shadow
               const resolvedStyles: ResolvedStylesBySlots<string> = {};
 
               Object.keys(stylesBySlots).forEach(slotName => {

--- a/packages/cra-template/.eslintrc.json
+++ b/packages/cra-template/.eslintrc.json
@@ -1,4 +1,11 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
-  "root": true
+  "root": true,
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": "../../tsconfig.json"
+      }
+    }
+  }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,7 @@
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.4.0",
-    "eslint-plugin-deprecation": "^1.2.0",
+    "eslint-plugin-deprecation": "^1.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -9,29 +9,29 @@
   },
   "license": "MIT",
   "scripts": {
-    "lint": "eslint --ext .js src"
+    "build": "tsc --noEmit",
+    "lint": "eslint --ext .js --cache ."
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.4.0",
-    "@typescript-eslint/experimental-utils": "^3.4.0",
-    "@typescript-eslint/parser": "^3.4.0",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/experimental-utils": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-import-resolver-typescript": "^2.0.0",
-    "eslint-plugin-deprecation": "^1.1.0",
-    "eslint-plugin-import": "^2.21.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-plugin-deprecation": "^1.2.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
-    "eslint-plugin-react-hooks": "^4.0.8",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "jju": "^1.4.0"
   },
   "devDependencies": {
-    "@types/eslint": "^7.2.0",
-    "eslint": "^7.1.0"
+    "@types/eslint": "7.2.10"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0",
+    "eslint": "^7.0.0",
     "typescript": "^4.1.0"
   },
   "files": [

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -9,8 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc --noEmit",
-    "lint": "eslint --ext .js --cache ."
+    "lint": "tsc --noEmit && eslint --ext .js --cache ."
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -1,5 +1,4 @@
 // @ts-check
-const fs = require('fs');
 const path = require('path');
 const configHelpers = require('../utils/configHelpers');
 
@@ -24,8 +23,10 @@ const config = {
     },
     'import/resolver': {
       typescript: {
-        alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory
-        project: [path.join(process.cwd(), 'tsconfig.json'), path.join(gitRoot, 'tsconfig.json')].filter(fs.existsSync),
+        // always try to resolve types under `<root>@types` directory
+        alwaysTryTypes: true,
+        // NOTE: For packages without a tsconfig.json, override with "project": "../../tsconfig.json"
+        project: ['./tsconfig.json', path.join(gitRoot, 'tsconfig.json')],
       },
     },
   },
@@ -366,7 +367,7 @@ const getOverrides = () => [
   {
     files: [...configHelpers.devDependenciesFiles],
     rules: {
-      'import/no-extraneous-dependencies': ['error', { packageDir: [process.cwd(), gitRoot] }],
+      'import/no-extraneous-dependencies': ['error', { packageDir: ['.', gitRoot] }],
     },
   },
 ];

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -1,5 +1,9 @@
 // @ts-check
+const fs = require('fs');
+const path = require('path');
 const configHelpers = require('../utils/configHelpers');
+
+const gitRoot = configHelpers.findGitRoot();
 
 /** @type {import("eslint").Linter.Config} */
 const config = {
@@ -21,7 +25,7 @@ const config = {
     'import/resolver': {
       typescript: {
         alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory
-        directory: process.cwd(),
+        project: [path.join(process.cwd(), 'tsconfig.json'), path.join(gitRoot, 'tsconfig.json')].filter(fs.existsSync),
       },
     },
   },
@@ -304,6 +308,7 @@ const getOverrides = () => [
           ],
         },
       ],
+      '@typescript-eslint/no-shadow': 'error',
 
       // permanently disable due to using other rules which do the same thing
       camelcase: 'off', // redundant with @typescript-eslint/naming-convention
@@ -311,6 +316,7 @@ const getOverrides = () => [
       // permanently disable due to improper TS handling or unnecessary for TS
       // (and not covered by plugin:@typescript-eslint/eslint-recommended)
       'no-empty-function': 'off',
+      'no-shadow': 'off',
       'no-unused-vars': 'off',
       'react/jsx-filename-extension': 'off',
     },
@@ -360,12 +366,7 @@ const getOverrides = () => [
   {
     files: [...configHelpers.devDependenciesFiles],
     rules: {
-      'import/no-extraneous-dependencies': [
-        'error',
-        {
-          packageDir: [process.cwd(), configHelpers.findGitRoot()],
-        },
-      ],
+      'import/no-extraneous-dependencies': ['error', { packageDir: [process.cwd(), gitRoot] }],
     },
   },
 ];

--- a/packages/eslint-plugin/src/rules/no-visibility-modifiers.js
+++ b/packages/eslint-plugin/src/rules/no-visibility-modifiers.js
@@ -1,5 +1,5 @@
 // @ts-check
-/** @type {*} */
+// @ts-ignore
 const util = require('@typescript-eslint/eslint-plugin/dist/util');
 const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
 const createRule = require('../utils/createRule');

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -38,9 +38,6 @@ const camelOrPascalOrUpperCase = `(${camelOrPascalCase}|${upperCase})`;
 const builtins = '^(any|Number|number|String|string|Boolean|boolean|Undefined|undefined)$';
 
 module.exports = {
-  /** File extensions to lint (with leading .) */
-  extensions: ['.ts', '.tsx', '.js', '.jsx'],
-
   /** Test-related files */
   testFiles,
 

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
     "checkJs": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,
-    "strict": true
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/fluentui/docs/src/examples/components/Pill/Variations/PillExampleActionable.tsx
+++ b/packages/fluentui/docs/src/examples/components/Pill/Variations/PillExampleActionable.tsx
@@ -5,6 +5,7 @@ const PillActionableExample = () => (
   <Pill
     actionable
     onDismiss={(e, data) => {
+      // eslint-disable-next-line no-console
       console.log(e, data);
     }}
   >

--- a/packages/fluentui/docs/src/types.ts
+++ b/packages/fluentui/docs/src/types.ts
@@ -71,6 +71,7 @@ export type KnobGeneratorOptions = {
 };
 export type KnobDefinition = UseKnobOptions<any> & { hook: Function };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type KnobGenerator<T> = (options: KnobGeneratorOptions) => KnobDefinition;
 
 export type KnobComponentGenerators<P> = Partial<Record<keyof P, KnobGenerator<any>>>;

--- a/packages/fluentui/react-bindings/src/compose/consts.ts
+++ b/packages/fluentui/react-bindings/src/compose/consts.ts
@@ -80,7 +80,12 @@ export type Input<TElementType extends React.ElementType = 'div', TProps = {}> =
   | InputComposeComponent<TProps>
   | ComposeRenderFunction<TElementType, TProps & { as?: React.ElementType }>;
 
-export type ComposeRenderFunction<TElementType extends React.ElementType = 'div', TProps = {}, _TState = TProps> = (
+export type ComposeRenderFunction<
+  TElementType extends React.ElementType = 'div',
+  TProps = {},
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _TState = TProps
+> = (
   props: TProps,
   ref: React.Ref<TElementType extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[TElementType] : TElementType>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -323,17 +323,14 @@ export const Designer: React.FunctionComponent = () => {
     },
   };
 
-  const handleKeyDown = React.useCallback(
-    (e: KeyboardEvent) => {
-      let command = '';
-      command += e.altKey ? 'Alt+' : '';
-      command += e.ctrlKey || e.metaKey ? 'Ctrl+' : '';
-      command += e.shiftKey ? 'Shift+' : '';
-      command += e.key;
-      hotkeys.hasOwnProperty(command) && hotkeys[command]();
-    },
-    [hotkeys],
-  );
+  const handleKeyDown = (e: KeyboardEvent) => {
+    let command = '';
+    command += e.altKey ? 'Alt+' : '';
+    command += e.ctrlKey || e.metaKey ? 'Ctrl+' : '';
+    command += e.shiftKey ? 'Shift+' : '';
+    command += e.key;
+    hotkeys.hasOwnProperty(command) && hotkeys[command]();
+  };
 
   const handleOpenAddComponentDialog = React.useCallback(
     (uuid: string, where: string) => {

--- a/packages/fluentui/react-builder/src/components/List.tsx
+++ b/packages/fluentui/react-builder/src/components/List.tsx
@@ -14,7 +14,7 @@ export type ListProps = {
 export const List: React.FunctionComponent<ListProps> = ({ onDragStart, style }) => {
   const [filter, setFilter] = React.useState<string>('');
 
-  const filterRegexp = new RegExp(filter, 'i');
+  const filterRegexp = React.useMemo(() => new RegExp(filter, 'i'), [filter]);
 
   const handleMouseDown = React.useCallback(
     componentInfo => e => {

--- a/packages/fluentui/react-northstar/.eslintrc.json
+++ b/packages/fluentui/react-northstar/.eslintrc.json
@@ -10,9 +10,13 @@
     },
     {
       "files": "src/**/*.{ts,tsx}",
+      "parserOptions": {
+        "lib": ["es2015", "dom"]
+      },
       "globals": {
         "document": "off",
-        "window": "off"
+        "window": "off",
+        "JSX": "readonly"
       },
       "rules": {
         "no-undef": "error"

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -166,6 +166,9 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
   setStart();
   const inputRef = React.useRef<HTMLElement>();
 
+  // FIXME: This object is created every render, causing a cascade of useCallback/useEffect re-runs.
+  // Needs to be reworked by someone who understands the intent for when various updates ought to happen.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const dateFormatting: ICalendarStrings = {
     formatDay: props.formatDay,
     formatYear: props.formatYear,

--- a/packages/fluentui/react-northstar/src/components/Design/Design.tsx
+++ b/packages/fluentui/react-northstar/src/components/Design/Design.tsx
@@ -18,6 +18,7 @@ export type DesignProps = {
 /**
  * The Design component provides a theme safe subset of CSS for designing layouts.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function Design<DesignProps>({ config, children }) {
   const context = useFluentContext();
   const getConfig = React.useCallback(() => config, [config]);

--- a/packages/fluentui/react-northstar/test/utils/withProvider.tsx
+++ b/packages/fluentui/react-northstar/test/utils/withProvider.tsx
@@ -24,6 +24,7 @@ export const EmptyThemeProvider: React.FunctionComponent<{
   return <Unstable_FluentContextProvider value={value}>{children}</Unstable_FluentContextProvider>;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const mountWithProvider = <C extends React.Component, P = C['props'], S = C['state']>(
   node: React.ReactElement<P>,
   options?: MountRendererProps,
@@ -34,6 +35,7 @@ export const mountWithProvider = <C extends React.Component, P = C['props'], S =
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const mountWithProviderAndGetComponent = <C extends React.Component, P = C['props'], S = C['state']>(
   Component: ComponentType<P>,
   elementToMount: React.ReactElement<P>,

--- a/packages/foundation-legacy/etc/foundation-legacy.api.md
+++ b/packages/foundation-legacy/etc/foundation-legacy.api.md
@@ -191,7 +191,7 @@ export type IViewComponent<TViewProps> = (props: React_2.PropsWithChildren<TView
 
 export { legacyStyled }
 
-// @public
+// @public @deprecated
 export const ThemeProvider: React_2.FunctionComponent<IThemeProviderProps>;
 
 // @public

--- a/packages/foundation-legacy/src/ThemeProvider.tsx
+++ b/packages/foundation-legacy/src/ThemeProvider.tsx
@@ -12,6 +12,8 @@ export interface IThemeProviderProps {
  * for a given scheme name.
  *
  * @param providers - Injected providers for accessing theme data and providing it via a Customizer component.
+ * @deprecated This is an old ThemeProvider implementation. New code should use the ThemeProvider exported from
+ * `@fluentui/react` (or `@fluentui/react/lib/Theme`) instead.
  */
 export const ThemeProvider: React.FunctionComponent<IThemeProviderProps> = (props: IThemeProviderProps) => {
   const { scheme, theme, ...rest } = props;
@@ -23,6 +25,6 @@ export const ThemeProvider: React.FunctionComponent<IThemeProviderProps> = (prop
     return getThemedContext(context, scheme, theme);
   };
 
-  // eslint-disable-next-line react/jsx-no-bind
+  // eslint-disable-next-line react/jsx-no-bind, deprecation/deprecation
   return <Customizer {...rest} contextTransform={contextTransform} />;
 };

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
-import { Customizer, TextField, Stack, Fabric, Checkbox, SearchBox, Link, Label, Text } from '@fluentui/react';
+import {
+  Customizer as DeprecatedCustomizer,
+  TextField,
+  Stack,
+  Checkbox,
+  SearchBox,
+  Link,
+  Label,
+  Text,
+  ThemeProvider,
+} from '@fluentui/react';
 import { DefaultButton, CompoundButton, PrimaryButton } from '@fluentui/react/lib/Button';
 import {
   AzureCustomizationsLight,
@@ -30,6 +40,10 @@ import { PivotBasicExample } from '../components/Pivots.stories';
 import { TeachingBubbleBasicExample } from '../components/TeachingBubble.stories';
 import { MessageBarBasicExample } from '../components/messageBar.stories';
 import { TooltipBasicExample } from '../components/tooltip.stories';
+
+// Workaround to prevent errors on usage of Customizer, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const Customizer = DeprecatedCustomizer;
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -137,32 +151,32 @@ const Example = () => (
 
 export const Light = () => (
   <Customizer {...AzureCustomizationsLight}>
-    <Fabric applyThemeToBody>
+    <ThemeProvider applyTo="body">
       <Example />
-    </Fabric>
+    </ThemeProvider>
   </Customizer>
 );
 
 export const Dark = () => (
   <Customizer {...AzureCustomizationsDark}>
-    <Fabric applyThemeToBody>
+    <ThemeProvider applyTo="body">
       <Example />
-    </Fabric>
+    </ThemeProvider>
   </Customizer>
 );
 
 export const HighContrastLight = () => (
   <Customizer {...AzureCustomizationsHighContrastLight}>
-    <Fabric applyThemeToBody>
+    <ThemeProvider applyTo="body">
       <Example />
-    </Fabric>
+    </ThemeProvider>
   </Customizer>
 );
 
 export const HighContrastDark = () => (
   <Customizer {...AzureCustomizationsHighContrastDark}>
-    <Fabric applyThemeToBody>
+    <ThemeProvider applyTo="body">
       <Example />
-    </Fabric>
+    </ThemeProvider>
   </Customizer>
 );

--- a/packages/react-examples/src/azure-themes/stories/components/comboBox.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/comboBox.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
   ComboBox,
-  Fabric,
   IComboBox,
   IComboBoxOption,
   IComboBoxProps,
   mergeStyles,
   SelectableOptionMenuItemType,
+  ThemeProvider,
 } from '@fluentui/react';
 import { PrimaryButton } from '@fluentui/react/lib/Button';
 
@@ -49,7 +49,7 @@ export class ComboBoxBasicExample extends React.Component<{}, IComboBoxBasicExam
 
   public render(): JSX.Element {
     return (
-      <Fabric className={wrapperClassName}>
+      <ThemeProvider className={wrapperClassName}>
         <div>
           {/* This example demonstrates various props, but only `options` is required. */}
           <ComboBox
@@ -120,7 +120,7 @@ export class ComboBoxBasicExample extends React.Component<{}, IComboBoxBasicExam
         />
 
         <ComboBox disabled label="Disabled ComboBox" defaultSelectedKey="D" options={INITIAL_OPTIONS} />
-      </Fabric>
+      </ThemeProvider>
     );
   }
 

--- a/packages/react-examples/src/azure-themes/stories/components/detailsList.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/detailsList.stories.tsx
@@ -3,8 +3,8 @@ import { Announced } from '@fluentui/react/lib/Announced';
 import { TextField, ITextFieldStyles } from '@fluentui/react/lib/TextField';
 import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
-import { Fabric } from '@fluentui/react/lib/Fabric';
 import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { ThemeProvider } from '@fluentui/react';
 
 const exampleChildClass = mergeStyles({
   display: 'block',
@@ -60,7 +60,7 @@ export class DetailsListCompactExample extends React.Component<{}, IDetailsListC
     const { items, selectionDetails } = this.state;
 
     return (
-      <Fabric>
+      <ThemeProvider>
         <div className={exampleChildClass}>{selectionDetails}</div>
         <Announced message={selectionDetails} />
         <TextField
@@ -85,7 +85,7 @@ export class DetailsListCompactExample extends React.Component<{}, IDetailsListC
             checkButtonAriaLabel="Row checkbox"
           />
         </MarqueeSelection>
-      </Fabric>
+      </ThemeProvider>
     );
   }
 

--- a/packages/react-examples/src/react-avatar/Avatar/Avatar.stories.tsx
+++ b/packages/react-examples/src/react-avatar/Avatar/Avatar.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarExamples } from '@fluentui/example-data';
-import { Button, SpinButton, Stack, ThemeProvider } from '@fluentui/react';
+import { PrimaryButton, SpinButton, Stack, ThemeProvider } from '@fluentui/react';
 import { Avatar, AvatarProps, renderAvatar, useAvatar, useAvatarStyles } from '@fluentui/react-avatar';
 import { useBoolean } from '@fluentui/react-hooks';
 import {
@@ -194,9 +194,7 @@ export const ActiveAnimation = () => {
           />
         </div>
         <Stack tokens={{ childrenGap: 8, maxWidth: 220 }}>
-          <Button primary onClick={React.useCallback(() => setActive(a => !a), [])}>
-            Toggle Active
-          </Button>
+          <PrimaryButton onClick={React.useCallback(() => setActive(a => !a), [])}>Toggle Active</PrimaryButton>
           <SpinButton
             label="activeDisplay"
             value={activeDisplay}

--- a/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Styled.Example.tsx
+++ b/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Styled.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Customizer } from '@fluentui/react/lib/Utilities';
+import { Customizer as DeprecatedCustomizer } from '@fluentui/react/lib/Utilities';
 import { ITheme, createTheme, DefaultPalette } from '@fluentui/react/lib/Styling';
 import { FocusZone } from '@fluentui/react/lib/FocusZone';
 import {
@@ -10,6 +10,10 @@ import {
   ICollapsibleSectionTitleComponent,
   ICollapsibleSectionTitleStylesReturnType,
 } from '@fluentui/react-experiments/lib/CollapsibleSection';
+
+// Workaround to prevent errors on usage of Customizer in this file, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const Customizer = DeprecatedCustomizer;
 
 const getPropStyles: ICollapsibleSectionComponent['styles'] = (props, theme): ICollapsibleSectionStylesReturnType => ({
   root: [

--- a/packages/react-examples/src/react-experiments/Slider/Slider.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Slider/Slider.Example.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
-import { Slider } from '@fluentui/react-experiments';
+import { Slider as DeprecatedSlider } from '@fluentui/react-experiments';
 import { IStackTokens, Stack } from '@fluentui/react';
+
+// Workaround to prevent errors on usage of Slider, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const Slider = DeprecatedSlider;
 
 export interface ISliderBasicExampleState {
   value: number;

--- a/packages/react-examples/src/react-experiments/Slider/Slider.Vertical.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Slider/Slider.Vertical.Example.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
-import { Slider } from '@fluentui/react-experiments/lib/Slider';
+import { Slider as DeprecatedSlider } from '@fluentui/react-experiments';
 import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
+
+// Workaround to prevent errors on usage of Slider, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const Slider = DeprecatedSlider;
 
 export interface ISliderVerticalExampleState {
   value: number;

--- a/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Custom.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Custom.Example.tsx
@@ -23,7 +23,11 @@ import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/Button';
 
 import { CollapsibleSectionRecursiveExample } from '@fluentui/react-examples/lib/react-experiments/CollapsibleSection/CollapsibleSection.Recursive.Example';
 
-import { ThemeProvider } from '@fluentui/foundation-legacy';
+import { ThemeProvider as DeprecatedThemeProvider } from '@fluentui/foundation-legacy';
+
+// Workaround to prevent errors on usage of ThemeProvider, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const ThemeProvider = DeprecatedThemeProvider;
 
 const regionStyles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => ({
   root: {
@@ -182,6 +186,7 @@ export class ThemingSchemesCustomExample extends React.Component<{}, IThemingExa
   };
 
   public render(): JSX.Element {
+    // eslint-disable-next-line deprecation/deprecation
     return <Customizer settings={{ theme: schemeThemeCustom }}>{this._renderSchemedComponents()}</Customizer>;
   }
 

--- a/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Variant.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Variant.Example.tsx
@@ -22,7 +22,11 @@ import { getNeutralVariant, getSoftVariant, getStrongVariant } from '@fluentui/s
 
 import { CollapsibleSectionRecursiveExample } from '@fluentui/react-examples/lib/react-experiments/CollapsibleSection/CollapsibleSection.Recursive.Example';
 
-import { ThemeProvider } from '@fluentui/foundation-legacy';
+import { ThemeProvider as DeprecatedThemeProvider } from '@fluentui/foundation-legacy';
+
+// Workaround to prevent errors on usage of ThemeProvider, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const ThemeProvider = DeprecatedThemeProvider;
 
 const regionStyles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => ({
   root: {
@@ -61,6 +65,7 @@ export class ThemingSchemesVariantExample extends React.Component<{}, IThemingEx
   };
 
   public render(): JSX.Element {
+    // eslint-disable-next-line deprecation/deprecation
     return <Customizer settings={{ theme: schemeThemeVariants }}>{this._renderSchemedComponents()}</Customizer>;
   }
 

--- a/packages/react-examples/src/react-tabs/Tabs/Tabs.OverflowMenu.Example.tsx
+++ b/packages/react-examples/src/react-tabs/Tabs/Tabs.OverflowMenu.Example.tsx
@@ -10,7 +10,9 @@ export const TabsOverflowMenuExample: React.FunctionComponent = () => {
 
   return (
     <>
-      <Fabric dir={rtl ? 'rtl' : 'ltr'}>
+      <Fabric // eslint-disable-line deprecation/deprecation
+        dir={rtl ? 'rtl' : 'ltr'}
+      >
         <Tabs
           aria-label="Tabs Overflow Menu Example"
           tabFormat={tabs ? 'tabs' : 'links'}
@@ -41,6 +43,7 @@ export const TabsOverflowMenuExample: React.FunctionComponent = () => {
             <Label>Tab #8</Label>
           </TabItem>
         </Tabs>
+        {/* eslint-disable-next-line deprecation/deprecation */}
       </Fabric>
       <div style={{ background: '#EEE', marginTop: 10 }}>
         <Toggle label="overflow" offText="none" onText="menu" checked={overflow} onChange={toggleOverflow} />

--- a/packages/react-examples/src/react/HoverCard/HoverCard.Basic.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.Basic.Example.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import { HoverCard, IExpandingCardProps } from '@fluentui/react/lib/HoverCard';
-import { Fabric } from '@fluentui/react/lib/Fabric';
-import { DetailsList, buildColumns, IColumn } from '@fluentui/react/lib/DetailsList';
+import {
+  DetailsList,
+  buildColumns,
+  IColumn,
+  mergeStyleSets,
+  HoverCard,
+  IExpandingCardProps,
+  ThemeProvider,
+} from '@fluentui/react';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
-import { mergeStyleSets } from '@fluentui/react/lib/Styling';
 
 const classNames = mergeStyleSets({
   compactCard: {
@@ -69,11 +74,11 @@ const onRenderItemColumn = (item: IExampleItem, index: number, column: IColumn):
 };
 
 export const HoverCardBasicExample: React.FunctionComponent = () => (
-  <Fabric>
+  <ThemeProvider>
     <p>
       Hover over the <i>location</i> cell of a row item to see the card or use the keyboard to navigate to it.
     </p>
     <p>When using the keyboard to tab to it, the card will open but navigation inside of it will not be available.</p>
     <DetailsList setKey="hoverSet" items={items} columns={columns} onRenderItemColumn={onRenderItemColumn} />
-  </Fabric>
+  </ThemeProvider>
 );

--- a/packages/react-examples/src/react/HoverCard/HoverCard.EventListenerTarget.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.EventListenerTarget.Example.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { HoverCard, IPlainCardProps, HoverCardType, DirectionalHint, Fabric, mergeStyleSets } from '@fluentui/react';
+import {
+  HoverCard,
+  IPlainCardProps,
+  HoverCardType,
+  DirectionalHint,
+  ThemeProvider,
+  mergeStyleSets,
+} from '@fluentui/react';
 import { IconButton } from '@fluentui/react/lib/Button';
 
 const classNames = mergeStyleSets({
@@ -27,7 +34,7 @@ export const HoverCardEventListenerTargetExample: React.FunctionComponent = () =
     directionalHint: DirectionalHint.rightTopEdge,
   };
   return (
-    <Fabric>
+    <ThemeProvider>
       <p>
         Using the target to tag hover card on the right side of Emoji icon, and using eventListenerTarget to launch the
         card only when hovering over the text field, hovering over the icon doesn't trigger card open.
@@ -44,6 +51,6 @@ export const HoverCardEventListenerTargetExample: React.FunctionComponent = () =
           eventListenerTarget={eventListenerTargetRef.current}
         />
       </span>
-    </Fabric>
+    </ThemeProvider>
   );
 };

--- a/packages/react-examples/src/react/HoverCard/HoverCard.InstantDismiss.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.InstantDismiss.Example.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { HoverCard, IHoverCard, IPlainCardProps, HoverCardType } from '@fluentui/react/lib/HoverCard';
-import { Fabric } from '@fluentui/react/lib/Fabric';
-import { DefaultButton } from '@fluentui/react/lib/Button';
-import { mergeStyleSets } from '@fluentui/react/lib/Styling';
+import {
+  HoverCard,
+  IHoverCard,
+  IPlainCardProps,
+  HoverCardType,
+  ThemeProvider,
+  DefaultButton,
+  mergeStyleSets,
+} from '@fluentui/react';
 
 const classNames = mergeStyleSets({
   plainCard: {
@@ -47,7 +52,7 @@ export const HoverCardInstantDismissExample: React.FunctionComponent = () => {
     onRenderPlainCard: onRenderPlainCard,
   };
   return (
-    <Fabric>
+    <ThemeProvider>
       <p>
         In cases where an instant dismiss of the card is needed, public method
         <i>dismiss()</i> can be used through its <i>componentRef</i> prop.
@@ -61,6 +66,6 @@ export const HoverCardInstantDismissExample: React.FunctionComponent = () => {
       >
         <span className={classNames.target}>Hover Over Me</span>
       </HoverCard>
-    </Fabric>
+    </ThemeProvider>
   );
 };

--- a/packages/react-examples/src/react/HoverCard/HoverCard.PlainCard.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.PlainCard.Example.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
-import { HoverCard, IPlainCardProps, HoverCardType } from '@fluentui/react/lib/HoverCard';
-import { DetailsList, buildColumns, IColumn } from '@fluentui/react/lib/DetailsList';
+import {
+  HoverCard,
+  IPlainCardProps,
+  HoverCardType,
+  DetailsList,
+  buildColumns,
+  IColumn,
+  ThemeProvider,
+  Image,
+  ImageFit,
+  getColorFromString,
+  mergeStyles,
+} from '@fluentui/react';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
-import { Image, ImageFit } from '@fluentui/react/lib/Image';
-import { Fabric } from '@fluentui/react/lib/Fabric';
-import { getColorFromString } from '@fluentui/react/lib/Color';
-import { mergeStyles } from '@fluentui/react/lib/Styling';
 
 const itemClass = mergeStyles({
   selectors: {
@@ -45,11 +52,11 @@ const onRenderItemColumn = (item: IExampleItem, index: number, column: IColumn):
 
 export const HoverCardPlainCardExample: React.FunctionComponent = () => {
   return (
-    <Fabric>
+    <ThemeProvider>
       <p>
         Hover over the <i>color</i> cell of a row item to see the card.
       </p>
       <DetailsList setKey="hoverSet" items={items} columns={columns} onRenderItemColumn={onRenderItemColumn} />
-    </Fabric>
+    </ThemeProvider>
   );
 };

--- a/packages/react-examples/src/react/HoverCard/HoverCard.Target.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.Target.Example.tsx
@@ -6,7 +6,7 @@ import {
   DetailsList,
   buildColumns,
   IColumn,
-  Fabric,
+  ThemeProvider,
   KeyCodes,
   mergeStyleSets,
 } from '@fluentui/react';
@@ -109,7 +109,7 @@ const onRenderItemColumn = (item: IExampleItem, index: number, column: IColumn):
 
 export const HoverCardTargetExample: React.FunctionComponent = () => {
   return (
-    <Fabric>
+    <ThemeProvider>
       <p>
         Hover over the <strong>key</strong> cell of a row item to see the card or use the keyboard to navigate to it by
         tabbing to a row and hitting the right arrow key.
@@ -126,6 +126,6 @@ export const HoverCardTargetExample: React.FunctionComponent = () => {
         onRenderItemColumn={onRenderItemColumn}
         ariaLabel="Hover card DetailsList test"
       />
-    </Fabric>
+    </ThemeProvider>
   );
 };

--- a/packages/react-examples/src/react/Layer/Layer.Customized.Example.tsx
+++ b/packages/react-examples/src/react/Layer/Layer.Customized.Example.tsx
@@ -25,6 +25,7 @@ export const LayerCustomizedExample: React.FunctionComponent = () => {
       </p>
       <Toggle label="Show panel" inlineLabel checked={isPanelOpen} onChange={isPanelOpen ? dismissPanel : showPanel} />
       <Toggle label="Trap panel" inlineLabel checked={trapPanel} onChange={toggleTrapPanel} />
+      {/* eslint-disable-next-line deprecation/deprecation */}
       <Customizer scopedSettings={scopedSettings}>
         {isPanelOpen && (
           <Panel
@@ -37,6 +38,7 @@ export const LayerCustomizedExample: React.FunctionComponent = () => {
             This panel {trapPanel ? 'is' : 'is not'} trapped.
           </Panel>
         )}
+        {/* eslint-disable-next-line deprecation/deprecation */}
       </Customizer>
       <LayerHost id={layerHostId} className={layerHostClass} />
     </div>

--- a/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
+++ b/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
@@ -14,6 +14,7 @@ export const PivotOverflowMenuExample: React.FunctionComponent = () => {
         <Toggle label="linkFormat" offText="links" onText="tabs" checked={tabs} onChange={toggleTabs} />
         <Toggle label="direction" offText="ltr" onText="rtl" checked={rtl} onChange={toggleRtl} />
       </div>
+      {/* eslint-disable-next-line deprecation/deprecation */}
       <Fabric dir={rtl ? 'rtl' : 'ltr'}>
         <Pivot
           aria-label="Pivot Overflow Menu Example"
@@ -45,6 +46,7 @@ export const PivotOverflowMenuExample: React.FunctionComponent = () => {
             <Label>Pivot #8</Label>
           </PivotItem>
         </Pivot>
+        {/* eslint-disable-next-line deprecation/deprecation */}
       </Fabric>
     </>
   );

--- a/packages/react-examples/src/react/Shimmer/Shimmer.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Shimmer/Shimmer.Basic.Example.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Shimmer, ShimmerElementType, IShimmerElement } from '@fluentui/react/lib/Shimmer';
-import { Fabric } from '@fluentui/react/lib/Fabric';
-import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { Shimmer, ShimmerElementType, IShimmerElement, ThemeProvider, mergeStyles } from '@fluentui/react';
 
 const wrapperClass = mergeStyles({
   padding: 2,
@@ -54,7 +52,7 @@ const shimmerVerticalElement: IShimmerElement[] = [
 
 export const ShimmerBasicExample: React.FunctionComponent = () => {
   return (
-    <Fabric className={wrapperClass}>
+    <ThemeProvider className={wrapperClass}>
       Basic Shimmer with no elements provided. It defaults to a line of 16px height.
       <Shimmer />
       <Shimmer width="75%" />
@@ -65,6 +63,6 @@ export const ShimmerBasicExample: React.FunctionComponent = () => {
       <Shimmer width="70%" shimmerElements={shimmerWithElementThirdRow} />
       Variations of vertical alignment for Circles and Lines.
       <Shimmer shimmerElements={shimmerVerticalElement} />
-    </Fabric>
+    </ThemeProvider>
   );
 };

--- a/packages/react-examples/src/react/Shimmer/Shimmer.CustomElements.Example.tsx
+++ b/packages/react-examples/src/react/Shimmer/Shimmer.CustomElements.Example.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Shimmer, ShimmerElementsGroup, ShimmerElementType } from '@fluentui/react/lib/Shimmer';
-import { Fabric } from '@fluentui/react/lib/Fabric';
-import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { Shimmer, ShimmerElementType, ShimmerElementsGroup, ThemeProvider, mergeStyles } from '@fluentui/react';
 
 const wrapperClass = mergeStyles({
   padding: 2,
@@ -97,10 +95,10 @@ const getCustomElementsExampleThree = (): JSX.Element => {
 };
 
 export const ShimmerCustomElementsExample: React.FunctionComponent = () => (
-  <Fabric className={wrapperClass}>
+  <ThemeProvider className={wrapperClass}>
     Using ShimmerElementsGroup component to build complex structures of the placeholder you need.
     <Shimmer customElementsGroup={getCustomElementsExampleOne()} width="350" />
     <Shimmer customElementsGroup={getCustomElementsExampleTwo()} width="550" />
     <Shimmer customElementsGroup={getCustomElementsExampleThree()} width="90%" />
-  </Fabric>
+  </ThemeProvider>
 );

--- a/packages/react-examples/src/react/Shimmer/Shimmer.Styling.Example.tsx
+++ b/packages/react-examples/src/react/Shimmer/Shimmer.Styling.Example.tsx
@@ -5,12 +5,12 @@ import {
   IShimmerStyles,
   ShimmerElementsGroup,
   ShimmerElementType,
-} from '@fluentui/react/lib/Shimmer';
-import { mergeStyleSets, ITheme, createTheme } from '@fluentui/react/lib/Styling';
-import { Customizer } from '@fluentui/react/lib/Utilities';
+  mergeStyleSets,
+  createTheme,
+  ThemeProvider,
+} from '@fluentui/react';
 
-// Custom theme passed to Customizer
-const customThemeForShimmer: ITheme = createTheme({
+const customThemeForShimmer = createTheme({
   palette: {
     // palette slot used in Shimmer for main background
     neutralLight: '#bdd4ed',
@@ -157,11 +157,11 @@ export const ShimmerStylingExample: React.FunctionComponent = () => {
       <div>
         <b>2. </b>Another way of doing it by using <b>Customizer</b> component wrapper.
       </div>
-      <Customizer settings={{ theme: { ...customThemeForShimmer } }}>
+      <ThemeProvider theme={customThemeForShimmer}>
         <div className={classNames.themedBackgroundWrapper2}>
           <Shimmer customElementsGroup={getCustomElements()} width="300" />
         </div>
-      </Customizer>
+      </ThemeProvider>
       <div>
         <b>3. </b>Style overrides of shimmering wave using <b>styles</b> prop.
       </div>

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -3,33 +3,27 @@
 exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
 <div
   className=
-      ms-Fabric
+
       {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
         padding-bottom: 2px;
         padding-left: 2px;
         padding-right: 2px;
         padding-top: 2px;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
       }
       & > .ms-Shimmer-container {
         margin-bottom: 10px;
         margin-left: 0;
         margin-right: 0;
         margin-top: 10px;
+      }
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Basic Shimmer with no elements provided. It defaults to a line of 16px height.

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -3,33 +3,27 @@
 exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly 1`] = `
 <div
   className=
-      ms-Fabric
+
       {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
         padding-bottom: 2px;
         padding-left: 2px;
         padding-right: 2px;
         padding-top: 2px;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
       }
       & > .ms-Shimmer-container {
         margin-bottom: 10px;
         margin-left: 0;
         margin-right: 0;
         margin-top: 10px;
+      }
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Using ShimmerElementsGroup component to build complex structures of the placeholder you need.

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -1161,431 +1161,445 @@ Array [
     className=
 
         {
-          align-items: center;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
           background: #0078D4;
-          display: flex;
-          height: 100px;
-          justify-content: center;
-          margin-bottom: 10px;
-          margin-left: 0;
-          margin-right: 0;
-          margin-top: 10px;
-          outline-offset: -10px;
-          outline: 1px solid #323130;
-          width: 400px;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
         }
   >
     <div
       className=
-          ms-Shimmer-container
+
           {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: auto;
-            position: relative;
+            align-items: center;
+            background: #0078D4;
+            display: flex;
+            height: 100px;
+            justify-content: center;
+            margin-bottom: 10px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 10px;
+            outline-offset: -10px;
+            outline: 1px solid #323130;
+            width: 400px;
           }
     >
       <div
         className=
-            ms-Shimmer-shimmerWrapper
+            ms-Shimmer-container
             {
-              background-color: #7AAFE7;
-              overflow: hidden;
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: auto;
               position: relative;
-              transform: translateZ(0);
-              transition: opacity 200ms;
             }
-            & > * {
-              transform: translateZ(0);
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              -ms-high-contrast-adjust: none;
-              background: WindowText
-                                    linear-gradient(
-                                      to right,
-                                      transparent 0%,
-                                      Window 50%,
-                                      transparent 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-              forced-color-adjust: none;
-            }
-        style={
-          Object {
-            "width": "300",
-          }
-        }
       >
         <div
           className=
-              ms-Shimmer-shimmerGradient
+              ms-Shimmer-shimmerWrapper
               {
-                animation-direction: normal;
-                animation-duration: 2s;
-                animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
-                animation-timing-function: ease-in-out;
-                background: #7AAFE7
-                                    linear-gradient(
-                                      to right,
-                                      #7AAFE7 0%,
-                                      #bdd4ed 50%,
-                                      #7AAFE7 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-                height: 100%;
-                left: 0px;
-                position: absolute;
-                top: 0px;
-                transform: translateX(-100%);
-                width: 100%;
+                background-color: #7AAFE7;
+                overflow: hidden;
+                position: relative;
+                transform: translateZ(0);
+                transition: opacity 200ms;
               }
-        />
-        <div
+              & > * {
+                transform: translateZ(0);
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                background: WindowText
+                                      linear-gradient(
+                                        to right,
+                                        transparent 0%,
+                                        Window 50%,
+                                        transparent 100%)
+                                      0 0 / 90% 100%
+                                      no-repeat;
+                forced-color-adjust: none;
+              }
           style={
             Object {
-              "display": "flex",
+              "width": "300",
             }
           }
         >
           <div
             className=
-                ms-ShimmerElementsGroup-root
+                ms-Shimmer-shimmerGradient
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  position: relative;
+                  animation-direction: normal;
+                  animation-duration: 2s;
+                  animation-iteration-count: infinite;
+                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+                  animation-timing-function: ease-in-out;
+                  background: #7AAFE7
+                                      linear-gradient(
+                                        to right,
+                                        #7AAFE7 0%,
+                                        #bdd4ed 50%,
+                                        #7AAFE7 100%)
+                                      0 0 / 90% 100%
+                                      no-repeat;
+                  height: 100%;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transform: translateX(-100%);
+                  width: 100%;
                 }
+          />
+          <div
             style={
               Object {
-                "width": "auto",
+                "display": "flex",
               }
             }
           >
             <div
               className=
-                  ms-ShimmerCircle-root
+                  ms-ShimmerElementsGroup-root
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    border-bottom-style: solid;
-                    border-bottom-width: 0px;
-                    border-color: #0078D4;
-                    border-top-style: solid;
-                    border-top-width: 0px;
-                    box-sizing: content-box;
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
-                    min-width: 40px;
-                    width: 40px;
+                    position: relative;
                   }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border-color: Window;
-                  }
+              style={
+                Object {
+                  "width": "auto",
+                }
+              }
             >
-              <svg
+              <div
                 className=
-                    ms-ShimmerCircle-svg
+                    ms-ShimmerCircle-root
                     {
-                      display: block;
-                      fill: #0078D4;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-bottom-style: solid;
+                      border-bottom-width: 0px;
+                      border-color: #0078D4;
+                      border-top-style: solid;
+                      border-top-width: 0px;
+                      box-sizing: content-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      min-width: 40px;
+                      width: 40px;
                     }
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                      fill: Window;
+                      border-color: Window;
                     }
-                height={40}
-                viewBox="0 0 10 10"
-                width={40}
               >
-                <path
-                  d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
-                />
-              </svg>
+                <svg
+                  className=
+                      ms-ShimmerCircle-svg
+                      {
+                        display: block;
+                        fill: #0078D4;
+                      }
+                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                        fill: Window;
+                      }
+                  height={40}
+                  viewBox="0 0 10 10"
+                  width={40}
+                >
+                  <path
+                    d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className=
+                    ms-ShimmerGap-root
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078D4;
+                      border-bottom-style: solid;
+                      border-bottom-width: 0px;
+                      border-color: #0078D4;
+                      border-top-style: solid;
+                      border-top-width: 0px;
+                      box-sizing: content-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: Window;
+                      border-color: Window;
+                    }
+                style={
+                  Object {
+                    "minWidth": "16px",
+                    "width": 16,
+                  }
+                }
+              />
             </div>
             <div
               className=
-                  ms-ShimmerGap-root
+                  ms-ShimmerElementsGroup-root
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: #0078D4;
-                    border-bottom-style: solid;
-                    border-bottom-width: 0px;
-                    border-color: #0078D4;
-                    border-top-style: solid;
-                    border-top-width: 0px;
-                    box-sizing: content-box;
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: wrap;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    background-color: Window;
-                    border-color: Window;
-                  }
-              style={
-                Object {
-                  "minWidth": "16px",
-                  "width": 16,
-                }
-              }
-            />
-          </div>
-          <div
-            className=
-                ms-ShimmerElementsGroup-root
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: wrap;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  position: relative;
-                }
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              className=
-                  ms-ShimmerLine-root
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border-bottom-style: solid;
-                    border-bottom-width: 0px;
-                    border-color: #0078D4;
-                    border-top-style: solid;
-                    border-top-width: 10px;
-                    border-width: 0px;
-                    box-sizing: content-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 10px;
                     position: relative;
                   }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border-color: Window;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
-                    fill: Window;
-                  }
               style={
                 Object {
-                  "minWidth": "auto",
                   "width": "100%",
                 }
               }
             >
-              <svg
+              <div
                 className=
-                    ms-ShimmerLine-topLeftCorner
+                    ms-ShimmerLine-root
                     {
-                      fill: #0078D4;
-                      left: 0;
-                      position: absolute;
-                      top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-bottom-style: solid;
+                      border-bottom-width: 0px;
+                      border-color: #0078D4;
+                      border-top-style: solid;
+                      border-top-width: 10px;
+                      border-width: 0px;
+                      box-sizing: content-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 10px;
+                      position: relative;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-                />
-              </svg>
-              <svg
-                className=
-                    ms-ShimmerLine-topRightCorner
-                    {
-                      fill: #0078D4;
-                      position: absolute;
-                      right: 0;
-                      top: 0;
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-                />
-              </svg>
-              <svg
-                className=
-                    ms-ShimmerLine-bottomRightCorner
-                    {
-                      bottom: 0;
-                      fill: #0078D4;
-                      position: absolute;
-                      right: 0;
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
+                      fill: Window;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-                />
-              </svg>
-              <svg
-                className=
-                    ms-ShimmerLine-bottomLeftCorner
-                    {
-                      bottom: 0;
-                      fill: #0078D4;
-                      left: 0;
-                      position: absolute;
-                    }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className=
-                  ms-ShimmerLine-root
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border-bottom-style: solid;
-                    border-bottom-width: 6px;
-                    border-color: #0078D4;
-                    border-top-style: solid;
-                    border-top-width: 6px;
-                    border-width: 0px;
-                    box-sizing: content-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 8px;
-                    position: relative;
+                style={
+                  Object {
+                    "minWidth": "auto",
+                    "width": "100%",
                   }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border-color: Window;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
-                    fill: Window;
-                  }
-              style={
-                Object {
-                  "minWidth": "auto",
-                  "width": "90%",
                 }
-              }
-            >
-              <svg
-                className=
-                    ms-ShimmerLine-topLeftCorner
-                    {
-                      fill: #0078D4;
-                      left: 0;
-                      position: absolute;
-                      top: 0;
-                    }
-                height="2"
-                width="2"
               >
-                <path
-                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-                />
-              </svg>
-              <svg
+                <svg
+                  className=
+                      ms-ShimmerLine-topLeftCorner
+                      {
+                        fill: #0078D4;
+                        left: 0;
+                        position: absolute;
+                        top: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-topRightCorner
+                      {
+                        fill: #0078D4;
+                        position: absolute;
+                        right: 0;
+                        top: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-bottomRightCorner
+                      {
+                        bottom: 0;
+                        fill: #0078D4;
+                        position: absolute;
+                        right: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-bottomLeftCorner
+                      {
+                        bottom: 0;
+                        fill: #0078D4;
+                        left: 0;
+                        position: absolute;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                  />
+                </svg>
+              </div>
+              <div
                 className=
-                    ms-ShimmerLine-topRightCorner
+                    ms-ShimmerLine-root
                     {
-                      fill: #0078D4;
-                      position: absolute;
-                      right: 0;
-                      top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-bottom-style: solid;
+                      border-bottom-width: 6px;
+                      border-color: #0078D4;
+                      border-top-style: solid;
+                      border-top-width: 6px;
+                      border-width: 0px;
+                      box-sizing: content-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 8px;
+                      position: relative;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-                />
-              </svg>
-              <svg
-                className=
-                    ms-ShimmerLine-bottomRightCorner
-                    {
-                      bottom: 0;
-                      fill: #0078D4;
-                      position: absolute;
-                      right: 0;
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border-color: Window;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-                />
-              </svg>
-              <svg
-                className=
-                    ms-ShimmerLine-bottomLeftCorner
-                    {
-                      bottom: 0;
-                      fill: #0078D4;
-                      left: 0;
-                      position: absolute;
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& > * {
+                      fill: Window;
                     }
-                height="2"
-                width="2"
-              >
-                <path
-                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className=
-                  ms-ShimmerGap-root
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #0078D4;
-                    border-bottom-style: solid;
-                    border-bottom-width: 0px;
-                    border-color: #0078D4;
-                    border-top-style: solid;
-                    border-top-width: 0px;
-                    box-sizing: content-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 20px;
+                style={
+                  Object {
+                    "minWidth": "auto",
+                    "width": "90%",
                   }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    background-color: Window;
-                    border-color: Window;
-                  }
-              style={
-                Object {
-                  "minWidth": "auto",
-                  "width": "10%",
                 }
-              }
-            />
+              >
+                <svg
+                  className=
+                      ms-ShimmerLine-topLeftCorner
+                      {
+                        fill: #0078D4;
+                        left: 0;
+                        position: absolute;
+                        top: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-topRightCorner
+                      {
+                        fill: #0078D4;
+                        position: absolute;
+                        right: 0;
+                        top: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-bottomRightCorner
+                      {
+                        bottom: 0;
+                        fill: #0078D4;
+                        position: absolute;
+                        right: 0;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                  />
+                </svg>
+                <svg
+                  className=
+                      ms-ShimmerLine-bottomLeftCorner
+                      {
+                        bottom: 0;
+                        fill: #0078D4;
+                        left: 0;
+                        position: absolute;
+                      }
+                  height="2"
+                  width="2"
+                >
+                  <path
+                    d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className=
+                    ms-ShimmerGap-root
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078D4;
+                      border-bottom-style: solid;
+                      border-bottom-width: 0px;
+                      border-color: #0078D4;
+                      border-top-style: solid;
+                      border-top-width: 0px;
+                      box-sizing: content-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      background-color: Window;
+                      border-color: Window;
+                    }
+                style={
+                  Object {
+                    "minWidth": "auto",
+                    "width": "10%",
+                  }
+                }
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
@@ -79,7 +79,7 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target={true}
-      id="checkbox-2"
+      id="checkbox-1"
       onChange={[Function]}
       type="checkbox"
     />
@@ -107,7 +107,7 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-2"
+      htmlFor="checkbox-1"
     >
       <div
         className=

--- a/packages/react-monaco-editor/src/demo/index.tsx
+++ b/packages/react-monaco-editor/src/demo/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './App';
-import { mergeStyles, initializeIcons, Fabric } from '@fluentui/react';
+import { mergeStyles, initializeIcons, ThemeProvider } from '@fluentui/react';
 
 initializeIcons();
 
@@ -17,8 +17,8 @@ mergeStyles({
 });
 
 ReactDOM.render(
-  <Fabric>
+  <ThemeProvider>
     <App />
-  </Fabric>,
+  </ThemeProvider>,
   document.getElementById('content'),
 );

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -373,7 +373,6 @@ export function usePopper(
     React.useEffect(() => {
       if (containerRef.current) {
         const contentNode = containerRef.current;
-        // eslint-disable-next-line deprecation/deprecation
         const treeWalker = contentNode.ownerDocument?.createTreeWalker(contentNode, NodeFilter.SHOW_ELEMENT, {
           acceptNode: hasAutofocusFilter,
         });

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -53,7 +53,7 @@ export interface ComponentProps {
 }
 
 // @public
-export type ComponentState<RefType, Props, ShorthandProps extends keyof Props = never, DefaultedProps extends keyof ResolvedShorthandProps<Props, ShorthandProps> = never> = RequiredProps<ResolvedShorthandProps<Props, ShorthandProps>, DefaultedProps> & {
+export type ComponentState<RefType, Props, ShorthandPropNames extends keyof Props = never, DefaultedPropNames extends keyof ResolvedShorthandProps<Props, ShorthandPropNames> = never> = RequiredProps<ResolvedShorthandProps<Props, ShorthandPropNames>, DefaultedPropNames> & {
     as?: React_2.ElementType;
     ref: RefType;
 };

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -65,17 +65,17 @@ export type RequiredProps<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: T[P
  * * Ensures the specified ShorthandProps are of type ObjectShorthandProps<T>
  * * Marks the given DefaultedProps as required (-?)
  *
- * @param Props - The component's Props type
- * @param RefType - The type of the state.ref property; e.g. `React.Ref<HTMLElement>`
- * @param ShorthandProps - The keys of Props that correspond to ShorthandProps
- * @param DefaultedProps - The keys of Props that will always have a default value provided
+ * @template Props - The component's Props type
+ * @template RefType - The type of the state.ref property; e.g. `React.Ref<HTMLElement>`
+ * @template ShorthandPropNames - The keys of Props that correspond to ShorthandProps
+ * @template DefaultedPropNames - The keys of Props that will always have a default value provided
  */
 export type ComponentState<
   RefType,
   Props,
-  ShorthandProps extends keyof Props = never,
-  DefaultedProps extends keyof ResolvedShorthandProps<Props, ShorthandProps> = never
-> = RequiredProps<ResolvedShorthandProps<Props, ShorthandProps>, DefaultedProps> & {
+  ShorthandPropNames extends keyof Props = never,
+  DefaultedPropNames extends keyof ResolvedShorthandProps<Props, ShorthandPropNames> = never
+> = RequiredProps<ResolvedShorthandProps<Props, ShorthandPropNames>, DefaultedPropNames> & {
   as?: React.ElementType;
   ref: RefType;
 };

--- a/packages/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-utilities/src/ssr/SSRContext.tsx
@@ -69,7 +69,6 @@ export function useIsSSR(): boolean {
     // eslint-disable-next-line
     React.useLayoutEffect(() => {
       setIsSSR(false);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
   }
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8618,7 +8618,7 @@ export class List<T = any> extends React_2.Component<IListProps<T>, IListState<T
     // (undocumented)
     forceUpdate(): void;
     // (undocumented)
-    static getDerivedStateFromProps<T = any>(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
+    static getDerivedStateFromProps<U = any>(nextProps: IListProps<U>, previousState: IListState<U>): IListState<U>;
     // (undocumented)
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
     getTotalListHeight(): number;

--- a/packages/react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react/src/components/Fabric/Fabric.base.tsx
@@ -68,6 +68,7 @@ function useRenderedContent(
   if (needsTheme) {
     // Disabling ThemeProvider here because theme doesn't need to be re-provided by ThemeProvider if dir has changed.
     renderedContent = (
+      // eslint-disable-next-line deprecation/deprecation
       <Customizer settings={{ theme: getFabricTheme(theme, dir === 'rtl') }}>{renderedContent}</Customizer>
     );
   }

--- a/packages/react/src/components/Fabric/Fabric.test.tsx
+++ b/packages/react/src/components/Fabric/Fabric.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { create } from '@fluentui/utilities/lib/test';
 //import { Customizer } from '@fluentui/utilities';

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -117,9 +117,11 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
       <span className="ms-layer" ref={mergedRef}>
         {layerElement &&
           ReactDOM.createPortal(
+            /* eslint-disable deprecation/deprecation */
             <Fabric {...(!eventBubblingEnabled && getFilteredEvents())} className={classNames.content}>
               {children}
             </Fabric>,
+            /* eslint-enable deprecation/deprecation */
             layerElement,
           )}
       </span>

--- a/packages/react/src/components/Link/Link.test.tsx
+++ b/packages/react/src/components/Link/Link.test.tsx
@@ -97,9 +97,10 @@ describe('Link', () => {
     expect(
       /ms-Link($| )/.test(
         ReactDOM.renderToStaticMarkup(
+          // eslint-disable-next-line deprecation/deprecation
           <Customizer settings={{ theme: NoClassNamesTheme }}>
             <Link href="helloworld.html">My Link</Link>
-          </Customizer>,
+          </Customizer>, // eslint-disable-line deprecation/deprecation
         ),
       ),
     ).toBe(false);

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -140,10 +140,10 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _scrollTop: number;
   private _pageCache: IPageCache<T>;
 
-  public static getDerivedStateFromProps<T = any>(
-    nextProps: IListProps<T>,
-    previousState: IListState<T>,
-  ): IListState<T> {
+  public static getDerivedStateFromProps<U = any>(
+    nextProps: IListProps<U>,
+    previousState: IListState<U>,
+  ): IListState<U> {
     return previousState.getDerivedStateFromProps(nextProps, previousState);
   }
 

--- a/packages/react/src/components/Stack/Stack.test.tsx
+++ b/packages/react/src/components/Stack/Stack.test.tsx
@@ -200,12 +200,13 @@ describe('Stack', () => {
 
   it('renders horizontal Stack with a gap in rtl context correctly', () => {
     const component = renderer.create(
+      // eslint-disable-next-line deprecation/deprecation
       <Fabric dir="rtl">
         <Stack horizontal tokens={{ childrenGap: 10 }}>
           <Stack.Item>Item 1</Stack.Item>
           <Stack.Item>Item 2</Stack.Item>
         </Stack>
-      </Fabric>,
+      </Fabric>, // eslint-disable-line deprecation/deprecation
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
@@ -74,9 +74,10 @@ describe('makeStyles', () => {
     });
 
     safeMount(
+      // eslint-disable-next-line deprecation/deprecation
       <Customizer settings={{ theme: customTheme }}>
         <ThemeStyledComponent />
-      </Customizer>,
+      </Customizer>, // eslint-disable-line deprecation/deprecation
     );
     expect(stylesheet.getRules()).toEqual('.root-0{background:purple;}');
   });

--- a/packages/utilities/src/customizations/Customizer.test.tsx
+++ b/packages/utilities/src/customizations/Customizer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { customizable } from './customizable';
 import { Customizer } from './Customizer';

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/server';
 import { mount } from 'enzyme';

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { styled } from './styled';
 import * as renderer from 'react-test-renderer';

--- a/packages/web-components/src/tooltip/index.ts
+++ b/packages/web-components/src/tooltip/index.ts
@@ -1,5 +1,5 @@
 import { customElement } from '@microsoft/fast-element';
-import { createTooltipTemplate, createTooltipTemplate as template, Tooltip } from '@microsoft/fast-foundation';
+import { createTooltipTemplate, Tooltip } from '@microsoft/fast-foundation';
 import { TooltipStyles as styles } from './tooltip.styles';
 
 /**

--- a/scripts/lint-staged/eslint.js
+++ b/scripts/lint-staged/eslint.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const glob = require('glob');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { rollup: lernaAliases } = require('lerna-alias');
@@ -9,51 +9,47 @@ const exec = require('../exec');
 
 const eslintForPackageScript = path.join(__dirname, 'eslint-for-package.js');
 
-// Paths to packages with an eslintrc (with any extension)
-const packagesWithEslint = Object.values(lernaAliases({ sourceDirectory: false })).filter(
-  packagePath => !!glob.sync(path.join(packagePath, '.eslintrc*')).length,
-);
-
 const files = process.argv.slice(2);
-
-runEslintOnFilesGroupedPerPackage(groupFilesByPackage(files));
 
 /**
  * Since we have an eslint config file per package we need to respect this when running
  * eslint for staged files. To do this we group the files per package name. This function takes
  * a list of package names and returns an object with the package root as the key and the files
  * in that package as the value.
- *
- * @param {string[]} files
- * @returns {{[packagePath: string]: string[]}}
+ * @returns {{ [packagePath: string]: string[] }}
  */
-function groupFilesByPackage(files) {
-  return files
-    .map(file => [packagesWithEslint.find(packagePath => file.startsWith(packagePath)), file])
-    .filter(
-      ([packagePath, file]) =>
-        // Exclude files in a package without an eslintrc (or not in a package at all)
-        !!packagePath &&
-        // For now, exclude files that are not under src or test--these would cause errors if the
-        // package's eslint config uses @typescript-eslint/parser with 'project' (tsconfig path)
-        // option, because only src and test will be included in the tsconfig.
-        /^(src|test)\b/.test(path.relative(packagePath, file)),
-    )
-    .reduce((filesByPackage, [packagePath, file]) => {
+function groupFilesByPackage() {
+  /** @type {{ [packagePath: string]: string[] }} */
+  const filesByPackage = {};
+
+  const packagesWithEslint = Object.values(lernaAliases({ sourceDirectory: false })).filter(
+    packagePath =>
+      // exclude @fluentui/noop (northstar packages root)
+      path.basename(packagePath) !== 'fluentui' &&
+      // only include packages with an eslintrc (any extension)
+      fs.readdirSync(packagePath).some(f => f.startsWith('.eslintrc')),
+  );
+
+  for (const file of files) {
+    const packagePath = packagesWithEslint.find(packagePath => file.startsWith(packagePath));
+    // Exclude files in a package without an eslintrc (or not in a package at all)
+    if (packagePath) {
       if (!filesByPackage[packagePath]) {
         filesByPackage[packagePath] = [];
       }
       filesByPackage[packagePath].push(file);
-      return filesByPackage;
-    }, {});
+    }
+  }
+
+  return filesByPackage;
 }
 
 /**
  * Runs eslint for the staged files in the packages that require it.
- *
- * @param {{[packagePath: string]: string[]}} filesGroupedByPackage
  */
-async function runEslintOnFilesGroupedPerPackage(filesGroupedByPackage) {
+async function runEslintOnFilesGroupedPerPackage() {
+  const filesGroupedByPackage = groupFilesByPackage();
+
   // Log an empty line on error to make the eslint output look better
   console.log('');
 
@@ -62,15 +58,9 @@ async function runEslintOnFilesGroupedPerPackage(filesGroupedByPackage) {
 
   await queue.addAll(
     Object.entries(filesGroupedByPackage).map(([packagePath, files]) => async () => {
-      // We can't just run the eslint CLI on the filenames because directly passed filenames
-      // override ignores configured elsewhere (so files that should be ignored would be linted).
-      // So manually filter out ignored files then run eslint via its API as described here:
-      //   https://www.npmjs.com/package/lint-staged#how-can-i-ignore-files-from-eslintignore-
-      // In our case, we also need to run it in a different subprocess per package because some
-      // of our eslint config relies on process.cwd() to infer info about the package.
-      return exec(`node ${eslintForPackageScript} ${files.join(' ')}`, undefined, packagePath, process).catch((
-        /** @type {import("../exec").ExecResult} */ err,
-      ) => {
+      // This script handles running eslint on ONLY the appropriate files for each package.
+      // See its comments for more details.
+      return exec(`node ${eslintForPackageScript} ${files.join(' ')}`, undefined, packagePath, process).catch(() => {
         // The subprocess should already have handled logging. Just mark that there was an error.
         hasError = true;
       });
@@ -89,3 +79,8 @@ async function runEslintOnFilesGroupedPerPackage(filesGroupedByPackage) {
       }
     });
 }
+
+runEslintOnFilesGroupedPerPackage().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -63,7 +63,6 @@
     "dotparser": "^1.0.0",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
-    "eslint": "^7.1.0",
     "express": "^4.15.4",
     "extract-comments": "^1.0.0",
     "find-free-port": "~2.0.0",

--- a/scripts/tasks/eslint-constants.js
+++ b/scripts/tasks/eslint-constants.js
@@ -1,0 +1,8 @@
+/** Constants used by the eslint task and scripts/lint-staged/eslint-for-package.js */
+module.exports = {
+  /** List of file extensions to lint, in format used by eslint (comma-separated, with leading .) */
+  extensions: '.ts,.tsx,.js,.jsx',
+
+  /** Subdirectory to lint within package (relative path) */
+  directory: 'src',
+};

--- a/scripts/tasks/eslint.ts
+++ b/scripts/tasks/eslint.ts
@@ -1,11 +1,11 @@
 import { eslintTask } from 'just-scripts';
-import * as configHelpers from '@fluentui/eslint-plugin/src/utils/configHelpers';
 import * as path from 'path';
+import * as constants from './eslint-constants';
 
 export const eslint = eslintTask({
   // TODO: also lint config files?
-  files: [path.join(process.cwd(), 'src')],
-  extensions: configHelpers.extensions.join(','),
+  files: [path.join(process.cwd(), constants.directory)],
+  extensions: constants.extensions,
   cache: true, // only lint files changed since last lint
   fix: process.argv.includes('--fix'),
   // If requested, display a table with 10 slowest rules after running.

--- a/tools/.eslintrc.json
+++ b/tools/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/node"],
   "rules": {
-    "import/no-extraneous-dependencies": "off"
+    // In nx run nx-workspace-tools:lint this is resolved relative to the repo root
+    "import/no-extraneous-dependencies": ["error", { "packageDir": ["."] }]
   },
   "root": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12053,10 +12053,10 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-deprecation@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.0.tgz#e12333a857986fc87fa2eff44c7425eba9653070"
-  integrity sha512-SrZqomFYofRbxJ9dlAcu526/tiZoWoZgHdZWKHjrRT/uLfTtTTjdVf0gdy0AZxK8nH5ri0fukgwS28llUueitA==
+eslint-plugin-deprecation@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.1.tgz#ab1b80d7d0b8ce694f646ed41e03f90d3f0fbcd0"
+  integrity sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.19.2 || ^3.0.0"
     tslib "^1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,13 @@
     events "^3.0.0"
     tslib "^1.10.0"
 
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/code-frame@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -377,7 +384,7 @@
     "@babel/traverse" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/highlight@^7.0.0", "@babel/highlight@^7.12.13", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13", "@babel/highlight@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
   integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
@@ -1428,6 +1435,21 @@
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
@@ -4783,15 +4805,10 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
-"@types/eslint@*", "@types/eslint@^7.2.0":
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
-  integrity sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
+"@types/eslint@*", "@types/eslint@7.2.10":
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.10.tgz#4b7a9368d46c0f8cd5408c23288a59aa2394d917"
+  integrity sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -5620,93 +5637,75 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.23.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+"@typescript-eslint/eslint-plugin@4.22.0", "@typescript-eslint/eslint-plugin@^2.23.0", "@typescript-eslint/eslint-plugin@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
+  integrity sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.4.0.tgz#8378062e6be8a1d049259bdbcf27ce5dfbeee62b"
-  integrity sha512-wfkpiqaEVhZIuQRmudDszc01jC/YR7gMSxa6ulhggAe/Hs0KVIuo9wzvFiDbG3JD5pRFQoqnf4m7REDsUvBnMQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "3.4.0"
+    "@typescript-eslint/experimental-utils" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.22.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.34.0", "@typescript-eslint/experimental-utils@^2.5.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
+  integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
+    "@typescript-eslint/scope-manager" "4.22.0"
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/typescript-estree" "4.22.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@3.4.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.4.0.tgz#8a44dfc6fb7f1d071937b390fe27608ebda122b8"
-  integrity sha512-rHPOjL43lOH1Opte4+dhC0a/+ks+8gOBwxXnyrZ/K4OTAChpSjP76fbI8Cglj7V5GouwVAGaK+xVwzqTyE/TPw==
+"@typescript-eslint/parser@4.22.0", "@typescript-eslint/parser@^2.23.0", "@typescript-eslint/parser@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
+  integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "3.4.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^2.23.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/parser@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.4.0.tgz#fe52b68c5cb3bba3f5d875bd17adb70420d49d8d"
-  integrity sha512-ZUGI/de44L5x87uX5zM14UYcbn79HSXUR+kzcqU42gH0AgpdB/TjuJy3m4ezI7Q/jk3wTQd755mxSDLhQP79KA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.4.0"
-    "@typescript-eslint/typescript-estree" "3.4.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
+    "@typescript-eslint/scope-manager" "4.22.0"
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/typescript-estree" "4.22.0"
     debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
+
+"@typescript-eslint/scope-manager@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
+  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
+  dependencies:
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/visitor-keys" "4.22.0"
+
+"@typescript-eslint/types@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
+  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
+
+"@typescript-eslint/typescript-estree@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
+  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
+  dependencies:
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/visitor-keys" "4.22.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.4.0.tgz#6a787eb70b48969e4cd1ea67b057083f96dfee29"
-  integrity sha512-zKwLiybtt4uJb4mkG5q2t6+W7BuYx2IISiDNV+IY68VfoGwErDx/RfVI7SWL4gnZ2t1A1ytQQwZ+YOJbHHJ2rw==
+"@typescript-eslint/visitor-keys@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
+  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
   dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    "@typescript-eslint/types" "4.22.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@uifabric/merge-styles@^7.19.1":
   version "7.19.1"
@@ -6285,15 +6284,10 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.1.0:
+acorn-jsx@^5.1.0, acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
-
-acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
 acorn-walk@^6.0.1:
   version "6.1.1"
@@ -6315,25 +6309,15 @@ acorn@5.X, acorn@^5.0.3, acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.4.1, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^6.2.1:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
-
-acorn@^7.1.0:
+acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
 acorn@^8.0.4:
   version "8.0.4"
@@ -6477,17 +6461,7 @@ ajv@^5.0.0, ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
-  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.5.5, ajv@~6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -6497,14 +6471,14 @@ ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@~6.12.3:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+ajv@^8.0.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.2.0.tgz#c89d3380a784ce81b2085f48811c4c101df4c602"
+  integrity sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==
   dependencies:
     fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 amdefine@>=0.0.4:
@@ -12052,23 +12026,23 @@ eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-import-resolver-node@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
-  integrity sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+eslint-import-resolver-node@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   dependencies:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-import-resolver-typescript@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.0.0.tgz#e95f126cc12d3018b9cc11692b4dbfd3e17d3ea6"
-  integrity sha512-bT5Frpl8UWoHBtY25vKUOMoVIMlJQOMefHLyQ4Tz3MQpIZ2N6yYKEEIHMo38bszBNUuMBW6M3+5JNYxeiGFH4w==
+eslint-import-resolver-typescript@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz#ec1e7063ebe807f0362a7320543aaed6fe1100e1"
+  integrity sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
   dependencies:
     debug "^4.1.1"
+    glob "^7.1.6"
     is-glob "^4.0.1"
-    resolve "^1.12.0"
-    tiny-glob "^0.2.6"
+    resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
 eslint-module-utils@^2.6.0:
@@ -12079,10 +12053,10 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-deprecation@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.1.0.tgz#46793ebbec9555d167d59c851ae3da0a21532189"
-  integrity sha512-+oDa6JbdZXyh7Bx2zx7VoDFZvFnV1pZVPVo/bEGVkuXlLih/evX0LQG2/nSuNg83CmwZTcAFZXXpLgsX4ctIDQ==
+eslint-plugin-deprecation@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.0.tgz#e12333a857986fc87fa2eff44c7425eba9653070"
+  integrity sha512-SrZqomFYofRbxJ9dlAcu526/tiZoWoZgHdZWKHjrRT/uLfTtTTjdVf0gdy0AZxK8nH5ri0fukgwS28llUueitA==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.19.2 || ^3.0.0"
     tslib "^1.10.0"
@@ -12096,17 +12070,17 @@ eslint-plugin-es@4.1.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-import@^2.20.1, eslint-plugin-import@^2.21.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
-  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
+eslint-plugin-import@^2.20.1, eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
+    eslint-import-resolver-node "^0.3.4"
     eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"
@@ -12137,10 +12111,10 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-react-hooks@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.8.tgz#a9b1e3d57475ccd18276882eff3d6cba00da7a56"
-  integrity sha512-6SSb5AiMCPd8FDJrzah+Z4F44P2CdOaK026cXFV+o/xSRzfOiV1FNFeLl2z6xm3yqWOQEZ5OfVgiec90qV2xrQ==
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
 eslint-plugin-react@^7.19.0, eslint-plugin-react@^7.20.0:
   version "7.20.0"
@@ -12183,48 +12157,54 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
-  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^6.8.0, eslint@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.1.0.tgz#d9a1df25e5b7859b0a3d86bb05f0940ab676a851"
-  integrity sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@7.25.0, eslint@^6.8.0, eslint@^7.1.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
+  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-    eslint-visitor-keys "^1.1.0"
-    espree "^7.0.0"
-    esquery "^1.2.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^12.1.0"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.14"
+    lodash "^4.17.21"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -12233,7 +12213,7 @@ eslint@^6.8.0, eslint@^7.1.0:
     semver "^7.2.1"
     strip-ansi "^6.0.0"
     strip-json-comments "^3.1.0"
-    table "^5.2.3"
+    table "^6.0.4"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
@@ -12242,14 +12222,14 @@ esm@3.2.25, esm@^3.2.25:
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
-espree@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.0.0.tgz#8a7a60f218e69f120a842dc24c5a88aa7748a74e"
-  integrity sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
-    acorn "^7.1.1"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.1.0"
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
 
 esprima-extract-comments@^1.1.0:
   version "1.1.0"
@@ -12273,21 +12253,14 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
-  dependencies:
-    estraverse "^4.1.0"
-
-esrecurse@^4.3.0:
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -12299,17 +12272,12 @@ estraverse@^1.9.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
   integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -12954,12 +12922,12 @@ figures@^3.0.0, figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
-    flat-cache "^2.0.1"
+    flat-cache "^3.0.4"
 
 file-loader@6.2.0, file-loader@^6.0.0:
   version "6.2.0"
@@ -13237,14 +13205,13 @@ flamegrill@0.2.0:
     puppeteer "^1.13.0"
     yargs-parser "^13.1.0"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
 
 flat@^4.1.0:
   version "4.1.0"
@@ -13262,6 +13229,11 @@ flatted@^2.0.0, flatted@^2.0.1, flatted@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 flow-parser@0.*:
   version "0.130.0"
@@ -14093,6 +14065,13 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globals@^13.6.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
+  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+  dependencies:
+    type-fest "^0.20.2"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -14106,11 +14085,6 @@ globalthis@^1.0.0:
     define-properties "^1.1.2"
     function-bind "^1.1.1"
     object-keys "^1.0.12"
-
-globalyzer@^0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.4.tgz#bc8e273afe1ac7c24eea8def5b802340c5cc534f"
-  integrity sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==
 
 globby@*, globby@^10.0.1:
   version "10.0.2"
@@ -14175,11 +14149,6 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
-
-globrex@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
-  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 globule@^1.0.0:
   version "1.2.1"
@@ -17205,6 +17174,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -18197,7 +18171,7 @@ lodash.find@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
   integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
 
-lodash.flatten@^4.2.0:
+lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
@@ -18377,12 +18351,17 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
 lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.13, lodash@~4.17.15:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.13, lodash@~4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -23997,7 +23976,7 @@ riceburn@^1.3.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -24801,15 +24780,6 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
-
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -25677,15 +25647,10 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.0.1, strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
 strip-outer@^1.0.0, strip-outer@^1.0.1:
   version "1.0.1"
@@ -25937,15 +25902,18 @@ tabbable@^4.0.0:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
   integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+table@^6.0.4:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.6.0.tgz#905654b79df98d9e9a973de1dd58682532c40e8e"
+  integrity sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==
   dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    ajv "^8.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
 
 tabster@^0.6.2:
   version "0.6.2"
@@ -26328,14 +26296,6 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
-tiny-glob@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.6.tgz#9e056e169d9788fe8a734dfa1ff02e9b92ed7eda"
-  integrity sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==
-  dependencies:
-    globalyzer "^0.1.0"
-    globrex "^0.1.1"
 
 tiny-invariant@^1.0.2, tiny-invariant@^1.1.0:
   version "1.1.0"
@@ -26858,6 +26818,11 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.3.0:
   version "0.3.1"
@@ -28506,13 +28471,6 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18025
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update eslint-related dependencies to be compatible with TS 4.1, including proper parsing for `import type`/`export type`.

**After this change, it will probably be necessary for everyone to delete their local eslint caches** (`yarn rimraf '{apps,packages}/*/.eslintcache'` or similar) to avoid some weird false positives.

Thanks to one or more of the updated deps (hard to say which), usage of React components is now flagged! :tada: However, this meant that a bunch more rule disables had to be added, mainly for usage of `Fabric` and `Customizer`. Where it made sense and was clearly safe, I went ahead and changed these to use `ThemeProvider`, but in other cases I just disabled the rule.

There are also a few other interesting changes that I'll comment on inline.

Related references:
- [`@typescript-eslint/*` v4 release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.0.0)
- [`@typescript-eslint/*` v3 release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0)