### PR TITLE
Dropdown: multiselect dropdown options now pass ariaLabel prop to Checkbox input.

### DIFF
--- a/change/@fluentui-react-e46ffcf0-68ff-4a3c-9463-4407f1854e0a.json
+++ b/change/@fluentui-react-e46ffcf0-68ff-4a3c-9463-4407f1854e0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: multiselect dropdown options now pass ariaLabel prop to Checkbox input.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -819,6 +819,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         styles={multiSelectItemStyles}
         ariaPositionInSet={this._sizePosCache.positionInSet(item.index)}
         ariaSetSize={this._sizePosCache.optionSetSize}
+        ariaLabel={item.ariaLabel}
       />
     );
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18313 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- For multiselect `Dropdown`, each option will now pass their appropriate `aria-label` (if it has one) to the `Checkbox`.