### PR TITLE
fix(Menu): Add accessible high contrast border

### DIFF
--- a/change/@fluentui-react-menu-0f426f3d-d647-41df-ad13-d92c74a8e62d.json
+++ b/change/@fluentui-react-menu-0f426f3d-d647-41df-ad13-d92c74a8e62d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Add high contrast border",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-66a8721e-d9da-4353-84ae-57a863330966.json
+++ b/change/@fluentui-react-menu-66a8721e-d9da-4353-84ae-57a863330966.json
@@ -1,6 +1,0 @@
-{
-  "type": "prerelease",
-  "packageName": "@fluentui/react-menu",
-  "email": "lingfan.gao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-menu-66a8721e-d9da-4353-84ae-57a863330966.json
+++ b/change/@fluentui-react-menu-66a8721e-d9da-4353-84ae-57a863330966.json
@@ -1,0 +1,6 @@
+{
+  "type": "prerelease",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/Menu/useMenuStyles.ts
+++ b/packages/react-menu/src/components/Menu/useMenuStyles.ts
@@ -11,6 +11,7 @@ const useStyles = makeStyles({
     boxShadow: `${theme.alias.shadow.shadow16}`,
     paddingTop: '4px',
     paddingBottom: '4px',
+    border: `1px solid ${theme.alias.color.neutral.strokeAccessible}`,
   }),
 });
 


### PR DESCRIPTION
⚠Unfortunately the expansion of border css property to atomic classes actually does take 1KB

Adds an accessible border around the menu in HC mode so the menu does
not blend in with the surroundings

Before:
![image](https://user-images.githubusercontent.com/20744592/119643299-de6cd180-be1b-11eb-8e01-7a450b267743.png)


After:
![image](https://user-images.githubusercontent.com/20744592/119642947-87ff9300-be1b-11eb-80e4-d3b799102c45.png)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
