### PR TITLE
fix(DetailsList): update element with columnheader name and description ARIA attributes

### DIFF
--- a/change/@fluentui-react-6fbb3480-ce20-4cf1-8c34-4383a538ed1d.json
+++ b/change/@fluentui-react-6fbb3480-ce20-4cf1-8c34-4383a538ed1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update DetailsList columnheader element with name and description ARIA attributes",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-4d59f869-7776-43cb-8bbd-bc9f1614dcc7.json
+++ b/change/@fluentui-react-examples-4d59f869-7776-43cb-8bbd-bc9f1614dcc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "snapshot updates for DetailsList",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -557,6 +557,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
             </label>
             <div
               aria-colindex={2}
+              aria-labelledby="header4-name-name"
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -636,7 +637,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header4-name-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -353,6 +353,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
           </label>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -432,7 +433,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -615,7 +615,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Red"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -787,7 +786,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Green"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -959,7 +957,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Blue"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -1131,7 +1128,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Alpha"
-                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -615,6 +615,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Red"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -786,6 +787,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Green"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -957,6 +959,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Blue"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field
@@ -1128,6 +1131,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     <input
                       aria-invalid={false}
                       aria-label="Alpha"
+                      aria-live="assertive"
                       autoComplete="off"
                       className=
                           ms-TextField-field

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -353,6 +353,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           </label>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -432,7 +433,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -543,6 +543,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           />
           <div
             aria-colindex={3}
+            aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -622,7 +623,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -581,6 +581,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               </label>
               <div
                 aria-colindex={2}
+                aria-labelledby="header4-column1-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -660,7 +661,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header4-column1-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -771,6 +771,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               />
               <div
                 aria-colindex={3}
+                aria-labelledby="header4-column2-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -850,7 +851,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header4-column2-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -565,6 +565,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               </label>
               <div
                 aria-colindex={2}
+                aria-labelledby="header4-column1-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -644,7 +645,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header4-column1-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -755,6 +755,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               />
               <div
                 aria-colindex={3}
+                aria-labelledby="header4-column2-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -834,7 +835,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header4-column2-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -352,6 +352,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
           </label>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -431,7 +432,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -542,6 +542,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
           />
           <div
             aria-colindex={3}
+            aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -621,7 +622,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -438,6 +438,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-thumbnail-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -517,7 +518,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -327,6 +327,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-thumbnail-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -406,7 +407,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -916,6 +916,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               </label>
               <div
                 aria-colindex={2}
+                aria-labelledby="header8-thumbnail-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -995,7 +996,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 >
                   <span
                     aria-haspopup={false}
-                    aria-labelledby="header8-thumbnail-name"
                     className=
                         ms-DetailsHeader-cellTitle
                         {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -839,6 +839,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             </div>
             <div
               aria-colindex={2}
+              aria-labelledby="header6-name-name"
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -918,7 +919,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header6-name-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1029,6 +1029,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             />
             <div
               aria-colindex={3}
+              aria-labelledby="header6-color-name"
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1108,7 +1109,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <span
                   aria-haspopup={false}
-                  aria-labelledby="header6-color-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -438,6 +438,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -517,7 +518,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -628,6 +628,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
           />
           <div
             aria-colindex={3}
+            aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -707,7 +708,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -352,6 +352,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
           </label>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-filepath-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -431,7 +432,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-filepath-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -486,6 +486,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
           </div>
           <div
             aria-colindex={3}
+            aria-labelledby="header1-size-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -565,7 +566,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-size-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -353,6 +353,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
           </label>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -432,7 +433,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -639,6 +639,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
           />
           <div
             aria-colindex={3}
+            aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -718,7 +719,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -829,6 +829,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
           />
           <div
             aria-colindex={4}
+            aria-labelledby="header1-column3-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -908,7 +909,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -267,6 +267,7 @@ Array [
             >
               <div
                 aria-colindex={1}
+                aria-label="FileType"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -346,7 +347,6 @@ Array [
                 >
                   <span
                     aria-haspopup={false}
-                    aria-label="FileType"
                     className=
                         ms-DetailsHeader-cellTitle
                         {

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -89,6 +89,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -168,7 +169,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -279,6 +279,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
           />
           <div
             aria-colindex={2}
+            aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -358,7 +359,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -89,6 +89,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -168,7 +169,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -279,6 +279,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
           />
           <div
             aria-colindex={2}
+            aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -358,7 +359,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-column2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -93,12 +93,25 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       ? composeRenderFunction(column.onRenderHeader, defaultOnRenderHeader(this._classNames))
       : defaultOnRenderHeader(this._classNames);
 
+    const hasInnerButton =
+      column.columnActionsMode !== ColumnActionsMode.disabled &&
+      (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined);
+    const accNameDescription = {
+      'aria-label': column.isIconOnly ? column.name : undefined,
+      'aria-labelledby': column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,
+      'aria-describedby':
+        !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleLabel()
+          ? `${parentId}-${column.key}-tooltip`
+          : undefined,
+    };
+
     return (
       <>
         <div
           key={column.key}
           ref={this._root}
           role={'columnheader'}
+          {...(!hasInnerButton && accNameDescription)}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
           aria-colindex={columnIndex}
           className={classNames.root}
@@ -127,21 +140,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
               children: (
                 <span
                   id={`${parentId}-${column.key}`}
-                  aria-label={column.isIconOnly ? column.name : undefined}
-                  aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name`}
                   className={classNames.cellTitle}
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
-                  role={
-                    column.columnActionsMode !== ColumnActionsMode.disabled &&
-                    (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined)
-                      ? 'button'
-                      : undefined
-                  }
-                  aria-describedby={
-                    !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleLabel()
-                      ? `${parentId}-${column.key}-tooltip`
-                      : undefined
-                  }
+                  role={hasInnerButton ? 'button' : undefined}
+                  {...(hasInnerButton && accNameDescription)}
                   onContextMenu={this._onColumnContextMenu}
                   onClick={this._onColumnClick}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -373,7 +373,9 @@ export interface IColumn {
 
   /**
    * Accessible label for the column. The column name will still be used as the primary label,
-   * but this text (if specified) will be read after the column name.
+   * but this text (if specified) will be used as the column description.
+   * WARNING: grid column descriptions are often ignored by screen readers, so any necessary information
+   * should go directly in the column content
    */
   ariaLabel?: string;
 

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -284,6 +284,7 @@ exports[`DetailsHeader can render 1`] = `
   </div>
   <div
     aria-colindex={2}
+    aria-labelledby="header0-a-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -363,7 +364,6 @@ exports[`DetailsHeader can render 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header0-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -474,6 +474,7 @@ exports[`DetailsHeader can render 1`] = `
   />
   <div
     aria-colindex={3}
+    aria-labelledby="header0-b-name"
     aria-sort="ascending"
     className=
         ms-DetailsHeader-cell
@@ -554,7 +555,6 @@ exports[`DetailsHeader can render 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header0-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -696,6 +696,7 @@ exports[`DetailsHeader can render 1`] = `
   />
   <div
     aria-colindex={4}
+    aria-labelledby="header0-c-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -776,7 +777,6 @@ exports[`DetailsHeader can render 1`] = `
       <span
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header0-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1072,6 +1072,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
   </div>
   <div
     aria-colindex={2}
+    aria-labelledby="header2-a-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -1151,7 +1152,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header2-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1262,6 +1262,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
   />
   <div
     aria-colindex={3}
+    aria-labelledby="header2-b-name"
     aria-sort="ascending"
     className=
         ms-DetailsHeader-cell
@@ -1342,7 +1343,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header2-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1484,6 +1484,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
   />
   <div
     aria-colindex={4}
+    aria-labelledby="header2-c-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -1564,7 +1565,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
       <span
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header2-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1991,6 +1991,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
   </div>
   <div
     aria-colindex={2}
+    aria-labelledby="header6-a-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -2070,7 +2071,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header6-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2181,6 +2181,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
   />
   <div
     aria-colindex={3}
+    aria-describedby="header6-b-tooltip"
+    aria-labelledby="header6-b-name"
     aria-sort="ascending"
     className=
         ms-DetailsHeader-cell
@@ -2260,9 +2262,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           }
     >
       <span
-        aria-describedby="header6-b-tooltip"
         aria-haspopup={false}
-        aria-labelledby="header6-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2427,6 +2427,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
   />
   <div
     aria-colindex={4}
+    aria-describedby="header6-c-tooltip"
+    aria-labelledby="header6-c-name"
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -2506,10 +2508,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           }
     >
       <span
-        aria-describedby="header6-c-tooltip"
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header6-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2175,6 +2175,7 @@ exports[`DetailsList renders List correctly 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header9-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -2254,7 +2255,6 @@ exports[`DetailsList renders List correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2780,6 +2780,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-describedby="header1-column_key_0-tooltip"
+            aria-labelledby="header1-column_key_0-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -2858,9 +2860,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-describedby="header1-column_key_0-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header1-column_key_0-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2937,6 +2937,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           </label>
           <div
             aria-colindex={3}
+            aria-describedby="header1-column_key_1-tooltip"
+            aria-labelledby="header1-column_key_1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3015,9 +3017,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-describedby="header1-column_key_1-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header1-column_key_1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3094,6 +3094,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           </label>
           <div
             aria-colindex={4}
+            aria-describedby="header1-column_key_2-tooltip"
+            aria-labelledby="header1-column_key_2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3172,9 +3174,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-describedby="header1-column_key_2-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header1-column_key_2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3251,6 +3251,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           </label>
           <div
             aria-colindex={5}
+            aria-describedby="header1-column_key_3-tooltip"
+            aria-labelledby="header1-column_key_3-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3329,9 +3331,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-describedby="header1-column_key_3-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header1-column_key_3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3408,6 +3408,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           </label>
           <div
             aria-colindex={6}
+            aria-describedby="header1-column_key_4-tooltip"
+            aria-labelledby="header1-column_key_4-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3486,9 +3488,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-describedby="header1-column_key_4-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header1-column_key_4-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3981,6 +3981,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header33-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -4060,7 +4061,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header33-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4587,6 +4587,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header13-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -4666,7 +4667,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4777,6 +4777,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
           />
           <div
             aria-colindex={3}
+            aria-labelledby="header13-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -4856,7 +4857,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4967,6 +4967,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
           />
           <div
             aria-colindex={4}
+            aria-labelledby="header13-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -5046,7 +5047,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5572,6 +5572,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-describedby="header5-column_key_0-tooltip"
+            aria-labelledby="header5-column_key_0-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -5650,9 +5652,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header5-column_key_0-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header5-column_key_0-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5732,6 +5732,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           </span>
           <div
             aria-colindex={3}
+            aria-describedby="header5-column_key_1-tooltip"
+            aria-labelledby="header5-column_key_1-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -5810,9 +5812,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header5-column_key_1-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header5-column_key_1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5892,6 +5892,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           </span>
           <div
             aria-colindex={4}
+            aria-describedby="header5-column_key_2-tooltip"
+            aria-labelledby="header5-column_key_2-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -5970,9 +5972,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header5-column_key_2-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header5-column_key_2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6052,6 +6052,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           </span>
           <div
             aria-colindex={5}
+            aria-describedby="header5-column_key_3-tooltip"
+            aria-labelledby="header5-column_key_3-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6130,9 +6132,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header5-column_key_3-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header5-column_key_3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6212,6 +6212,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           </span>
           <div
             aria-colindex={6}
+            aria-describedby="header5-column_key_4-tooltip"
+            aria-labelledby="header5-column_key_4-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6290,9 +6292,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-describedby="header5-column_key_4-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header5-column_key_4-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6633,6 +6633,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
           </div>
           <div
             aria-colindex={1}
+            aria-labelledby="header37-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6712,7 +6713,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header37-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -327,6 +327,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -406,7 +407,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -461,6 +461,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
           </div>
           <div
             aria-colindex={3}
+            aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -540,7 +541,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -595,6 +595,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
           </div>
           <div
             aria-colindex={4}
+            aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -674,7 +675,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header1-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1164,6 +1164,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header13-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1243,7 +1244,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1298,6 +1298,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
           </div>
           <div
             aria-colindex={3}
+            aria-labelledby="header13-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1377,7 +1378,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1432,6 +1432,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
           </div>
           <div
             aria-colindex={4}
+            aria-labelledby="header13-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1511,7 +1512,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header13-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2516,6 +2516,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header5-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -2595,7 +2596,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header5-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2650,6 +2650,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
           </div>
           <div
             aria-colindex={3}
+            aria-labelledby="header5-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -2729,7 +2730,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header5-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2784,6 +2784,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
           </div>
           <div
             aria-colindex={4}
+            aria-labelledby="header5-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -2863,7 +2864,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header5-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3353,6 +3353,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
           </div>
           <div
             aria-colindex={2}
+            aria-labelledby="header9-key-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3432,7 +3433,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3487,6 +3487,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
           </div>
           <div
             aria-colindex={3}
+            aria-labelledby="header9-name-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3566,7 +3567,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3621,6 +3621,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
           </div>
           <div
             aria-colindex={4}
+            aria-labelledby="header9-value-name"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3700,7 +3701,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [11798](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11798)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

DetailsList places `aria-label`, `aria-labelledby`, and `aria-describedby` on a span inside the column header, regardless of whether that element is a button or not. I've updated the logic to put the name/desc attributes on the span only if it's a button and can support a name/desc, and on the columnheader itself if not.

I also added extra info & a warning to the docs for the IColumn interface's `ariaLabel` prop, since descriptions on column headers have pretty flaky support. Whether the description comes from a `title` attribute or ARIA, neither NVDA nor JAWS reads that information on a column header, though Narrator does. In the future, we should probably avoid putting info in columnheader descriptions, but for now this update will give slightly better support without breaking current implementations.
