### PR TITLE
Disable errexit for yarn-ci

### DIFF
--- a/yarn-ci.sh
+++ b/yarn-ci.sh
@@ -8,6 +8,12 @@ MAX_RETRIES=3
 LOG_ERROR="##vso[task.logissue type=error]"
 LOG_WARNING="##vso[task.logissue type=warning]"
 
+# In .devops/templates/tools.yml we enable errexit and errtrace to ensure that the whole task fails
+# if any line of a multi-line script fails. However, that's not desirable here since the `timeout`
+# command below is intended to exit non-zero if a timeout occurs. (+o means turn option off)
+set +o errexit
+set +o errtrace
+
 while [ $attempt -le $MAX_RETRIES ]; do
   printf "\n\nRunning yarn (attempt $attempt)...\n\n"
 


### PR DESCRIPTION
This PR fixes an issue introduced by a bad interaction of workarounds for other issues.

Initial issue: `yarn` sometimes hangs indefinitely in CI (on Linux but not Windows), very intermittently and without enough logging to help figure out why. As a workaround, we added a script `yarn-ci.sh` which wraps the `yarn` call with [GNU `timeout`](https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html) to stop it and retry after 5 minutes. *(note: `midgard-yarn` is a faster version of `yarn` v1, and I'm pretty sure the timeout issue predated it.)*
https://github.com/microsoft/fluentui/blob/d55424d83709eb72acd3bae2af85b42ab05b5aad/yarn-ci.sh#L16

Next issue: Some of the script tasks in our build pipelines use multi-line scripts. In theory if *any* line fails, the whole task ought to fail, but that wasn't happening because [ADO won't enable](https://github.com/microsoft/azure-pipelines-agent/issues/1803) the `errexit` [shell option](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html). Previously we worked around this by adding `&&` between all script lines, but it was easy to forget in new scripts. [This comment](https://github.com/microsoft/azure-pipelines-agent/issues/1803#issuecomment-655855735) pointed to a workaround (hack) of setting the options via a task variable (which gets turned into an environment variable on subsequent tasks), so we added that to `.devops/templates/tools.yml`.
https://github.com/microsoft/fluentui/blob/d55424d83709eb72acd3bae2af85b42ab05b5aad/.devops/templates/tools.yml#L20-L22

Together, these workarounds caused another issue: in the yarn retry wrapper, if `timeout` detects a timeout, it will (intermediately) exit with code 124. `yarn-ci.sh` detects this and used to handle it properly. HOWEVER, with `errexit` enabled, this intermediate failure causes the whole task to immediately exit as a failure ([example build](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=201900&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=5eede49d-1524-5afc-1944-c920f2f180f3)). 

So...this PR turns off the `errexit` setting (and related `errtrace`) specifically within the `yarn-ci` script.

(Open to better ideas for any of the above, but unless it's something we can do right away I'd like to go ahead and merge this. As far as fixing upstream: `yarn` maintainers won't accept fixes for v1, though adding more logging to `midgard-yarn` could be an option if we want to go that route. The `errexit` issue has been reported to ADO, as linked above, and they refuse to change it. )