### PR TITLE
Remove mentions of deprecated getting started templates from website

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
@@ -1,68 +1,15 @@
-Fluent UI React provides several starter kit options. Make sure you have the [latest LTS Node.js](https://nodejs.org/en/) installed, then choose one of the options below:
+The easiest way to create a new project with Fluent UI is using our [Create React App](https://facebook.github.io/create-react-app/) template `@fluentui/cra-template`.
 
-- [Option 1: Quick start](#option-1-quick-start)
-- [Option 2: Using Create React App](#option-2-create-react-app)
-- [Option 3: Using Gatsby.js](#option-3-gatsbyjs)
-
-### Option 1: Quick start
-
-Open a terminal and go to the folder where you want the project created, then run:
+Make sure you have the [latest LTS Node.js](https://nodejs.org/en/) installed, then open a terminal and run the following (using your desired app name instead of `my-app`):
 
 ```shell
-npm init uifabric
-```
-
-It'll prompt you for a project name. For example, if you call the project `my-app`, you can start it like this:
-
-```shell
-cd my-app
-npm start
-```
-
-Open up the `App.tsx` file and start editing. You'll see your changes in the browser seconds after you hit save.
-
-This scaffold uses the [Just](https://github.com/microsoft/just) build library. It is very flexible and requires no "eject" script to allow customizing configuration.
-
-### Option 2: Create React App
-
-Fluent UI also provides a template for [Create React App](https://facebook.github.io/create-react-app/) which is
-a popular development stack maintained by the creators of React.
-
-To get up and running, all you need is to boot Create React App using our `@fluentui/cra-template` template.
-To do this, open a terminal and run:
-
-```shell
-# with npx
+# Option 1: using npx/npm
 npx create-react-app my-app --template @fluentui/cra-template
-
-# with npm
-npm init react-app my-app --template @fluentui/cra-template
-
-# with yarn
-yarn create react-app my-app --template @fluentui/cra-template
-```
-
-Then you can start the app like this:
-
-```shell
-# with npm (default)
 cd my-app
 npm start
 
-# with yarn (optional)
+# Option 2: using yarn
+yarn create react-app my-app --template @fluentui/cra-template
 cd my-app
 yarn start
 ```
-
-### Option 3: Gatsby.js
-
-To start creating a blazing fast static website or app using Fluent UI and [Gatsby.js](https://www.gatsbyjs.org/), run the following in a terminal:
-
-```shell
-npm install -g gatsby-cli
-gatsby new gatsby-site kenotron/gatsby-starter-uifabric
-cd gatsby-site
-gatsby develop
-```
-
-This app can be deployed to the cloud in one click—[learn more here](https://github.com/microsoft/gatsby-starter-uifabric#-deploy).

--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
@@ -9,7 +9,7 @@ cd my-app
 npm start
 
 # Option 2: using yarn
-yarn create react-app my-app --template @fluentui/cra-template
+yarn create-react-app my-app --template @fluentui/cra-template
 cd my-app
 yarn start
 ```

--- a/change/@fluentui-public-docsite-9b21a70d-292a-4208-a9ea-0c3b14676f90.json
+++ b/change/@fluentui-public-docsite-9b21a70d-292a-4208-a9ea-0c3b14676f90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove mentions of deprecated getting started templates from website",
+  "packageName": "@fluentui/public-docsite",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17945
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Our website still mentions some very outdated templates in the getting started sections. Remove mention of those and only suggest our new CRA template to reduce confusion.
