### PR TITLE
chore(nx): add explicit workspace layout so built in generators like …

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,11 @@
       }
     }
   },
+  "workspaceLayout": {
+    "libsDir": "packages",
+    "appsDir": "apps"
+  },
+  "affected": { "defaultBase": "master" },
   "projects": {
     "a11y-tests": { "implicitDependencies": [] },
     "codesandbox-react-northstar-template": { "implicitDependencies": [] },
@@ -131,6 +136,5 @@
     "@fluentui/scripts": { "implicitDependencies": [] },
     "@fluentui/react-popover": { "implicitDependencies": [] },
     "nx-workspace-tools": { "tags": [] }
-  },
-  "affected": { "defaultBase": "master" }
+  }
 }


### PR DESCRIPTION
…move,remove works

#### Pull request checklist

- ~[ ] Addresses an existing issue:~
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

This PR adds proper setup for nx workspace layout

**More context:**

Default nx workspace config for layout is 
-   ` "libsDir": "libs"` - where libraries are generated
-    `"appsDir": "apps"` - where apps are generated

Since we used `nx migration` automation tool (which is imperfect) workspace layout was not setup properly
-> thus current setup was not reflecting the actual monorepo setup
-> none of built-in generators worked



#### Focus areas to test

(optional)
