### PR TITLE
DatePicker: when textfield prop received contains an id, that id is now properly applied to TextField input

### DIFF
--- a/change/@fluentui-react-c75e27e7-cff5-49a1-b4cc-e380915f84f8.json
+++ b/change/@fluentui-react-c75e27e7-cff5-49a1-b4cc-e380915f84f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: when textfield prop received contains an id, that id is now properly applied to TextField input",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -426,6 +426,8 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties, ['value']);
   const iconProps = textFieldProps && textFieldProps.iconProps;
+  const textFieldId =
+    textFieldProps && textFieldProps.id && textFieldProps.id !== id ? textFieldProps.id : id + '-label';
 
   return (
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>
@@ -452,7 +454,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
           tabIndex={tabIndex}
           readOnly={!allowTextInput}
           {...textFieldProps}
-          id={id + '-label'}
+          id={textFieldId}
           className={css(classNames.textField, textFieldProps && textFieldProps.className)}
           iconProps={{
             iconName: 'Calendar',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18091 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- DatePicker now correctly passes `id` in `textfield` prop to `TextField` input. 
	- only use `textfield` prop `id` when it doesn't equal the `id` of the `DatePicker` root (if one is passed). If it does, fallback to existing logic.