### PR TITLE
Fix private package generation

### DIFF
--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -1,6 +1,7 @@
 {
   "name": "{{{packageNpmName}}}",
   "version": "9.0.0-alpha.0",
+  "private": true,
   "description": "{{{description}}}",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
Currently the plopfile assumes `private: true` to be the default in
`package.json`, but that property does not exist in the template.

Result: Any new package created is always
published regardless of the answer to the prompt. 😭

Adds `private: true` to them template so that the package generation prompt works as
expected

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
