### PR TITLE
feat(Menu): Menu can cover its trigger

### DIFF
--- a/change/@fluentui-react-menu-4c9717a3-4aae-4d0f-91c6-cc525d332b37.json
+++ b/change/@fluentui-react-menu-4c9717a3-4aae-4d0f-91c6-cc525d332b37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(Menu): Menu can cover its trigger",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/.storybook/preview.js
+++ b/packages/react-menu/.storybook/preview.js
@@ -1,3 +1,4 @@
 import * as rootPreview from '../../../.storybook/preview';
 
 export const decorators = [...rootPreview.decorators];
+export const parameters = { layout: 'centered' };

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -39,7 +39,11 @@ describe('MenuTrigger', () => {
 
 describe('Custom Trigger', () => {
   it('should open menu when clicked', () => {
-    cy.visitStory('Menu', customTriggerStory).contains('Custom Trigger').click().get(menuSelector).should('be.visible');
+    cy.visitStory('Menu', customTriggerStory)
+      .contains('Custom Trigger')
+      .click()
+      .get(menuSelector)
+      .should('be.visible');
   });
 
   it('should dismiss the menu when click outside', () => {
@@ -55,7 +59,12 @@ describe('Custom Trigger', () => {
 
 describe('MenuItem', () => {
   it('should close the menu when clicked', () => {
-    cy.visitStory('Menu', defaultStory).get(menuTriggerSelector).trigger('click').get(menuItemSelector).first().click();
+    cy.visitStory('Menu', defaultStory)
+      .get(menuTriggerSelector)
+      .trigger('click')
+      .get(menuItemSelector)
+      .first()
+      .click();
 
     cy.get(menuSelector).should('not.be.exist');
   });
@@ -77,7 +86,9 @@ describe('MenuItem', () => {
       .trigger('click')
       .get(menuItemSelector)
       .each(el => {
-        cy.wrap(el).trigger('mouseover').should('be.focused');
+        cy.wrap(el)
+          .trigger('mouseover')
+          .should('be.focused');
       });
   });
 });
@@ -157,11 +168,22 @@ describe('MenuItemRadio', () => {
       .first()
       .click();
 
-    cy.get(menuTriggerSelector).trigger('click').get(menuItemRadioSelector).eq(1).click();
+    cy.get(menuTriggerSelector)
+      .trigger('click')
+      .get(menuItemRadioSelector)
+      .eq(1)
+      .click();
 
-    cy.get(menuTriggerSelector).trigger('click').get(menuItemRadioSelector).eq(2).click();
+    cy.get(menuTriggerSelector)
+      .trigger('click')
+      .get(menuItemRadioSelector)
+      .eq(2)
+      .click();
 
-    cy.get(menuTriggerSelector).trigger('click').get('[aria-checked="true"]').should('have.length', 1);
+    cy.get(menuTriggerSelector)
+      .trigger('click')
+      .get('[aria-checked="true"]')
+      .should('have.length', 1);
   });
 });
 
@@ -177,7 +199,9 @@ describe('Menu', () => {
   });
 
   it('should be dismissed on outside click', () => {
-    cy.visitStory('Menu', defaultStory).get(menuTriggerSelector).click();
+    cy.visitStory('Menu', defaultStory)
+      .get(menuTriggerSelector)
+      .click();
 
     cy.get('body').click('bottomRight');
 
@@ -220,7 +244,9 @@ describe('Menu', () => {
               .type(key)
               .get(menuSelector)
               .within(() => {
-                cy.get(menuItemSelector).first().should('be.focused');
+                cy.get(menuItemSelector)
+                  .first()
+                  .should('be.focused');
               });
           })
           .get(menuSelector)
@@ -250,7 +276,10 @@ describe('Menu', () => {
           .type('{rightarrow}')
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).type('{rightarrow}').focused().type(key);
+            cy.get(menuTriggerSelector)
+              .type('{rightarrow}')
+              .focused()
+              .type(key);
           })
           .get(menuSelector)
           .should('have.length', 1);

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -4,9 +4,15 @@ const menuItemCheckboxSelector = '[role="menuitemcheckbox"]';
 const menuItemRadioSelector = '[role="menuitemradio"]';
 const menuSelector = '[role="menu"]';
 
+const defaultStory = 'Default';
+const customTriggerStory = 'CustomTrigger';
+const selectionGroupStory = 'SelectionGroup';
+const nestedMenuStory = 'NestedSubmenus';
+const nestedMenuControlledStory = 'NestedSubmenusControlled';
+
 describe('MenuTrigger', () => {
   it('should open menu when clicked', () => {
-    cy.visitStory('Menu', 'TextOnly')
+    cy.visitStory('Menu', defaultStory)
       .get(menuTriggerSelector)
       .click()
       .get(menuSelector)
@@ -18,7 +24,7 @@ describe('MenuTrigger', () => {
 
   ['downarrow', 'enter', ' '].forEach(key => {
     it(`should open menu with ${key === ' ' ? 'space' : key}`, () => {
-      cy.visitStory('Menu', 'TextOnly')
+      cy.visitStory('Menu', defaultStory)
         .get(menuTriggerSelector)
         .focus()
         .type(`{${key}}`)
@@ -33,15 +39,11 @@ describe('MenuTrigger', () => {
 
 describe('Custom Trigger', () => {
   it('should open menu when clicked', () => {
-    cy.visitStory('Menu', 'CustomTrigger')
-      .contains('Custom Trigger')
-      .click()
-      .get(menuSelector)
-      .should('be.visible');
+    cy.visitStory('Menu', customTriggerStory).contains('Custom Trigger').click().get(menuSelector).should('be.visible');
   });
 
   it('should dismiss the menu when click outside', () => {
-    cy.visitStory('Menu', 'CustomTrigger')
+    cy.visitStory('Menu', customTriggerStory)
       .contains('Custom Trigger')
       .click()
       .get('body')
@@ -53,18 +55,13 @@ describe('Custom Trigger', () => {
 
 describe('MenuItem', () => {
   it('should close the menu when clicked', () => {
-    cy.visitStory('Menu', 'TextOnly')
-      .get(menuTriggerSelector)
-      .trigger('click')
-      .get(menuItemSelector)
-      .first()
-      .click();
+    cy.visitStory('Menu', defaultStory).get(menuTriggerSelector).trigger('click').get(menuItemSelector).first().click();
 
     cy.get(menuSelector).should('not.be.exist');
   });
 
   it('should not close the menu when disabled on click', () => {
-    cy.visitStory('Menu', 'TextOnly')
+    cy.visitStory('Menu', defaultStory)
       .get(menuTriggerSelector)
       .trigger('click')
       .get('[aria-disabled="true"]')
@@ -75,21 +72,19 @@ describe('MenuItem', () => {
   });
 
   it('should focus on hover', () => {
-    cy.visitStory('Menu', 'TextOnly')
+    cy.visitStory('Menu', defaultStory)
       .get(menuTriggerSelector)
       .trigger('click')
       .get(menuItemSelector)
       .each(el => {
-        cy.wrap(el)
-          .trigger('mouseover')
-          .should('be.focused');
+        cy.wrap(el).trigger('mouseover').should('be.focused');
       });
   });
 });
 
 describe('MenuItemCheckbox', () => {
   it('should be selected on click', () => {
-    cy.visitStory('Menu', 'SelectionGroup')
+    cy.visitStory('Menu', selectionGroupStory)
       .get(menuTriggerSelector)
       .trigger('click')
       .get(menuItemCheckboxSelector)
@@ -105,7 +100,7 @@ describe('MenuItemCheckbox', () => {
 
   ['enter', ' '].forEach(key => {
     it(`should be selected on ${key === ' ' ? 'space' : key} key`, () => {
-      cy.visitStory('Menu', 'SelectionGroup')
+      cy.visitStory('Menu', selectionGroupStory)
         .get(menuTriggerSelector)
         .trigger('click')
         .get(menuItemCheckboxSelector)
@@ -123,7 +118,7 @@ describe('MenuItemCheckbox', () => {
 
 describe('MenuItemRadio', () => {
   it('should be selected on', () => {
-    cy.visitStory('Menu', 'SelectionGroup')
+    cy.visitStory('Menu', selectionGroupStory)
       .get(menuTriggerSelector)
       .trigger('click')
       .get(menuItemRadioSelector)
@@ -139,7 +134,7 @@ describe('MenuItemRadio', () => {
 
   ['enter', ' '].forEach(key => {
     it(`should be selected on ${key === ' ' ? 'space' : key} key`, () => {
-      cy.visitStory('Menu', 'SelectionGroup')
+      cy.visitStory('Menu', selectionGroupStory)
         .get(menuTriggerSelector)
         .trigger('click')
         .get(menuItemRadioSelector)
@@ -155,35 +150,24 @@ describe('MenuItemRadio', () => {
   });
 
   it('should only have one item selected', () => {
-    cy.visitStory('Menu', 'SelectionGroup')
+    cy.visitStory('Menu', selectionGroupStory)
       .get(menuTriggerSelector)
       .trigger('click')
       .get(menuItemRadioSelector)
       .first()
       .click();
 
-    cy.get(menuTriggerSelector)
-      .trigger('click')
-      .get(menuItemRadioSelector)
-      .eq(1)
-      .click();
+    cy.get(menuTriggerSelector).trigger('click').get(menuItemRadioSelector).eq(1).click();
 
-    cy.get(menuTriggerSelector)
-      .trigger('click')
-      .get(menuItemRadioSelector)
-      .eq(2)
-      .click();
+    cy.get(menuTriggerSelector).trigger('click').get(menuItemRadioSelector).eq(2).click();
 
-    cy.get(menuTriggerSelector)
-      .trigger('click')
-      .get('[aria-checked="true"]')
-      .should('have.length', 1);
+    cy.get(menuTriggerSelector).trigger('click').get('[aria-checked="true"]').should('have.length', 1);
   });
 });
 
 describe('Menu', () => {
   it('should be dismissed with Escape', () => {
-    cy.visitStory('Menu', 'TextOnly')
+    cy.visitStory('Menu', defaultStory)
       .get(menuTriggerSelector)
       .click()
       .focused()
@@ -193,9 +177,7 @@ describe('Menu', () => {
   });
 
   it('should be dismissed on outside click', () => {
-    cy.visitStory('Menu', 'TextOnly')
-      .get(menuTriggerSelector)
-      .click();
+    cy.visitStory('Menu', defaultStory).get(menuTriggerSelector).click();
 
     cy.get('body').click('bottomRight');
 
@@ -203,7 +185,7 @@ describe('Menu', () => {
   });
 
   it('should be dismissed on with {leftarrow} when not a submenu', () => {
-    cy.visitStory('Menu', 'TextOnly')
+    cy.visitStory('Menu', defaultStory)
       .get(menuTriggerSelector)
       .click()
       .focused()
@@ -213,7 +195,7 @@ describe('Menu', () => {
   });
 });
 
-['NestedSubmenus', 'NestedSubmenusControlled'].forEach(story => {
+[nestedMenuStory, nestedMenuControlledStory].forEach(story => {
   describe(`Nested Menus (${story.includes('Controlled') ? 'Controlled' : 'Uncontrolled'})`, () => {
     it('should open on trigger hover', () => {
       cy.visitStory('Menu', story)
@@ -238,9 +220,7 @@ describe('Menu', () => {
               .type(key)
               .get(menuSelector)
               .within(() => {
-                cy.get(menuItemSelector)
-                  .first()
-                  .should('be.focused');
+                cy.get(menuItemSelector).first().should('be.focused');
               });
           })
           .get(menuSelector)
@@ -270,10 +250,7 @@ describe('Menu', () => {
           .type('{rightarrow}')
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector)
-              .type('{rightarrow}')
-              .focused()
-              .type(key);
+            cy.get(menuTriggerSelector).type('{rightarrow}').focused().type(key);
           })
           .get(menuSelector)
           .should('have.length', 1);

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -193,8 +193,7 @@ export interface MenuOpenChangeData extends Pick<MenuState, 'open'> {
 export type MenuOpenEvents = MouseEvent | TouchEvent | React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.FocusEvent<HTMLElement>;
 
 // @public
-export interface MenuProps extends MenuListProps {
-    align?: PositioningProps['align'];
+export interface MenuProps extends MenuListProps, Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset'> {
     children: React_2.ReactNode;
     defaultOpen?: boolean;
     inline?: boolean;
@@ -204,7 +203,6 @@ export interface MenuProps extends MenuListProps {
     openOnContext?: boolean;
     // (undocumented)
     openOnHover?: boolean;
-    position?: PositioningProps['position'];
 }
 
 // @public (undocumented)

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -15,8 +15,8 @@ import { boolean } from '@storybook/addon-knobs';
 
 import { CutIcon, PasteIcon, EditIcon, AcceptIcon } from './tmp-icons.stories';
 
-export const TextOnly = (props: Pick<MenuProps, 'openOnHover' | 'openOnContext' | 'defaultOpen'>) => (
-  <Menu openOnHover={props.openOnHover} openOnContext={props.openOnContext} defaultOpen={props.defaultOpen}>
+export const Default = (props: Partial<MenuProps>) => (
+  <Menu {...props}>
     <MenuTrigger>
       <button>Toggle menu</button>
     </MenuTrigger>
@@ -58,7 +58,7 @@ export const AligningWithSelectableItems = () => (
   </Menu>
 );
 
-export const DefaultOpen = () => <TextOnly defaultOpen />;
+export const DefaultOpen = () => <Default defaultOpen />;
 
 export const ControlledPopup = () => {
   const [open, setOpen] = React.useState(false);
@@ -111,7 +111,7 @@ export const MenuTriggerInteractions = () => {
   const context = boolean('context', false);
   const hover = boolean('hover', false);
 
-  return <TextOnly openOnContext={context} openOnHover={hover} />;
+  return <Default openOnContext={context} openOnHover={hover} />;
 };
 
 export const SelectionGroup = () => (

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -293,7 +293,15 @@ export const NestedSubmenus = (props: { controlled: boolean }) => {
   );
 };
 
+NestedSubmenus.parameters = {
+  layout: 'padded',
+};
+
 export const NestedSubmenusControlled = () => <NestedSubmenus controlled />;
+
+NestedSubmenusControlled.parameters = {
+  layout: 'padded',
+};
 
 export default {
   // use the Components prefix and (react-menu) suffix to have the same naming convention as react-examples

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -7,7 +7,9 @@ import { MenuListProps } from '../MenuList/index';
  * Extends and drills down Menulist props to simplify API
  * {@docCategory Menu }
  */
-export interface MenuProps extends MenuListProps {
+export interface MenuProps
+  extends MenuListProps,
+    Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset'> {
   /**
    * Explicitly require children
    */
@@ -33,16 +35,6 @@ export interface MenuProps extends MenuListProps {
    * Wrapper to style and add events for the popup
    */
   menuPopup?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
-
-  /**
-   * Where the menu is positioned with respect to the trigger
-   */
-  position?: PositioningProps['position'];
-
-  /**
-   * How the menu is aligned wtih respect to the trigger
-   */
-  align?: PositioningProps['align'];
 
   /*
    * Opens the menu on hover

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -65,6 +65,7 @@ export const useMenu = (props: MenuProps, ref: React.Ref<HTMLElement>, defaultPr
   const { targetRef: triggerRef, containerRef: menuPopupRef } = usePopper({
     align: state.align,
     position: state.position,
+    coverTarget: state.coverTarget,
   });
   state.menuPopupRef = menuPopupRef;
   state.triggerRef = triggerRef;


### PR DESCRIPTION
Leverages `usePopper` changes in #18254 to allow `Menu` to cover its
trigger.

![OtsEPQ9SLT](https://user-images.githubusercontent.com/20744592/118985032-64050300-b97e-11eb-87af-af4ea272facd.gif)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
