### PR TITLE
Slider fixes after function component conversion; add missing parameters

### DIFF
--- a/change/@fluentui-react-7b6f0ac2-8938-4b2b-87df-d7867da25015.json
+++ b/change/@fluentui-react-7b6f0ac2-8938-4b2b-87df-d7867da25015.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Slider: fix issues from function component conversion",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-7b6f0ac2-8938-4b2b-87df-d7867da25015.json
+++ b/change/@fluentui-react-7b6f0ac2-8938-4b2b-87df-d7867da25015.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Slider: fix issues from function component conversion",
+  "type": "minor",
+  "comment": "Slider: add event to onChange, add range to onChanged, and fix issues from function component conversion",
   "packageName": "@fluentui/react",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-examples-3233ea6b-d35c-4491-b3bd-f891422f1e2d.json
+++ b/change/@fluentui-react-examples-3233ea6b-d35c-4491-b3bd-f891422f1e2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update example snapshots",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -367,7 +367,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Slider-slideBox
             ms-Slider-showValue
-            ms-Slider-showTransitions
             {
               align-items: center;
               background: transparent;
@@ -481,7 +480,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
                   position: absolute;
                   top: -6px;
                   transform: translateX(-50%);
-                  transition: left 0.367s cubic-bezier(.1,.9,.2,1);
                   width: 16px;
                 }
             style={
@@ -501,7 +499,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
                 }
                 {
                   background: #c8c6c4;
-                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                   border: 1px solid WindowText;
@@ -523,7 +520,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
                 }
                 {
                   background: #605e5c;
-                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                   background-color: WindowText;
@@ -545,7 +541,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
                 }
                 {
                   background: #c8c6c4;
-                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                   border: 1px solid WindowText;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7450,8 +7450,8 @@ export interface ISliderProps extends Omit<React_2.HTMLAttributes<HTMLDivElement
     lowerValue?: number;
     max?: number;
     min?: number;
-    onChange?: (value: number, range?: [number, number]) => void;
-    onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
+    onChange?: (value: number, range?: [number, number], event?: React_2.MouseEvent | React_2.TouchEvent | MouseEvent | TouchEvent | React_2.KeyboardEvent) => void;
+    onChanged?: (event: any, value: number, range?: [number, number]) => void;
     originFromZero?: boolean;
     ranged?: boolean;
     showValue?: boolean;

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -70,14 +70,16 @@ describe('Slider', () => {
     expect(label.prop('htmlFor')).toBe('test_id');
   });
 
-  it('can set id on range slider', () => {
-    wrapper = mount(<Slider ranged />);
+  it('can set id via buttonProps', () => {
+    // Not the recommended way of doing things, but it should work consistently still
+    wrapper = mount(<Slider buttonProps={{ id: 'test_id' }} styles={{ titleLabel: 'test_label' }} />);
 
-    const lowerValueThumb = wrapper.find('.ms-Slider-thumb').at(0);
-    expect(lowerValueThumb.getDOMNode().id).toEqual(`${MIN_PREFIX}-Slider0`);
+    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
 
-    const upperValueThumb = wrapper.find('.ms-Slider-thumb').at(1);
-    expect(upperValueThumb.getDOMNode().id).toEqual(`${MAX_PREFIX}-Slider0`);
+    // properly associates label with custom id
+    const label = wrapper.find('label.test_label');
+    expect(label.prop('htmlFor')).toBe('test_id');
   });
 
   it('handles zero default value', () => {

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -6,7 +6,6 @@ import { resetIds, KeyCodes } from '@fluentui/utilities';
 import { create } from '@fluentui/utilities/lib/test';
 import { Slider } from './Slider';
 import { ISlider } from './Slider.types';
-import { ONKEYDOWN_TIMEOUT_DURATION } from './useSlider';
 import { isConformant } from '../../common/isConformant';
 
 const MIN_PREFIX = 'min';
@@ -23,6 +22,9 @@ describe('Slider', () => {
     if (wrapper) {
       wrapper.unmount();
       wrapper = undefined;
+    }
+    if ((setTimeout as any).mock) {
+      jest.useRealTimers();
     }
   });
 
@@ -43,89 +45,127 @@ describe('Slider', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('calls onChange when slider value changes', () => {
-    const onChange = jest.fn();
-    wrapper = mount(<Slider onChange={onChange} defaultValue={5} />);
+  it('can provide the current value', () => {
+    const slider = React.createRef<ISlider>();
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
-
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-    // Default min is 0.
-    expect(onChange.mock.calls.length).toEqual(1);
+    wrapper = mount(<Slider defaultValue={12} min={0} max={100} componentRef={slider} />);
+    expect(slider.current?.value).toEqual(12);
   });
 
-  it('calls onChange when range slider range changes', () => {
-    const onChange = jest.fn();
-    wrapper = mount(<Slider onChange={onChange} defaultValue={5} ranged />);
+  it('can provide the current range', () => {
+    const slider = React.createRef<ISlider>();
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
-
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-    // Default min is 0.
-    expect(onChange.mock.calls.length).toEqual(1);
+    wrapper = mount(<Slider defaultValue={12} min={0} max={100} componentRef={slider} ranged />);
+    expect(slider.current?.range).toEqual([0, 12]);
   });
 
-  it('does not call onChange with range when ranged is false', () => {
+  it('can set id', () => {
+    wrapper = mount(<Slider id="test_id" styles={{ titleLabel: 'test_label' }} />);
+
+    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
+
+    // properly associates label with custom id
+    const label = wrapper.find('label.test_label');
+    expect(label.prop('htmlFor')).toBe('test_id');
+  });
+
+  it('can set id on range slider', () => {
+    wrapper = mount(<Slider ranged />);
+
+    const lowerValueThumb = wrapper.find('.ms-Slider-thumb').at(0);
+    expect(lowerValueThumb.getDOMNode().id).toEqual(`${MIN_PREFIX}-Slider0`);
+
+    const upperValueThumb = wrapper.find('.ms-Slider-thumb').at(1);
+    expect(upperValueThumb.getDOMNode().id).toEqual(`${MAX_PREFIX}-Slider0`);
+  });
+
+  it('handles zero default value', () => {
+    const slider = React.createRef<ISlider>();
+
+    wrapper = mount(<Slider defaultValue={0} min={-100} max={100} componentRef={slider} />);
+    expect(slider.current!.value).toEqual(0);
+  });
+
+  it('handles zero value', () => {
+    const slider = React.createRef<ISlider>();
+
+    wrapper = mount(<Slider value={0} min={-100} max={100} componentRef={slider} />);
+    expect(slider.current!.value).toEqual(0);
+  });
+
+  it('calls onChange and onChanged when slider value changes with mouse', () => {
     const onChange = jest.fn();
-    wrapper = mount(<Slider onChange={onChange} defaultValue={5} />);
+    const onChanged = jest.fn();
+    const slider = React.createRef<ISlider>();
+    wrapper = mount(<Slider onChange={onChange} defaultValue={5} onChanged={onChanged} componentRef={slider} />);
 
     const sliderLine = wrapper.find('.ms-Slider-line');
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
+    // Default min is 0.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(0);
+    expect(onChanged).toHaveBeenCalledTimes(0); // not called yet
+    expect(slider.current!.value).toBe(0);
+
+    // have to use a real event to trigger onChanged
+    window.dispatchEvent(new Event('mouseup'));
+    expect(onChange).toHaveBeenCalledTimes(1); // not called again
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged.mock.calls[0][1]).toEqual(0);
+  });
+
+  it('calls onChange and onChanged when range slider range changes with mouse', () => {
+    const onChange = jest.fn();
+    const onChanged = jest.fn();
+    const slider = React.createRef<ISlider>();
+    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} defaultValue={5} ranged componentRef={slider} />);
+
+    const sliderLine = wrapper.find('.ms-Slider-line');
+    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+
+    sliderLine.getDOMNode().getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
+
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
+    // Default min is 0.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual([0, 5]);
+    expect(onChanged).toHaveBeenCalledTimes(0);
+    expect(slider.current!.range).toEqual([0, 5]);
+
+    window.dispatchEvent(new Event('mouseup'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged.mock.calls[0][2]).toEqual([0, 5]);
+  });
+
+  it('does not call onChange or onChanged with range when ranged is false', () => {
+    const onChange = jest.fn();
+    const onChanged = jest.fn();
+    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} defaultValue={5} />);
+
+    const sliderLine = wrapper.find('.ms-Slider-line');
+    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+
+    sliderLine.getDOMNode().getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
+
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
 
     expect(onChange.mock.calls[0][1]).toBeUndefined();
+
+    window.dispatchEvent(new Event('mouseup'));
+    expect(onChanged.mock.calls[0][2]).toBeUndefined();
   });
 
   it('can slide to default min/max and execute onChange', () => {
-    let changedValue;
-    const onChange = (val: number) => {
-      changedValue = val;
-    };
+    const onChange = jest.fn();
 
     wrapper = mount(<Slider onChange={onChange} />);
 
@@ -133,38 +173,23 @@ describe('Slider', () => {
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 100,
-      clientY: 0,
-    });
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
+
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 100, clientY: 0 });
 
     // Default max is 10.
-    expect(changedValue).toEqual(10);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(10);
 
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
 
     // Default min is 0.
-    expect(changedValue).toEqual(0);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[1][0]).toEqual(0);
   });
 
   it('updates the upper value thumb when click to the right side of it', () => {
-    let range;
-    const onChange = (val: number, sliderRange: [number, number]) => {
-      range = sliderRange;
-    };
+    const onChange = jest.fn();
 
     wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
 
@@ -172,28 +197,16 @@ describe('Slider', () => {
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 80,
-      clientY: 0,
-    });
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    expect(range).toEqual([0, 8]);
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 80, clientY: 0 });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual([0, 8]);
   });
 
   it('updates the upper value thumb when click close to it', () => {
-    let range;
-    const onChange = (val: number, sliderRange: [number, number]) => {
-      range = sliderRange;
-    };
+    const onChange = jest.fn();
 
     wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
 
@@ -201,50 +214,35 @@ describe('Slider', () => {
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 40,
-      clientY: 0,
-    });
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    expect(range).toEqual([0, 4]);
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 40, clientY: 0 });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual([0, 4]);
   });
 
   it('updates the lower value thumb when click close to it', () => {
-    let range;
-    const onChange = (val: number, sliderRange: [number, number]) => {
-      range = sliderRange;
-    };
+    const onChange = jest.fn();
+    const onChanged = jest.fn();
 
-    wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
+    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} ranged defaultValue={5} />);
 
     const sliderLine = wrapper.find('.ms-Slider-line');
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 10,
-      clientY: 0,
-    });
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    expect(range).toEqual([1, 5]);
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 10, clientY: 0 });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual([1, 5]);
+
+    // test onChanged here too, since the earlier tests don't cover the lower thumb
+    window.dispatchEvent(new Event('mouseup'));
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged.mock.calls[0][2]).toEqual([1, 5]);
   });
 
   it('updates the lower value thumb when click to the left of it', () => {
@@ -259,25 +257,11 @@ describe('Slider', () => {
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
 
     sliderLine.getDOMNode().getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-      } as DOMRect);
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 10,
-      clientY: 0,
-    });
+      ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', {
-      type: 'mousedown',
-      clientX: 20,
-      clientY: 0,
-    });
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 10, clientY: 0 });
+
+    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 20, clientY: 0 });
 
     expect(range).toEqual([2, 5]);
   });
@@ -288,51 +272,6 @@ describe('Slider', () => {
     wrapper.find('button').forEach(button => {
       expect(button.prop('type')).toEqual('button');
     });
-  });
-
-  it('can provide the current value', () => {
-    const slider = React.createRef<ISlider>();
-
-    wrapper = mount(<Slider label="slider" defaultValue={12} min={0} max={100} componentRef={slider} />);
-    expect(slider.current!.value).toEqual(12);
-  });
-
-  it('can provide the current range', () => {
-    const slider = React.createRef<ISlider>();
-
-    wrapper = mount(<Slider label="slider" defaultValue={12} min={0} max={100} componentRef={slider} ranged />);
-    expect(slider.current!.range).toEqual([0, 12]);
-  });
-
-  it('can set id on slider', () => {
-    wrapper = mount(<Slider buttonProps={{ id: 'test_id' }} />);
-
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
-    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
-  });
-
-  it('can set id on range slider', () => {
-    wrapper = mount(<Slider ranged />);
-
-    const lowerValueThumb = wrapper.find('.ms-Slider-thumb').at(0);
-    expect(lowerValueThumb.getDOMNode().id).toEqual(`${MIN_PREFIX}-Slider0`);
-
-    const upperValueThumb = wrapper.find('.ms-Slider-thumb').at(1);
-    expect(upperValueThumb.getDOMNode().id).toEqual(`${MAX_PREFIX}-Slider0`);
-  });
-
-  it('should be able to handler zero default value', () => {
-    const slider = React.createRef<ISlider>();
-
-    wrapper = mount(<Slider label="slider" defaultValue={0} min={-100} max={100} componentRef={slider} />);
-    expect(slider.current!.value).toEqual(0);
-  });
-
-  it('should be able to handler zero value', () => {
-    const slider = React.createRef<ISlider>();
-
-    wrapper = mount(<Slider label="slider" value={0} min={-100} max={100} componentRef={slider} />);
-    expect(slider.current!.value).toEqual(0);
   });
 
   it('renders correct aria-valuetext', () => {
@@ -436,12 +375,8 @@ describe('Slider', () => {
 
     // onChanged should only be called after a delay
     expect(onChanged).toHaveBeenCalledTimes(0);
-
-    setTimeout(() => {
-      expect(onChanged).toHaveBeenCalledTimes(1);
-    }, ONKEYDOWN_TIMEOUT_DURATION);
-
     jest.runOnlyPendingTimers();
+    expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
   it('onChanged returns the correct value', () => {
@@ -462,13 +397,8 @@ describe('Slider', () => {
 
     // onChanged should only be called after a delay
     expect(onChanged).toHaveBeenCalledTimes(0);
-
-    setTimeout(() => {
-      expect(onChanged).toHaveBeenCalledTimes(1);
-    }, ONKEYDOWN_TIMEOUT_DURATION);
-
     jest.runOnlyPendingTimers();
-
+    expect(onChanged).toHaveBeenCalledTimes(1);
     expect(onChanged.mock.calls[0][1]).toEqual(2);
   });
 
@@ -512,7 +442,7 @@ describe('Slider', () => {
 
     sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
 
-    expect(slider.current?.value).toEqual(3);
+    expect(slider.current?.range).toEqual([0, 3]);
 
     // Get the second argument passed into the call
     expect(onChange.mock.calls[0][1]).toEqual([0, 2]);

--- a/packages/react/src/components/Slider/Slider.types.ts
+++ b/packages/react/src/components/Slider/Slider.types.ts
@@ -92,12 +92,16 @@ export interface ISliderProps
    * Callback when the value has been changed.
    * If `ranged` is true, `value` is the upper value, and `range` contains the lower and upper bounds of the range.
    */
-  onChange?: (value: number, range?: [number, number]) => void;
+  onChange?: (
+    value: number,
+    range?: [number, number],
+    ev?: React.FormEvent<HTMLElement> | MouseEvent | TouchEvent,
+  ) => void;
 
   /**
    * Callback on mouse up or touch end
    */
-  onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
+  onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number, range?: [number, number]) => void;
 
   /**
    * A description of the Slider for the benefit of screen readers.
@@ -140,7 +144,8 @@ export interface ISliderProps
   className?: string;
 
   /**
-   * Additional props on the thumb button within the slider.
+   * Additional props for the actual `role="slider"` (slider box) element.
+   * (Note that this element is not actually a button in the current implementation.)
    */
   buttonProps?: React.HTMLAttributes<HTMLButtonElement>;
 

--- a/packages/react/src/components/Slider/Slider.types.ts
+++ b/packages/react/src/components/Slider/Slider.types.ts
@@ -89,19 +89,24 @@ export interface ISliderProps
   showValue?: boolean;
 
   /**
-   * Callback when the value has been changed.
+   * Callback when the value has been changed. This will be called on every individual step;
+   * to only be notified after changes have stopped, use `onChanged` instead.
    * If `ranged` is true, `value` is the upper value, and `range` contains the lower and upper bounds of the range.
    */
   onChange?: (
     value: number,
     range?: [number, number],
-    ev?: React.FormEvent<HTMLElement> | MouseEvent | TouchEvent,
+    event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent,
   ) => void;
 
   /**
-   * Callback on mouse up or touch end
+   * Callback on mouse up, touch end, or after key presses have stopped.
+   * To be notified on every individual step, use `onChange` instead.
+   * @param event - Type is `React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent`
+   * (may be corrected in a future major version)
    */
-  onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number, range?: [number, number]) => void;
+  // TODO: fix event type if we release another major version
+  onChanged?: (event: any, value: number, range?: [number, number]) => void;
 
   /**
    * A description of the Slider for the benefit of screen readers.

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider.types';
-import { useId, useControllableValue, useConst, useAsync } from '@fluentui/react-hooks';
+import { useId, useControllableValue, useConst, useSetTimeout } from '@fluentui/react-hooks';
 import {
   KeyCodes,
   css,
@@ -100,7 +100,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
   } = props;
 
   const disposables = React.useRef<(() => void)[]>([]);
-  const async = useAsync();
+  const { setTimeout, clearTimeout } = useSetTimeout();
   const sliderLine = React.useRef<HTMLDivElement>(null);
 
   // Casting here is necessary because useControllableValue expects the event for the change callback
@@ -144,14 +144,14 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
   const steps = (max - min) / step;
 
   const clearOnKeyDownTimer = (): void => {
-    async.clearTimeout(internalState.onKeyDownTimer);
+    clearTimeout(internalState.onKeyDownTimer);
     internalState.onKeyDownTimer = -1;
   };
 
   const setOnKeyDownTimer = (event: React.KeyboardEvent) => {
     clearOnKeyDownTimer();
     if (onChanged) {
-      internalState.onKeyDownTimer = async.setTimeout(() => {
+      internalState.onKeyDownTimer = setTimeout(() => {
         onChanged(
           event,
           internalState.latestValue,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18203 (more completely), fixes #18364
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#18304 fixed an issue where `onChanged` was using a stale captured value. This PR is a follow-up with a more thorough fix to prevent use of stale captured values, along with some other issues I noticed comparing the function component version of Slider to the v7 version:
- Switch to `internalState` pattern for accessing the latest value (avoiding stale captures) and storing other information that needs to be accessible and up to date in various callbacks, but shouldn't cause re-renders
- Restore logic for whether to show step-snapping animations while dragging the slider (`showTransitions`). This was very convoluted in v7 and understandably got lost in the function component conversion. I'm pretty sure I've restored the behavior to the original intent, with better naming and comments.
- Remove unnecessary casts and non-null assertions
- If `id` is provided in props, it should be used instead of an auto-generated ID

I also fixed some issues with the change callbacks:
- Add `event` parameter to `onChange`
- Add `range` parameter to `onChanged`
- `onChanged` had an incorrect type for `event`: `MouseEvent | TouchEvent | KeyboardEvent`. Looking at the actual code (which also required a bunch of fixes for incorrect event type assumptions), the correct type is `React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent`. Unfortunately I'm pretty sure changing to the proper type would be a breaking change for consumers with `strictFunctionTypes` enabled, so instead I changed the type to `any` for now and added a comment documenting the possible types. (Open to suggestions for other approaches here.)
- Add more thorough tests for `onChanged`