### PR TITLE
fix(MessageBar): setting role based on MessageBarType

### DIFF
--- a/change/@fluentui-react-2a377817-44f9-4770-9aa1-f5b8f13e04ea.json
+++ b/change/@fluentui-react-2a377817-44f9-4770-9aa1-f5b8f13e04ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MessageBar: setting `role` based on `MessageBarType` for improved accessibility",
+  "packageName": "@fluentui/react",
+  "email": "cujurgen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5929,6 +5929,7 @@ export interface IMessageBarProps extends React_2.HTMLAttributes<HTMLElement>, R
     messageBarType?: MessageBarType;
     onDismiss?: (ev?: React_2.MouseEvent<HTMLElement | BaseButton | Button>) => any;
     overflowButtonAriaLabel?: string;
+    role?: string;
     styles?: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles>;
     theme?: ITheme;
     truncated?: boolean;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5929,7 +5929,7 @@ export interface IMessageBarProps extends React_2.HTMLAttributes<HTMLElement>, R
     messageBarType?: MessageBarType;
     onDismiss?: (ev?: React_2.MouseEvent<HTMLElement | BaseButton | Button>) => any;
     overflowButtonAriaLabel?: string;
-    role?: string;
+    role?: 'alert' | 'status' | 'none';
     styles?: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles>;
     theme?: ITheme;
     truncated?: boolean;

--- a/packages/react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.base.tsx
@@ -28,6 +28,16 @@ const getAnnouncementPriority = (messageBarType: MessageBarType): 'assertive' | 
   return 'polite';
 };
 
+const getRole = (messageBarType: MessageBarType): 'alert' | 'status' => {
+  switch (messageBarType) {
+    case MessageBarType.blocked:
+    case MessageBarType.error:
+    case MessageBarType.severeWarning:
+      return 'alert';
+  }
+  return 'status';
+};
+
 export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.forwardRef<
   HTMLDivElement,
   IMessageBarProps
@@ -91,7 +101,12 @@ export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.f
             <Icon iconName={ICON_MAP[messageBarType!]} className={classNames.icon} />
           )}
         </div>
-        <div className={classNames.text} id={labelId} role="status" aria-live={getAnnouncementPriority(messageBarType)}>
+        <div
+          className={classNames.text}
+          id={labelId}
+          role={getRole(messageBarType)}
+          aria-live={getAnnouncementPriority(messageBarType)}
+        >
           <span className={classNames.innerText} {...nativeProps}>
             <DelayedRender>
               <span>{children}</span>

--- a/packages/react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.base.tsx
@@ -64,6 +64,7 @@ export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.f
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(props, htmlElementProperties, [
     'className',
+    'role',
   ]);
 
   const classNames: { [key in keyof IMessageBarStyles]: string } = getClassNames(styles, {

--- a/packages/react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.base.tsx
@@ -59,6 +59,7 @@ export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.f
     truncated,
     dismissButtonAriaLabel,
     messageBarIconProps,
+    role,
   } = props;
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(props, htmlElementProperties, [
@@ -104,7 +105,7 @@ export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.f
         <div
           className={classNames.text}
           id={labelId}
-          role={getRole(messageBarType)}
+          role={role || getRole(messageBarType)}
           aria-live={getAnnouncementPriority(messageBarType)}
         >
           <span className={classNames.innerText} {...nativeProps}>

--- a/packages/react/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.test.tsx
@@ -207,4 +207,20 @@ describe('MessageBar', () => {
       expect(expandElement.exists()).toBe(false);
     });
   });
+
+  describe('role attribute', () => {
+    it('is present only once', () => {
+      const wrapper = mount(<MessageBar />);
+      const roleElements = wrapper.find('.ms-MessageBar [role]');
+      expect(roleElements.length).toBe(1);
+    });
+
+    it('is present only once when custom role attribute exists', () => {
+      const role = 'banner';
+      const wrapper = mount(<MessageBar role={role} />);
+      const roleElements = wrapper.find('.ms-MessageBar [role]');
+      expect(roleElements.length).toBe(1);
+      expect(roleElements.prop('role')).toBe(role);
+    });
+  });
 });

--- a/packages/react/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.test.tsx
@@ -216,7 +216,7 @@ describe('MessageBar', () => {
     });
 
     it('is present only once when custom role attribute exists', () => {
-      const role = 'banner';
+      const role = 'none';
       const wrapper = mount(<MessageBar role={role} />);
       const roleElements = wrapper.find('.ms-MessageBar [role]');
       expect(roleElements.length).toBe(1);

--- a/packages/react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/react/src/components/MessageBar/MessageBar.types.ts
@@ -95,6 +95,12 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement>, Rea
    * If unset, default will be the icon set by messageBarType.
    */
   messageBarIconProps?: IIconProps;
+
+  /**
+   * Custom role to apply to the MessageBar.
+   * @defaultvalue `alert` or `status` (based on `MessageBarType`)
+   */
+  role?: string;
 }
 
 /**

--- a/packages/react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/react/src/components/MessageBar/MessageBar.types.ts
@@ -100,7 +100,7 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement>, Rea
    * Custom role to apply to the MessageBar.
    * @defaultvalue `alert` or `status` (based on `MessageBarType`)
    */
-  role?: string;
+  role?: 'alert' | 'status' | 'none';
 }
 
 /**

--- a/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`MessageBar renders a error MessageBar correctly 1`] = `
             forced-color-adjust: none;
           }
       id="MessageBar0"
-      role="status"
+      role="alert"
     >
       <span
         className=
@@ -595,7 +595,7 @@ exports[`MessageBar renders a multiline error MessageBar correctly 1`] = `
             forced-color-adjust: none;
           }
       id="MessageBar0"
-      role="status"
+      role="alert"
     >
       <span
         className=
@@ -840,7 +840,7 @@ exports[`MessageBar renders a multiline severeWarning MessageBar correctly 1`] =
             forced-color-adjust: none;
           }
       id="MessageBar0"
-      role="status"
+      role="alert"
     >
       <span
         className=
@@ -1209,7 +1209,7 @@ exports[`MessageBar renders a severeWarning MessageBar correctly 1`] = `
             forced-color-adjust: none;
           }
       id="MessageBar0"
-      role="status"
+      role="alert"
     >
       <span
         className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16453
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Following [the direction in this comment](https://github.com/microsoft/fluentui/issues/16453#issuecomment-793277320) to replace the static `role="status"` with a value based on the `MessageBarType`.

The implementation mimics the existing `getAnnouncementPriority` function that defines the `aria-live` value. Those could potentially be combined, but the one-to-one, function/prop definition is nice too.

#### Focus areas to test

`MessageBar` component
