### PR TITLE
fix: update color on active state for accent button in high contrast mode

### DIFF
--- a/change/@fluentui-web-components-188e5592-2326-4e9c-99b5-38b5f81bac7f.json
+++ b/change/@fluentui-web-components-188e5592-2326-4e9c-99b5-38b5f81bac7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add active state on accent button for high contrast",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -203,7 +203,8 @@ export const AccentButtonStyles = css`
             color: ${SystemColors.HighlightText};
         }
 
-        :host([appearance="accent"]) .control:hover {
+        :host([appearance="accent"]) .control:hover,
+        :host([appearance="accent"]:active) .control:active {
             background: ${SystemColors.HighlightText};
             border-color: ${SystemColors.Highlight};
             color: ${SystemColors.Highlight};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

set active state on appearance accent button to remove the accent color when button is pressed.

before
![image](https://user-images.githubusercontent.com/37851220/118726109-b2cb6500-b7e5-11eb-94bd-a29a8a20be8e.png)

after
![image](https://user-images.githubusercontent.com/37851220/118726123-b8c14600-b7e5-11eb-9df7-b5a4daaecde2.png)


#### Focus areas to test

(optional)
