### PR TITLE
Charting: Accessibility aria-labelledby issue resolved in Stacked bar chart, Horizontal bar chart and Vertical bar chart. 

### DIFF
--- a/change/@fluentui-react-charting-86a24ea5-e5cb-479c-bcab-7da222df5e8a.json
+++ b/change/@fluentui-react-charting-86a24ea5-e5cb-479c-bcab-7da222df5e8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "aria-labelledby accessibility issue resolved by adding role and aria-label",
+  "packageName": "@fluentui/react-charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-86a24ea5-e5cb-479c-bcab-7da222df5e8a.json
+++ b/change/@fluentui-react-charting-86a24ea5-e5cb-479c-bcab-7da222df5e8a.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "aria-labelledby accessibility issue resolved by adding role and aria-label",
   "packageName": "@fluentui/react-charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -267,6 +267,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
               : undefined
           }
           aria-labelledby={this._calloutId}
+          role="img"
+          aria-label="Horizontal bar chart"
           onBlur={this._hoverOff}
           onMouseLeave={this._hoverOff}
         />

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -164,6 +164,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}
+          role="img"
+          aria-label="Multi stacked bar chart"
           onMouseOver={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
           onMouseMove={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
           onMouseLeave={point.placeHolder ? undefined : this._onBarLeave}

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -250,6 +250,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
+          aria-label="Stacked bar chart"
+          role="img"
           aria-labelledby={this._calloutId}
           onMouseOver={this._onBarHover.bind(this, pointData, color, point)}
           onMouseMove={this._onBarHover.bind(this, pointData, color, point)}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
               className=
 
@@ -92,6 +93,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#e81123"
@@ -102,6 +104,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
               className=
 
@@ -118,6 +121,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -193,6 +197,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
               className=
 
@@ -209,6 +214,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#0078d4"
@@ -219,6 +225,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
               className=
 
@@ -235,6 +242,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -381,6 +389,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout12"
               className=
 
@@ -397,6 +406,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#e81123"
@@ -407,6 +417,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout12"
               className=
 
@@ -423,6 +434,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -494,6 +506,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout12"
               className=
 
@@ -510,6 +523,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#0078d4"
@@ -520,6 +534,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout12"
               className=
 
@@ -536,6 +551,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -686,6 +702,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout3"
               className=
 
@@ -702,6 +719,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#e81123"
@@ -712,6 +730,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout3"
               className=
 
@@ -728,6 +747,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -803,6 +823,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout3"
               className=
 
@@ -819,6 +840,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#0078d4"
@@ -829,6 +851,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout3"
               className=
 
@@ -845,6 +868,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -932,6 +956,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout9"
               className=
 
@@ -948,6 +973,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#e81123"
@@ -958,6 +984,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout9"
               className=
 
@@ -974,6 +1001,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -1049,6 +1077,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout9"
               className=
 
@@ -1065,6 +1094,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#0078d4"
@@ -1075,6 +1105,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout9"
               className=
 
@@ -1091,6 +1122,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -1420,6 +1452,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
               className=
 
@@ -1436,6 +1469,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#e81123"
@@ -1446,6 +1480,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
               className=
 
@@ -1462,6 +1497,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"
@@ -1537,6 +1573,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                 }
           >
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
               className=
 
@@ -1553,6 +1590,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#0078d4"
@@ -1563,6 +1601,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               />
             </g>
             <g
+              aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
               className=
 
@@ -1579,6 +1618,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
+              role="img"
             >
               <rect
                 fill="#107c10"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout0"
             className=
 
@@ -102,6 +103,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -112,6 +114,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout0"
             className=
 
@@ -129,6 +132,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -233,6 +237,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout12"
             className=
 
@@ -250,6 +255,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -260,6 +266,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout12"
             className=
 
@@ -277,6 +284,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -367,6 +375,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout8"
             className=
 
@@ -384,6 +393,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -394,6 +404,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout8"
             className=
 
@@ -411,6 +422,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -515,6 +527,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout2"
             className=
 
@@ -532,6 +545,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -542,6 +556,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout2"
             className=
 
@@ -559,6 +574,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -636,6 +652,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout6"
             className=
 
@@ -653,6 +670,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -663,6 +681,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout6"
             className=
 
@@ -680,6 +699,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -784,6 +804,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout4"
             className=
 
@@ -801,6 +822,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -811,6 +833,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout4"
             className=
 
@@ -828,6 +851,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"
@@ -905,6 +929,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
       >
         <g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout10"
             className=
 
@@ -922,6 +947,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#5c005c"
@@ -932,6 +958,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             />
           </g>
           <g
+            aria-label="Stacked bar chart"
             aria-labelledby="callout10"
             className=
 
@@ -949,6 +976,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             onMouseMove={[Function]}
             onMouseOver={[Function]}
             pointerEvents="all"
+            role="img"
           >
             <rect
               fill="#e81123"

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -474,6 +474,8 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
             this._refCallback(e, point.legend!);
           }}
           onMouseOver={this._onBarHover.bind(this, point, colorScale(point.y))}
+          aria-label="Vertical bar chart"
+          role="img"
           aria-labelledby={`toolTip${this._calloutId}`}
           onMouseLeave={this._onBarLeave}
           onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
@@ -517,6 +519,8 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
           height={Math.max(yBarScale(point.y), 0)}
+          aria-label="Vertical bar chart"
+          role="img"
           aria-labelledby={`toolTip${this._calloutId}`}
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!);

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -98,6 +98,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout0"
           className=
 
@@ -111,11 +112,13 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout0"
           className=
 
@@ -129,11 +132,13 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout0"
           className=
 
@@ -147,6 +152,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -578,6 +584,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout12"
           className=
 
@@ -591,11 +598,13 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout12"
           className=
 
@@ -609,11 +618,13 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout12"
           className=
 
@@ -627,6 +638,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -1038,6 +1050,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout4"
           className=
 
@@ -1051,11 +1064,13 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout4"
           className=
 
@@ -1069,11 +1084,13 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout4"
           className=
 
@@ -1087,6 +1104,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -1195,6 +1213,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout8"
           className=
 
@@ -1208,11 +1227,13 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout8"
           className=
 
@@ -1226,11 +1247,13 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout8"
           className=
 
@@ -1244,6 +1267,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -1675,6 +1699,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout16"
           className=
 
@@ -1688,11 +1713,13 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout16"
           className=
 
@@ -1706,11 +1733,13 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout16"
           className=
 
@@ -1724,6 +1753,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -2155,6 +2185,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout20"
           className=
 
@@ -2168,11 +2199,13 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout20"
           className=
 
@@ -2186,11 +2219,13 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout20"
           className=
 
@@ -2204,6 +2239,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}
@@ -2635,6 +2671,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
       />
       <g>
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout24"
           className=
 
@@ -2648,11 +2685,13 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={56}
           y={-24}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout24"
           className=
 
@@ -2666,11 +2705,13 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
+          aria-label="Vertical bar chart"
           aria-labelledby="toolTipcallout24"
           className=
 
@@ -2684,6 +2725,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={-2}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

In SVG's, If we use aria-labelledby we need to add role also. To resolve Accessibility Insights for web, Added role and aria-label to the below charts. 
1. Stacked bar chart
2. Multi stacked bar chart
3. Horizontal bar chart
4. Vertical bar chart

#### Focus areas to test

Stacked bar chart
Multi stacked bar chart
Horizontal bar chart
Vertical bar chart
