### PR TITLE
[react-northstar] Allow switching to V2 themes in maximized examples

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Performance
 
 ### Documentation
-- Allow switching to V2 themes in maximized examples @Hirse [#18292](https://github.com/microsoft/fluentui/pull/18292)
+- Allow switching to V2 themes in maximized examples @Hirse ([#18292](https://github.com/microsoft/fluentui/pull/18292))
 
 <!--------------------------------[ v0.56.0 ]------------------------------- -->
 ## [v0.56.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.56.0) (2021-05-14)

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Performance
 
 ### Documentation
+- Allow switching to V2 themes in maximized examples @Hirse [#18292](https://github.com/microsoft/fluentui/pull/18292)
 
 <!--------------------------------[ v0.56.0 ]------------------------------- -->
 ## [v0.56.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.56.0) (2021-05-14)

--- a/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
+++ b/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
@@ -1,4 +1,11 @@
-import { Provider, teamsTheme, teamsHighContrastTheme, teamsDarkTheme } from '@fluentui/react-northstar';
+import {
+  Provider,
+  teamsDarkTheme,
+  teamsDarkV2Theme,
+  teamsHighContrastTheme,
+  teamsTheme,
+  teamsV2Theme,
+} from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { match } from 'react-router-dom';
@@ -20,8 +27,10 @@ type ExternalExampleLayoutProps = {
 
 const themes = {
   teams: teamsTheme,
+  teamsV2: teamsV2Theme,
   teamsHighContrast: teamsHighContrastTheme,
   teamsDark: teamsDarkTheme,
+  teamsDarkV2: teamsDarkV2Theme,
 };
 
 const ExternalExampleLayout: React.FC<ExternalExampleLayoutProps> = props => {


### PR DESCRIPTION
Allows switching to V2 themes in maximized/popped out examples using `switchTheme('teamsV2')`.
![image](https://user-images.githubusercontent.com/2564094/119276649-1aabf200-bbd0-11eb-9423-c155346a5451.png)
