### PR TITLE
fix(ColorPicker): remove aria-live attribute from text input

### DIFF
--- a/change/@fluentui-react-0d92acc2-f2f4-4e08-b7e0-7a261002ab10.json
+++ b/change/@fluentui-react-0d92acc2-f2f4-4e08-b7e0-7a261002ab10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove aria-live from ColorPicker text input",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-1000b1c9-e34f-40cb-b8c3-047e0b31073a.json
+++ b/change/@fluentui-react-examples-1000b1c9-e34f-40cb-b8c3-047e0b31073a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "snapshot updates for ColorPicker aria-live attribute",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -615,7 +615,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Red"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -787,7 +786,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Green"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -959,7 +957,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Blue"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -1131,7 +1128,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Alpha"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -251,7 +251,6 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                         value={this._getDisplayValue(comp)}
                         spellCheck={false}
                         ariaLabel={textLabels[comp]}
-                        aria-live={comp !== 'hex' ? 'assertive' : undefined}
                         autoComplete="off"
                       />
                     </td>

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -579,7 +579,6 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -751,7 +750,6 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -923,7 +921,6 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1095,7 +1092,6 @@ exports[`ColorPicker renders correctly 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Alpha"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1803,7 +1799,6 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -1975,7 +1970,6 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -2147,7 +2141,6 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -2319,7 +2312,6 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Alpha"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3004,7 +2996,6 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Red"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3176,7 +3167,6 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Green"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3348,7 +3338,6 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Blue"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field
@@ -3520,7 +3509,6 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   <input
                     aria-invalid={false}
                     aria-label="Transparency"
-                    aria-live="assertive"
                     autoComplete="off"
                     className=
                         ms-TextField-field


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There's an `aria-live` attribute directly on a text input in the ColorPicker, which at best will do nothing (since it's actually not supposed to work), and at worst will announce value changes, resulting in a double keyboard echo for screen reader users. That's quite a negative experience when typing, so we definitely want to avoid any uses of `aria-live` on anything that takes direct user input.

I'm sure this originally came from a bad accessibility bug; whatever it was, there's no legitimate reason to add aria-live to edit fields, and in the future we should summarily close any bug that asks for us to do that 😄.

