### PR TITLE
fix(makeStyles): use CSS like order to expand shorthands

### DIFF
--- a/change/@fluentui-make-styles-f747ecb1-3ca9-4e73-a260-19e0acf904e6.json
+++ b/change/@fluentui-make-styles-f747ecb1-3ca9-4e73-a260-19e0acf904e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use CSS-like order to expand shorthands",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/runtime/expandShorthand.test.ts
+++ b/packages/make-styles/src/runtime/expandShorthand.test.ts
@@ -1,0 +1,54 @@
+import { expandShorthand } from './expandShorthand';
+
+describe('expandShorthand', () => {
+  it('should expand a mix of shorthands and longhands based on order', () => {
+    expect(expandShorthand({ marginLeft: '10px', margin: '5px' })).toMatchInlineSnapshot(`
+      Object {
+        "marginBottom": "5px",
+        "marginLeft": "5px",
+        "marginRight": "5px",
+        "marginTop": "5px",
+      }
+    `);
+    expect(expandShorthand({ margin: '5px', marginLeft: '10px' })).toMatchInlineSnapshot(`
+      Object {
+        "marginBottom": "5px",
+        "marginLeft": "10px",
+        "marginRight": "5px",
+        "marginTop": "5px",
+      }
+    `);
+    expect(expandShorthand({ marginRight: '10px', margin: '5px', marginLeft: '10px' })).toMatchInlineSnapshot(`
+      Object {
+        "marginBottom": "5px",
+        "marginLeft": "10px",
+        "marginRight": "5px",
+        "marginTop": "5px",
+      }
+    `);
+  });
+
+  it('"undefined" is ignored', () => {
+    expect(expandShorthand({ margin: '5px', marginLeft: undefined })).toMatchInlineSnapshot(`
+      Object {
+        "marginBottom": "5px",
+        "marginLeft": "5px",
+        "marginRight": "5px",
+        "marginTop": "5px",
+      }
+    `);
+  });
+
+  it('should expand nested objects', () => {
+    expect(expandShorthand({ ':hover': { padding: '10px' } })).toMatchInlineSnapshot(`
+      Object {
+        ":hover": Object {
+          "paddingBottom": "10px",
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
+          "paddingTop": "10px",
+        },
+      }
+    `);
+  });
+});

--- a/packages/make-styles/src/runtime/expandShorthand.ts
+++ b/packages/make-styles/src/runtime/expandShorthand.ts
@@ -2,6 +2,7 @@ import { expandProperty } from 'inline-style-expand-shorthand';
 import { MakeStyles } from '../types';
 
 export function expandShorthand(style: MakeStyles, result: MakeStyles = {}): MakeStyles {
+  // eslint-disable-next-line guard-for-in
   for (const property in style) {
     const value = style[property];
 
@@ -13,6 +14,7 @@ export function expandShorthand(style: MakeStyles, result: MakeStyles = {}): Mak
       } else {
         result[property] = value;
       }
+      // eslint-disable-next-line eqeqeq
     } else if (value == null) {
       // should skip
     } else if (Array.isArray(value)) {

--- a/packages/make-styles/src/runtime/expandShorthand.ts
+++ b/packages/make-styles/src/runtime/expandShorthand.ts
@@ -1,6 +1,10 @@
 import { expandProperty } from 'inline-style-expand-shorthand';
 import { MakeStyles } from '../types';
 
+/**
+ * A function that expands longhand properties ("margin", "padding") to their shorthand versions ("margin-left", etc.).
+ * Follows CSS-like order in expansion i.e. last defined property wins.
+ */
 export function expandShorthand(style: MakeStyles, result: MakeStyles = {}): MakeStyles {
   // eslint-disable-next-line guard-for-in
   for (const property in style) {

--- a/packages/make-styles/src/runtime/expandShorthand.ts
+++ b/packages/make-styles/src/runtime/expandShorthand.ts
@@ -1,0 +1,26 @@
+import { expandProperty } from 'inline-style-expand-shorthand';
+import { MakeStyles } from '../types';
+
+export function expandShorthand(style: MakeStyles, result: MakeStyles = {}): MakeStyles {
+  for (const property in style) {
+    const value = style[property];
+
+    if (typeof value === 'string' || typeof value === 'number') {
+      const expansion = expandProperty(property, value);
+
+      if (expansion) {
+        Object.assign(result, expansion);
+      } else {
+        result[property] = value;
+      }
+    } else if (value == null) {
+      // should skip
+    } else if (Array.isArray(value)) {
+      result[property] = value;
+    } else if (typeof value === 'object') {
+      result[property] = expandShorthand(value);
+    }
+  }
+
+  return result;
+}

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -144,6 +144,60 @@ describe('resolveStyleRules', () => {
       `);
     });
 
+    it('shorthands and longhands work like in CSS', () => {
+      expect(
+        resolveStyleRules({
+          margin: '5px',
+          marginLeft: '10px',
+        }),
+      ).toMatchInlineSnapshot(`
+        .f1rqyxcv {
+          margin-top: 5px;
+        }
+        .fq02s400 {
+          margin-right: 5px;
+        }
+        .f1f7bkv5 {
+          margin-left: 5px;
+        }
+        .f475ppk0 {
+          margin-bottom: 5px;
+        }
+        .f1oou7ox {
+          margin-left: 10px;
+        }
+        .f1pxv85q {
+          margin-right: 10px;
+        }
+      `);
+
+      expect(
+        resolveStyleRules({
+          marginLeft: '10px',
+          margin: '5px',
+        }),
+      ).toMatchInlineSnapshot(`
+        .f1f7bkv5 {
+          margin-left: 5px;
+        }
+        .fq02s400 {
+          margin-right: 5px;
+        }
+        .f1rqyxcv {
+          margin-top: 5px;
+        }
+        .fq02s400 {
+          margin-right: 5px;
+        }
+        .f1f7bkv5 {
+          margin-left: 5px;
+        }
+        .f475ppk0 {
+          margin-bottom: 5px;
+        }
+      `);
+    });
+
     it('performs vendor prefixing', () => {
       expect(resolveStyleRules({ display: 'flex' })).toMatchInlineSnapshot(`
         .f22iagw0 {

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -1,10 +1,10 @@
 import { convert, convertProperty } from 'rtl-css-js/core';
-import { expand } from 'inline-style-expand-shorthand';
 
 import { HASH_PREFIX } from '../constants';
 import { MakeStyles, MakeStylesResolvedRule } from '../types';
 import { compileCSS, CompileCSSOptions } from './compileCSS';
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
+import { expandShorthand } from './expandShorthand';
 import { hashString } from './utils/hashString';
 import { generateCombinedQuery } from './utils/generateCombinedMediaQuery';
 import { isMediaQuerySelector } from './utils/isMediaQuerySelector';
@@ -30,7 +30,7 @@ export function resolveStyleRules(
   result: Record<string, MakeStylesResolvedRule> = {},
   rtlValue?: string,
 ): Record<string, MakeStylesResolvedRule> {
-  const expandedStyles: MakeStyles = expand(resolveProxyValues(styles));
+  const expandedStyles: MakeStyles = expandShorthand(resolveProxyValues(styles));
 
   // eslint-disable-next-line guard-for-in
   for (const property in expandedStyles) {

--- a/typings/inline-style-expand-shorthand/index.d.ts
+++ b/typings/inline-style-expand-shorthand/index.d.ts
@@ -1,3 +1,5 @@
 declare module 'inline-style-expand-shorthand' {
   export function expand(style: Object): Object;
+  export function expandWithMerge(style: Object): Object;
+  export function expandProperty(property: string, value: number | string | null): Object;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18157
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `expandShorthand` function (still uses `inline-style-expand-shorthand`) to expand shorthands in style definitions. Own implementation is required to archive CSS like order of expansion.

```js
import { expand, expandWithMerge } from "inline-style-expand-shorthand";

expand({ marginLeft: "10px", margin: "5px" });
// ✅ { "marginBottom": "5px", "marginLeft": "5px", "marginRight": "5px", "marginTop": "5px" }
expand({ margin: "5px", marginLeft: "10px" });
// ❌ { "marginBottom": "5px", "marginLeft": "5px", "marginRight": "5px", "marginTop": "5px" }
//                                            ^ this should be "10px"

expandWithMerge({ marginLeft: "10px", margin: "5px" });
// ❌ { "marginBottom": "5px", "marginLeft": "10px", "marginRight": "5px", "marginTop": "5px" }
//                                            ^ this should be "5px"
expandWithMerge({ margin: "5px", marginLeft: "10px" });
// ✅ { "marginBottom": "5px", "marginLeft": "10px", "marginRight": "5px", "marginTop": "5px" }

// ------

expandShorthand({ marginLeft: "10px", margin: "5px" });
// ✅ { "marginBottom": "5px", "marginLeft": "5px", "marginRight": "5px", "marginTop": "5px" }
expandShorthand({ margin: "5px", marginLeft: "10px" });
// ✅ { "marginBottom": "5px", "marginLeft": "10px", "marginRight": "5px", "marginTop": "5px" }
```

This happens as `expand()` and `expandWithMerge()` from `inline-style-shorthand` will mutate objects (expanded properties will not change order), while current implementation creates a new object.

---

Unit tests were added.
