### PR TITLE
fix(makeStyles): throw when is used inside a React component

### DIFF
--- a/change/@fluentui-react-make-styles-60ba58aa-a178-46e8-bdba-9cde8b340ddd.json
+++ b/change/@fluentui-react-make-styles-60ba58aa-a178-46e8-bdba-9cde8b340ddd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "throw when is used inside a React component",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-make-styles/src/makeStyles.test.tsx
+++ b/packages/react-make-styles/src/makeStyles.test.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { makeStyles } from './makeStyles';
+
+describe('makeStyles', () => {
+  it('works outside of React components', () => {
+    expect(() => makeStyles({ root: { color: 'red' } })).not.toThrow();
+  });
+
+  it('throws inside React components', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const Example: React.FC = () => {
+      makeStyles({ root: { color: 'red' } });
+      return null;
+    };
+    const container = document.createElement('div');
+
+    expect(() => ReactDOM.render(<Example />, container)).toThrow(/All makeStyles\(\) calls should be top level/);
+  });
+});

--- a/packages/react-make-styles/src/makeStyles.ts
+++ b/packages/react-make-styles/src/makeStyles.ts
@@ -1,11 +1,32 @@
 import { makeStyles as vanillaMakeStyles, MakeStylesOptions, MakeStylesStyleRule } from '@fluentui/make-styles';
 import { useFluent } from '@fluentui/react-shared-contexts';
 import { Theme } from '@fluentui/react-theme';
+import * as React from 'react';
 
 import { useRenderer } from './RendererContext';
 
+function isInsideComponent() {
+  try {
+    React.useContext(({} as unknown) as React.Context<unknown>);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export function makeStyles<Slots extends string>(stylesBySlots: Record<Slots, MakeStylesStyleRule<Theme>>) {
   const getStyles = vanillaMakeStyles(stylesBySlots);
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (isInsideComponent()) {
+      throw new Error(
+        [
+          "makeStyles(): this function cannot be called in component's scope.",
+          'All makeStyles() calls should be top level i.e. in a root scope of a file.',
+        ].join(' '),
+      );
+    }
+  }
 
   return function useClasses(): Record<Slots, string> {
     const { dir } = useFluent();

--- a/packages/react-make-styles/src/makeStyles.ts
+++ b/packages/react-make-styles/src/makeStyles.ts
@@ -7,6 +7,7 @@ import { useRenderer } from './RendererContext';
 
 function isInsideComponent() {
   try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useContext(({} as unknown) as React.Context<unknown>);
     return true;
   } catch (e) {


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

By design `makeStyles()` cannot be used inside React components, only top level calls are allowed:

```tsx
const useClasses = makeStyles(); // ✅ that's good

function App() {
  const useClasses = makeStyles(); // ❌ will generate classes on each render, not compatible with Babel plugin
}
```

This PR adds a runtime check to prevent usages of `makeStyles()` inside React components.
