### PR TITLE
chore(storybook): Don't serialize theme object

### DIFF
--- a/packages/react-storybook/src/knobs/useFluentTheme.ts
+++ b/packages/react-storybook/src/knobs/useFluentTheme.ts
@@ -22,8 +22,9 @@ const themeOptions = [
 
 export const useFluentTheme = (): { label: string; theme: Theme } => {
   // Casting any here due to issue: https://github.com/storybookjs/storybook/issues/9751
+  const themeLabels = themeOptions.map(option => ({ label: option.label }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { label } = select(themeSelectorLabel, themeOptions as any, themeOptions[0] as any);
+  const { label } = select(themeSelectorLabel, themeLabels, themeLabels[0] as any);
 
   // Can't trust storybook not to HTML encode theme values
   const { theme } = themeOptions.find(pair => pair.label === label) || { theme: webLightTheme };


### PR DESCRIPTION
Currently the theme object is being serialized in the knob which
results in a hideous URL when setting knob values on navigation.

before:
![image](https://user-images.githubusercontent.com/20744592/118826537-dbbe2980-b8bb-11eb-8062-b4dbe1591de9.png)

after:

`http://localhost:33651/?path=/story/components-menulist--text-only&knob-Use React.StrictMode=&knob-Theme[label]=Teams High Contrast`

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
