### PR TITLE
perf: improve mergeThemes()

### DIFF
--- a/change/@fluentui-react-shared-contexts-8e62c590-311b-4c59-8cae-e8c2c456f11d.json
+++ b/change/@fluentui-react-shared-contexts-8e62c590-311b-4c59-8cae-e8c2c456f11d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "set null as default value for ThemeContext",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-533dff75-86c1-4bc5-b503-543242fd5910.json
+++ b/change/@fluentui-react-theme-533dff75-86c1-4bc5-b503-543242fd5910.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "perf: avoid deep merge in mergeThemes() if possible",
+  "packageName": "@fluentui/react-theme",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-shared-contexts/src/ThemeContext/ThemeContext.ts
+++ b/packages/react-shared-contexts/src/ThemeContext/ThemeContext.ts
@@ -1,7 +1,7 @@
 import { ThemeContextValue } from './ThemeContext.types';
 import * as React from 'react';
 
-export const ThemeContext = React.createContext({} as ThemeContextValue);
+export const ThemeContext = React.createContext((null as unknown) as ThemeContextValue);
 
 export function useTheme(): ThemeContextValue {
   return React.useContext(ThemeContext);

--- a/packages/react-theme/src/utils/mergeThemes.test.ts
+++ b/packages/react-theme/src/utils/mergeThemes.test.ts
@@ -34,4 +34,9 @@ describe('mergeThemes', () => {
       }
     `);
   });
+
+  it('avoids unnecessary merges', () => {
+    expect(mergeThemes(teamsLightTheme, undefined)).toBe(teamsLightTheme);
+    expect(mergeThemes(undefined, teamsLightTheme)).toBe(teamsLightTheme);
+  });
 });

--- a/packages/react-theme/src/utils/mergeThemes.ts
+++ b/packages/react-theme/src/utils/mergeThemes.ts
@@ -48,6 +48,15 @@ function _merge<T extends Object>(target: T, source: T, circularReferences: any[
   return target;
 }
 
-export function mergeThemes(a: Theme, b: PartialTheme | Theme): Theme {
-  return merge({}, a, b) as Theme;
+export function mergeThemes(a: Theme | undefined, b: PartialTheme | Theme | undefined): Theme {
+  // Deep merge impacts perf: we should like to avoid it if it's possible
+  if (a && b) {
+    return merge({}, a, b) as Theme;
+  }
+
+  if (a) {
+    return a;
+  }
+
+  return b as Theme;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR improves perf of `mergeThemes()`: avoids merging of themes until it's necessary. This allows to improve perf of `ThemeProvider` for ~20% as this piece is eliminated in common use cases:

![image](https://user-images.githubusercontent.com/14183168/117963367-967c8380-b320-11eb-85dc-e8dc80d73740.png)
