### PR TITLE
Recipients: LeftArrow on text in recipients well just deletes it. 

### DIFF
--- a/change/@fluentui-react-experiments-049e3b94-591d-46da-a33f-346775ae272e.json
+++ b/change/@fluentui-react-experiments-049e3b94-591d-46da-a33f-346775ae272e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Set suggestedDisplayValue for Autofill",
+  "comment": "UnifiedPicker: set suggestedDisplayValue for Autofill",
   "packageName": "@fluentui/react-experiments",
   "email": "litong@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-experiments-049e3b94-591d-46da-a33f-346775ae272e.json
+++ b/change/@fluentui-react-experiments-049e3b94-591d-46da-a33f-346775ae272e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set suggestedDisplayValue for Autofill",
+  "packageName": "@fluentui/react-experiments",
+  "email": "litong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -634,6 +634,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           }
           disabled={false}
           onPaste={_onPaste}
+          suggestedDisplayValue={queryString}
         />
       </div>
     );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #115907
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Repro:
Type text into UPP recipients well.  Hit left or right arrow.
Actual: text field becomes empty
Expected: cursor moves to previous or next character in input

Fix:
UnifiedPicker uses Autofill as the input component.  Autofill by design replaces input text with suggestedDisplayValue when left or right arrow key is pressed.  Because suggestedDisplayValue prop is empty, the text gets deleted.  Fix is to set and pass queryString as the suggestedDisplayValue to ensure that Autofill's replacement text matches current.  Alternative fix to prevent Autofill from handling left/right arrow has problems because we do want to allow parent div to get keydown and select recipients.

#### Focus areas to test

Ensure queryString is current most inputted text.  
