### PR TITLE
DetailsList - add option to customize the filter icon

### DIFF
--- a/change/@fluentui-react-434c69f9-76ec-4314-bd8c-4be217a8373f.json
+++ b/change/@fluentui-react-434c69f9-76ec-4314-bd8c-4be217a8373f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow custom filter icons for the details header",
+  "packageName": "@fluentui/react",
+  "email": "khhuynh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2945,6 +2945,7 @@ export interface IColumn {
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
+    onRenderFilterIcon?: IRenderFunction<IDetailsColumnProps>;
     onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2916,6 +2916,7 @@ export interface IColumn {
     data?: any;
     fieldName?: string;
     filterAriaLabel?: string;
+    filterIconName?: string;
     flexGrow?: number;
     getValueKey?: (item?: any, index?: number, column?: IColumn) => string;
     groupAriaLabel?: string;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3567,9 +3567,9 @@ export interface IDetailsCheckboxProps {
 }
 
 // @public (undocumented)
-export interface IDetailsColumnFilterIconProps extends IDetailsColumnProps {
+export interface IDetailsColumnFilterIconProps extends IIconProps {
     // (undocumented)
-    iconProps?: IIconProps;
+    columnProps?: IDetailsColumnProps;
 }
 
 // @public (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2916,7 +2916,6 @@ export interface IColumn {
     data?: any;
     fieldName?: string;
     filterAriaLabel?: string;
-    filterIconName?: string;
     flexGrow?: number;
     getValueKey?: (item?: any, index?: number, column?: IColumn) => string;
     groupAriaLabel?: string;
@@ -2945,7 +2944,7 @@ export interface IColumn {
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
-    onRenderFilterIcon?: IRenderFunction<IDetailsColumnProps>;
+    onRenderFilterIcon?: IRenderFunction<IDetailsColumnFilterIconProps>;
     onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;
@@ -3565,6 +3564,12 @@ export interface IDetailsCheckboxProps {
     checked: boolean;
     // (undocumented)
     theme?: ITheme;
+}
+
+// @public (undocumented)
+export interface IDetailsColumnFilterIconProps extends IDetailsColumnProps {
+    // (undocumented)
+    iconProps?: IIconProps;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -171,7 +171,11 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                   {column.isGrouped && <IconComponent className={classNames.nearIcon} iconName="GroupedDescending" />}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
-                    <IconComponent aria-hidden={true} className={classNames.filterChevron} iconName="ChevronDown" />
+                    <IconComponent
+                      aria-hidden={true}
+                      className={classNames.filterChevron}
+                      iconName={column.filterIconName ? column.filterIconName : 'ChevronDown'}
+                    />
                   )}
                 </span>
               ),

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -177,7 +177,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
                     !column.isIconOnly &&
-                    onRenderFilterIcon(this.props)}
+                    onRenderFilterIcon({ columnProps: this.props })}
                 </span>
               ),
             },
@@ -240,8 +240,8 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
   private _onRenderFilterIcon = (classNames: IProcessedStyleSet<IDetailsColumnStyles>) => (
     props: IDetailsColumnFilterIconProps,
   ): JSX.Element => {
-    const { iconProps, useFastIcons } = props;
-    const IconComponent = useFastIcons ? FontIcon : Icon;
+    const { columnProps, ...iconProps } = props;
+    const IconComponent = columnProps?.useFastIcons ? FontIcon : Icon;
 
     return (
       <IconComponent iconName="ChevronDown" aria-hidden={true} className={classNames.filterChevron} {...iconProps} />

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -177,7 +177,12 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
                     !column.isIconOnly &&
-                    onRenderFilterIcon({ columnProps: this.props })}
+                    onRenderFilterIcon({
+                      'aria-hidden': true,
+                      columnProps: this.props,
+                      className: classNames.filterChevron,
+                      iconName: 'ChevronDown',
+                    })}
                 </span>
               ),
             },
@@ -243,9 +248,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     const { columnProps, ...iconProps } = props;
     const IconComponent = columnProps?.useFastIcons ? FontIcon : Icon;
 
-    return (
-      <IconComponent iconName="ChevronDown" aria-hidden={true} className={classNames.filterChevron} {...iconProps} />
-    );
+    return <IconComponent {...iconProps} />;
   };
 
   private _onRenderColumnHeaderTooltip = (tooltipHostProps: IDetailsColumnRenderTooltipProps): JSX.Element => {

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -89,6 +89,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
 
+    const onRenderFilterIcon = column.onRenderFilterIcon
+      ? composeRenderFunction(column.onRenderFilterIcon, this._onRenderFilterIcon(this._classNames))
+      : this._onRenderFilterIcon(this._classNames);
+
     const onRenderHeader = column.onRenderHeader
       ? composeRenderFunction(column.onRenderHeader, defaultOnRenderHeader(this._classNames))
       : defaultOnRenderHeader(this._classNames);
@@ -170,13 +174,9 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
                   {column.isGrouped && <IconComponent className={classNames.nearIcon} iconName="GroupedDescending" />}
 
-                  {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
-                    <IconComponent
-                      aria-hidden={true}
-                      className={classNames.filterChevron}
-                      iconName={column.filterIconName ? column.filterIconName : 'ChevronDown'}
-                    />
-                  )}
+                  {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
+                    !column.isIconOnly &&
+                    onRenderFilterIcon(this.props)}
                 </span>
               ),
             },
@@ -235,6 +235,22 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       delete this._dragDropSubscription;
     }
   }
+
+  private _onRenderFilterIcon = (classNames: IProcessedStyleSet<IDetailsColumnStyles>) => (
+    props: IDetailsColumnProps,
+  ): JSX.Element => {
+    const { useFastIcons, column } = props;
+    const { filterIconName } = column;
+    const IconComponent = useFastIcons ? FontIcon : Icon;
+
+    return (
+      <IconComponent
+        aria-hidden={true}
+        className={classNames.filterChevron}
+        iconName={filterIconName ? filterIconName : 'ChevronDown'}
+      />
+    );
+  };
 
   private _onRenderColumnHeaderTooltip = (tooltipHostProps: IDetailsColumnRenderTooltipProps): JSX.Element => {
     return <span className={tooltipHostProps.hostClassName}>{tooltipHostProps.children}</span>;

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -17,6 +17,7 @@ import {
   IDetailsColumnProps,
   IDetailsColumnStyles,
   IDetailsColumnRenderTooltipProps,
+  IDetailsColumnFilterIconProps,
 } from './DetailsColumn.types';
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
@@ -237,18 +238,13 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
   }
 
   private _onRenderFilterIcon = (classNames: IProcessedStyleSet<IDetailsColumnStyles>) => (
-    props: IDetailsColumnProps,
+    props: IDetailsColumnFilterIconProps,
   ): JSX.Element => {
-    const { useFastIcons, column } = props;
-    const { filterIconName } = column;
+    const { iconProps, useFastIcons } = props;
     const IconComponent = useFastIcons ? FontIcon : Icon;
 
     return (
-      <IconComponent
-        aria-hidden={true}
-        className={classNames.filterChevron}
-        iconName={filterIconName ? filterIconName : 'ChevronDown'}
-      />
+      <IconComponent iconName="ChevronDown" aria-hidden={true} className={classNames.filterChevron} {...iconProps} />
     );
   };
 

--- a/packages/react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsColumn.types.ts
@@ -6,6 +6,7 @@ import { ITooltipHostProps } from '../../Tooltip';
 import { IDragDropHelper } from '../../DragDrop';
 import { ICellStyleProps } from './DetailsRow.types';
 import { ITheme, IStyle } from '../../Styling';
+import { IIconProps } from '../Icon/Icon.types';
 
 /**
  * {@docgategory DetailsList}
@@ -192,4 +193,11 @@ export interface IDetailsColumnStyles {
    * Transparent no border region while drag & drop occurs to avoid content shift.
    */
   noBorderWhileDragging: IStyle;
+}
+
+/**
+ * {@docCategory DetailsList}
+ */
+export interface IDetailsColumnFilterIconProps extends IDetailsColumnProps {
+  iconProps?: IIconProps;
 }

--- a/packages/react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsColumn.types.ts
@@ -198,6 +198,6 @@ export interface IDetailsColumnStyles {
 /**
  * {@docCategory DetailsList}
  */
-export interface IDetailsColumnFilterIconProps extends IDetailsColumnProps {
-  iconProps?: IIconProps;
+export interface IDetailsColumnFilterIconProps extends IIconProps {
+  columnProps?: IDetailsColumnProps;
 }

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -439,6 +439,9 @@ export interface IColumn {
   /** Custom renderer for column header divider. */
   onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
 
+  /** Custom renderer for filter icon. */
+  onRenderFilterIcon?: IRenderFunction<IDetailsColumnProps>;
+
   /** Custom renderer for column header content, instead of the default text rendering. */
   onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
 

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -12,7 +12,12 @@ import { IList, IListProps, ScrollToMode } from '../../List';
 import { ITheme, IStyle } from '../../Styling';
 import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 import { IDetailsCheckboxProps } from './DetailsRowCheck.types';
-import { IDetailsColumnStyleProps, IDetailsColumnProps, IDetailsColumnStyles } from './DetailsColumn.types';
+import {
+  IDetailsColumnStyleProps,
+  IDetailsColumnProps,
+  IDetailsColumnStyles,
+  IDetailsColumnFilterIconProps,
+} from './DetailsColumn.types';
 
 export {
   IDetailsHeaderProps,
@@ -397,9 +402,6 @@ export interface IColumn {
   /** Custom icon to use in the column header. */
   iconName?: string;
 
-  /** Custom icon to use for the filter icon in the column header. */
-  filterIconName?: string;
-
   /**
    * Whether only the icon should be displayed in the column header.
    * If true, the column name and dropdown chevron will not be displayed.
@@ -440,7 +442,7 @@ export interface IColumn {
   onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
 
   /** Custom renderer for filter icon. */
-  onRenderFilterIcon?: IRenderFunction<IDetailsColumnProps>;
+  onRenderFilterIcon?: IRenderFunction<IDetailsColumnFilterIconProps>;
 
   /** Custom renderer for column header content, instead of the default text rendering. */
   onRenderHeader?: IRenderFunction<IDetailsColumnProps>;

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -397,6 +397,9 @@ export interface IColumn {
   /** Custom icon to use in the column header. */
   iconName?: string;
 
+  /** Custom icon to use for the filter icon in the column header. */
+  filterIconName?: string;
+
   /**
    * Whether only the icon should be displayed in the column header.
    * If true, the column name and dropdown chevron will not be displayed.


### PR DESCRIPTION
#### Pull request checklist

- [] Addresses an existing issue: Fixes #
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ODSP is looking to update chevrons in the detailsList to use `ChevronDownSmall`. Adding the option to pass in a `filterIconName` to customize the icon in the details header

#### Focus areas to test

(optional)
