### PR TITLE
[v7.0] DatePicker: when textfield prop received contains an id, that id is now properly applied to TextField input

### DIFF
--- a/change/office-ui-fabric-react-dca37dd9-d2dc-49ae-a15f-e5e9274bec62.json
+++ b/change/office-ui-fabric-react-dca37dd9-d2dc-49ae-a15f-e5e9274bec62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: when textfield prop received contains an id, that id is now properly applied to TextField input.",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -195,6 +195,8 @@ export class DatePickerBase extends React.Component<IDatePickerProps, IDatePicke
     const calloutId = getId('DatePicker-Callout');
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['value']);
     const iconProps = textFieldProps && textFieldProps.iconProps;
+    const textFieldId =
+      textFieldProps && textFieldProps.id && textFieldProps.id !== this._id ? textFieldProps.id : this._id + '-label';
 
     return (
       <div {...nativeProps} className={classNames.root}>
@@ -221,7 +223,7 @@ export class DatePickerBase extends React.Component<IDatePickerProps, IDatePicke
             tabIndex={tabIndex}
             readOnly={!allowTextInput}
             {...textFieldProps}
-            id={this._id + '-label'}
+            id={textFieldId}
             className={css(classNames.textField, textFieldProps && textFieldProps.className)}
             iconProps={{
               iconName: 'Calendar',


### PR DESCRIPTION
cherry-pick of #18102 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18091 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- DatePicker now correctly passes `id` in `textfield` prop to `TextField` input. 
	- only use `textfield` prop `id` when it doesn't equal the `id` of the `DatePicker` root (if one is passed). If it does, fallback to existing logic.