### PR TITLE
feat(Popover): Popover can cover its target

### DIFF
--- a/packages/react-popover/.storybook/preview.js
+++ b/packages/react-popover/.storybook/preview.js
@@ -1,3 +1,4 @@
 import * as rootPreview from '../../../.storybook/preview';
 
 export const decorators = [...rootPreview.decorators];
+export const parameters = { layout: 'centered' };

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -52,7 +52,7 @@ export interface PopoverContextValue extends Pick<PopoverState, 'open' | 'setOpe
 export type PopoverDefaultedProps = never;
 
 // @public
-export interface PopoverProps extends Pick<PopperOptions, 'position' | 'align' | 'offset'>, Pick<PortalProps, 'mountNode'> {
+export interface PopoverProps extends Pick<PopperOptions, 'position' | 'align' | 'offset' | 'coverTarget'>, Pick<PortalProps, 'mountNode'> {
     // (undocumented)
     children: React_2.ReactNode;
     defaultOpen?: boolean;

--- a/packages/react-popover/src/Popover.stories.tsx
+++ b/packages/react-popover/src/Popover.stories.tsx
@@ -41,6 +41,22 @@ Default.argTypes = {
     defaultValue: false,
     control: 'boolean',
   },
+
+  position: {
+    type: { name: 'string', required: false },
+    control: {
+      type: 'select',
+      options: ['above', 'below', 'before', 'after'],
+    },
+  },
+
+  align: {
+    type: { name: 'string', required: false },
+    control: {
+      type: 'select',
+      options: ['top', 'bottom', 'start', 'end', 'center'],
+    },
+  },
 };
 
 export const AnchorToTarget = () => {
@@ -146,6 +162,10 @@ export const NestedPopovers = () => {
       </PopoverContent>
     </Popover>
   );
+};
+
+NestedPopovers.parameters = {
+  layout: 'padded',
 };
 
 export default {

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -6,7 +6,7 @@ import { PortalProps } from '@fluentui/react-portal';
  * Popover Props
  */
 export interface PopoverProps
-  extends Pick<PopperOptions, 'position' | 'align' | 'offset'>,
+  extends Pick<PopperOptions, 'position' | 'align' | 'offset' | 'coverTarget'>,
     Pick<PortalProps, 'mountNode'> {
   children: React.ReactNode;
   /**

--- a/packages/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-popover/src/components/Popover/usePopover.ts
@@ -82,6 +82,7 @@ function usePopoverRefs(state: PopoverState): PopoverState {
     align: state.align,
     position: state.position,
     target: state.target,
+    coverTarget: state.coverTarget,
   });
 
   state.contentRef = contentRef;

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -51,6 +51,7 @@ export interface PositioningProps {
     arrowPadding?: number;
     autoSize?: AutoSize;
     containerRef?: React_2.Ref<PopperRefHandle>;
+    coverTarget?: boolean;
     flipBoundary?: Boundary;
     offset?: Offset;
     overflowBoundary?: Boundary;

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -89,6 +89,11 @@ export interface PositioningProps {
    * Manual override for popper target. Useful for scenarios where a component accepts user prop to override target
    */
   target?: HTMLElement | null;
+
+  /**
+   * Modifiees position and alignment it will cover the target
+   */
+  coverTarget?: boolean;
 }
 
 export interface PopperOptions extends PositioningProps {


### PR DESCRIPTION
Adds an extra option and modifier `coverTarget` to `usePopper` hook to
modify popper offsets so that it can over the reference rect.

Add this option as a prop to `Popover` so that it can cover the target

![Y9Jj14AelP](https://user-images.githubusercontent.com/20744592/118804538-18caf180-b8a5-11eb-8f8a-6c2b3efd886d.gif)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
