### PR TITLE
Exposing AnimationStyles as getters so that the keyframes are registered on demand and avoid server-side rendering collisions due to side effects

### DIFF
--- a/change/@fluentui-theme-7c4b678f-a240-4eb2-bc39-7bd405086d7e.json
+++ b/change/@fluentui-theme-7c4b678f-a240-4eb2-bc39-7bd405086d7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exposing AnimationStyles as getters so that the keyframes are registered on demand and avoid server-side rendering collisions due to side effects.",
+  "packageName": "@fluentui/theme",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theme/src/motion/AnimationStyles.ts
+++ b/packages/theme/src/motion/AnimationStyles.ts
@@ -89,53 +89,132 @@ export const AnimationVariables: IAnimationVariables = {
 };
 
 /**
- * All Fabric standard animations, exposed as json objects referencing predefined
+ * All Fluent standard animations, exposed as json objects referencing predefined
  * keyframes. These objects can be mixed in with other class definitions.
+ *
+ * The objects are exposed as getters so that the keyframes are registered on demand, ensuring that classname
+ * collisions that could happen while doing server-side rendering due to side effects are avoided.
  */
 export const AnimationStyles: IAnimationStyles = {
-  slideRightIn10: _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN10}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightIn20: _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN20}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightIn40: _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN40}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightIn400: _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN400}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftIn10: _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN10}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftIn20: _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN20}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftIn40: _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN40}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftIn400: _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN400}`, DURATION_3, EASING_FUNCTION_1),
-  slideUpIn10: _createAnimation(`${FADE_IN},${SLIDE_UP_IN10}`, DURATION_3, EASING_FUNCTION_1),
-  slideUpIn20: _createAnimation(`${FADE_IN},${SLIDE_UP_IN20}`, DURATION_3, EASING_FUNCTION_1),
-  slideDownIn10: _createAnimation(`${FADE_IN},${SLIDE_DOWN_IN10}`, DURATION_3, EASING_FUNCTION_1),
-  slideDownIn20: _createAnimation(`${FADE_IN},${SLIDE_DOWN_IN20}`, DURATION_3, EASING_FUNCTION_1),
+  get slideRightIn10() {
+    return _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightIn20() {
+    return _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightIn40() {
+    return _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN40}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightIn400() {
+    return _createAnimation(`${FADE_IN},${SLIDE_RIGHT_IN400}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftIn10() {
+    return _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftIn20() {
+    return _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftIn40() {
+    return _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN40}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftIn400() {
+    return _createAnimation(`${FADE_IN},${SLIDE_LEFT_IN400}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideUpIn10() {
+    return _createAnimation(`${FADE_IN},${SLIDE_UP_IN10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideUpIn20() {
+    return _createAnimation(`${FADE_IN},${SLIDE_UP_IN20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideDownIn10() {
+    return _createAnimation(`${FADE_IN},${SLIDE_DOWN_IN10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideDownIn20() {
+    return _createAnimation(`${FADE_IN},${SLIDE_DOWN_IN20}`, DURATION_3, EASING_FUNCTION_1);
+  },
 
-  slideRightOut10: _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT10}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightOut20: _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT20}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightOut40: _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT40}`, DURATION_3, EASING_FUNCTION_1),
-  slideRightOut400: _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT400}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftOut10: _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT10}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftOut20: _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT20}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftOut40: _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT40}`, DURATION_3, EASING_FUNCTION_1),
-  slideLeftOut400: _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT400}`, DURATION_3, EASING_FUNCTION_1),
-  slideUpOut10: _createAnimation(`${FADE_OUT},${SLIDE_UP_OUT10}`, DURATION_3, EASING_FUNCTION_1),
-  slideUpOut20: _createAnimation(`${FADE_OUT},${SLIDE_UP_OUT20}`, DURATION_3, EASING_FUNCTION_1),
-  slideDownOut10: _createAnimation(`${FADE_OUT},${SLIDE_DOWN_OUT10}`, DURATION_3, EASING_FUNCTION_1),
-  slideDownOut20: _createAnimation(`${FADE_OUT},${SLIDE_DOWN_OUT20}`, DURATION_3, EASING_FUNCTION_1),
+  get slideRightOut10() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightOut20() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightOut40() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT40}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideRightOut400() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_RIGHT_OUT400}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftOut10() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftOut20() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftOut40() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT40}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideLeftOut400() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_LEFT_OUT400}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideUpOut10() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_UP_OUT10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideUpOut20() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_UP_OUT20}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideDownOut10() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_DOWN_OUT10}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get slideDownOut20() {
+    return _createAnimation(`${FADE_OUT},${SLIDE_DOWN_OUT20}`, DURATION_3, EASING_FUNCTION_1);
+  },
 
-  scaleUpIn100: _createAnimation(`${FADE_IN},${SCALE_UP100}`, DURATION_3, EASING_FUNCTION_1),
-  scaleDownIn100: _createAnimation(`${FADE_IN},${SCALE_DOWN100}`, DURATION_3, EASING_FUNCTION_1),
-  scaleUpOut103: _createAnimation(`${FADE_OUT},${SCALE_UP103}`, DURATION_1, EASING_FUNCTION_2),
-  scaleDownOut98: _createAnimation(`${FADE_OUT},${SCALE_DOWN98}`, DURATION_1, EASING_FUNCTION_2),
+  get scaleUpIn100() {
+    return _createAnimation(`${FADE_IN},${SCALE_UP100}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get scaleDownIn100() {
+    return _createAnimation(`${FADE_IN},${SCALE_DOWN100}`, DURATION_3, EASING_FUNCTION_1);
+  },
+  get scaleUpOut103() {
+    return _createAnimation(`${FADE_OUT},${SCALE_UP103}`, DURATION_1, EASING_FUNCTION_2);
+  },
+  get scaleDownOut98() {
+    return _createAnimation(`${FADE_OUT},${SCALE_DOWN98}`, DURATION_1, EASING_FUNCTION_2);
+  },
 
-  fadeIn100: _createAnimation(FADE_IN, DURATION_1, EASING_FUNCTION_2),
-  fadeIn200: _createAnimation(FADE_IN, DURATION_2, EASING_FUNCTION_2),
-  fadeIn400: _createAnimation(FADE_IN, DURATION_3, EASING_FUNCTION_2),
-  fadeIn500: _createAnimation(FADE_IN, DURATION_4, EASING_FUNCTION_2),
+  get fadeIn100() {
+    return _createAnimation(FADE_IN, DURATION_1, EASING_FUNCTION_2);
+  },
+  get fadeIn200() {
+    return _createAnimation(FADE_IN, DURATION_2, EASING_FUNCTION_2);
+  },
+  get fadeIn400() {
+    return _createAnimation(FADE_IN, DURATION_3, EASING_FUNCTION_2);
+  },
+  get fadeIn500() {
+    return _createAnimation(FADE_IN, DURATION_4, EASING_FUNCTION_2);
+  },
 
-  fadeOut100: _createAnimation(FADE_OUT, DURATION_1, EASING_FUNCTION_2),
-  fadeOut200: _createAnimation(FADE_OUT, DURATION_2, EASING_FUNCTION_2),
-  fadeOut400: _createAnimation(FADE_OUT, DURATION_3, EASING_FUNCTION_2),
-  fadeOut500: _createAnimation(FADE_OUT, DURATION_4, EASING_FUNCTION_2),
+  get fadeOut100() {
+    return _createAnimation(FADE_OUT, DURATION_1, EASING_FUNCTION_2);
+  },
+  get fadeOut200() {
+    return _createAnimation(FADE_OUT, DURATION_2, EASING_FUNCTION_2);
+  },
+  get fadeOut400() {
+    return _createAnimation(FADE_OUT, DURATION_3, EASING_FUNCTION_2);
+  },
+  get fadeOut500() {
+    return _createAnimation(FADE_OUT, DURATION_4, EASING_FUNCTION_2);
+  },
 
-  rotate90deg: _createAnimation(ROTATE90, '0.1s', EASING_FUNCTION_2),
-  rotateN90deg: _createAnimation(ROTATE_N90, '0.1s', EASING_FUNCTION_2),
+  get rotate90deg() {
+    return _createAnimation(ROTATE90, '0.1s', EASING_FUNCTION_2);
+  },
+  get rotateN90deg() {
+    return _createAnimation(ROTATE_N90, '0.1s', EASING_FUNCTION_2);
+  },
 
   // expandCollapse 100/200/400, delay 100/200
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Exposing `AnimationStyles` as getters so that the keyframes are registered on demand and avoid server-side rendering collisions due to side effects.

#### Focus areas to test

(optional)
