### PR TITLE
Scope E2E to converged components only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
           SourcePath: 'apps/pr-deploy-site/dist'
           storage: $(azureStorage)
 
-      # scopes e2e tests to converged package storyboo
+      # scopes e2e tests to converged package storybook by scoping to the converged suite package
       - script: |
           yarn e2e $(sinceArg) --scope @fluentui/react-components
         displayName: Cypress E2E tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,9 +90,10 @@ jobs:
           SourcePath: 'apps/pr-deploy-site/dist'
           storage: $(azureStorage)
 
-      # - script: |
-      #     yarn e2e $(sinceArg)
-      #   displayName: Cypress E2E tests
+      # scopes e2e tests to converged package storyboo
+      - script: |
+          yarn e2e $(sinceArg) --scope @fluentui/react-components
+        displayName: Cypress E2E tests
 
       - task: GithubPRStatus@0
         displayName: 'Update PR deploy site github status'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
           SourcePath: 'apps/pr-deploy-site/dist'
           storage: $(azureStorage)
 
-      # scopes e2e tests to converged package storybook by scoping to the converged suite package
+      # only run e2e tests when converged storybook is published by scoping to the converged suite package
       - script: |
           yarn e2e $(sinceArg) --scope @fluentui/react-components
         displayName: Cypress E2E tests


### PR DESCRIPTION
Scope in Lage is currently broken as `react-examples` depends on most
things in the repository.

converged E2E tests are built to run on deployed storybooks, by scoping
to the `react-components` package it should guarantee that they are only
run when the `react-components` storybook is deployed

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
