### PR TITLE
fix: set SVG to correct high contrast color

### DIFF
--- a/change/@fluentui-web-components-817a28a9-502c-4c88-82c5-e7d1e68d725e.json
+++ b/change/@fluentui-web-components-817a28a9-502c-4c88-82c5-e7d1e68d725e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add end start selector",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -108,16 +108,16 @@ export const BreadcrumbItemStyles = css`
   neutralForegroundRestBehavior,
   forcedColorsStylesheetBehavior(
     css`
-      :host(:not([href])) {
+      :host(:not([href])),
+      .start,
+      .end,
+      .separator {
           color: ${SystemColors.ButtonText};
           fill: currentcolor;
       }
       .control:hover .content::before,
       .control:${focusVisible} .content::before {
         background: ${SystemColors.LinkText};
-      }
-      .separator {
-        fill: ${SystemColors.ButtonText};
       }
     `,
   ),


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added and combined end, start and spearator selectors into one ruleset.

before
![image](https://user-images.githubusercontent.com/37851220/118340060-7dfe9b80-b4cf-11eb-9e88-e8ea7480fcb3.png)

after
![image](https://user-images.githubusercontent.com/37851220/118340068-85be4000-b4cf-11eb-8b74-9ee0bbb23a51.png)


#### Focus areas to test

(optional)
