### PR TITLE
feat(tools): implement jest updates for migration generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vrtest": "cd apps && cd vr-tests && yarn screener"
   },
   "devDependencies": {
+    "@angular-devkit/schematics": "12.0.2",
     "@babel/core": "7.12.16",
     "@ctrl/tinycolor": "3.3.4",
     "@microsoft/api-extractor": "7.13.0",
@@ -152,10 +153,10 @@
     "tslib": "2.2.0",
     "typescript": "4.1.5",
     "webpack": "5.21.2",
-    "webpack-cli": "4.3.1",
-    "webpack-dev-server": "4.0.0-beta.0",
     "webpack-bundle-analyzer": "4.4.2",
+    "webpack-cli": "4.3.1",
     "webpack-dev-middleware": "4.2.0",
+    "webpack-dev-server": "4.0.0-beta.0",
     "webpack-hot-middleware": "2.25.0",
     "yargs": "13.3.2"
   },

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -6,7 +6,11 @@ import {
   stripIndents,
   addProjectConfiguration,
   readWorkspaceConfiguration,
+  updateJson,
 } from '@nrwl/devkit';
+import { serializeJson, stringUtils } from '@nrwl/workspace';
+
+import { TsConfig } from '../../types';
 
 import generator from './index';
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
@@ -17,145 +21,296 @@ describe('migrate-converged-pkg generator', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'jest.config.js',
+      stripIndents`
+      module.exports = {
+          projects: []
+      }`,
+    );
     tree = setupDummyPackage(tree, options);
   });
 
-  it('should update local tsconfig.json', async () => {
-    const projectConfig = readProjectConfiguration(tree, options.name);
-    function getTsConfig() {
-      return readJson(tree, `${projectConfig.root}/tsconfig.json`);
-    }
-    let tsConfig = getTsConfig();
+  describe('general', () => {
+    it.skip(`should throw error if provided name doesn't match existing package`, async () => {
+      expect(readProjectConfiguration(tree, '@proj/non-existent-lib')).toThrowErrorMatchingInlineSnapshot();
+    });
+    it.skip(`should throw error if user wants migrate non converged package`, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      updateJson(tree, `${projectConfig.root}/tsconfig.json`, json => {
+        json.version = '8.0.0';
+        return json;
+      });
 
-    expect(tsConfig).toMatchInlineSnapshot(`
-      Object {
-        "compilerOptions": Object {
-          "baseUrl": ".",
-          "typeRoots": Array [
-            "../../node_modules/@types",
-            "../../typings",
-          ],
-        },
-      }
-    `);
-
-    await generator(tree, options);
-
-    tsConfig = getTsConfig();
-
-    expect(tsConfig).toMatchInlineSnapshot(`
-      Object {
-        "compilerOptions": Object {
-          "declaration": true,
-          "experimentalDecorators": true,
-          "importHelpers": true,
-          "jsx": "react",
-          "lib": Array [
-            "es5",
-            "dom",
-          ],
-          "module": "commonjs",
-          "noUnusedLocals": true,
-          "outDir": "dist",
-          "preserveConstEnums": true,
-          "target": "es5",
-          "types": Array [
-            "jest",
-            "custom-global",
-            "inline-style-expand-shorthand",
-          ],
-        },
-        "extends": "../../tsconfig.base.json",
-        "include": Array [
-          "src",
-        ],
-      }
-    `);
+      expect(await generator(tree, options)).rejects.toMatchInlineSnapshot();
+    });
   });
 
-  it('should update root tsconfig.base.json', async () => {
-    function getBaseTsConfig() {
-      return readJson(tree, `/tsconfig.base.json`);
-    }
-
-    let rootTsConfig = getBaseTsConfig();
-
-    expect(rootTsConfig).toMatchInlineSnapshot(`
-      Object {
-        "compilerOptions": Object {
-          "paths": Object {},
-        },
+  describe(`tsconfig updates`, () => {
+    it('should update package local tsconfig.json', async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      function getTsConfig() {
+        return readJson(tree, `${projectConfig.root}/tsconfig.json`);
       }
-    `);
+      let tsConfig = getTsConfig();
 
-    await generator(tree, options);
-
-    rootTsConfig = getBaseTsConfig();
-
-    expect(rootTsConfig).toMatchInlineSnapshot(`
-      Object {
-        "compilerOptions": Object {
-          "paths": Object {
-            "@proj/react-dummy": Array [
-              "packages/react-dummy/src/index.ts",
-            ],
-          },
+      expect(tsConfig).toEqual({
+        compilerOptions: {
+          baseUrl: '.',
+          typeRoots: ['../../node_modules/@types', '../../typings'],
         },
-      }
-    `);
+      });
+
+      await generator(tree, options);
+
+      tsConfig = getTsConfig();
+
+      expect(tsConfig).toEqual({
+        compilerOptions: {
+          declaration: true,
+          experimentalDecorators: true,
+          importHelpers: true,
+          jsx: 'react',
+          lib: ['es5', 'dom'],
+          module: 'commonjs',
+          noUnusedLocals: true,
+          outDir: 'dist',
+          preserveConstEnums: true,
+          target: 'es5',
+          types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
+        },
+        extends: '../../tsconfig.base.json',
+        include: ['src'],
+      });
+    });
+
+    it('should update root tsconfig.base.json by missing package alias and all missing aliases based on packages dependencies list', async () => {
+      let rootTsConfig = getBaseTsConfig(tree);
+
+      setupDummyPackage(tree, { name: '@proj/react-make-styles', dependencies: {} });
+      setupDummyPackage(tree, { name: '@proj/react-theme', dependencies: {} });
+      setupDummyPackage(tree, { name: '@proj/react-utilities', dependencies: {} });
+
+      expect(rootTsConfig).toEqual({
+        compilerOptions: {
+          paths: {},
+        },
+      });
+
+      await generator(tree, options);
+
+      rootTsConfig = getBaseTsConfig(tree);
+
+      expect(rootTsConfig.compilerOptions.paths).toEqual(
+        expect.objectContaining({
+          '@proj/react-dummy': ['packages/react-dummy/src/index.ts'],
+          '@proj/react-make-styles': ['packages/react-make-styles/src/index.ts'],
+          '@proj/react-theme': ['packages/react-theme/src/index.ts'],
+          '@proj/react-utilities': ['packages/react-utilities/src/index.ts'],
+        }),
+      );
+
+      expect(
+        Object.keys(
+          rootTsConfig.compilerOptions.paths as Required<Pick<TsConfig['compilerOptions'], 'paths'>>['paths'],
+        ),
+      ).not.toContain(['tslib', 'someThirdPartyDep']);
+    });
   });
+
+  describe(`jest config updates`, () => {
+    it(`should setup new local jest config which extends from root `, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      const workspaceConfig = readWorkspaceConfiguration(tree);
+      let jestConfig = tree.read(`${projectConfig.root}/jest.config.js`)?.toString('utf-8');
+
+      expect(jestConfig).toMatchInlineSnapshot(`
+        "const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+        const path = require('path');
+
+        const config = createConfig({
+        setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
+        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+        });
+
+        module.exports = config;"
+      `);
+
+      await generator(tree, options);
+
+      jestConfig = tree.read(`${projectConfig.root}/jest.config.js`)?.toString('utf-8');
+
+      expect(jestConfig).toMatchInlineSnapshot(`
+        "// @ts-check
+
+        /**
+        * @type {jest.InitialOptions}
+        */
+        module.exports = {
+        displayName: 'react-dummy',
+        preset: '../../jest.preset.js',
+        globals: {
+        'ts-jest': {
+        tsConfig: '<rootDir>/tsconfig.json',
+        diagnostics: false,
+        },
+        },
+        transform: {
+        '^.+\\\\\\\\.tsx?$': 'ts-jest',
+        },
+        coverageDirectory: './coverage',
+        setupFilesAfterEnv: ['./config/tests.js'],
+        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+        };"
+      `);
+    });
+
+    it(`should add project to root jest.config.js`, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      let jestConfig = tree.read(`/jest.config.js`)?.toString('utf-8');
+
+      expect(jestConfig).toMatchInlineSnapshot(`
+        "module.exports = {
+        projects: []
+        }"
+      `);
+
+      await generator(tree, options);
+
+      jestConfig = tree.read(`/jest.config.js`)?.toString('utf-8');
+
+      expect(jestConfig).toMatchInlineSnapshot(`
+        "module.exports = {
+        projects: [\\"<rootDir>/packages/react-dummy\\"]
+        }"
+      `);
+    });
+  });
+
+  describe.skip(`storybook updates`, () => {
+    it(`should setup local storybook`, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      const projectStorybookConfigPath = `${projectConfig.root}/.storybook`;
+
+      expect(tree.exists(projectStorybookConfigPath)).toBeFalsy();
+
+      await generator(tree, options);
+
+      expect(tree.exists(projectStorybookConfigPath)).toBeTruthy();
+      expect(readJson(tree, `${projectStorybookConfigPath}/tsconfig.json`)).toMatchInlineSnapshot();
+      expect(tree.read(`${projectStorybookConfigPath}/main.js`)).toMatchInlineSnapshot();
+      expect(tree.read(`${projectStorybookConfigPath}/preview.js`)).toMatchInlineSnapshot();
+    });
+
+    it(`should move stories from react-examples package to local package within sourceRoot`, async () => {
+      setupDummyPackage(tree, {
+        name: '@proj/react-examples',
+        version: '8.0.0',
+        dependencies: {
+          [options.name]: '9.0.40-alpha1',
+          '@proj/old-v8-foo': '8.0.40',
+          '@proj/old-v8-bar': '8.0.41',
+        },
+      });
+
+      const workspaceConfig = readWorkspaceConfiguration(tree);
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      const normalizedProjectName = options.name.replace(`@${workspaceConfig.npmScope}/`, '');
+      const reactExamplesConfig = readProjectConfiguration(tree, '@proj/react-examples');
+      const pathToStoriesWithinReactExamples = `${reactExamplesConfig.root}/src/${normalizedProjectName}`;
+
+      tree.write(
+        `${pathToStoriesWithinReactExamples}/${stringUtils.classify(normalizedProjectName)}/${stringUtils.classify(
+          normalizedProjectName,
+        )}.stories.tsx`,
+        '',
+      );
+      tree.write(
+        `${pathToStoriesWithinReactExamples}/${stringUtils.classify(normalizedProjectName)}Other/${stringUtils.classify(
+          normalizedProjectName,
+        )}Other.stories.tsx`,
+        '',
+      );
+
+      expect(tree.exists(pathToStoriesWithinReactExamples)).toBeTruthy();
+
+      await generator(tree, options);
+
+      expect(tree.exists(pathToStoriesWithinReactExamples)).toBeFalsy();
+      expect(tree.exists(`${projectConfig.root}/src/${stringUtils.classify(normalizedProjectName)}.stories.tsx`));
+      expect(tree.exists(`${projectConfig.root}/src/${stringUtils.classify(normalizedProjectName)}Other.stories.tsx`));
+    });
+  });
+
+  describe.skip('package.json updates', () => {});
 });
 
 // ==== helpers ====
 
-function serializeJson(value: unknown) {
-  return JSON.stringify(value, null, 2);
+function getBaseTsConfig(tree: Tree) {
+  return readJson<TsConfig>(tree, `/tsconfig.base.json`);
 }
 
-function setupDummyPackage(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+function setupDummyPackage(
+  tree: Tree,
+  options: MigrateConvergedPkgGeneratorSchema & Partial<{ version: string; dependencies: Record<string, string> }>,
+) {
   const workspaceConfig = readWorkspaceConfiguration(tree);
-  const pkgName = options.name;
+  const defaults = {
+    version: '9.0.0-alpha.40',
+    dependencies: {
+      [`@${workspaceConfig.npmScope}/react-make-styles`]: '^9.0.0-alpha.38',
+      [`@${workspaceConfig.npmScope}/react-theme`]: '^9.0.0-alpha.13',
+      [`@${workspaceConfig.npmScope}/react-utilities`]: '^9.0.0-alpha.25',
+      tslib: '^2.1.0',
+      someThirdPartyDep: '^11.1.2',
+    },
+  };
+  const normalizedOptions = { ...defaults, ...options };
+  const pkgName = normalizedOptions.name;
   const paths = {
-    root: `packages/${options.name.replace(`@${workspaceConfig.npmScope}/`, '')}`,
+    root: `packages/${normalizedOptions.name.replace(`@${workspaceConfig.npmScope}/`, '')}`,
   };
 
-  const dummyPackageJson = {
-    name: pkgName,
-    scripts: {
-      build: 'just-scripts build',
-      clean: 'just-scripts clean',
-      'code-style': 'just-scripts code-style',
-      just: 'just-scripts',
-      lint: 'just-scripts lint',
-      start: 'just-scripts dev:storybook',
-      'start-test': 'just-scripts jest-watch',
-      test: 'just-scripts test',
-      'update-snapshots': 'just-scripts jest -u',
+  const templates = {
+    packageJson: {
+      name: pkgName,
+      version: normalizedOptions.version,
+      scripts: {
+        build: 'just-scripts build',
+        clean: 'just-scripts clean',
+        'code-style': 'just-scripts code-style',
+        just: 'just-scripts',
+        lint: 'just-scripts lint',
+        start: 'just-scripts dev:storybook',
+        'start-test': 'just-scripts jest-watch',
+        test: 'just-scripts test',
+        'update-snapshots': 'just-scripts jest -u',
+      },
+      dependencies: normalizedOptions.dependencies,
     },
-  };
-
-  const dummyTsConfig = {
-    compilerOptions: {
-      baseUrl: '.',
-      typeRoots: ['../../node_modules/@types', '../../typings'],
+    tsConfig: {
+      compilerOptions: {
+        baseUrl: '.',
+        typeRoots: ['../../node_modules/@types', '../../typings'],
+      },
     },
+    jestConfig: stripIndents`
+      const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+      const path = require('path');
+
+      const config = createConfig({
+        setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
+        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+      });
+
+      module.exports = config;
+    `,
   };
 
-  const dummyJestConfig = stripIndents`
-    const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-    const path = require('path');
-
-    const config = createConfig({
-      setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
-      snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
-    });
-
-    module.exports = config;
-`;
-
-  tree.write(`${paths.root}/package.json`, serializeJson(dummyPackageJson));
-  tree.write(`${paths.root}/tsconfig.json`, serializeJson(dummyTsConfig));
-  tree.write(`${paths.root}/jest.config.js`, dummyJestConfig);
+  tree.write(`${paths.root}/package.json`, serializeJson(templates.packageJson));
+  tree.write(`${paths.root}/tsconfig.json`, serializeJson(templates.tsConfig));
+  tree.write(`${paths.root}/jest.config.js`, templates.jestConfig);
 
   addProjectConfiguration(tree, pkgName, {
     root: paths.root,

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -88,7 +88,7 @@ describe('migrate-converged-pkg generator', () => {
 
     // eslint-disable-next-line @fluentui/max-len
     it('should update root tsconfig.base.json with migrated package alias including all missing aliases based on packages dependencies list', async () => {
-      function getBaseTsConfig(tree: Tree) {
+      function getBaseTsConfig() {
         return readJson<TsConfig>(tree, `/tsconfig.base.json`);
       }
 
@@ -96,7 +96,7 @@ describe('migrate-converged-pkg generator', () => {
       setupDummyPackage(tree, { name: '@proj/react-theme', dependencies: {} });
       setupDummyPackage(tree, { name: '@proj/react-utilities', dependencies: {} });
 
-      let rootTsConfig = getBaseTsConfig(tree);
+      let rootTsConfig = getBaseTsConfig();
 
       expect(rootTsConfig).toEqual({
         compilerOptions: {
@@ -106,7 +106,7 @@ describe('migrate-converged-pkg generator', () => {
 
       await generator(tree, options);
 
-      rootTsConfig = getBaseTsConfig(tree);
+      rootTsConfig = getBaseTsConfig();
 
       expect(rootTsConfig.compilerOptions.paths).toEqual(
         expect.objectContaining({

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -19,10 +19,10 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
 /**
  * TASK:
  * 1. migrate to typescript path aliases - #18343 ✅
- * 2. migrate to use standard jest powered by TS path aliases
- * 3. setup docs task to run api-extractor for local changes verification
- * 4. bootstrap new storybook config
- * 5. collocate all package stories from `react-examples`
+ * 2. migrate to use standard jest powered by TS path aliases - #18368 ✅
+ * 3. bootstrap new storybook config
+ * 4. collocate all package stories from `react-examples`
+ * 5. update npm scripts (setup docs task to run api-extractor for local changes verification)
  */
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
@@ -86,7 +86,12 @@ const templates = {
   `,
 };
 
-function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+/**
+ * @private
+ * @param host
+ * @param options
+ */
+export function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchema) {
   const defaults = {};
   const workspaceConfig = readWorkspaceConfiguration(host);
   const projectConfig = readProjectConfiguration(host, options.name);
@@ -96,6 +101,10 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
     ...options,
     projectConfig,
     workspaceConfig: workspaceConfig,
+    /**
+     * package name without npmScope (@scopeName)
+     */
+    normalizedPkgName: options.name.replace(`@${workspaceConfig.npmScope}/`, ''),
     paths: {
       packageJson: joinPathFragments(projectConfig.root, 'package.json'),
       tsconfig: joinPathFragments(projectConfig.root, 'tsconfig.json'),
@@ -108,8 +117,7 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
 }
 
 function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
-  const normalizedPkgName = options.name.replace(`@${options.workspaceConfig.npmScope}/`, '');
-  tree.write(options.paths.jestConfig, templates.jest({ pkgName: normalizedPkgName }));
+  tree.write(options.paths.jestConfig, templates.jest({ pkgName: options.normalizedPkgName }));
 
   return tree;
 }

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -5,13 +5,20 @@ import {
   readProjectConfiguration,
   readWorkspaceConfiguration,
   joinPathFragments,
+  readJson,
+  getProjects,
+  stripIndents,
 } from '@nrwl/devkit';
+import { serializeJson } from '@nrwl/workspace';
+import { updateJestConfig } from '@nrwl/jest/src/generators/jest-project/lib/update-jestconfig';
+
+import { TsConfig } from '../../types';
 
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
 
 /**
  * TASK:
- * 1. migrate to typescript path aliases - #18343 ✅ (partially done)
+ * 1. migrate to typescript path aliases - #18343 ✅
  * 2. migrate to use standard jest powered by TS path aliases
  * 3. setup docs task to run api-extractor for local changes verification
  * 4. bootstrap new storybook config
@@ -26,6 +33,10 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
   // 1. update TsConfigs
   updatedLocalTsConfig(tree, options);
   updatedBaseTsConfig(tree, options);
+
+  // 2. update Jest
+  updateLocalJestConfig(tree, options);
+  updateRootJestConfig(tree, options);
 
   formatFiles(tree);
 }
@@ -50,7 +61,29 @@ const templates = {
     },
     include: ['src'],
   },
-  jest: {},
+  jest: (options: { pkgName: string }) => stripIndents`
+      // @ts-check
+
+      /**
+      * @type {jest.InitialOptions}
+      */
+      module.exports = {
+        displayName: '${options.pkgName}',
+        preset: '../../jest.preset.js',
+        globals: {
+          'ts-jest': {
+            tsConfig: '<rootDir>/tsconfig.json',
+            diagnostics: false,
+          },
+        },
+        transform: {
+          '^.+\\.tsx?$': 'ts-jest',
+        },
+        coverageDirectory: './coverage',
+        setupFilesAfterEnv: ['./config/tests.js'],
+        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+      };
+  `,
 };
 
 function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchema) {
@@ -74,8 +107,17 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
   };
 }
 
-function serializeJson(value: unknown) {
-  return JSON.stringify(value, null, 2);
+function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
+  const normalizedPkgName = options.name.replace(`@${options.workspaceConfig.npmScope}/`, '');
+  tree.write(options.paths.jestConfig, templates.jest({ pkgName: normalizedPkgName }));
+
+  return tree;
+}
+
+function updateRootJestConfig(tree: Tree, options: NormalizedSchema) {
+  updateJestConfig(tree, { project: options.name });
+
+  return tree;
 }
 
 function updatedLocalTsConfig(tree: Tree, options: NormalizedSchema) {
@@ -85,9 +127,24 @@ function updatedLocalTsConfig(tree: Tree, options: NormalizedSchema) {
 }
 
 function updatedBaseTsConfig(tree: Tree, options: NormalizedSchema) {
-  // @TODO: add missing dependencies from migrated package to path aliases
-  updateJson(tree, options.paths.rootTsconfig, json => {
+  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const allProjects = getProjects(tree);
+
+  const projectPkgJson = readJson<{ dependencies: Record<string, string> }>(tree, options.paths.packageJson);
+
+  const depsThatNeedToBecomeAliases = Object.keys(projectPkgJson.dependencies)
+    .filter(pkgName => pkgName.startsWith(`@${workspaceConfig.npmScope}`))
+    .reduce((acc, pkgName) => {
+      acc[pkgName] = [`${allProjects.get(pkgName)?.root}/src/index.ts`];
+
+      return acc;
+    }, {} as Required<Pick<TsConfig['compilerOptions'], 'paths'>>['paths']);
+
+  updateJson<TsConfig, TsConfig>(tree, options.paths.rootTsconfig, json => {
+    json.compilerOptions.paths = json.compilerOptions.paths ?? {};
     json.compilerOptions.paths[options.name] = [`${options.projectConfig.root}/src/index.ts`];
+
+    Object.assign(json.compilerOptions.paths, depsThatNeedToBecomeAliases);
 
     return json;
   });

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -6,11 +6,13 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Library name",
+      "description": "Package name",
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "Which converged package would you like migrate to new DX? (ex: @fluentui/react-menu)",
+      "pattern": "^[a-zA-Z].*$"
     }
   },
   "required": ["name"]

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -1,0 +1,8 @@
+export interface TsConfig {
+  extends?: string;
+  compilerOptions: import('typescript').CompilerOptions;
+  include?: Array<string>;
+  files?: Array<string>;
+  exclude?: Array<string>;
+  references?: Array<{ path: string }>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+"@angular-devkit/core@12.0.2":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-12.0.2.tgz#53023140f1b011ba42eb118b1c5ab932a8069f97"
+  integrity sha512-n7BmZAW0nx4pEigdAsibvtIm4Vjk1IwY3Bbc8fqD+AQpdYCo+Ake1Eu6fL2XoW8Yco7U4JYYdn/uodWEgBdroQ==
+  dependencies:
+    ajv "8.2.0"
+    ajv-formats "2.0.2"
+    fast-json-stable-stringify "2.1.0"
+    magic-string "0.25.7"
+    rxjs "6.6.7"
+    source-map "0.7.3"
+
+"@angular-devkit/schematics@12.0.2":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-12.0.2.tgz#e53030340377117e57d87356d979d7b215e6037e"
+  integrity sha512-PS+SrRhAc/lyRfuBsi6Rt2yV7IA34B7T6J0K8/Av0GABZ83x+0vLiZC39eSPS1X8qcM/U09pCfDT8Q6ZQPCICA==
+  dependencies:
+    "@angular-devkit/core" "12.0.2"
+    ora "5.4.0"
+    rxjs "6.6.7"
+
 "@azure/abort-controller@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.0.1.tgz#8510935b25ac051e58920300e9d7b511ca6e656a"
@@ -6423,6 +6444,13 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.0.2.tgz#69875cb99d76c74be46e9c7a4444bc232354eba0"
+  integrity sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
@@ -6437,6 +6465,16 @@ ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv@8.2.0, ajv@^8.0.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.2.0.tgz#c89d3380a784ce81b2085f48811c4c101df4c602"
+  integrity sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ajv@8.4.0:
   version "8.4.0"
@@ -6476,10 +6514,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.2.0.tgz#c89d3380a784ce81b2085f48811c4c101df4c602"
-  integrity sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==
+ajv@^8.0.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.5.0.tgz#695528274bcb5afc865446aa275484049a18ae4b"
+  integrity sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -7950,6 +7988,15 @@ bl@^4.0.1:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 blob-util@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
@@ -9103,6 +9150,11 @@ cli-spinners@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.3.0.tgz#0632239a4b5aa4c958610142c34bb7a651fc8df5"
   integrity sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==
+
+cli-spinners@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
+  integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
 
 cli-table3@0.5.1:
   version "0.5.1"
@@ -12720,6 +12772,11 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
+fast-json-stable-stringify@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -15837,6 +15894,11 @@ is-installed-globally@^0.3.2:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-ip@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
@@ -16138,6 +16200,11 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-upper-case@^1.1.0:
   version "1.1.2"
@@ -18397,6 +18464,14 @@ log-symbols@^4.0.0:
   dependencies:
     chalk "^4.0.0"
 
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
@@ -18558,7 +18633,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
-magic-string@^0.25.2:
+magic-string@0.25.7, magic-string@^0.25.2:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -20584,6 +20659,21 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ora@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.0.tgz#42eda4855835b9cd14d33864c97a3c95a3f56bf4"
+  integrity sha512-1StwyXQGoU6gdjYkyVcqOLnVlbKj+6yPNNOxJVgpt9t4eksKjiriiHuxktLYkgllwk+D6MbC4ihH84L1udRXPg==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 ora@^3.4.0:
   version "3.4.0"
@@ -24142,7 +24232,7 @@ rxjs-for-await@0.0.2:
   resolved "https://registry.yarnpkg.com/rxjs-for-await/-/rxjs-for-await-0.0.2.tgz#26598a1d6167147cc192172970e7eed4e620384b"
   integrity sha512-IJ8R/ZCFMHOcDIqoABs82jal00VrZx8Xkgfe7TOKoaRPAW5nH/VFlG23bXpeGdrmtqI9UobFPgUKgCuFc7Lncw==
 
-rxjs@>=6.4.0, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.5.5, rxjs@^6.6.0:
+rxjs@6.6.7, rxjs@>=6.4.0, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.5.5, rxjs@^6.6.0:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -25060,6 +25150,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.7.3, source-map@^0.7.3, source-map@~0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -25076,11 +25171,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3, source-map@~0.7.2:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 source-map@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Co-authored-by: ling1726 <ling1726@users.noreply.github.com>
Co-authored-by: André <andrefcdias@users.noreply.github.com>

#### Pull request checklist

- [x] Addresses an existing issue: implements partially #16889
- ~[ ] Include a change request file using `$ yarn change`~


#### Description of changes

This is 1st phase for implementing migration generator with nx:

TASK:

- ~migrate to typescript path aliases~
- migrate to use standard jest powered by TS path aliases ( THIS PR ✅ )
- bootstrap new storybook config 
- collocate all package stories from `react-examples` 
- update npm scripts (setup docs task to run api-extractor for local changes verification)

#### Focus areas to test

(optional)
