### PR TITLE
fix: fix tootlip trigger events handler

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `aria-hidden="true"` to `PillIcon` and `PillImage` @assuncaocharles ([#18118](https://github.com/microsoft/fluentui/pull/18118))
 - Support selection with Space key for selectable `Pill` @assuncaocharles ([#18138](https://github.com/microsoft/fluentui/pull/18138))
 - Add Avatar* styles to theme types @assuncaocharles ([#17782](https://github.com/microsoft/fluentui/pull/17782))
+- Fix events passed to `Tooltip` trigger @assuncaocharles ([#18234](https://github.com/microsoft/fluentui/pull/18234))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -232,7 +232,7 @@ export const Tooltip: React.FC<TooltipProps> &
     <>
       {triggerElement && (
         <Ref innerRef={triggerRef}>
-          {React.cloneElement(triggerElement, { ...getA11Props('trigger', triggerProps), ...triggerElement.props })}
+          {React.cloneElement(triggerElement, getA11Props('trigger', { ...triggerElement.props, ...triggerProps }))}
         </Ref>
       )}
       <PortalInner mountNode={mountNode}>

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -232,7 +232,7 @@ export const Tooltip: React.FC<TooltipProps> &
     <>
       {triggerElement && (
         <Ref innerRef={triggerRef}>
-          {React.cloneElement(triggerElement, { ...getA11Props('trigger', triggerProps), ...triggerElement.props })}
+          {React.cloneElement(triggerElement, { ...triggerElement.props, ...getA11Props('trigger', triggerProps) })}
         </Ref>
       )}
       <PortalInner mountNode={mountNode}>

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -232,7 +232,7 @@ export const Tooltip: React.FC<TooltipProps> &
     <>
       {triggerElement && (
         <Ref innerRef={triggerRef}>
-          {React.cloneElement(triggerElement, { ...triggerElement.props, ...getA11Props('trigger', triggerProps) })}
+          {React.cloneElement(triggerElement, { ...getA11Props('trigger', triggerProps), ...triggerElement.props })}
         </Ref>
       )}
       <PortalInner mountNode={mountNode}>

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -231,7 +231,9 @@ export const Tooltip: React.FC<TooltipProps> &
   const element = (
     <>
       {triggerElement && (
-        <Ref innerRef={triggerRef}>{React.cloneElement(triggerElement, getA11Props('trigger', triggerProps))}</Ref>
+        <Ref innerRef={triggerRef}>
+          {React.cloneElement(triggerElement, { ...getA11Props('trigger', triggerProps), ...triggerElement.props })}
+        </Ref>
       )}
       <PortalInner mountNode={mountNode}>
         <Popper

--- a/packages/fluentui/react-northstar/test/specs/components/Tooltip/Tooltip-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tooltip/Tooltip-test.tsx
@@ -70,13 +70,24 @@ describe('Tooltip', () => {
     });
   });
 
-  describe('open', () => {
-    it('is passed to "Popper" as "enabled"', () => {
-      const wrapper = mountWithProvider(<Tooltip trigger={<button />} content="Foo" />);
-      expect(wrapper.find('Popper').prop('enabled')).toBe(false);
+  test('it should call trigger events', () => {
+    const onKeyDown = jest.fn();
 
-      wrapper.setProps({ open: true });
-      expect(wrapper.find('Popper').prop('enabled')).toBe(true);
-    });
+    mountWithProvider(<Tooltip open={false} trigger={<Button onKeyDown={onKeyDown} />} content="Hi" />)
+      .find('button')
+      .simulate('keydown', { keyCode: 13 });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledWith(expect.objectContaining({ type: 'keydown' }));
+  });
+});
+
+describe('open', () => {
+  it('is passed to "Popper" as "enabled"', () => {
+    const wrapper = mountWithProvider(<Tooltip trigger={<button />} content="Foo" />);
+    expect(wrapper.find('Popper').prop('enabled')).toBe(false);
+
+    wrapper.setProps({ open: true });
+    expect(wrapper.find('Popper').prop('enabled')).toBe(true);
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Passing events to `Tooltip` trigger was not being called because `Tooltip`  props were being override. Following scenario would break:

```typescript
 <Tooltip
    content={"oi"}
    pointing={false}
    trigger={
      <Button
        onKeyDown={(e) => {
          console.log("keyDown");
        }}
        content="Click here"
      />
    }
  />
```

#### Focus areas to test

(optional)
