### PR TITLE
fix(Calendar): aria-label format to day, month, year

### DIFF
--- a/change/@fluentui-react-30918b99-3db2-495f-8779-aa5042aaff74.json
+++ b/change/@fluentui-react-30918b99-3db2-495f-8779-aa5042aaff74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Calenda :announce the date in the order [day], [month], [year]",
+  "packageName": "@fluentui/react",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -211,7 +211,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
     day.originalDate.getDate() +
     ', ' +
     strings.months[day.originalDate.getMonth()] +
-    ',' +
+    ', ' +
     day.originalDate.getFullYear();
 
   if (day.isMarked) {

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -207,7 +207,13 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
     }
   };
 
-  let ariaLabel = dateTimeFormatter.formatMonthDayYear(day.originalDate, strings);
+  let ariaLabel =
+    day.originalDate.getDay() +
+    ',' +
+    strings.months[day.originalDate.getMonth()] +
+    ',' +
+    day.originalDate.getFullYear();
+
   if (day.isMarked) {
     ariaLabel = ariaLabel + ', ' + strings.dayMarkedAriaLabel;
   }

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -209,7 +209,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
 
   let ariaLabel =
     day.originalDate.getDate() +
-    ',' +
+    ', ' +
     strings.months[day.originalDate.getMonth()] +
     ',' +
     day.originalDate.getFullYear();

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -208,7 +208,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
   };
 
   let ariaLabel =
-    day.originalDate.getDay() +
+    day.originalDate.getDate() +
     ',' +
     strings.months[day.originalDate.getMonth()] +
     ',' +

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -650,7 +650,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 21, 2018"
+              aria-label="21,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -763,7 +763,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 22, 2018"
+              aria-label="22,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -876,7 +876,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 23, 2018"
+              aria-label="23,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -989,7 +989,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 24, 2018"
+              aria-label="24,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1102,7 +1102,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 25, 2018"
+              aria-label="25,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1215,7 +1215,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 26, 2018"
+              aria-label="26,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1328,7 +1328,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 27, 2018"
+              aria-label="27,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1462,7 +1462,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 28, 2018"
+              aria-label="28,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1591,7 +1591,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 29, 2018"
+              aria-label="29,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1720,7 +1720,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 30, 2018"
+              aria-label="30,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1849,7 +1849,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="December 31, 2018"
+              aria-label="31,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2007,7 +2007,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="January 1, 2019"
+              aria-label="1,January,2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -2147,7 +2147,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="January 2, 2019"
+              aria-label="2,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2272,7 +2272,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="January 3, 2019"
+              aria-label="3,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2397,7 +2397,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 4, 2019"
+              aria-label="4,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2506,7 +2506,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 5, 2019"
+              aria-label="5,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2615,7 +2615,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 6, 2019"
+              aria-label="6,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2724,7 +2724,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 7, 2019"
+              aria-label="7,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2833,7 +2833,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 8, 2019"
+              aria-label="8,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2942,7 +2942,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 9, 2019"
+              aria-label="9,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3051,7 +3051,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 10, 2019"
+              aria-label="10,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3853,7 +3853,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 23, 2018"
+              aria-label="23,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3966,7 +3966,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 24, 2018"
+              aria-label="24,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4079,7 +4079,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 25, 2018"
+              aria-label="25,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4192,7 +4192,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 26, 2018"
+              aria-label="26,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4305,7 +4305,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 27, 2018"
+              aria-label="27,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4418,7 +4418,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 28, 2018"
+              aria-label="28,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4531,7 +4531,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="December 29, 2018"
+              aria-label="29,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4665,7 +4665,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="December 30, 2018"
+              aria-label="30,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4794,7 +4794,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="December 31, 2018"
+              aria-label="31,December,2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4952,7 +4952,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="January 1, 2019"
+              aria-label="1,January,2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -5092,7 +5092,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 2, 2019"
+              aria-label="2,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5217,7 +5217,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 3, 2019"
+              aria-label="3,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5342,7 +5342,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 4, 2019"
+              aria-label="4,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5467,7 +5467,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="January 5, 2019"
+              aria-label="5,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5592,7 +5592,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 6, 2019"
+              aria-label="6,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5701,7 +5701,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 7, 2019"
+              aria-label="7,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5810,7 +5810,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 8, 2019"
+              aria-label="8,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5919,7 +5919,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 9, 2019"
+              aria-label="9,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6028,7 +6028,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 10, 2019"
+              aria-label="10,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6137,7 +6137,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 11, 2019"
+              aria-label="11,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6246,7 +6246,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="January 12, 2019"
+              aria-label="12,January,2019"
               aria-readonly={true}
               aria-selected={false}
               className=

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -650,7 +650,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="21,December,2018"
+              aria-label="21, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -763,7 +763,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="22,December,2018"
+              aria-label="22, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -876,7 +876,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="23,December,2018"
+              aria-label="23, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -989,7 +989,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="24,December,2018"
+              aria-label="24, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1102,7 +1102,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="25,December,2018"
+              aria-label="25, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1215,7 +1215,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="26,December,2018"
+              aria-label="26, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1328,7 +1328,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="27,December,2018"
+              aria-label="27, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1462,7 +1462,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="28,December,2018"
+              aria-label="28, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1591,7 +1591,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="29,December,2018"
+              aria-label="29, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1720,7 +1720,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="30,December,2018"
+              aria-label="30, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -1849,7 +1849,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="31,December,2018"
+              aria-label="31, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2007,7 +2007,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="1,January,2019"
+              aria-label="1, January, 2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -2147,7 +2147,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="2,January,2019"
+              aria-label="2, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2272,7 +2272,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           >
             <button
               aria-disabled={false}
-              aria-label="3,January,2019"
+              aria-label="3, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2397,7 +2397,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="4,January,2019"
+              aria-label="4, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2506,7 +2506,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="5,January,2019"
+              aria-label="5, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2615,7 +2615,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="6,January,2019"
+              aria-label="6, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2724,7 +2724,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="7,January,2019"
+              aria-label="7, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2833,7 +2833,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="8,January,2019"
+              aria-label="8, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -2942,7 +2942,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="9,January,2019"
+              aria-label="9, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3051,7 +3051,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="10,January,2019"
+              aria-label="10, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3853,7 +3853,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="23,December,2018"
+              aria-label="23, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -3966,7 +3966,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="24,December,2018"
+              aria-label="24, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4079,7 +4079,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="25,December,2018"
+              aria-label="25, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4192,7 +4192,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="26,December,2018"
+              aria-label="26, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4305,7 +4305,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="27,December,2018"
+              aria-label="27, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4418,7 +4418,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="28,December,2018"
+              aria-label="28, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4531,7 +4531,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="29,December,2018"
+              aria-label="29, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4665,7 +4665,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="30,December,2018"
+              aria-label="30, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4794,7 +4794,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="31,December,2018"
+              aria-label="31, December, 2018"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -4952,7 +4952,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-current="date"
               aria-disabled={false}
-              aria-label="1,January,2019"
+              aria-label="1, January, 2019"
               aria-readonly={true}
               aria-selected={true}
               className=
@@ -5092,7 +5092,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="2,January,2019"
+              aria-label="2, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5217,7 +5217,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="3,January,2019"
+              aria-label="3, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5342,7 +5342,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="4,January,2019"
+              aria-label="4, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5467,7 +5467,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="5,January,2019"
+              aria-label="5, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5592,7 +5592,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="6,January,2019"
+              aria-label="6, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5701,7 +5701,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="7,January,2019"
+              aria-label="7, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5810,7 +5810,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="8,January,2019"
+              aria-label="8, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -5919,7 +5919,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="9,January,2019"
+              aria-label="9, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6028,7 +6028,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="10,January,2019"
+              aria-label="10, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6137,7 +6137,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="11,January,2019"
+              aria-label="11, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=
@@ -6246,7 +6246,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             <button
               aria-disabled={false}
               aria-hidden={true}
-              aria-label="12,January,2019"
+              aria-label="12, January, 2019"
               aria-readonly={true}
               aria-selected={false}
               className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16072 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changed the ariaLabel creation from using the dateTimeFormatter to a static string that is formed in this way: [day], [month], [year].

#### Focus areas to test

Aria lables of the calendar component
