### PR TITLE
fix(Checkbox): remove aria-hidden from label text

### DIFF
--- a/change/@fluentui-react-c757f967-65ec-4bc3-b1e3-d8ddaef31a3d.json
+++ b/change/@fluentui-react-c757f967-65ec-4bc3-b1e3-d8ddaef31a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove aria-hidden attribute from label text, add title attribute to input so it provides the accessible description",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-a03be53e-ea14-41aa-90d5-6aa69cae0a7c.json
+++ b/change/@fluentui-react-examples-a03be53e-ea14-41aa-90d5-6aa69cae0a7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots for checkbox label aria-hidden update\"",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -61,7 +61,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="Unchecked checkbox (uncontrolled)"
       checked={false}
       className=
 
@@ -161,7 +160,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -228,7 +226,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="true"
-      aria-label="Checked checkbox (uncontrolled)"
       checked={true}
       className=
 
@@ -331,7 +328,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -362,7 +358,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
     <input
       aria-checked="false"
       aria-disabled={true}
-      aria-label="Disabled checkbox"
       checked={false}
       className=
 
@@ -464,7 +459,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -496,7 +490,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
     <input
       aria-checked="true"
       aria-disabled={true}
-      aria-label="Disabled checked checkbox"
       checked={true}
       className=
 
@@ -600,7 +593,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -67,7 +67,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
   >
     <input
       aria-checked="mixed"
-      aria-label="Indeterminate checkbox (uncontrolled)"
       checked={false}
       className=
 
@@ -187,7 +186,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -248,7 +246,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
   >
     <input
       aria-checked="mixed"
-      aria-label="Indeterminate checkbox which defaults to true when clicked (uncontrolled)"
       checked={true}
       className=
 
@@ -368,7 +365,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -399,7 +395,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
     <input
       aria-checked="mixed"
       aria-disabled={true}
-      aria-label="Disabled indeterminate checkbox"
       checked={false}
       className=
 
@@ -520,7 +515,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -584,7 +578,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
   >
     <input
       aria-checked="mixed"
-      aria-label="Indeterminate checkbox (controlled)"
       checked={false}
       className=
 
@@ -704,7 +697,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -70,7 +70,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="true"
-      aria-label="Controlled checkbox"
       checked={true}
       className=
 
@@ -173,7 +172,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -232,7 +230,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="Checkbox rendered with boxSide \\"end\\""
       checked={false}
       className=
 
@@ -334,7 +331,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -392,7 +388,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="Checkbox with link inside the label"
       checked={false}
       className=
 
@@ -594,7 +589,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="Checkbox with extra props for the input (including data-*)"
       checked={false}
       className=
 
@@ -697,7 +691,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1170,7 +1170,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
     >
       <input
         aria-checked="true"
-        aria-label="Fade In"
         checked={true}
         className=
 
@@ -1273,7 +1272,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           </i>
         </div>
         <span
-          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -61,7 +61,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
     >
       <input
         aria-checked="false"
-        aria-label="A Checkbox"
         checked={false}
         className=
 
@@ -162,7 +161,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           </i>
         </div>
         <span
-          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -140,7 +140,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -240,7 +239,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -299,7 +297,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -399,7 +396,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2072,7 +2072,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -2172,7 +2171,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -2231,7 +2229,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -2331,7 +2328,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -140,7 +140,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -240,7 +239,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -299,7 +297,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -399,7 +396,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -141,7 +141,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -241,7 +240,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -300,7 +298,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -400,7 +397,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -140,7 +140,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -240,7 +239,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -299,7 +297,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -399,7 +396,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1492,7 +1492,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -1592,7 +1591,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -1651,7 +1649,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -1751,7 +1748,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -140,7 +140,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
   >
     <input
       aria-checked="false"
-      aria-label="Disable People Picker"
       checked={false}
       className=
 
@@ -240,7 +239,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -299,7 +297,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
   >
     <input
       aria-checked="false"
-      aria-label="Delay Suggestion Results"
       checked={false}
       className=
 
@@ -399,7 +396,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -70,7 +70,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
   >
     <input
       aria-checked="true"
-      aria-label="Include persona details"
       checked={true}
       className=
 
@@ -173,7 +172,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
@@ -62,7 +62,6 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
   >
     <input
       aria-checked="true"
-      aria-label="My Checkbox"
       checked={true}
       className=
 
@@ -165,7 +164,6 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
         </i>
       </div>
       <span
-        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -19,7 +19,6 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       ariaPositionInSet,
       ariaSetSize,
       title,
-      label,
       checkmarkIconProps,
       styles,
       theme,
@@ -68,7 +67,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
           return null;
         }
         return checkboxProps.label ? (
-          <span aria-hidden="true" className={classNames.text} title={checkboxProps.title}>
+          <span className={classNames.text} title={checkboxProps.title}>
             {checkboxProps.label}
           </span>
         ) : null;
@@ -96,7 +95,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       title,
       onChange,
       'aria-disabled': disabled,
-      'aria-label': ariaLabel || label,
+      'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       'aria-describedby': ariaDescribedBy,
       'aria-posinset': ariaPositionInSet,
@@ -106,7 +105,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
 
     return (
       <div className={classNames.root} title={title} ref={mergedRootRefs}>
-        <input {...mergedInputProps} ref={inputRef} data-ktp-execute-target={true} />
+        <input {...mergedInputProps} ref={inputRef} title={title} data-ktp-execute-target={true} />
         <label className={classNames.label} htmlFor={id}>
           <div className={classNames.checkbox} data-ktp-target={true}>
             <Icon iconName="CheckMark" {...checkmarkIconProps} className={classNames.checkmark} />

--- a/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`Checkbox renders checked correctly 1`] = `
 >
   <input
     aria-checked="true"
-    aria-label="Standard checkbox"
     checked={true}
     className=
 
@@ -152,7 +151,6 @@ exports[`Checkbox renders checked correctly 1`] = `
       </i>
     </div>
     <span
-      aria-hidden="true"
       className=
           ms-Checkbox-text
           {
@@ -219,7 +217,6 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
 >
   <input
     aria-checked="mixed"
-    aria-label="Standard checkbox"
     checked={false}
     className=
 
@@ -339,7 +336,6 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       </i>
     </div>
     <span
-      aria-hidden="true"
       className=
           ms-Checkbox-text
           {
@@ -400,7 +396,6 @@ exports[`Checkbox renders unchecked correctly 1`] = `
 >
   <input
     aria-checked="false"
-    aria-label="Standard checkbox"
     checked={false}
     className=
 
@@ -500,7 +495,6 @@ exports[`Checkbox renders unchecked correctly 1`] = `
       </i>
     </div>
     <span
-      aria-hidden="true"
       className=
           ms-Checkbox-text
           {

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -1669,7 +1669,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                 >
                   <input
                     aria-checked="false"
-                    aria-label="Option 1"
                     aria-selected="false"
                     class=
 
@@ -1885,7 +1884,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                 >
                   <input
                     aria-checked="true"
-                    aria-label="Option 2"
                     aria-selected="true"
                     checked=""
                     class=

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -626,7 +626,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                   >
                     <input
                       aria-checked="true"
-                      aria-label="1"
                       aria-posinset="1"
                       aria-selected="true"
                       aria-setsize="2"
@@ -880,7 +879,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                 >
                   <input
                     aria-checked="false"
-                    aria-label="2"
                     aria-posinset="2"
                     aria-selected="false"
                     aria-setsize="2"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When responding to an invalid accessibility bug, I noticed that at some point someone had added `aria-hidden` to the label text of the Checkbox component. Which is, y'know, actually *really bad* 😅.

This PR removes the aria-hidden, and also updates the `aria-label` and `title` properties so a) aria-label is only added if an `ariaLabel` is passed in, otherwise relying on the actual label, and b) the `title` actually provides descriptive text to the input.

I'm also following up on why an accessibility bug was logged asking for `aria-hidden` to be added in the first place.
