### PR TITLE
 fix(makeStyles): fix issues with :global pseudo

### DIFF
--- a/change/@fluentui-make-styles-b9ae88ad-0fd4-4f1a-8982-d52795063b4b.json
+++ b/change/@fluentui-make-styles-b9ae88ad-0fd4-4f1a-8982-d52795063b4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(makeStyles): fix issues with :global pseudo",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/runtime/compileCSS.ts
+++ b/packages/make-styles/src/runtime/compileCSS.ts
@@ -1,6 +1,7 @@
 import { compile, middleware, prefixer, rulesheet, serialize, stringify } from 'stylis';
 
 import { hyphenateProperty } from './utils/hyphenateProperty';
+import { normalizeNestedProperty } from './utils/normalizeNestedProperty';
 
 export interface CompileCSSOptions {
   className: string;
@@ -73,10 +74,15 @@ export function compileCSS(options: CompileCSSOptions): [string /* ltr definitio
   // https://github.com/thysultan/stylis.js/issues/253
   // https://github.com/thysultan/stylis.js/issues/252
   if (pseudo.indexOf(':global(') === 0) {
-    const globalSelector = /global\((.+)\)/.exec(pseudo)?.[1];
+    // 👇 :global(GROUP_1)GROUP_2
+    const GLOBAL_PSEUDO_REGEX = /global\((.+)\)(.+)?/;
+    const [, globalSelector, restPseudo = ''] = GLOBAL_PSEUDO_REGEX.exec(pseudo)!;
 
-    const ltrRule = `${classNameSelector} ${cssDeclaration}`;
-    const rtlRule = rtlProperty ? `${rtlClassNameSelector} ${rtlCSSDeclaration}` : '';
+    // should be normalized to handle ":global(SELECTOR) &"
+    const normalizedPseudo = normalizeNestedProperty(restPseudo.trim());
+
+    const ltrRule = `${classNameSelector}${normalizedPseudo} ${cssDeclaration}`;
+    const rtlRule = rtlProperty ? `${rtlClassNameSelector}${normalizedPseudo} ${rtlCSSDeclaration}` : '';
 
     cssRule = `${globalSelector} { ${ltrRule}; ${rtlRule} }`;
   } else {

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -350,6 +350,59 @@ describe('resolveStyleRules', () => {
         }
       `);
     });
+
+    it('handles :global selector', () => {
+      expect(
+        resolveStyleRules({
+          ':global(body)': {
+            ':focus': {
+              color: 'green',
+              ':hover': { color: 'blue' },
+              '& .foo': { color: 'yellow' },
+            },
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        body .f192vvyd:focus {
+          color: green;
+        }
+        body .f1tz2pjr:focus:hover {
+          color: blue;
+        }
+        body .f1dl7obt:focus .foo {
+          color: yellow;
+        }
+      `);
+      expect(
+        resolveStyleRules({
+          ':global(body) :focus': { color: 'green' },
+          ':global(body) :focus:hover': { color: 'blue' },
+          ':global(body) :focus .foo': { color: 'yellow' },
+        }),
+      ).toMatchInlineSnapshot(`
+        body .frou13r0:focus {
+          color: green;
+        }
+        body .f1emv7y1:focus:hover {
+          color: blue;
+        }
+        body .f1g015sp:focus .foo {
+          color: yellow;
+        }
+      `);
+    });
+
+    // it.todo('supports :global as a nested selector', () => {
+    //   expect(
+    //     resolveStyleRules({
+    //       ':focus': { ':global(body)': { color: 'green' } },
+    //     }),
+    //   ).toMatchInlineSnapshot(`
+    //     body .fm1e7ra0:focus {
+    //       color: green;
+    //     }
+    //   `);
+    // });
   });
 
   describe('keyframes', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR improves handling of `:global` selectors, previously all nested pseudo selectors have been silently removed:

```tsx
':global(body)': {
  ':focus': { color: 'green' }
}
// outputs CSS without ":focus" 💣
// body .f192vvyd { color: green; }
```

_Thanks to @bsunderhus for reporting and collaborating of a fix._ ❤️ 