### PR TITLE
Deprecated react-popup

### DIFF
--- a/change/@fluentui-react-popup-5ca62cce-4b45-42ab-b786-9cd4568dac5d.json
+++ b/change/@fluentui-react-popup-5ca62cce-4b45-42ab-b786-9cd4568dac5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Deprecated react-popup",
+  "packageName": "@fluentui/react-popup",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popup/README.md
+++ b/packages/react-popup/README.md
@@ -1,11 +1,3 @@
 # @fluentui/react-popup
 
-**React Popup components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
-To import React Popup components:
-
-```js
-import { ComponentName } from '@fluentui/react-popup';
-```
+This package is deprecated and will be potentially renamed to `@fluentui/react-popover`


### PR DESCRIPTION
Once this change is published, will follow up with [npm-deprecate](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions) for the published package and then deleting from the repo

Due to the decision to rename `Popup` to `Popover` this PR adds a
deprecation notice to the `react-popup` README


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
