### PR TITLE
fix fluent release pipeline error on canary release

### DIFF
--- a/scripts/fluentui-publish/index.ts
+++ b/scripts/fluentui-publish/index.ts
@@ -74,7 +74,7 @@ export function fluentuiLernaPublish(bumpType, skipConfirm = false, npmTagForCan
   }
 
   if (result.status) {
-    throw new Error(result.error?.stack || `lerna publish failed with status ${result.status}`);
+    throw new Error(`lerna publish failed with status ${result.status}\nstderr: ${result.stderr}`);
   }
 }
 
@@ -86,7 +86,7 @@ const execCommandSync = (cwd: string, command: string, args: string[]) => {
     encoding: 'utf-8',
   });
   if (result.status) {
-    throw new Error(result.error?.stack || `'${command} ${args.join(' ')}' failed with status ${result.status}`);
+    throw new Error(`'${command} ${args.join(' ')}' failed with status ${result.status}\nstderr: ${result.stderr}`);
   }
   return result.stdout;
 };

--- a/scripts/fluentui-publish/index.ts
+++ b/scripts/fluentui-publish/index.ts
@@ -100,7 +100,7 @@ export function fluentuiPostPublishValidation() {
 
   // sync fluent version
   execCommandSync(gitRoot, 'yarn', ['syncpack:fix']);
-  const gitStatus = execCommandSync(gitRoot, 'git', ['status', '--porcelain']);
+  const gitStatus = execCommandSync(gitRoot, 'git', ['status', '--porcelain', `\\*package.json`]);
   if (gitStatus.length !== 0) {
     execCommandSync(gitRoot, 'git', ['add', `\\*package.json`]);
     execCommandSync(gitRoot, 'git', ['commit', '-m', `"chore: fix dependencies after react-northstar release"`]);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The fluent ui release pipeline gets the below error when trying to release canary:
```bash
$ node -r ./scripts/ts-node-register ./scripts/fluentui-publish post-publish

/mnt/work/6/s/scripts/fluentui-publish/index.ts:89
    throw new Error(result.error?.stack || `'${command} ${args.join(' ')}' failed with status ${result.status}`);
          ^
Error: 'git commit -m "chore: fix dependencies after react-northstar release"' failed with status 1
    at execCommandSync (/mnt/work/6/s/scripts/fluentui-publish/index.ts:89:11)
    at fluentuiPostPublishValidation (/mnt/work/6/s/scripts/fluentui-publish/index.ts:106:5)
    at run (/mnt/work/6/s/scripts/fluentui-publish/index.ts:186:7)
    at Object.<anonymous> (/mnt/work/6/s/scripts/fluentui-publish/index.ts:193:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/mnt/work/6/s/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/mnt/work/6/s/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
error Command failed with exit code 1.

```

This is likely happening because there's no changes to any package.json for canary release.
I made a code change to only do this `git commit` when there's any package.json change detected

#### Focus areas to test

(optional)
