### PR TITLE
fix: focus zone to ignore not focusable element

### DIFF
--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -27,7 +27,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
 - Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 - Adding aria-hidden to bumper elements so that they are not read by screen readers @khmakoto ([#14376](https://github.com/microsoft/fluentui/pull/14376))
-- Added `shouldIgnoreNotFocusable` to props to skip `onFocus` event for elements with `data-is-focusable="false"` ([#18297](https://github.com/microsoft/fluentui/pull/18297))
+- Added `shouldIgnoreNotFocusable` to props to skip `onFocus` event for elements with `data-is-focusable="false"` @assuncaocharles ([#18297](https://github.com/microsoft/fluentui/pull/18297))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -27,6 +27,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
 - Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
 - Adding aria-hidden to bumper elements so that they are not read by screen readers @khmakoto ([#14376](https://github.com/microsoft/fluentui/pull/14376))
+- Added `shouldIgnoreNotFocusable` to props to skip `onFocus` event for elements with `data-is-focusable="false"` ([#18297](https://github.com/microsoft/fluentui/pull/18297))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -109,6 +109,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
     isRtl: PropTypes.bool,
     preventFocusRestoration: PropTypes.bool,
     pagingSupportDisabled: PropTypes.bool,
+    shouldIgnoreNotFocusable: PropTypes.bool,
   };
 
   static defaultProps: FocusZoneProps = {
@@ -427,7 +428,12 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
       stopFocusPropagation,
       shouldFocusInnerElementWhenReceivedFocus,
       defaultTabbableElement,
+      shouldIgnoreNotFocusable,
     } = this.props;
+
+    if (shouldIgnoreNotFocusable && ev.target?.dataset.isFocusable === 'false') {
+      return;
+    }
 
     let newActiveElement: HTMLElement | null | undefined;
     const isImmediateDescendant = this.isImmediateDescendantOfZone(ev.target as HTMLElement);

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -76,6 +76,11 @@ export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttribute
   shouldResetActiveElementWhenTabFromZone?: boolean;
 
   /**
+   * If true elements containing data-is-focusable="false" will not be counted skipping onFocus event
+   */
+  shouldIgnoreNotFocusable?: boolean;
+
+  /**
    * Determines whether the FocusZone will walk up the DOM trying to invoke click callbacks on focusable elements on
    * Enter and Space keydowns to ensure accessibility for tags that don't guarantee this behavior.
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Skip `_onFocus` event for elements that has `data-is-focusable="false"` set. 

#### Focus areas to test

(optional)
