### PR TITLE
fix(Detailslist): removes duplicate description from header checkbox and aria-label from generic

### DIFF
--- a/change/@fluentui-react-d1ed5b45-1541-46ec-865f-963b0fe4fe88.json
+++ b/change/@fluentui-react-d1ed5b45-1541-46ec-865f-963b0fe4fe88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix name and description on DetailsHeader checkbox",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-d6acacea-3d96-4e7c-8235-b6527ae02a2b.json
+++ b/change/@fluentui-react-examples-d6acacea-3d96-4e7c-8235-b6527ae02a2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "snapshot changes for react DetailsHeader updates",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -293,7 +293,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header4-check"
+              aria-labelledby="header4-checkTooltip"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -342,7 +342,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header4-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -89,7 +89,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -138,7 +138,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -776,7 +776,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header11-check"
+              aria-labelledby="header11-checkTooltip"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -825,7 +825,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header11-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -89,7 +89,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -138,7 +138,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -317,7 +317,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header4-check"
+                aria-labelledby="header4-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -366,7 +366,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -301,7 +301,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header4-check"
+                aria-labelledby="header4-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -350,7 +350,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -295,7 +295,7 @@ Array [
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header2-check"
+              aria-labelledby="header2-checkTooltip"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -344,7 +344,6 @@ Array [
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header2-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -489,7 +489,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           >
             <div
               aria-colindex={1}
-              aria-labelledby="header6-check"
+              aria-labelledby="header6-checkTooltip"
               className=
                   ms-DetailsHeader-cell
                   ms-DetailsHeader-cellIsCheck
@@ -538,7 +538,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header6-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -89,7 +89,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -138,7 +138,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -227,7 +227,7 @@ export class DetailsHeaderBase
               <div
                 key="__checkbox"
                 className={classNames.cellIsCheck}
-                aria-labelledby={`${this._id}-check`}
+                aria-labelledby={`${this._id}-checkTooltip`}
                 onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
                 aria-colindex={1}
                 role={'columnheader'}
@@ -245,15 +245,6 @@ export class DetailsHeaderBase
                           selectionMode === SelectionMode.multiple
                             ? ariaLabelForSelectAllCheckbox
                             : ariaLabelForSelectionColumn
-                        }
-                        aria-describedby={
-                          !isCheckboxHidden
-                            ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip
-                              ? `${this._id}-checkTooltip`
-                              : undefined
-                            : ariaLabelForSelectionColumn && !this.props.onRenderColumnHeaderTooltip
-                            ? `${this._id}-checkTooltip`
-                            : undefined
                         }
                         data-is-focusable={!isCheckboxHidden || undefined}
                         isHeader={true}

--- a/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -318,15 +318,15 @@ describe('DetailsHeader', () => {
         selectionMode={SelectionMode.multiple}
         layoutMode={DetailsListLayoutMode.fixedColumns}
         columns={columns}
+        ariaLabelForSelectAllCheckbox={'Toggle selection for all items'}
       />,
     );
 
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  // if ariaLabelForSelectAllCheckbox is not provided, the select all checkbox label should not
-  // be rendered and therefore aria-describedby should not exist on the select all checkbox
-  it('does not accessible label for select all checkbox or aria-describedby', () => {
+  // if ariaLabelForSelectAllCheckbox is not provided, the select all checkbox label should not be rendered
+  it('does not render label for select all column header without string', () => {
     const component = mount(
       <DetailsHeader
         selection={_selection}
@@ -341,16 +341,12 @@ describe('DetailsHeader', () => {
       .getDOMNode()
       .getAttribute('aria-labelledby');
 
-    expect(
-      component.find(`#${selectAllCheckBoxAriaLabelledBy}`).first().getDOMNode().hasAttribute('aria-describedby'),
-    ).toBe(false);
-
-    expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(0);
+    expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}`).length).toEqual(0);
   });
 
   // if ariaLabelForSelectAllCheckbox is passed in and onRenderColumnHeaderTooltip is not,
-  // the select all checkbox label should be rendered and aria-describedby on select all
-  // checkbox should exist with a valid id
+  // the checkbox should use it as an aria-label, and the columnheader
+  // should have aria-labelledby pointing to a valid id
   it('renders accessible label for select all checkbox and valid aria-describedby', () => {
     const component = mount(
       <DetailsHeader
@@ -362,16 +358,16 @@ describe('DetailsHeader', () => {
       />,
     );
 
-    const selectAllCheckBoxAriaLabelledBy = component
+    const selectAllColumnAriaLabelledBy = component
       .find('[aria-colindex=1]')
       .getDOMNode()
       .getAttribute('aria-labelledby');
 
-    expect(
-      component.find(`#${selectAllCheckBoxAriaLabelledBy}`).first().getDOMNode().getAttribute('aria-describedby')!,
-    ).toEqual(`${selectAllCheckBoxAriaLabelledBy}Tooltip`);
+    expect(component.find(`#${selectAllColumnAriaLabelledBy}`).length).toEqual(1);
 
-    expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(1);
+    const selectAllCheckboxLabel = component.find('[role="checkbox"]').getDOMNode().getAttribute('aria-label');
+
+    expect(selectAllCheckboxLabel).toEqual('Toggle selection for all items');
   });
 
   it('should mark the columns as draggable', () => {

--- a/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -5,7 +5,7 @@ import {
   IDetailsRowCheckStyleProps,
   IDetailsRowCheckStyles,
 } from './DetailsRowCheck.types';
-import { css, styled, classNamesFunction, composeRenderFunction } from '../../Utilities';
+import { css, styled, classNamesFunction, composeRenderFunction, getNativeElementProps } from '../../Utilities';
 import { Check } from '../../Check';
 import { getStyles } from './DetailsRowCheck.styles';
 import { ITheme } from '../../Styling';
@@ -50,6 +50,8 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     theme,
   };
 
+  const divProps = getNativeElementProps('div', buttonProps, ['aria-label', 'aria-labelledby', 'aria-describedby']);
+
   return canSelect ? (
     <div
       {...buttonProps}
@@ -65,7 +67,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     </div>
   ) : (
     // eslint-disable-next-line deprecation/deprecation
-    <div {...buttonProps} className={css(classNames.root, classNames.check)} />
+    <div {...divProps} className={css(classNames.root, classNames.check)} />
   );
 };
 

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`DetailsHeader can render 1`] = `
 >
   <div
     aria-colindex={1}
-    aria-labelledby="header0-check"
+    aria-labelledby="header0-checkTooltip"
     className=
         ms-DetailsHeader-cell
         ms-DetailsHeader-cellIsCheck
@@ -964,7 +964,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
 >
   <div
     aria-colindex={1}
-    aria-labelledby="header2-check"
+    aria-labelledby="header2-checkTooltip"
     className=
         ms-DetailsHeader-cell
         ms-DetailsHeader-cellIsCheck
@@ -1752,7 +1752,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
 >
   <div
     aria-colindex={1}
-    aria-labelledby="header6-check"
+    aria-labelledby="header6-checkTooltip"
     className=
         ms-DetailsHeader-cell
         ms-DetailsHeader-cellIsCheck
@@ -1801,6 +1801,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <div
         aria-checked={false}
+        aria-label="Toggle selection for all items"
         className=
             ms-DetailsRow-check
             ms-DetailsHeader-check
@@ -1989,6 +1990,29 @@ exports[`DetailsHeader renders accessible labels 1`] = `
       </div>
     </span>
   </div>
+  <label
+    aria-hidden={true}
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          width: 1px;
+        }
+    id="header6-checkTooltip"
+  >
+    Toggle selection for all items
+  </label>
   <div
     aria-colindex={2}
     aria-labelledby="header6-a-name"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -1936,7 +1936,7 @@ exports[`DetailsList renders List correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header9-check"
+            aria-labelledby="header9-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -2921,7 +2921,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -4122,7 +4122,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header33-check"
+            aria-labelledby="header33-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -5108,7 +5108,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header13-check"
+            aria-labelledby="header13-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -6093,7 +6093,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header5-check"
+            aria-labelledby="header5-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -925,7 +925,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header13-check"
+            aria-labelledby="header13-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -2277,7 +2277,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header5-check"
+            aria-labelledby="header5-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -3114,7 +3114,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header9-check"
+            aria-labelledby="header9-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck

--- a/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         >
           <div
             aria-colindex={1}
-            aria-labelledby="header1-check"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18363
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR has two changes:
1. When the DetailsList selectionMode is single, the checkbox is rendered as a generic `<div>`, which doesn't support a name. I removed the name/description props on `DetailsRowCheck` in that case, and point the columnheader's `aria-labelledby` to the label element instead of the checkbox to compensate (which is likely better anyway).
2. The checkbox had a name & description that were guaranteed to be duplicates, so I removed the `aria-describedby` attribute.
