### PR TITLE
fix contextual menu hierarchy issue

### DIFF
--- a/change/office-ui-fabric-react-2daa4450-7d1b-4803-be64-1665305316ac.json
+++ b/change/office-ui-fabric-react-2daa4450-7d1b-4803-be64-1665305316ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix contextual menu hierachy issue",
+  "packageName": "office-ui-fabric-react",
+  "email": "rongqizhou@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -667,7 +667,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
       return (
         <li role="presentation" key={sectionProps.key || sectionItem.key || `section-${index}`}>
           <div {...groupProps}>
-            <ul className={this._classNames.list} role="menu">
+            <ul className={this._classNames.list} role="presentation">
               {sectionProps.topDivider && this._renderSeparator(index, menuClassNames, true, true)}
               {headerItem &&
                 this._renderListItem(headerItem, sectionItem.key || index, menuClassNames, sectionItem.title)}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://github.com/microsoft/fluentui/issues/17628
- [x] Include a change request file using `$ yarn change`

#### Description of changes

back port section ul role from this PR.
ContextualMenu: element that's focused when menu is opened now has role = "menu"
https://github.com/microsoft/fluentui/pull/17683

#### Focus areas to test

(optional)
