### PR TITLE
chore(makeStyles): hash properties

### DIFF
--- a/change/@fluentui-babel-make-styles-85057104-26d5-46fe-903b-fea73c49b998.json
+++ b/change/@fluentui-babel-make-styles-85057104-26d5-46fe-903b-fea73c49b998.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update fixtures to use hashed properties",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-make-styles-99f5fb4f-adc7-4e1a-b629-ecdd9e71d237.json
+++ b/change/@fluentui-make-styles-99f5fb4f-adc7-4e1a-b629-ecdd9e71d237.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use hashed properties to improve bundle size",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/arrow-function-body/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-body/output.ts
@@ -11,9 +11,9 @@ function buttonTokens(theme: Theme) {
 
 export const useStyles = __styles({
   root: {
-    backgroundColor: ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
-    color: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    ':hovercolor': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
+    '3e3pzq0': ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
+    sj55zd0: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '1i91k9c': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/arrow-function-nesting/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-nesting/output.ts
@@ -2,9 +2,9 @@ import { __styles } from '@fluentui/react-make-styles';
 import { colorBlue } from './consts';
 export const useStyles = __styles({
   root: {
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    ':hovercolor': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
-    ':focus:hovercolor': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
-    ' .foo:hovercolor': ['', 'f1gwxnus', '.f1gwxnus .foo:hover{color:var(--alias-color-green-foreground1);}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '1i91k9c': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
+    '1b9khzn': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
+    '1tk3f3y': ['', 'f1gwxnus', '.f1gwxnus .foo:hover{color:var(--alias-color-green-foreground1);}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/arrow-function/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function/output.ts
@@ -1,11 +1,11 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles = __styles({
   root: {
-    backgroundColor: ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
-    color: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '3e3pzq0': ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
+    sj55zd0: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
   },
   rootPrimary: {
-    color: ['', 'f1qa0pc1', '.f1qa0pc1{color:var(--alias-color-brand-brandBackground);}'],
+    sj55zd0: ['', 'f1qa0pc1', '.f1qa0pc1{color:var(--alias-color-brand-brandBackground);}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/commonjs/output.ts
+++ b/packages/babel-make-styles/__fixtures__/commonjs/output.ts
@@ -4,9 +4,9 @@ const react_make_styles_1 = require('@fluentui/react-make-styles');
 
 const useStyles = react_make_styles_1.__styles({
   root: {
-    fontSize: ['', 'flcnb000', '.flcnb000{font-size:var(--global-type-fontSizes-base-300);}'],
-    lineHeight: ['', 'f1syuwty', '.f1syuwty{line-height:var(--global-type-lineHeights-base-300);}'],
-    fontWeight: ['', 'f1du0uop', '.f1du0uop{font-weight:var(--global-type-fontWeights-regular);}'],
+    '1e2twd7': ['', 'flcnb000', '.flcnb000{font-size:var(--global-type-fontSizes-base-300);}'],
+    '1g96gwp': ['', 'f1syuwty', '.f1syuwty{line-height:var(--global-type-lineHeights-base-300);}'],
+    '1hrd7zp': ['', 'f1du0uop', '.f1du0uop{font-weight:var(--global-type-fontWeights-regular);}'],
   },
 });
 

--- a/packages/babel-make-styles/__fixtures__/compiled-optional-chaining/output.ts
+++ b/packages/babel-make-styles/__fixtures__/compiled-optional-chaining/output.ts
@@ -11,7 +11,7 @@ export var makeButtonTokens = (theme: Theme) => {
 };
 export var useStyles = __styles({
   rootPrimary: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
-    background: ['', 'f1pzj0k4', '.f1pzj0k4{background:var(--alias-color-brand-brandBackgroundHover);}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    ayd6f00: ['', 'f1pzj0k4', '.f1pzj0k4{background:var(--alias-color-brand-brandBackgroundHover);}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/function/output.ts
+++ b/packages/babel-make-styles/__fixtures__/function/output.ts
@@ -1,11 +1,11 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles = __styles({
   root: {
-    backgroundColor: ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
-    color: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '3e3pzq0': ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
+    sj55zd0: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
   },
   rootPrimary: {
-    color: ['', 'f1qa0pc1', '.f1qa0pc1{color:var(--alias-color-brand-brandBackground);}'],
+    sj55zd0: ['', 'f1qa0pc1', '.f1qa0pc1{color:var(--alias-color-brand-brandBackground);}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/multiple-declarations/output.ts
+++ b/packages/babel-make-styles/__fixtures__/multiple-declarations/output.ts
@@ -1,11 +1,11 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles1 = __styles({
   root: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
   },
 });
 export const useStyles2 = __styles({
   root: {
-    color: ['', 'fka9v860', '.fka9v860{color:green;}'],
+    sj55zd0: ['', 'fka9v860', '.fka9v860{color:green;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-computed-keys/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-computed-keys/output.ts
@@ -2,14 +2,14 @@ import { __styles } from '@fluentui/react-make-styles';
 const rootSlot = 'root';
 export const useStyles = __styles({
   [rootSlot]: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
-    paddingTop: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
-    paddingRight: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
-    paddingBottom: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
-    paddingLeft: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    z8tnut0: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
+    z189sj0: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
+    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    uwmqm30: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
   },
   [rootSlot + 'primary']: {
-    background: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
-    marginLeft: ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
+    ayd6f00: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
+    '5rg6f30': ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
@@ -2,25 +2,25 @@ import { __styles } from '@fluentui/react-make-styles';
 import { flexStyles, gridStyles } from './mixins';
 export const useStyles = __styles({
   root: {
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    flexDirection: [
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '1eiy3e4': [
       '',
       'f1vx9l62',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
     ],
   },
   icon: {
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    flexDirection: [
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '1eiy3e4': [
       '',
       'f1vx9l62',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
     ],
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
   },
   image: {
-    display: ['', 'f13qh94s', '.f13qh94s{display:grid;}'],
-    gridGap: ['', 'fz444870', '.fz444870{grid-gap:10px;}'],
-    color: ['', 'fka9v860', '.fka9v860{color:green;}'],
+    mc9l5x0: ['', 'f13qh94s', '.f13qh94s{display:grid;}'],
+    w08cwm0: ['', 'fz444870', '.fz444870{grid-gap:10px;}'],
+    sj55zd0: ['', 'fka9v860', '.fka9v860{color:green;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-nesting/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-nesting/output.ts
@@ -2,9 +2,9 @@ import { __styles } from '@fluentui/react-make-styles';
 import { colorBlue } from './consts';
 export const useStyles = __styles({
   root: {
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    ':hovercolor': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
-    ':focus:hovercolor': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
-    ' .foo:hovercolor': ['', 'fh8e7tb0', '.fh8e7tb0 .foo:hover{color:green;}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    '1i91k9c': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
+    '1b9khzn': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
+    '1tk3f3y': ['', 'fh8e7tb0', '.fh8e7tb0 .foo:hover{color:green;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-variables/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-variables/output.ts
@@ -3,15 +3,15 @@ import { colorGreen, theme } from './vars';
 const colorRed = 'red';
 export const useStyles = __styles({
   root: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
-    paddingTop: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
-    paddingRight: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
-    paddingBottom: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
-    paddingLeft: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    z8tnut0: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
+    z189sj0: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
+    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    uwmqm30: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
   },
   icon: {
-    color: ['', 'fusgiwz0', '.fusgiwz0{color:#000;}'],
-    background: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
-    marginLeft: ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
+    sj55zd0: ['', 'fusgiwz0', '.fusgiwz0{color:#000;}'],
+    ayd6f00: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
+    '5rg6f30': ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object/output.ts
@@ -1,14 +1,14 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles = __styles({
   root: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
-    paddingTop: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
-    paddingRight: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
-    paddingBottom: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
-    paddingLeft: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    z8tnut0: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
+    z189sj0: ['', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}', 'fycuoez0', '.fycuoez0{padding-left:4px;}'],
+    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    uwmqm30: ['', 'fycuoez0', '.fycuoez0{padding-left:4px;}', 'f8wuabp0', '.f8wuabp0{padding-right:4px;}'],
   },
   icon: {
-    background: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
-    marginLeft: ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
+    ayd6f00: ['', 'f65sxns0', '.f65sxns0{background:green;}'],
+    '5rg6f30': ['', 'fjf1xye0', '.fjf1xye0{margin-left:4px;}', 'f8zmjen0', '.f8zmjen0{margin-right:4px;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/shared-mixins/output.ts
+++ b/packages/babel-make-styles/__fixtures__/shared-mixins/output.ts
@@ -2,12 +2,12 @@ import { __styles } from '@fluentui/react-make-styles';
 import { sharedStyles } from './mixins';
 export const useStyles = __styles({
   root: {
-    display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+    mc9l5x0: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
   },
   container: {
-    display: ['', 'f13qh94s', '.f13qh94s{display:grid;}'],
+    mc9l5x0: ['', 'f13qh94s', '.f13qh94s{display:grid;}'],
   },
   icon: {
-    color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+    sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
   },
 });

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -586,8 +586,8 @@ describe('resolveStyleRules', () => {
   describe('output', () => {
     it('contains less members for properties that do not depend on text direction', () => {
       expect(resolveStyleRules({ color: 'red', paddingLeft: '10px' })).toEqual({
-        color: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
-        paddingLeft: ['', 'frdkuqy0', '.frdkuqy0{padding-left:10px;}', 'f81rol60', '.f81rol60{padding-right:10px;}'],
+        sj55zd0: ['', 'fe3e8s90', '.fe3e8s90{color:red;}'],
+        uwmqm30: ['', 'frdkuqy0', '.frdkuqy0{padding-left:10px;}', 'f81rol60', '.f81rol60{padding-right:10px;}'],
       });
     });
   });

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -90,6 +90,7 @@ export function resolveStyleRules(
         resolvedRule.push(rtlClassName, rtlCSS);
       }
       // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
+      // ".foo :hover" => "abcd"
       const resolvedKey = hashString(key);
 
       result[resolvedKey] = resolvedRule;

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -89,8 +89,10 @@ export function resolveStyleRules(
       if (rtlCSS) {
         resolvedRule.push(rtlClassName, rtlCSS);
       }
+      // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
+      const resolvedKey = hashString(key);
 
-      result[key] = resolvedRule;
+      result[resolvedKey] = resolvedRule;
     } else if (property === 'animationName') {
       const animationNames = Array.isArray(value) ? value : [value];
       let keyframeCSS = '';


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR implements one of ideas that were planned initially for `makeStyles`, it's hashing of mergeable properties. It had not priority before we implemented build time transform, but now properties are staying in bundles 😮

```diff
- display: ['', 'f22iagw0', '.f22iagw0{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
- ':hovercolor': ['h', 'faf35ka0', '.faf35ka0:hover{color:red;}'],
+ '3e3pzq0': ['', 'fbrlg6g0', '.fbrlg6g0{background-color:var(--global-color-black);}'],
+ sj55zd0: ['', 'fk38h1u0', '.fk38h1u0{color:var(--alias-color-blue-border2);}'],
```

Hashing will not affect functionality (we will still be able to merge properties), but allows to reduce size of as hashes are much shorter than long selectors:

![image](https://user-images.githubusercontent.com/14183168/117034939-16dd2c00-ad04-11eb-8d14-3e2ef199ede4.png)

---

All changes are happening in `packages/make-styles/src/runtime/resolveStyleRules.ts`, all other changes are related to fixtures/snapshots.