### PR TITLE
List: change type of version prop to any

### DIFF
--- a/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
+++ b/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "change in onRenderCell prop will re-render the list",
+  "packageName": "@fluentui/react",
+  "email": "hetanthakkar1@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
+++ b/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "change in onRenderCell prop will re-render the list",
+  "comment": "changed thr type of version prop to any",
   "packageName": "@fluentui/react",
   "email": "hetanthakkar1@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
+++ b/change/@fluentui-react-406968b0-014c-4861-8a06-0af485c00635.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "changed thr type of version prop to any",
+  "comment": "List: changed the type of version prop to any",
   "packageName": "@fluentui/react",
   "email": "hetanthakkar1@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5767,7 +5767,7 @@ export interface IListProps<T = any> extends React_2.HTMLAttributes<List<T> | HT
     role?: string;
     startIndex?: number;
     usePageCache?: boolean;
-    version?: {};
+    version?: any;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -475,6 +475,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _getDerivedStateFromProps = (nextProps: IListProps<T>, previousState: IListState<T>): IListState<T> => {
     if (
       nextProps.items !== this.props.items ||
+      nextProps.onRenderCell !== this.props.onRenderCell ||
       nextProps.renderCount !== this.props.renderCount ||
       nextProps.startIndex !== this.props.startIndex ||
       nextProps.version !== this.props.version

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -475,7 +475,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _getDerivedStateFromProps = (nextProps: IListProps<T>, previousState: IListState<T>): IListState<T> => {
     if (
       nextProps.items !== this.props.items ||
-      nextProps.onRenderCell !== this.props.onRenderCell ||
       nextProps.renderCount !== this.props.renderCount ||
       nextProps.startIndex !== this.props.startIndex ||
       nextProps.version !== this.props.version

--- a/packages/react/src/components/List/List.types.ts
+++ b/packages/react/src/components/List/List.types.ts
@@ -253,7 +253,9 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
   onRenderSurface?: IRenderFunction<IListOnRenderSurfaceProps<T>>;
 
   /**
-   * A value which can be passed in to 'force update' the list.
+   * For perf reasons, List avoids re-rendering unless certain props have changed.
+   * Use this prop if you need to force it to re-render in other cases. You can pass any type of
+   * value as long as it only changes (`===` comparison) when a re-render should happen.
    */
   version?: any;
 

--- a/packages/react/src/components/List/List.types.ts
+++ b/packages/react/src/components/List/List.types.ts
@@ -253,9 +253,9 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
   onRenderSurface?: IRenderFunction<IListOnRenderSurfaceProps<T>>;
 
   /**
-   * An object which can be passed in as a fresh instance to 'force update' the list.
+   * A value which can be passed in to 'force update' the list.
    */
-  version?: {};
+  version?: any;
 
   /**
    * Whether to disable scroll state updates. This causes the isScrolling arg in onRenderCell to always be undefined.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18216
- [x] Include a change request file using `$ yarn change`

#### Description of changes

~~change in onRenderCell prop will now re-render the list~~

Changed type of `version` prop to `any` to indicate that any value can be used to force a re-render.

#### Focus areas to test

(optional)
