### PR TITLE
chore: revert usage of @fluentui/babel-make-styles in Storybook

### DIFF
--- a/change/@fluentui-react-examples-f891f396-4738-4e7c-a1b9-613977e4af56.json
+++ b/change/@fluentui-react-examples-f891f396-4738-4e7c-a1b9-613977e4af56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: revert usage of @fluentui/babel-make-styles in Storybook",
+  "packageName": "@fluentui/react-examples",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/.storybook/main.js
+++ b/packages/react-examples/.storybook/main.js
@@ -11,9 +11,6 @@ export default {
       options: { escapeHTML: false },
     },
   ],
-  babel: {
-    plugins: ['module:@fluentui/babel-make-styles'],
-  },
   typescript: {
     // disable react-docgen-typescript due to perf issues
     // (also appears that it would require more configuration to work properly)


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently the plugin breaks local workflow if you don't have the whole repo prebuilt 😯 This PR reverts this usage, we should add it back once current issues will be resolved.