### PR TITLE
ChoiceGroup: fills visible small dot in middle for checked selected item

### DIFF
--- a/change/@fluentui-react-ac9149b1-db4f-44b3-a34e-020214690590.json
+++ b/change/@fluentui-react-ac9149b1-db4f-44b3-a34e-020214690590.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup: fills visible small dot in middle for checked selected item",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-26091dd6-63f8-41c3-bfef-942a79e5b57c.json
+++ b/change/@fluentui-react-examples-26091dd6-63f8-41c3-bfef-942a79e5b57c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup: fills visible small dot in middle for checked selected item",
+  "packageName": "@fluentui/react-examples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -259,6 +259,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                   border-color: #005a9e;
                 }
                 &:hover:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:focus .ms-ChoiceFieldLabel {
@@ -268,6 +269,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                   border-color: #005a9e;
                 }
                 &:focus:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:before {
@@ -295,6 +297,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                   forced-color-adjust: none;
                 }
                 &:after {
+                  background: #0078d4;
                   border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -252,6 +252,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                   border-color: #005a9e;
                 }
                 &:hover:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:focus .ms-ChoiceFieldLabel {
@@ -261,6 +262,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                   border-color: #005a9e;
                 }
                 &:focus:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:before {
@@ -288,6 +290,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
                   forced-color-adjust: none;
                 }
                 &:after {
+                  background: #0078d4;
                   border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -434,6 +434,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   border-color: #005a9e;
                 }
                 &:hover:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:focus .ms-ChoiceFieldLabel {
@@ -443,6 +444,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   border-color: #005a9e;
                 }
                 &:focus:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:before {
@@ -470,6 +472,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   forced-color-adjust: none;
                 }
                 &:after {
+                  background: #0078d4;
                   border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -148,6 +148,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   opacity: 1;
                 }
                 &:hover:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:focus {
@@ -161,6 +162,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   opacity: 1;
                 }
                 &:focus:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:before {
@@ -190,6 +192,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   forced-color-adjust: none;
                 }
                 &:after {
+                  background: #0078d4;
                   border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -148,6 +148,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   opacity: 1;
                 }
                 &:hover:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:focus {
@@ -161,6 +162,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   opacity: 1;
                 }
                 &:focus:after {
+                  background: #005a9e;
                   border-color: #005a9e;
                 }
                 &:before {
@@ -190,6 +192,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   forced-color-adjust: none;
                 }
                 &:after {
+                  background: #0078d4;
                   border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -295,6 +295,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     border-color: #005a9e;
                   }
                   &:hover:after {
+                    background: #005a9e;
                     border-color: #005a9e;
                   }
                   &:focus .ms-ChoiceFieldLabel {
@@ -304,6 +305,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     border-color: #005a9e;
                   }
                   &:focus:after {
+                    background: #005a9e;
                     border-color: #005a9e;
                   }
                   &:before {
@@ -331,6 +333,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     forced-color-adjust: none;
                   }
                   &:after {
+                    background: #0078d4;
                     border-color: #0078d4;
                     border-radius: 50%;
                     border-style: solid;

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1488,6 +1488,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       border-color: #005a9e;
                     }
                     &:hover:after {
+                      background: #005a9e;
                       border-color: #005a9e;
                     }
                     &:focus .ms-ChoiceFieldLabel {
@@ -1497,6 +1498,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       border-color: #005a9e;
                     }
                     &:focus:after {
+                      background: #005a9e;
                       border-color: #005a9e;
                     }
                     &:before {
@@ -1524,6 +1526,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       forced-color-adjust: none;
                     }
                     &:after {
+                      background: #0078d4;
                       border-color: #0078d4;
                       border-radius: 50%;
                       border-style: solid;

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -139,6 +139,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
           },
         checked && {
           borderColor: dotCheckedHoveredColor,
+          background: dotCheckedHoveredColor,
         },
       ],
     },
@@ -220,6 +221,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       borderWidth: 5,
       borderStyle: 'solid',
       borderColor: disabled ? dotDisabledColor : dotCheckedColor,
+      background: dotCheckedColor,
       left: 5,
       top: 5,
       width: 10,

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -768,6 +768,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               border-color: #005a9e;
             }
             &:hover:after {
+              background: #005a9e;
               border-color: #005a9e;
             }
             &:focus .ms-ChoiceFieldLabel {
@@ -777,6 +778,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               border-color: #005a9e;
             }
             &:focus:after {
+              background: #005a9e;
               border-color: #005a9e;
             }
             &:before {
@@ -804,6 +806,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               forced-color-adjust: none;
             }
             &:after {
+              background: #0078d4;
               border-color: #0078d4;
               border-radius: 50%;
               border-style: solid;
@@ -1037,6 +1040,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               forced-color-adjust: none;
             }
             &:after {
+              background: #0078d4;
               border-color: #c8c6c4;
               border-radius: 50%;
               border-style: solid;
@@ -1593,6 +1597,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               opacity: 1;
             }
             &:hover:after {
+              background: #005a9e;
               border-color: #005a9e;
             }
             &:focus {
@@ -1606,6 +1611,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               opacity: 1;
             }
             &:focus:after {
+              background: #005a9e;
               border-color: #005a9e;
             }
             &:before {
@@ -1635,6 +1641,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               forced-color-adjust: none;
             }
             &:after {
+              background: #0078d4;
               border-color: #0078d4;
               border-radius: 50%;
               border-style: solid;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18004
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- adds `background` css property to fill small dot for checked item. Also added for `hover` selector.
![ChoiceGroup-1](https://user-images.githubusercontent.com/8649804/117203981-8c98d480-ada4-11eb-8820-dbe61bdfcbfe.JPG)
![ChoiceGroup-2](https://user-images.githubusercontent.com/8649804/117203993-8e629800-ada4-11eb-8115-c520ca4fdab2.JPG)


