### PR TITLE
Fixed invalid prop type warning of labelPosition

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `useCSS` hook was removed @layershifter ([#18139](https://github.com/microsoft/fluentui/pull/18139))
 
 ### Fixes
+- Fixed invalid prop type warning of Input and InputLabel by including "above" in labelPosition ([#18206](https://github.com/microsoft/fluentui/pull/18206))
 - Update border radius to 4px from 3px @notandrew ([#17748](https://github.com/microsoft/fluentui/pull/17748))
 - Fix `focusVisiblePlugin` removing `data-whatinput='initial'` selector @assuncaocharles ([#18074](https://github.com/microsoft/fluentui/pull/18074))
 - Fix `getPointerStyles` transform for emotion @assuncaocharles ([#18070](https://github.com/microsoft/fluentui/pull/18070))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `useCSS` hook was removed @layershifter ([#18139](https://github.com/microsoft/fluentui/pull/18139))
 
 ### Fixes
-- Fixed invalid prop type warning of Input and InputLabel by including "above" in labelPosition ([#18206](https://github.com/microsoft/fluentui/pull/18206))
+- Fixed invalid prop type warning of Input and InputLabel by including "above" in labelPosition @nancy2681 ([#18206](https://github.com/microsoft/fluentui/pull/18206))
 - Update border radius to 4px from 3px @notandrew ([#17748](https://github.com/microsoft/fluentui/pull/17748))
 - Fix `focusVisiblePlugin` removing `data-whatinput='initial'` selector @assuncaocharles ([#18074](https://github.com/microsoft/fluentui/pull/18074))
 - Fix `getPointerStyles` transform for emotion @assuncaocharles ([#18070](https://github.com/microsoft/fluentui/pull/18070))

--- a/packages/fluentui/react-northstar/src/components/Input/Input.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/Input.tsx
@@ -407,7 +407,7 @@ Input.propTypes = {
   disabled: PropTypes.bool,
   fluid: PropTypes.bool,
   label: customPropTypes.itemShorthand,
-  labelPosition: PropTypes.oneOf<LabelPosition>(['inside', 'inline']),
+  labelPosition: PropTypes.oneOf<LabelPosition>(['inline', 'above', 'inside']),
   icon: customPropTypes.shorthandAllowingChildren,
   iconPosition: PropTypes.oneOf(['start', 'end']),
   input: customPropTypes.itemShorthand,

--- a/packages/fluentui/react-northstar/src/components/Input/InputLabel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/InputLabel.tsx
@@ -40,7 +40,7 @@ InputLabel.defaultProps = {
 
 InputLabel.propTypes = {
   ...commonPropTypes.createCommon(),
-  labelPosition: PropTypes.oneOf<LabelPosition>(['inside', 'inline']),
+  labelPosition: PropTypes.oneOf<LabelPosition>(['inline', 'above', 'inside']),
   required: PropTypes.bool,
   hasValue: PropTypes.bool,
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18192 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fixed invalid prop type warning of Input and InputLabel by including "above" in labelPosition

#### Focus areas to test

(optional)
