### PR TITLE
Re-add Callout prop to allow dismiss on target click

### DIFF
--- a/change/@fluentui-react-ad79b351-36a2-4955-ba54-fde5cfc2b7b7.json
+++ b/change/@fluentui-react-ad79b351-36a2-4955-ba54-fde5cfc2b7b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add dismissOnTargetClick prop",
+  "packageName": "@fluentui/react",
+  "email": "anhw@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2355,6 +2355,7 @@ export interface ICalloutProps extends React_2.HTMLAttributes<HTMLDivElement>, R
     directionalHint?: DirectionalHint;
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
+    dismissOnTargetClick?: boolean;
     doNotLayer?: boolean;
     finalHeight?: number;
     gapSpace?: number;

--- a/packages/react/src/components/Callout/Callout.types.ts
+++ b/packages/react/src/components/Callout/Callout.types.ts
@@ -109,6 +109,12 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
   preventDismissOnLostFocus?: boolean;
 
   /**
+   * If true then the callout will dismiss when the target element is clicked
+   * @defaultvalue false
+   */
+  dismissOnTargetClick?: boolean;
+
+  /**
    * If defined, then takes priority over `preventDismissOnLostFocus`, `preventDismissOnResize`,
    * and `preventDismissOnScroll`.
    * If it returns true, the callout will not dismiss for this event.

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -295,6 +295,7 @@ function useDismissHandlers(
     preventDismissOnResize,
     // eslint-disable-next-line deprecation/deprecation
     preventDismissOnLostFocus,
+    dismissOnTargetClick,
     shouldDismissOnWindowFocus,
     preventDismissOnEvent,
   }: ICalloutProps,
@@ -352,6 +353,7 @@ function useDismissHandlers(
           isEventTargetOutsideCallout &&
           (!targetRef.current ||
             'stopPropagation' in targetRef.current ||
+            dismissOnTargetClick ||
             (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
       ) {
         onDismiss?.(ev);

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -409,6 +409,7 @@ function useDismissHandlers(
     targetWindow,
     onDismiss,
     shouldDismissOnWindowFocus,
+    dismissOnTargetClick,
     preventDismissOnLostFocus,
     preventDismissOnResize,
     preventDismissOnScroll,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Re-adds the `dismissOnTargetClick` Callout prop to allow for clicking the target for automatic dismissal.

OWA Calendar hit a scenario where teaching bubbles would not dismiss when their target is clicked, where the target has no control over the teaching bubble component. Previously the `dismissOnTargetClick` prop was utilized, but it was since removed in v8 and the issue re-surfaced.

This is a less intrusive implementation than the one introduced in #17810, which was later reverted in #18274 due to introducing unwanted side-effects.

#### Focus areas to test

(optional)
