### PR TITLE
DetailsList: fix line that throws undefined error in GroupedDetailsList

### DIFF
--- a/change/@fluentui-react-78cf8714-5e5f-4dcb-98e0-33d7283592a2.json
+++ b/change/@fluentui-react-78cf8714-5e5f-4dcb-98e0-33d7283592a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: fix line that throws undefined error in GroupedDetailsList\"",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -410,7 +410,6 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   }, [
     onRenderDetailsGroupHeader,
     adjustedColumns,
-    groups,
     groupNestingDepth,
     indentWidth,
     isHeaderVisible,

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -361,8 +361,9 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const finalOnRenderDetailsGroupHeader = React.useMemo(() => {
     return onRenderDetailsGroupHeader
       ? (groupHeaderProps: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
-          const { groups, groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined = groupIndex !== undefined ? groups?.[groupIndex]?.key : undefined;
+          const { groupIndex } = groupHeaderProps;
+          const groupKey: string | undefined =
+            groupIndex !== undefined ? groupHeaderProps.groups?.[groupIndex]?.key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount
@@ -389,8 +390,9 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
           );
         }
       : (groupHeaderProps: IGroupDividerProps, defaultRender: IRenderFunction<IGroupDividerProps>) => {
-          const { groups, groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined = groupIndex !== undefined ? groups?.[groupIndex]?.key : undefined;
+          const { groupIndex } = groupHeaderProps;
+          const groupKey: string | undefined =
+            groupIndex !== undefined ? groupHeaderProps.groups?.[groupIndex]?.key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -361,9 +361,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const finalOnRenderDetailsGroupHeader = React.useMemo(() => {
     return onRenderDetailsGroupHeader
       ? (groupHeaderProps: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
-          const { groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined =
-            groups && groupIndex !== undefined && groups[groupIndex] ? groups[groupIndex].key : undefined;
+          const { groups, groupIndex } = groupHeaderProps;
+          const groupKey: string | undefined = groupIndex !== undefined ? groups?.[groupIndex]?.key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount
@@ -390,9 +389,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
           );
         }
       : (groupHeaderProps: IGroupDividerProps, defaultRender: IRenderFunction<IGroupDividerProps>) => {
-          const { groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined =
-            groups && groupIndex !== undefined && groups[groupIndex] ? groups[groupIndex].key : undefined;
+          const { groups, groupIndex } = groupHeaderProps;
+          const groupKey: string | undefined = groupIndex !== undefined ? groups?.[groupIndex]?.key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -362,7 +362,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     return onRenderDetailsGroupHeader
       ? (groupHeaderProps: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
           const { groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined = groups && groupIndex !== undefined ? groups[groupIndex].key : undefined;
+          const groupKey: string | undefined =
+            groups && groupIndex !== undefined && groups[groupIndex] ? groups[groupIndex].key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount
@@ -390,7 +391,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         }
       : (groupHeaderProps: IGroupDividerProps, defaultRender: IRenderFunction<IGroupDividerProps>) => {
           const { groupIndex } = groupHeaderProps;
-          const groupKey: string | undefined = groups && groupIndex !== undefined ? groups[groupIndex].key : undefined;
+          const groupKey: string | undefined =
+            groups && groupIndex !== undefined && groups[groupIndex] ? groups[groupIndex].key : undefined;
           const totalRowCount: number =
             groupKey !== undefined && groupedDetailsListIndexMap[groupKey]
               ? groupedDetailsListIndexMap[groupKey].totalRowCount


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18123 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- added conditional that checks that a group at a specific index does exist first before trying to access its `key` property.
- makes sure that correct `groups` prop provided by `groupHeaderProps` is used for index-lookup.