### PR TITLE
fix: moved disabled style into the button styles file

### DIFF
--- a/change/@fluentui-web-components-33ee01f8-ba19-4b46-80cc-ec22b85b7483.json
+++ b/change/@fluentui-web-components-33ee01f8-ba19-4b46-80cc-ec22b85b7483.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update high contrast styles",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-web-components-33ee01f8-ba19-4b46-80cc-ec22b85b7483.json
+++ b/change/@fluentui-web-components-33ee01f8-ba19-4b46-80cc-ec22b85b7483.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "update high contrast styles",
+  "comment": "moved disabled styles from pattern styles to button styles",
   "packageName": "@fluentui/web-components",
   "email": "khamu@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -1,18 +1,154 @@
 import { css } from '@microsoft/fast-element';
+import { disabledCursor, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
+import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   AccentButtonStyles,
+  accentFillRestBehavior,
+  accentForegroundRestBehavior,
   BaseButtonStyles,
   LightweightButtonStyles,
+  neutralFillRestBehavior,
+  neutralFillStealthRestBehavior,
+  neutralOutlineRestBehavior,
   OutlineButtonStyles,
   StealthButtonStyles,
 } from '../styles/';
 import { appearanceBehavior } from '../utilities/behaviors';
 
 export const ButtonStyles = css`
+  :host([disabled]),
+  :host([disabled]:hover),
+  :host([disabled]:active) {
+    opacity: var(--disabled-opacity);
+    background-color: ${neutralFillRestBehavior.var};
+    cursor: ${disabledCursor};
+  }
+
   ${BaseButtonStyles}
 `.withBehaviors(
-  appearanceBehavior('accent', AccentButtonStyles),
-  appearanceBehavior('lightweight', LightweightButtonStyles),
-  appearanceBehavior('outline', OutlineButtonStyles),
-  appearanceBehavior('stealth', StealthButtonStyles),
+  forcedColorsStylesheetBehavior(
+    css`
+      :host(:not([disabled][href]):hover),
+      :host([appearance='neutral']:not([disabled]):hover) .control {
+        forced-color-adjust: none;
+        background-color: ${SystemColors.Highlight};
+        color: ${SystemColors.HighlightText};
+      }
+
+      .control:not([disabled]):hover,
+      :host([appearance='outline']) .control:hover {
+        border-color: ${SystemColors.ButtonText};
+      }
+
+      :host([disabled]),
+      :host([disabled]) .control {
+        forced-color-adjust: none;
+        background-color: ${SystemColors.ButtonFace};
+        border-color: ${SystemColors.GrayText};
+        color: ${SystemColors.GrayText};
+        cursor: ${disabledCursor};
+        opacity: 1;
+      }
+    `,
+  ),
+  appearanceBehavior(
+    'accent',
+    css`
+      :host([appearance='accent'][disabled]),
+      :host([appearance='accent'][disabled]:hover),
+      :host([appearance='accent'][disabled]:active) {
+        background: ${accentFillRestBehavior.var};
+      }
+
+      ${AccentButtonStyles}
+    `.withBehaviors(
+      forcedColorsStylesheetBehavior(
+        css`
+          :host([appearance='accent'][disabled]) .control,
+          :host([appearance='accent'][disabled]) .control:hover {
+            background: ${SystemColors.ButtonFace};
+            border-color: ${SystemColors.GrayText};
+            color: ${SystemColors.GrayText};
+          }
+        `,
+      ),
+    ),
+  ),
+  appearanceBehavior(
+    'lightweight',
+    css`
+      :host([appearance='lightweight'][disabled]:hover),
+      :host([appearance='lightweight'][disabled]:active) {
+        background-color: transparent;
+        color: ${accentForegroundRestBehavior.var};
+      }
+
+      :host([appearance='lightweight'][disabled]) .content::before,
+      :host([appearance='lightweight'][disabled]:hover) .content::before,
+      :host([appearance='lightweight'][disabled]:active) .content::before {
+        background: transparent;
+      }
+
+      ${LightweightButtonStyles}
+    `.withBehaviors(
+      forcedColorsStylesheetBehavior(
+        css`
+          :host([appearance='lightweight'][disabled]) .control {
+            forced-color-adjust: none;
+            color: ${SystemColors.GrayText};
+          }
+
+          :host([appearance='lightweight'][disabled]) .control:hover .content::before {
+            background: none;
+          }
+        `,
+      ),
+    ),
+  ),
+  appearanceBehavior(
+    'outline',
+    css`
+      :host([appearance='outline'][disabled]:hover),
+      :host([appearance='outline'][disabled]:active) {
+        background: transparent;
+        border-color: ${neutralOutlineRestBehavior.var};
+      }
+
+      ${OutlineButtonStyles}
+    `.withBehaviors(
+      forcedColorsStylesheetBehavior(
+        css`
+          :host([appearance='outline'][disabled]) .control {
+            border-color: ${SystemColors.GrayText};
+          }
+        `,
+      ),
+    ),
+  ),
+  appearanceBehavior(
+    'stealth',
+    css`
+      :host([appearance='stealth'][disabled]),
+      :host([appearance='stealth'][disabled]:hover),
+      :host([appearance='stealth'][disabled]:active) {
+        background: ${neutralFillStealthRestBehavior.var};
+      }
+
+      ${StealthButtonStyles}
+    `.withBehaviors(
+      forcedColorsStylesheetBehavior(
+        css`
+          :host([appearance='stealth'][disabled]) {
+            background: ${SystemColors.ButtonFace};
+          }
+
+          :host([appearance='stealth'][disabled]) .control {
+            background: ${SystemColors.ButtonFace};
+            border-color: transparent;
+            color: ${SystemColors.GrayText};
+          }
+        `,
+      ),
+    ),
+  ),
 );

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -28,25 +28,16 @@ export const ButtonStyles = css`
 `.withBehaviors(
   forcedColorsStylesheetBehavior(
     css`
-      :host(:not([disabled][href]):hover),
-      :host([appearance='neutral']:not([disabled]):hover) .control {
-        forced-color-adjust: none;
-        background-color: ${SystemColors.Highlight};
-        color: ${SystemColors.HighlightText};
-      }
-
-      .control:not([disabled]):hover,
-      :host([appearance='outline']) .control:hover {
-        border-color: ${SystemColors.ButtonText};
-      }
-
       :host([disabled]),
-      :host([disabled]) .control {
+      :host([disabled]:hover),
+      :host([disabled]:active),
+      :host([disabled]) .control,
+      :host([disabled]) .control:hover,
+      :host([appearance='neutral'][disabled]:hover) .control {
         forced-color-adjust: none;
         background-color: ${SystemColors.ButtonFace};
         border-color: ${SystemColors.GrayText};
         color: ${SystemColors.GrayText};
-        cursor: ${disabledCursor};
         opacity: 1;
       }
     `,
@@ -138,7 +129,8 @@ export const ButtonStyles = css`
     `.withBehaviors(
       forcedColorsStylesheetBehavior(
         css`
-          :host([appearance='stealth'][disabled]) {
+          :host([appearance='stealth'][disabled]),
+          :host([appearance='stealth'][disabled]:hover) {
             background: ${SystemColors.ButtonFace};
           }
 

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -127,6 +127,13 @@ export const BaseButtonStyles: ElementStyles = css`
           fill: currentcolor;
         }
 
+        :host(:not([disabled][href]):hover),
+        :host([appearance="neutral"]:not([disabled]):hover) .control {
+          forced-color-adjust: none;
+          background-color: ${SystemColors.Highlight};
+          color: ${SystemColors.HighlightText};
+        }
+
         .control:${focusVisible},
         :host([appearance="outline"]) .control:${focusVisible},
         :host([appearance="neutral"]:${focusVisible}) .control {
@@ -135,6 +142,11 @@ export const BaseButtonStyles: ElementStyles = css`
           border-color: ${SystemColors.ButtonText};
           box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
           color: ${SystemColors.HighlightText};
+        }
+
+        .control:not([disabled]):hover,
+        :host([appearance="outline"]) .control:hover {
+          border-color: ${SystemColors.ButtonText};
         }
 
         :host([href]) .control {
@@ -399,6 +411,9 @@ export const OutlineButtonStyles = css`
     css`
       :host([appearance='outline']) {
         border-color: ${SystemColors.ButtonText};
+      }
+      :host([appearance='outline'][href]) {
+        border-color: ${SystemColors.LinkText};
       }
     `,
   ),

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -1,6 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
-import { disabledCursor, display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
+import { display, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
 import { heightNumber } from '../size';
 import {
   accentFillActiveBehavior,
@@ -90,12 +90,6 @@ export const BaseButtonStyles: ElementStyles = css`
     border: 0;
   }
 
-  :host([disabled]) {
-    opacity: var(--disabled-opacity);
-    background-color: ${neutralFillRestBehavior.var};
-    cursor: ${disabledCursor};
-  }
-
   .start,
   .end {
     display: flex;
@@ -133,13 +127,6 @@ export const BaseButtonStyles: ElementStyles = css`
           fill: currentcolor;
         }
 
-        :host(:not([disabled][href]):hover),
-        :host([appearance="neutral"]:not([disabled]):hover) .control {
-          forced-color-adjust: none;
-          background-color: ${SystemColors.Highlight};
-          color: ${SystemColors.HighlightText};
-        }
-
         .control:${focusVisible},
         :host([appearance="outline"]) .control:${focusVisible},
         :host([appearance="neutral"]:${focusVisible}) .control {
@@ -148,21 +135,6 @@ export const BaseButtonStyles: ElementStyles = css`
           border-color: ${SystemColors.ButtonText};
           box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
           color: ${SystemColors.HighlightText};
-        }
-
-        .control:not([disabled]):hover,
-        :host([appearance="outline"]) .control:hover {
-          border-color: ${SystemColors.ButtonText};
-        }
-
-        :host([disabled]),
-        :host([disabled]) .control {
-            forced-color-adjust: none;
-            background-color: ${SystemColors.ButtonFace};
-            border-color: ${SystemColors.GrayText};
-            color: ${SystemColors.GrayText};
-            cursor: ${disabledCursor};
-            opacity: 1;
         }
 
         :host([href]) .control {
@@ -205,10 +177,6 @@ export const AccentButtonStyles = css`
     :host([appearance="accent"]) .control:${focusVisible} {
         box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var}, 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var}
     }
-
-    :host([appearance="accent"][disabled]) {
-        background: ${accentFillRestBehavior.var};
-    }
 `.withBehaviors(
   accentFillRestBehavior,
   accentForegroundCutRestBehavior,
@@ -232,13 +200,6 @@ export const AccentButtonStyles = css`
         :host([appearance="accent"]) .control:${focusVisible} {
             border-color: ${SystemColors.ButtonText};
             box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
-        }
-
-        :host([appearance="accent"][disabled]) .control,
-        :host([appearance="accent"][disabled]) .control:hover {
-            background: ${SystemColors.ButtonFace};
-            border-color: ${SystemColors.GrayText};
-            color: ${SystemColors.GrayText};
         }
 
         :host([appearance="accent"][href]) .control{
@@ -367,10 +328,6 @@ export const LightweightButtonStyles = css`
         background: ${neutralForegroundRestBehavior.var};
         height: calc(var(--focus-outline-width) * 1px);
     }
-
-    :host([appearance="lightweight"][disabled]) .content::before {
-        background: transparent;
-    }
 `.withBehaviors(
   accentForegroundRestBehavior,
   accentForegroundHoverBehavior,
@@ -391,15 +348,6 @@ export const LightweightButtonStyles = css`
         :host([appearance="lightweight"]) .control:hover .content::before,
         :host([appearance="lightweight"]) .control:${focusVisible} .content::before {
             background: ${SystemColors.Highlight};
-        }
-
-        :host([appearance="lightweight"][disabled]) .control {
-            forced-color-adjust: none;
-            color: ${SystemColors.GrayText};
-        }
-
-        :host([appearance="lightweight"][disabled]) .control:hover .content::before {
-            background: none;
         }
 
         :host([appearance="lightweight"][href]) .control:hover,
@@ -442,10 +390,6 @@ export const OutlineButtonStyles = css`
         box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var};
         border-color: ${neutralFocusBehavior.var};
     }
-
-    :host([appearance="outline"][disabled]) {
-        border-color: ${neutralOutlineRestBehavior.var};
-    }
 `.withBehaviors(
   neutralOutlineRestBehavior,
   neutralOutlineHoverBehavior,
@@ -455,10 +399,6 @@ export const OutlineButtonStyles = css`
     css`
       :host([appearance='outline']) {
         border-color: ${SystemColors.ButtonText};
-      }
-
-      :host([appearance='outline'][disabled]) .control {
-        border-color: ${SystemColors.GrayText};
       }
     `,
   ),
@@ -478,10 +418,6 @@ export const StealthButtonStyles = css`
 
   :host([appearance='stealth']:active) {
     background: ${neutralFillStealthActiveBehavior.var};
-  }
-
-  :host([appearance='stealth'][disabled]) {
-    background: ${neutralFillStealthRestBehavior.var};
   }
 `.withBehaviors(
   neutralFillStealthRestBehavior,
@@ -510,16 +446,6 @@ export const StealthButtonStyles = css`
             box-shadow: 0 0 0 1px ${SystemColors.Highlight};
             color: ${SystemColors.HighlightText};
             fill: currentcolor;
-        }
-
-        :host([appearance="stealth"][disabled]) {
-            background: ${SystemColors.ButtonFace};
-        }
-
-        :host([appearance="stealth"][disabled]) .control {
-            background: ${SystemColors.ButtonFace};
-            border-color: transparent;
-            color: ${SystemColors.GrayText};
         }
 
         :host([appearance="stealth"][href]) .control {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Move the disabled styles from pattern styles into button styles so the anchor button will not inherit the styles.

#### Focus areas to test

(optional)
