### PR TITLE
Inherit FocusBorder radius from ChatMessage

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))
 - Add `inline` to `ChatMessage`'s `actionMenu` prop that allows actionMenu to be rendered either inline or attached to body @yuanboxue-amber ([#18147](https://github.com/microsoft/fluentui/pull/18147))
+- Let focus-border inherit border-radius from `ChatMessage` @Hirse ([#18305](https://github.com/microsoft/fluentui/pull/18305))
 
 ### Performance
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -63,7 +63,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
         },
       }),
 
-      ...getBorderFocusStyles({ variables: siteVariables }),
+      ...getBorderFocusStyles({ borderRadius: 'inherit', variables: siteVariables }),
 
       // actions menu's appearance can be controlled by the value of showActionMenu variable - in this
       // case this variable will serve the single source of truth on whether actions menu should be shown.


### PR DESCRIPTION
#17748 increased the border-radius from 3px to 4px which also removed the default border-radius from `getBorderFocusStyles` as that falls back on `siteVariables.borderRadius`, which was replaced by `borderRadiusMedium`.

This PR fixes the focus-border border-radius for ChatMessage by inheriting it from the ChatMessage element to also reflect the `attached`-state of a message.
![ChatMessage FocusBorder with inherited radius](https://user-images.githubusercontent.com/2564094/119390879-8189e380-bc82-11eb-820d-e2e2d8126009.gif)

@notandrew Should `borderRadiusMedium` be aliased to `borderRadius` to restore the default case?
Alternatively, should `'inherit'` be the default for the focus-border to remove the necessity of setting it explicitly in most cases?