### PR TITLE
makeStyles: use shorter hashes for properties

### DIFF
--- a/change/@fluentui-babel-make-styles-2aae83a3-8ff5-4015-894b-67e0d376a55d.json
+++ b/change/@fluentui-babel-make-styles-2aae83a3-8ff5-4015-894b-67e0d376a55d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update fixtures to reflect hash generation updates",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-c6daf8ca-ce6a-4b10-a4c2-621b54b077b9.json
+++ b/change/@fluentui-make-styles-c6daf8ca-ce6a-4b10-a4c2-621b54b077b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use shorter hashes for properties",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/arrow-function-body/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-body/output.ts
@@ -11,9 +11,9 @@ function buttonTokens(theme: Theme) {
 
 export const useStyles = __styles({
   root: {
-    '3e3pzq': ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
+    De3pzq: ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
     sj55zd: ['', 'fk38h1u', '.fk38h1u{color:var(--alias-color-blue-border2);}'],
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    '1i91k9c': ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
+    Bi91k9c: ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/arrow-function-nesting/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-nesting/output.ts
@@ -3,8 +3,8 @@ import { colorBlue } from './consts';
 export const useStyles = __styles({
   root: {
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    '1i91k9c': ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
-    '1b9khzn': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
-    '1tk3f3y': ['', 'f1gwxnus', '.f1gwxnus .foo:hover{color:var(--alias-color-green-foreground1);}'],
+    Bi91k9c: ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
+    Bb9khzn: ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
+    Btk3f3y: ['', 'f1gwxnus', '.f1gwxnus .foo:hover{color:var(--alias-color-green-foreground1);}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/arrow-function/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function/output.ts
@@ -1,7 +1,7 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles = __styles({
   root: {
-    '3e3pzq': ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
+    De3pzq: ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
     sj55zd: ['', 'fk38h1u', '.fk38h1u{color:var(--alias-color-blue-border2);}'],
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
   },

--- a/packages/babel-make-styles/__fixtures__/commonjs/output.ts
+++ b/packages/babel-make-styles/__fixtures__/commonjs/output.ts
@@ -4,9 +4,9 @@ const react_make_styles_1 = require('@fluentui/react-make-styles');
 
 const useStyles = react_make_styles_1.__styles({
   root: {
-    '1e2twd7': ['', 'flcnb0', '.flcnb0{font-size:var(--global-type-fontSizes-base-300);}'],
-    '1g96gwp': ['', 'f1syuwty', '.f1syuwty{line-height:var(--global-type-lineHeights-base-300);}'],
-    '1hrd7zp': ['', 'f1du0uop', '.f1du0uop{font-weight:var(--global-type-fontWeights-regular);}'],
+    Be2twd7: ['', 'flcnb0', '.flcnb0{font-size:var(--global-type-fontSizes-base-300);}'],
+    Bg96gwp: ['', 'f1syuwty', '.f1syuwty{line-height:var(--global-type-lineHeights-base-300);}'],
+    Bhrd7zp: ['', 'f1du0uop', '.f1du0uop{font-weight:var(--global-type-fontWeights-regular);}'],
   },
 });
 

--- a/packages/babel-make-styles/__fixtures__/function/output.ts
+++ b/packages/babel-make-styles/__fixtures__/function/output.ts
@@ -1,7 +1,7 @@
 import { __styles } from '@fluentui/react-make-styles';
 export const useStyles = __styles({
   root: {
-    '3e3pzq': ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
+    De3pzq: ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
     sj55zd: ['', 'fk38h1u', '.fk38h1u{color:var(--alias-color-blue-border2);}'],
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
   },

--- a/packages/babel-make-styles/__fixtures__/object-computed-keys/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-computed-keys/output.ts
@@ -5,11 +5,11 @@ export const useStyles = __styles({
     sj55zd: ['', 'fe3e8s9', '.fe3e8s9{color:red;}'],
     z8tnut: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
     z189sj: ['', 'f8wuabp', '.f8wuabp{padding-right:4px;}', 'fycuoez', '.fycuoez{padding-left:4px;}'],
-    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    Byoj8tv: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
     uwmqm3: ['', 'fycuoez', '.fycuoez{padding-left:4px;}', 'f8wuabp', '.f8wuabp{padding-right:4px;}'],
   },
   [rootSlot + 'primary']: {
     ayd6f0: ['', 'f65sxns', '.f65sxns{background:green;}'],
-    '5rg6f3': ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
+    Frg6f3: ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
@@ -3,7 +3,7 @@ import { flexStyles, gridStyles } from './mixins';
 export const useStyles = __styles({
   root: {
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    '1eiy3e4': [
+    Beiy3e4: [
       '',
       'f1vx9l62',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
@@ -11,7 +11,7 @@ export const useStyles = __styles({
   },
   icon: {
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    '1eiy3e4': [
+    Beiy3e4: [
       '',
       'f1vx9l62',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',

--- a/packages/babel-make-styles/__fixtures__/object-nesting/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-nesting/output.ts
@@ -3,8 +3,8 @@ import { colorBlue } from './consts';
 export const useStyles = __styles({
   root: {
     mc9l5x: ['', 'f22iagw', '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
-    '1i91k9c': ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
-    '1b9khzn': ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
-    '1tk3f3y': ['', 'fh8e7tb', '.fh8e7tb .foo:hover{color:green;}'],
+    Bi91k9c: ['h', 'faf35ka', '.faf35ka:hover{color:red;}'],
+    Bb9khzn: ['f', 'f17t1d3d', '.f17t1d3d:focus:hover{color:blue;}'],
+    Btk3f3y: ['', 'fh8e7tb', '.fh8e7tb .foo:hover{color:green;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object-variables/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-variables/output.ts
@@ -6,12 +6,12 @@ export const useStyles = __styles({
     sj55zd: ['', 'fe3e8s9', '.fe3e8s9{color:red;}'],
     z8tnut: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
     z189sj: ['', 'f8wuabp', '.f8wuabp{padding-right:4px;}', 'fycuoez', '.fycuoez{padding-left:4px;}'],
-    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    Byoj8tv: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
     uwmqm3: ['', 'fycuoez', '.fycuoez{padding-left:4px;}', 'f8wuabp', '.f8wuabp{padding-right:4px;}'],
   },
   icon: {
     sj55zd: ['', 'fusgiwz', '.fusgiwz{color:#000;}'],
     ayd6f0: ['', 'f65sxns', '.f65sxns{background:green;}'],
-    '5rg6f3': ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
+    Frg6f3: ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
   },
 });

--- a/packages/babel-make-styles/__fixtures__/object/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object/output.ts
@@ -4,11 +4,11 @@ export const useStyles = __styles({
     sj55zd: ['', 'fe3e8s9', '.fe3e8s9{color:red;}'],
     z8tnut: ['', 'f10ra9hq', '.f10ra9hq{padding-top:4px;}'],
     z189sj: ['', 'f8wuabp', '.f8wuabp{padding-right:4px;}', 'fycuoez', '.fycuoez{padding-left:4px;}'],
-    '1yoj8tv': ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
+    Byoj8tv: ['', 'f1y2xyjm', '.f1y2xyjm{padding-bottom:4px;}'],
     uwmqm3: ['', 'fycuoez', '.fycuoez{padding-left:4px;}', 'f8wuabp', '.f8wuabp{padding-right:4px;}'],
   },
   icon: {
     ayd6f0: ['', 'f65sxns', '.f65sxns{background:green;}'],
-    '5rg6f3': ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
+    Frg6f3: ['', 'fjf1xye', '.fjf1xye{margin-left:4px;}', 'f8zmjen', '.f8zmjen{margin-right:4px;}'],
   },
 });

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -15,6 +15,7 @@ import { isObject } from './utils/isObject';
 import { getStyleBucketName } from './getStyleBucketName';
 import { hashClassName } from './utils/hashClassName';
 import { resolveProxyValues } from './createCSSVariablesProxy';
+import { hashPropertyKey } from './utils/hashPropertyKey';
 
 /**
  * Transforms input styles to resolved rules: generates classnames and CSS.
@@ -42,9 +43,8 @@ export function resolveStyleRules(
     }
 
     if (typeof value === 'string' || typeof value === 'number') {
-      // uniq key based on property & selector, used for merging later
-      const key = pseudo + media + support + property;
-
+      // uniq key based on a hash of property & selector, used for merging later
+      const key = hashPropertyKey(pseudo, media, support, property);
       const className = hashClassName({
         media,
         value: value.toString(),
@@ -86,14 +86,12 @@ export function resolveStyleRules(
       });
 
       const resolvedRule: MakeStylesResolvedRule = [getStyleBucketName(pseudo, media, support), className, ltrCSS];
+
       if (rtlCSS) {
         resolvedRule.push(rtlClassName, rtlCSS);
       }
-      // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
-      // ".foo :hover" => "abcd"
-      const resolvedKey = hashString(key);
 
-      result[resolvedKey] = resolvedRule;
+      result[key] = resolvedRule;
     } else if (property === 'animationName') {
       const animationNames = Array.isArray(value) ? value : [value];
       let keyframeCSS = '';

--- a/packages/make-styles/src/runtime/utils/hashPropertyKey.test.ts
+++ b/packages/make-styles/src/runtime/utils/hashPropertyKey.test.ts
@@ -1,0 +1,11 @@
+import { hashPropertyKey } from './hashPropertyKey';
+
+describe('hashPropertyKey', () => {
+  it('generates hashes that always start with letters', () => {
+    expect(hashPropertyKey('', '', '', 'color')).toBe('sj55zd');
+    expect(hashPropertyKey('', '', '', 'display')).toBe('mc9l5x');
+
+    expect(hashPropertyKey('', '', '', 'backgroundColor')).toBe('De3pzq');
+    expect(hashPropertyKey(':hover', '', '', 'color')).toBe('Bi91k9c');
+  });
+});

--- a/packages/make-styles/src/runtime/utils/hashPropertyKey.ts
+++ b/packages/make-styles/src/runtime/utils/hashPropertyKey.ts
@@ -1,0 +1,25 @@
+import hash from '@emotion/hash';
+
+export function hashPropertyKey(pseudo: string, media: string, support: string, property: string): string {
+  // uniq key based on property & selector, used for merging later
+  const computedKey = pseudo + media + support + property;
+
+  // "key" can be really long as it includes selectors, we use hashes to reduce sizes of keys
+  // ".foo :hover" => "abcd"
+  const hashedKey = hash(computedKey);
+
+  // As these hashes are used as object keys in build output we should avoid having numbers as a first character to
+  // avoid having quotes:
+  // {
+  //   "1abc": {}, // we don't want this
+  //   Aabc: {}, // no quotes
+  // }
+  const firstCharCode = hashedKey.charCodeAt(0);
+  const startsWithNumber = firstCharCode >= 48 && firstCharCode <= 57;
+
+  if (startsWithNumber) {
+    return String.fromCharCode(firstCharCode + 17) + hashedKey.substr(1);
+  }
+
+  return hashedKey;
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We are using hashes for property keys (#18038), this PR applies a small optimization:

```diff
-'3e3pzq': ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
+De3pzq: ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
```

As hashes can start with a number they could be escaped with quotes (that gives us two additional characters):

```js
{
  '3e3pzq': ['', 'fbrlg6g', '.fbrlg6g{background-color:var(--global-color-black);}'],
//       ^ quotes 😭
}
```

In this PR first char in hash for properties is replaced by a letter so escaping is not needed.
