### PR TITLE
Improving types of Playground used in react-button stories

### DIFF
--- a/change/@fluentui-react-examples-66580e39-4e09-4a52-ac6b-728258f8baac.json
+++ b/change/@fluentui-react-examples-66580e39-4e09-4a52-ac6b-728258f8baac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Improving types of Playground used in react-button stories.",
+  "packageName": "@fluentui/react-examples",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-button/Button/Button.stories.tsx
+++ b/packages/react-examples/src/react-button/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonProps } from '@fluentui/react-button';
-import { Playground, PlaygroundProps, PropDefinition } from '../Playground';
+import { Playground } from '../Playground';
+import { PlaygroundProps, PropDefinition } from '../Playground.types';
 
 // TODO: this is here while waiting for react-icons to merge
 const SVGIcon = () => (
@@ -100,7 +101,7 @@ export const Disabled = () => (
   </>
 );
 
-export const buttonBaseProps: PropDefinition[] = [
+export const buttonBaseProps: PropDefinition<ButtonProps>[] = [
   { propName: 'content', propType: 'string', defaultValue: 'This is a button', dependsOnProps: ['~iconOnly'] },
   { propName: 'disabled', propType: 'boolean' },
   { propName: 'icon', propType: 'boolean' },
@@ -117,7 +118,9 @@ export const buttonBaseProps: PropDefinition[] = [
   { propName: 'transparent', propType: 'boolean', dependsOnProps: ['~primary', '~subtle'] },
 ];
 
-const buttonProps: PlaygroundProps['sections'] = [{ sectionName: 'Button props', propList: buttonBaseProps }];
+const buttonProps: PlaygroundProps<ButtonProps>['sections'] = [
+  { sectionName: 'Button props', propList: buttonBaseProps },
+];
 
 export const ButtonPlayground = () => (
   <Playground sections={buttonProps}>

--- a/packages/react-examples/src/react-button/CompoundButton/CompoundButton.stories.tsx
+++ b/packages/react-examples/src/react-button/CompoundButton/CompoundButton.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { buttonBaseProps } from '../Button/Button.stories';
-import { Playground, PlaygroundProps, PropDefinition } from '../Playground';
+import { Playground } from '../Playground';
+import { PlaygroundProps, PropDefinition } from '../Playground.types';
 
-import { CompoundButton } from '@fluentui/react-button';
+import { CompoundButton, CompoundButtonProps } from '@fluentui/react-button';
 
-const compoundButtonBaseProps: PropDefinition[] = [
+const compoundButtonBaseProps: PropDefinition<CompoundButtonProps>[] = [
   {
     propName: 'secondaryContent',
     propType: 'string',
@@ -13,7 +14,7 @@ const compoundButtonBaseProps: PropDefinition[] = [
   },
 ];
 
-const compoundButtonProps: PlaygroundProps['sections'] = [
+const compoundButtonProps: PlaygroundProps<CompoundButtonProps>['sections'] = [
   { sectionName: 'Button props', propList: buttonBaseProps },
   { sectionName: 'CompoundButton props', propList: compoundButtonBaseProps },
 ];

--- a/packages/react-examples/src/react-button/Playground.tsx
+++ b/packages/react-examples/src/react-button/Playground.tsx
@@ -1,24 +1,7 @@
 import * as React from 'react';
 import { Checkbox, Dropdown, IDropdownOption, Stack, TextField } from '@fluentui/react';
 import { Text } from '@fluentui/react-text';
-
-/* eslint-disable @typescript-eslint/naming-convention */
-
-export interface PropDefinition {
-  propName: string;
-  propType: 'boolean' | 'string' | string[];
-  defaultValue?: boolean | string;
-  setDefaultValue?: (value: boolean) => void;
-  dependsOnProps?: string[];
-}
-
-export interface PlaygroundProps {
-  children: JSX.Element;
-  sections: Array<{
-    sectionName: string;
-    propList: PropDefinition[];
-  }>;
-}
+import { PlaygroundProps } from './Playground.types';
 
 const tableStyle: React.CSSProperties = {
   border: '1px solid black',
@@ -28,7 +11,7 @@ const cellStyle: React.CSSProperties = {
   padding: '5px',
 };
 
-export const Playground = (props: PlaygroundProps): JSX.Element => {
+export const Playground = function <TType>(props: PlaygroundProps<TType>): JSX.Element {
   const { children, sections } = props;
 
   const [componentProps, setComponentProps] = React.useState<{ [key in string]: boolean | string } | null>(null);
@@ -41,11 +24,12 @@ export const Playground = (props: PlaygroundProps): JSX.Element => {
   for (const section of sections) {
     const sectionList: JSX.Element[] = [];
     for (const prop of section.propList) {
+      const propName = prop.propName as string;
       const propType = prop.propType;
       let isPropEnabled = true;
 
       if (componentProps && prop.dependsOnProps) {
-        for (const dependentProp of prop.dependsOnProps) {
+        for (const dependentProp of prop.dependsOnProps as string[]) {
           isPropEnabled =
             isPropEnabled &&
             (dependentProp[0] === '~' ? !componentProps[dependentProp.substr(1)] : !!componentProps[dependentProp]);
@@ -53,38 +37,38 @@ export const Playground = (props: PlaygroundProps): JSX.Element => {
       }
 
       if (propType === 'boolean') {
-        newProps[prop.propName + 'Default'] = prop.defaultValue || false;
+        newProps[propName + 'Default'] = prop.defaultValue || false;
         const propDefaultValueChanged =
           componentProps &&
           prop.defaultValue !== undefined &&
-          prop.defaultValue !== componentProps[prop.propName + 'Default'];
+          prop.defaultValue !== componentProps[propName + 'Default'];
         const propEnabledValueChanged =
-          componentProps && componentProps[prop.propName] !== (componentProps[prop.propName] && isPropEnabled);
-        newProps[prop.propName] =
-          componentProps && componentProps[prop.propName] !== 'undefined' && !propDefaultValueChanged
-            ? componentProps[prop.propName] && isPropEnabled
-            : newProps[prop.propName + 'Default'];
+          componentProps && componentProps[propName] !== (componentProps[propName] && isPropEnabled);
+        newProps[propName] =
+          componentProps && componentProps[propName] !== 'undefined' && !propDefaultValueChanged
+            ? componentProps[propName] && isPropEnabled
+            : newProps[propName + 'Default'];
 
         if (propDefaultValueChanged || propEnabledValueChanged) {
-          prop.setDefaultValue?.(newProps[prop.propName] as boolean);
+          prop.setDefaultValue?.(newProps[propName] as boolean);
           booleanValueChanged = true;
         }
 
         const onBooleanPropChange = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
           const newComponentProps: { [key in string]: boolean | string } = { ...componentProps };
-          newComponentProps[prop.propName] = checked || false;
+          newComponentProps[propName] = checked || false;
           setComponentProps(newComponentProps);
           prop.setDefaultValue?.(checked || false);
         };
 
         sectionList.push(
-          <tr key={section.sectionName + '_' + prop.propName}>
-            <td style={cellStyle}>{prop.propName}:</td>
+          <tr key={section.sectionName + '_' + propName}>
+            <td style={cellStyle}>{propName}:</td>
             <td style={cellStyle}>
               <Checkbox
                 checked={
-                  componentProps && componentProps[prop.propName] !== undefined && !propDefaultValueChanged
-                    ? (componentProps[prop.propName] as boolean)
+                  componentProps && componentProps[propName] !== undefined && !propDefaultValueChanged
+                    ? (componentProps[propName] as boolean)
                     : (prop.defaultValue as boolean)
                 }
                 disabled={!isPropEnabled}
@@ -95,25 +79,25 @@ export const Playground = (props: PlaygroundProps): JSX.Element => {
           </tr>,
         );
       } else if (propType === 'string') {
-        newProps[prop.propName] = prop.defaultValue || '';
+        newProps[propName] = prop.defaultValue || '';
 
         const onStringPropChange = (
           ev?: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
           newValue?: string,
         ) => {
           const newComponentProps: { [key in string]: boolean | string } = { ...componentProps };
-          newComponentProps[prop.propName] = newValue || '';
+          newComponentProps[propName] = newValue || '';
           setComponentProps(newComponentProps);
         };
 
         sectionList.push(
-          <tr key={section.sectionName + '_' + prop.propName}>
-            <td style={cellStyle}>{prop.propName}:</td>
+          <tr key={section.sectionName + '_' + propName}>
+            <td style={cellStyle}>{propName}:</td>
             <td style={cellStyle}>
               <TextField
                 value={
-                  componentProps && componentProps[prop.propName]
-                    ? (componentProps[prop.propName] as string)
+                  componentProps && componentProps[propName]
+                    ? (componentProps[propName] as string)
                     : (prop.defaultValue as string)
                 }
                 disabled={!isPropEnabled}
@@ -125,7 +109,7 @@ export const Playground = (props: PlaygroundProps): JSX.Element => {
         );
       } else {
         const defaultSelectedKey = prop.defaultValue || propType[0];
-        newProps[prop.propName] = prop.defaultValue || propType[0];
+        newProps[propName] = prop.defaultValue || propType[0];
 
         const onOptionsPropChange = (
           ev?: React.FormEvent<HTMLDivElement>,
@@ -134,20 +118,20 @@ export const Playground = (props: PlaygroundProps): JSX.Element => {
         ) => {
           const newComponentProps: { [key in string]: boolean | string } = { ...componentProps };
           if (option) {
-            newComponentProps[prop.propName] = (option.key as string) || '';
+            newComponentProps[propName] = (option.key as string) || '';
             setComponentProps(newComponentProps);
           }
         };
 
         sectionList.push(
-          <tr key={section.sectionName + '_' + prop.propName}>
-            <td style={cellStyle}>{prop.propName}:</td>
+          <tr key={section.sectionName + '_' + propName}>
+            <td style={cellStyle}>{propName}:</td>
             <td style={cellStyle}>
               <Dropdown
                 disabled={!isPropEnabled}
                 selectedKey={
-                  componentProps && componentProps[prop.propName]
-                    ? (componentProps[prop.propName] as string)
+                  componentProps && componentProps[propName]
+                    ? (componentProps[propName] as string)
                     : (defaultSelectedKey as string)
                 }
                 options={propType.map(value => ({ key: value, text: value }))}

--- a/packages/react-examples/src/react-button/Playground.types.ts
+++ b/packages/react-examples/src/react-button/Playground.types.ts
@@ -23,7 +23,7 @@ export interface PropDefinition<TType> {
    * An array of prop names that this prop requires to be truthy or falsy (prop name preceded by '~') in order to enable
    * this prop.
    */
-  dependsOnProps?: (keyof TType | `~${StringKeyOf<TType>}`)[];
+  dependsOnProps?: (keyof TType | `~${StringKeyOf<TType>}` | 'content' | '~content')[];
 }
 
 /** Props received by the Playground component. */

--- a/packages/react-examples/src/react-button/Playground.types.ts
+++ b/packages/react-examples/src/react-button/Playground.types.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+/** Type to get only the string keys of T. */
+type StringKeyOf<T> = { [K in keyof T]: K extends string ? K : never }[keyof T];
+
+/** Definition for a prop that is to be controlled by the Playground.  */
+export interface PropDefinition<TType> {
+  /** Name of the prop. */
+  propName: keyof TType | 'content';
+
+  /** Type of the prop, it can be boolean, string or an array of defined string values. */
+  propType: 'boolean' | 'string' | string[];
+
+  /** Default value for the prop. */
+  defaultValue?: boolean | string;
+
+  /** Callback to set the default value of the prop if it is boolean and controlled behavior is wanted. */
+  setDefaultValue?: (value: boolean) => void;
+
+  /**
+   * An array of prop names that this prop requires to be truthy or falsy (prop name preceded by '~') in order to enable
+   * this prop.
+   */
+  dependsOnProps?: (keyof TType | `~${StringKeyOf<TType>}`)[];
+}
+
+/** Props received by the Playground component. */
+export interface PlaygroundProps<TType> {
+  /** Single children to clone with the playground props. */
+  children: React.ReactElement;
+
+  /** Sections of props for the playground, where each section has a name and an array of prop definitions. */
+  sections: Array<{
+    sectionName: string;
+    propList: PropDefinition<TType>[];
+  }>;
+}

--- a/packages/react-examples/src/react-button/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/react-examples/src/react-button/ToggleButton/ToggleButton.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { useBoolean } from '@fluentui/react-utilities';
 import { buttonBaseProps } from '../Button/Button.stories';
-import { Playground, PlaygroundProps, PropDefinition } from '../Playground';
+import { Playground } from '../Playground';
+import { PlaygroundProps, PropDefinition } from '../Playground.types';
 
-import { ToggleButton } from '@fluentui/react-button';
+import { ToggleButton, ToggleButtonProps } from '@fluentui/react-button';
 
 export const ToggleButtonPlayground = () => {
   const [checked, { setTrue: setTrueChecked, setFalse: setFalseChecked, toggle: toggleChecked }] = useBoolean(false);
@@ -16,7 +17,7 @@ export const ToggleButtonPlayground = () => {
     [setTrueChecked, setFalseChecked],
   );
 
-  const toggleButtonBaseProps: PropDefinition[] = React.useMemo(
+  const toggleButtonBaseProps: PropDefinition<ToggleButtonProps>[] = React.useMemo(
     () => [
       {
         propName: 'checked',
@@ -29,7 +30,7 @@ export const ToggleButtonPlayground = () => {
     [checked, setChecked],
   );
 
-  const toggleButtonProps: PlaygroundProps['sections'] = [
+  const toggleButtonProps: PlaygroundProps<ToggleButtonProps>['sections'] = [
     { sectionName: 'Button props', propList: buttonBaseProps },
     { sectionName: 'ToggleButton props', propList: toggleButtonBaseProps },
   ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Improving the types of the `Playground` component used in `react-button` stories to restrict the props that can be passed to only the ones present in the type of the component (for example `ButtonProps`.

Before, the following code would not trigger an error:

```tsx
interface ExampleProps {
  prop1: string;
  prop2: string;
  prop3: string;
}

const examplePropsDefinition: PropDefinition<ExampleProps>[] = [
  { propName: 'prop1', propType: 'string' },
  { propName: 'abcde', propType: 'string' },
  { propName: 'prop2', propType: 'string', dependsOnProps: ['abcde'] },
  { propName: 'prop3', propType: 'string', dependsOnProps: ['~prop1'] },
]
```

The same code will now trigger a couple of errors.

On this line `{ propName: 'abcde', propType: 'string' }`, there will be the following error:

![image](https://user-images.githubusercontent.com/7798177/119890890-36273d80-beed-11eb-949e-1f1e0825936c.png)

On this line `{ propName: 'prop2', propType: 'string', dependsOnProps: ['abcde'] }`, there will be the following error:

![image](https://user-images.githubusercontent.com/7798177/119891114-7c7c9c80-beed-11eb-802b-476f0e90d6a5.png)
