### PR TITLE
chore(PillGroup): add styles

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Pill/Variations/PillExampleSelectable.tsx
+++ b/packages/fluentui/docs/src/examples/components/Pill/Variations/PillExampleSelectable.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { Pill, CalendarIcon, Flex } from '@fluentui/react-northstar';
+import { Pill, CalendarIcon, PillGroup } from '@fluentui/react-northstar';
 
 const PillSelectableExample = () => (
-  <Flex>
+  <PillGroup>
     <Pill selectable image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobertTolbert.jpg">
       Pill with an image
     </Pill>
     <Pill selectable icon={<CalendarIcon />}>
       Pill with an icon
     </Pill>
-  </Flex>
+  </PillGroup>
 );
 
 export default PillSelectableExample;

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -102,6 +102,7 @@ export { pillContentStyles as PillContent } from './components/Pill/pillContentS
 export { pillActionStyles as PillAction } from './components/Pill/pillActionStyles';
 export { pillImageStyles as PillImage } from './components/Pill/pillImageStyles';
 export { pillIconStyles as PillIcon } from './components/Pill/pillIconStyles';
+export { pillGroupStyles as PillGroup } from './components/Pill/pillGroupStyles';
 
 export { popupContentStyles as PopupContent } from './components/Popup/popupContentStyles';
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Pill/pillGroupStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Pill/pillGroupStyles.ts
@@ -1,0 +1,9 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { PillIconStylesProps } from '../../../../components/Pill/PillIcon';
+import { PillVariables } from './pillVariables';
+
+export const pillGroupStyles: ComponentSlotStylesPrepared<PillIconStylesProps, PillVariables> = {
+  root: (): ICSSInJSStyle => ({
+    display: 'flex',
+  }),
+};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Add `pillGroupStyles` to fix wrong pills positioning:

Before:
<img width="384" alt="Screen Shot 2021-05-07 at 12 54 50" src="https://user-images.githubusercontent.com/8545105/117439686-71100400-af33-11eb-93f4-662ada2b8cba.png">
After: 
<img width="352" alt="Screen Shot 2021-05-07 at 12 54 41" src="https://user-images.githubusercontent.com/8545105/117439703-75d4b800-af33-11eb-963b-56567152c81e.png">


#### Focus areas to test

(optional)
