### PR TITLE
Fix ChatMessage badgeBar conflict with focusBorder

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix user selection narration with NVDA in `Dropdown` @kolaps33 ([#18339](https://github.com/microsoft/fluentui/pull/18339))
 - Fix `useAutoControlled` to use updated state @assuncaocharles ([#18338](https://github.com/microsoft/fluentui/pull/18338))
 - Fix RTL version of `NumberListIcon` @notandrew ([#18310](https://github.com/microsoft/fluentui/pull/18310))
+- Fix `ChatMessage` badge-bar conflict with focus-border @Hirse ([#18303](https://github.com/microsoft/fluentui/pull/18303))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleBadge.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleBadge.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
+import { Avatar, Chat, ChatItemProps, ShorthandCollection, Text } from '@fluentui/react-northstar';
 import { MentionIcon, RedbangIcon, AcceptIcon } from '@fluentui/react-icons-northstar';
 
 const robinAvatar = {
@@ -29,7 +29,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     gutter: <Avatar {...robinAvatar} />,
     message: (
       <Chat.Message
-        content="Sure @Cecil. Let's schedule a meeting."
+        content={['Sure ', <Text atMention="me" content="Cecil" />, ". Let's schedule a meeting."]}
         author="Robin Counts"
         timestamp="Yesterday, 10:15 PM"
         badge={{
@@ -38,7 +38,6 @@ const items: ShorthandCollection<ChatItemProps> = [
         variables={{ hasMention: true }}
       />
     ),
-    attached: 'top',
     key: 'message-id-2',
   },
 ];

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -71,6 +71,7 @@ export interface ChatMessageSlotClassNames {
   badge: string;
   content: string;
   reactionGroup: string;
+  bar: string;
 }
 
 export interface ChatMessageProps
@@ -183,6 +184,7 @@ export const chatMessageSlotClassNames: ChatMessageSlotClassNames = {
   badge: `${chatMessageClassName}__badge`,
   content: `${chatMessageClassName}__content`,
   reactionGroup: `${chatMessageClassName}__reactions`,
+  bar: `${chatMessageClassName}__bar`,
 };
 
 function partitionActionMenuPropsFromShorthand<P>(
@@ -513,6 +515,7 @@ export const ChatMessage: ComponentWithAs<'div', ChatMessageProps> &
           ) : (
             <>
               {actionMenuElement}
+              <div className={chatMessageSlotClassNames.bar}></div>
               {badgePosition === 'start' && badgeElement}
               {headerElement}
               {messageContent}

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -515,7 +515,7 @@ export const ChatMessage: ComponentWithAs<'div', ChatMessageProps> &
           ) : (
             <>
               {actionMenuElement}
-              <div className={chatMessageSlotClassNames.bar}></div>
+              <div className={chatMessageSlotClassNames.bar} />
               {badgePosition === 'start' && badgeElement}
               {headerElement}
               {messageContent}

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -50,8 +50,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       wordWrap: 'break-word',
 
       ...((v.hasMention || v.isImportant) && {
-        '::before': {
-          content: '""',
+        [`& .${chatMessageSlotClassNames.bar}`]: {
           backgroundColor: v.hasMention ? v.hasMentionColor : v.isImportantColor,
           height: '100%',
           left: '0',


### PR DESCRIPTION
#### Pull request checklist
Required for #18302 as the new compact styling makes this issue more visible.

#### Description of changes
ChatMessage that are marked as important or containing an at-mention display a colored bar on the left side.
![ChatMessage with important-bar](https://user-images.githubusercontent.com/2564094/119386506-7e8bf480-bc7c-11eb-95ea-39edd706a21c.png)

As this bar is realized using `::before` on the focusable root-slot, it conflicts with the focus-border style, causing the inner focus-border to only surround the bar instead of the whole message.

_Before: Conflict between important-bar and inner focus-border_
![Before: Conflict between important-bar and inner focus-border](https://user-images.githubusercontent.com/2564094/119386398-543a3700-bc7c-11eb-9465-f4d5b1fcba1b.png)

This PR changes the bar implementation to use a separate `div` to keep `::before` free for the focus-border.

_After: Fixed inner focus-border_
![After: Fixed inner focus-border](https://user-images.githubusercontent.com/2564094/119386086-e7bf3800-bc7b-11eb-95bd-c574e67dc3a5.png)

-----

_NB: Focus-border radius seems to be broken for ChatMessage since #17748._
