### PR TITLE
ComboBox: option title attribute passed is now correctly applied

### DIFF
--- a/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
+++ b/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "ComboBox: option title attribute passed is now correctly respected",
+  "comment": "ComboBox: option title attribute passed is now correctly respected.",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
+++ b/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "update conditional",
+  "comment": "ComboBox: option title attribute passed is now correctly respected",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
+++ b/change/@fluentui-react-87909893-48cf-46a9-9d8b-4a5a1a5c8ea8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update conditional",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1357,7 +1357,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const isChecked: boolean = this._isOptionChecked(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const title = getPreviewText(item);
+    const title = (item.title !== undefined && item.title) || getPreviewText(item);
 
     const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1357,7 +1357,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const isChecked: boolean = this._isOptionChecked(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const title = (item.title !== undefined && item.title) || getPreviewText(item);
+    const title = item.title !== undefined ? item.title : getPreviewText(item);
 
     const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1357,7 +1357,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const isChecked: boolean = this._isOptionChecked(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const title = item.title !== undefined ? item.title : getPreviewText(item);
+    const title = item.title ?? getPreviewText(item);
 
     const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18087 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- when passing in a `title` attribute to a `ComboBox` option, tooltip now correctly displays the `title` passed