### PR TITLE
DetailsList: custom group header props such as styles are now correctly applied

### DIFF
--- a/change/@fluentui-react-1f0f8534-00d4-435e-ac52-e93820e744d7.json
+++ b/change/@fluentui-react-1f0f8534-00d4-435e-ac52-e93820e744d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: custom group header props such as styles are now correctly applied.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -433,6 +433,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         selectAllButtonProps: {
           'aria-label': checkButtonGroupAriaLabel,
         },
+        ...groupProps?.headerProps,
       },
     };
   }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, checkButtonGroupAriaLabel, role]);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18159 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- custom `headerProps` passed by consumer via `groupProps`were being overwritten by default `headerProps` so had to make sure the custom `headerProps` were accounted for once again.
