### PR TITLE
fix(Combobox): remove aria-label by default from options

### DIFF
--- a/change/@fluentui-react-822e925d-afae-4fc3-b0e8-44dccea727cc.json
+++ b/change/@fluentui-react-822e925d-afae-4fc3-b0e8-44dccea727cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove aria-label from Combobox options when no ariaLabel prop is defined",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1379,7 +1379,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           role="option"
           // aria-selected should only be applied to checked items, not hovered items
           aria-selected={isChecked ? 'true' : 'false'}
-          ariaLabel={getPreviewText(item)}
+          ariaLabel={item.ariaLabel}
           disabled={item.disabled}
           title={title}
         >
@@ -1392,7 +1392,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       ) : (
         <Checkbox
           id={id + '-list' + item.index}
-          ariaLabel={getPreviewText(item)}
+          ariaLabel={item.ariaLabel}
           key={item.key}
           styles={optionStyles}
           className={'ms-ComboBox-option'}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -824,7 +824,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   </span>
                 </div>
                 <button
-                  aria-label="Option 1"
                   aria-selected="false"
                   class=
                       ms-Button
@@ -979,7 +978,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   role="separator"
                 />
                 <button
-                  aria-label="Option 2"
                   aria-selected="false"
                   class=
                       ms-Button


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18106
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This updates Combobox to only add the `aria-label` attribute to option children if the `ariaLabel` prop is passed in as part of that option's data. Right now, it applies ariaLabel all the time, which means if a team uses a custom render fn for the option, the text within the option will get overridden by the ariaLabel.

In the future, we should probably remove the possibility of adding an `ariaLabel` to the option at all, since I haven't been able to think of a single good use case for overriding the visible text (or child images/icons with alt text) on an option. Right now it seems a bit of a footgun, but slightly less so after this PR :)

#### Focus areas to test

Combobox, with and without option `ariaLabel` data
