### PR TITLE
 SearchBox: input event now properly returned in onChange callback

### DIFF
--- a/change/@fluentui-react-d68e6908-271d-467c-b178-bf520674bc9d.json
+++ b/change/@fluentui-react-d68e6908-271d-467c-b178-bf520674bc9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: input event now properly returned in onChange callback",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -126,7 +126,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
   );
 
   const onInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(ev.target.value);
+    setValue(ev.target.value, ev);
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18021
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- now passing `event` to `setValue` setter generated by [useControllableValue](https://github.com/microsoft/fluentui/blob/e2c19e3c3eaa4d9e5d04b8afb57ea7e78d8e9fe6/packages/react-hooks/src/useControllableValue.ts#L60) hook
