### PR TITLE
chore: enable Jest aliases for converged packages

### DIFF
--- a/change/@fluentui-babel-make-styles-732fb655-4bc9-410c-9295-65b4a63e69ab.json
+++ b/change/@fluentui-babel-make-styles-732fb655-4bc9-410c-9295-65b4a63e69ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-make-styles-474f1530-3940-4d7a-8756-158b7ab203dc.json
+++ b/change/@fluentui-jest-serializer-make-styles-474f1530-3940-4d7a-8756-158b7ab203dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-9e9dea14-b87d-45bf-980f-f1d2a7092234.json
+++ b/change/@fluentui-make-styles-9e9dea14-b87d-45bf-980f-f1d2a7092234.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-b3ef0111-9fd2-44c1-bf92-7f4052cf8d6f.json
+++ b/change/@fluentui-react-accordion-b3ef0111-9fd2-44c1-bf92-7f4052cf8d6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-21a1e5e3-c7ae-4ef4-a8ac-27394a627a13.json
+++ b/change/@fluentui-react-avatar-21a1e5e3-c7ae-4ef4-a8ac-27394a627a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-917804f6-1a2e-4eb5-b509-7f825e71acb7.json
+++ b/change/@fluentui-react-badge-917804f6-1a2e-4eb5-b509-7f825e71acb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-0a37b226-15a3-42d2-bb40-a58709703b18.json
+++ b/change/@fluentui-react-button-0a37b226-15a3-42d2-bb40-a58709703b18.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-2a4747d8-4c81-4ff7-bc66-99b53a44e661.json
+++ b/change/@fluentui-react-context-selector-2a4747d8-4c81-4ff7-bc66-99b53a44e661.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-b24f7bb1-6bb1-42af-8287-51ae7f4d0e29.json
+++ b/change/@fluentui-react-divider-b24f7bb1-6bb1-42af-8287-51ae7f4d0e29.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-divider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-efd46a3f-9f60-42e9-a96a-54b6b5a15be1.json
+++ b/change/@fluentui-react-image-efd46a3f-9f60-42e9-a96a-54b6b5a15be1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-edf521cb-4a34-40ba-a6eb-333d6aa96433.json
+++ b/change/@fluentui-react-label-edf521cb-4a34-40ba-a6eb-333d6aa96433.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-label",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-8b64eaaf-4030-4e7e-a9c2-0dd880dc4097.json
+++ b/change/@fluentui-react-link-8b64eaaf-4030-4e7e-a9c2-0dd880dc4097.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-038a0470-a3ad-413e-be38-9191d658b2cd.json
+++ b/change/@fluentui-react-make-styles-038a0470-a3ad-413e-be38-9191d658b2cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-64adf087-2e04-4cef-a979-16f4e98b37fe.json
+++ b/change/@fluentui-react-portal-64adf087-2e04-4cef-a979-16f4e98b37fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-1cfcc582-b1fa-4365-922a-d07915db4694.json
+++ b/change/@fluentui-react-positioning-1cfcc582-b1fa-4365-922a-d07915db4694.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-249f65e1-c9bb-426d-a4df-6baf660c7e85.json
+++ b/change/@fluentui-react-provider-249f65e1-c9bb-426d-a4df-6baf660c7e85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-c5d21ef7-3274-401f-814c-e6a9abd0af44.json
+++ b/change/@fluentui-react-shared-contexts-c5d21ef7-3274-401f-814c-e6a9abd0af44.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-dd24e5a8-7021-463a-8f83-b9607ee3375f.json
+++ b/change/@fluentui-react-tabster-dd24e5a8-7021-463a-8f83-b9607ee3375f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-tabster",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-1dd6baf4-6c07-4884-8379-0110ddb97ebc.json
+++ b/change/@fluentui-react-text-1dd6baf4-6c07-4884-8379-0110ddb97ebc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-text",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-098c69d5-c7b5-4939-986d-80eda37fea94.json
+++ b/change/@fluentui-react-theme-098c69d5-c7b5-4939-986d-80eda37fea94.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-theme",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-provider-19a8e085-8537-4960-8545-fca986fe5353.json
+++ b/change/@fluentui-react-theme-provider-19a8e085-8537-4960-8545-fca986fe5353.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-880acfbb-5bed-49dc-98cc-cecbc279543f.json
+++ b/change/@fluentui-react-tooltip-880acfbb-5bed-49dc-98cc-cecbc279543f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-f3259bbc-2401-4190-a173-c95d92b47194.json
+++ b/change/@fluentui-react-utilities-f3259bbc-2401-4190-a173-c95d92b47194.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable Jest aliases",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-make-styles/jest.config.js
+++ b/packages/babel-make-styles/jest.config.js
@@ -1,5 +1,7 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({});
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/jest-serializer-make-styles/jest.config.js
+++ b/packages/jest-serializer-make-styles/jest.config.js
@@ -1,3 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-module.exports = createConfig({});
+module.exports = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});

--- a/packages/make-styles/jest.config.js
+++ b/packages/make-styles/jest.config.js
@@ -1,5 +1,7 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig();
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/react-accordion/jest.config.js
+++ b/packages/react-accordion/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-avatar/jest.config.js
+++ b/packages/react-avatar/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-badge/jest.config.js
+++ b/packages/react-badge/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-button/jest.config.js
+++ b/packages/react-button/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-context-selector/jest.config.js
+++ b/packages/react-context-selector/jest.config.js
@@ -1,7 +1,8 @@
-const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });
 

--- a/packages/react-divider/jest.config.js
+++ b/packages/react-divider/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-image/jest.config.js
+++ b/packages/react-image/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-label/jest.config.js
+++ b/packages/react-label/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-link/jest.config.js
+++ b/packages/react-link/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-make-styles/jest.config.js
+++ b/packages/react-make-styles/jest.config.js
@@ -1,5 +1,7 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig();
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/react-popover/jest.config.js
+++ b/packages/react-popover/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-portal/jest.config.js
+++ b/packages/react-portal/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-positioning/jest.config.js
+++ b/packages/react-positioning/jest.config.js
@@ -1,5 +1,7 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({});
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/react-provider/jest.config.js
+++ b/packages/react-provider/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-shared-contexts/jest.config.js
+++ b/packages/react-shared-contexts/jest.config.js
@@ -1,5 +1,6 @@
 let path = require('path');
 let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });

--- a/packages/react-tabster/jest.config.js
+++ b/packages/react-tabster/jest.config.js
@@ -1,5 +1,7 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({});
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/react-text/jest.config.js
+++ b/packages/react-text/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-theme-provider/jest.config.js
+++ b/packages/react-theme-provider/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-theme/jest.config.js
+++ b/packages/react-theme/jest.config.js
@@ -1,5 +1,7 @@
 let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig();
+const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
+});
 
 module.exports = config;

--- a/packages/react-tooltip/jest.config.js
+++ b/packages/react-tooltip/jest.config.js
@@ -2,6 +2,7 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-utilities/jest.config.js
+++ b/packages/react-utilities/jest.config.js
@@ -2,6 +2,7 @@ let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 let path = require('path');
 
 const config = createConfig({
+  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds Jest aliases to avoid "build first" requirement for converged packages. It's done via `lerna-alias` as it's the simplest solution (and one-liner) and _we have Lerna configured in this repo_.

This solution is a short-term workaround to solve long standing DX problem.

##### Before

```sh
$ yarn workspace @fluentui/make-styles clean
$ yarn workspace @fluentui/react-make-styles clean
$ yarn workspace @fluentui/react-make-styles test
```

🚨 Tests require "build all first":

```
  ● Test suite failed to run

    Configuration error:

    Could not locate module @fluentui/make-styles mapped as:
    @fluentui/make-styles/lib-commonjs/index.

    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^@fluentui\/make-styles$/": "@fluentui/make-styles/lib-commonjs/index"
      },
      "resolver": null
    }

```

##### After

```sh
$ yarn workspace @fluentui/make-styles clean
$ yarn workspace @fluentui/react-make-styles clean
$ yarn workspace @fluentui/react-make-styles test
```

✅ Tests are passing.

```
 PASS  src/makeStyles.test.tsx
 PASS  src/createDOMRenderer.test.tsx
 PASS  src/renderToStyleElements-node.test.tsx
[1:21:20 PM] ■ finished 'jest' in 5.38s
```