### PR TITLE
AutoFill: for freeform ComboBox, cursor and characters added now behave correctly when trying to compose a composition string

### DIFF
--- a/change/@fluentui-react-c9950f11-7da1-4c49-a3b2-0c7d728da857.json
+++ b/change/@fluentui-react-c9950f11-7da1-4c49-a3b2-0c7d728da857.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "AutoFill: cursor and characters added now behave correctly when trying to compose a composition string in freeform ComboBox.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18165
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- added static flag `_isComposingString` (basically a copy of `_isComposing`) to prevent static `getDerivedStateFromProps` from updating state of `inputValue`. This needed to be done since `getDerivedStateFromProps` seems to cause the issue of input being duplicated since `_updateValue` already handles updating the state of `inputValue` for composition strings.
- The unpredictable cursor behavior was introduced by this change #17475 so I added an extra conditional that makes sure it doesn't enter this case (below) when user is writing a composition string. This now mimics the behavior of v7.
![image](https://user-images.githubusercontent.com/8649804/118201085-8beae880-b40b-11eb-9933-28fec64cfafa.png)

**Result:** 
![Combobox-Autofill](https://user-images.githubusercontent.com/8649804/118199454-03b71400-b408-11eb-9846-f3bf0c3e10a6.gif)
