### PR TITLE
Revert "Utilize `preventDismissOnEvent` property to check if click handler should discard Callout (#17810)"

### DIFF
--- a/change/@fluentui-react-6a8dd24f-237d-40b6-b7df-9a696e1245da.json
+++ b/change/@fluentui-react-6a8dd24f-237d-40b6-b7df-9a696e1245da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Utilize `preventDismissOnEvent` property to check if click handler should discard Callout (#17810)\"",
+  "packageName": "@fluentui/react",
+  "email": "anhw@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -218,9 +218,6 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
             menuProps={{
               items: contextualItems,
               directionalHint: DirectionalHint.bottomLeftEdge,
-              calloutProps: {
-                preventDismissOnEvent: () => true,
-              },
             }}
           />
           {overflowIndex !== lastItemIndex + 1 && (

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -352,8 +352,6 @@ function useDismissHandlers(
           isEventTargetOutsideCallout &&
           (!targetRef.current ||
             'stopPropagation' in targetRef.current ||
-            !preventDismissOnEvent ||
-            (preventDismissOnEvent && !preventDismissOnEvent(ev)) ||
             (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
       ) {
         onDismiss?.(ev);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18213
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Revert #17810 as it introduced unwanted click behavior with some components that use callouts

#### Focus areas to test

(optional)
