### PR TITLE
Docsite: button controls focus border now visible in High Contrast Mode

### DIFF
--- a/change/@fluentui-react-docsite-components-1b924a1a-8b34-4100-b57d-4de0c5966f1e.json
+++ b/change/@fluentui-react-docsite-components-1b924a1a-8b34-4100-b57d-4de0c5966f1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Docsite: button controls focus border now visible in High Contrast Mode",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.styles.ts
+++ b/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.styles.ts
@@ -1,4 +1,10 @@
-import { AnimationVariables, IRawStyle, getTheme, HighContrastSelector } from '@fluentui/react/lib/Styling';
+import {
+  AnimationVariables,
+  IRawStyle,
+  getTheme,
+  getFocusStyle,
+  HighContrastSelector,
+} from '@fluentui/react/lib/Styling';
 import { IStyleFunction } from '@fluentui/react/lib/Utilities';
 import { IDropdownStyles } from '@fluentui/react/lib/Dropdown';
 import { IButtonStyles } from '@fluentui/react/lib/Button';
@@ -79,26 +85,21 @@ export const getStyles: IStyleFunction<IExampleCardStyleProps, IExampleCardStyle
     ],
   };
 
+  const buttonHighContrastFocus = {
+    left: -1,
+    top: -1,
+    bottom: 1,
+    right: -1,
+    outlineColor: 'Highlight',
+    borderColor: 'Highlight',
+  };
+
   const buttonStyles: Partial<IButtonStyles> = {
     root: [
       sharedToggleButtonStyles,
       { lineHeight: '1' }, // quotes prevent interpretation as px
       globalClassNames.codeButton,
-      {
-        selectors: {
-          [HighContrastSelector]: {
-            selectors: {
-              ':focus': {
-                top: `-1px`,
-                bottom: '-1px',
-                left: '-1px',
-                right: '-1px',
-                border: '3px solid Highlight',
-              },
-            },
-          },
-        },
-      },
+      getFocusStyle(theme, { inset: 1, highContrastStyle: buttonHighContrastFocus, borderColor: 'transparent' }),
     ],
     label: {
       color: theme.palette.neutralDark,

--- a/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.styles.ts
+++ b/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.styles.ts
@@ -84,6 +84,21 @@ export const getStyles: IStyleFunction<IExampleCardStyleProps, IExampleCardStyle
       sharedToggleButtonStyles,
       { lineHeight: '1' }, // quotes prevent interpretation as px
       globalClassNames.codeButton,
+      {
+        selectors: {
+          [HighContrastSelector]: {
+            selectors: {
+              ':focus': {
+                top: `-1px`,
+                bottom: '-1px',
+                left: '-1px',
+                right: '-1px',
+                border: '3px solid Highlight',
+              },
+            },
+          },
+        },
+      },
     ],
     label: {
       color: theme.palette.neutralDark,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18051 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- the controls use the `Button` component and `Dropdown` component. I did not want to alter how `Button` handles its focus borders in High Contrast Mode so I've added some styling to the `ExampleCard` component used by the docsite to try and mimic `Dropdown`'s focus border style.
-
![Docsite Examples - update](https://user-images.githubusercontent.com/8649804/117351578-c0d2ca80-ae62-11eb-9440-f85c317c78fc.gif)

