### PR TITLE
initializeComponentsRefs: throw error message _onMount

### DIFF
--- a/change/@fluentui-utilities-7522454d-72cc-4a53-a91c-5ed161938197.json
+++ b/change/@fluentui-utilities-7522454d-72cc-4a53-a91c-5ed161938197.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "initializeComponentsRefs: throw error message onMount.",
+  "packageName": "@fluentui/utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/initializeComponentRef.ts
+++ b/packages/utilities/src/initializeComponentRef.ts
@@ -18,6 +18,10 @@ export function initializeComponentRef<TProps extends IBaseProps, TState>(obj: R
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _onMount(this: any): void {
+  if (!this.props) {
+    throw new Error(`this.props is undefined in initializeComponentRef for ${this.displayName || this.name}`);
+  }
+
   _setComponentRef(this.props.componentRef, this);
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18084 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- `_onMount` now logs an error if `this.props` is undefined. 