### PR TITLE
Slider: fix ally contrast flag for disabled sliders.

### DIFF
--- a/change/@fluentui-react-2ee6aa81-cb09-4936-9495-6086fb580a6c.json
+++ b/change/@fluentui-react-2ee6aa81-cb09-4936-9495-6086fb580a6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Slider: fix ally contrast flag for disabled slider",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -355,6 +355,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
         className: classNames.valueLabel,
         children: valueFormat ? valueFormat(value!) : value,
         disabled,
+        htmlFor: disabled ? id : undefined,
       }
     : undefined;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18223 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- value label text now has appropriate `for` attribute that points to the `Slider` control's id so it isn't flagged as an ally issue when `Slider` is disabled.
