### PR TITLE
makeStyles: Fixing typing issue that prevented the use of makeStyles with I***Styles interfaces

### DIFF
--- a/change/@fluentui-react-c129f068-dce0-4520-b633-9dc220a9b706.json
+++ b/change/@fluentui-react-c129f068-dce0-4520-b633-9dc220a9b706.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "makeStyles: Fixing typing issue that prevented the use of makeStyles with I***Styles interfaces.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8648,7 +8648,7 @@ export class ListPeoplePickerBase extends MemberListPeoplePicker {
 
 // @public
 export function makeStyles<TStyleSet extends {
-    [key: string]: IStyle;
+    [key in keyof TStyleSet]: IStyle;
 }>(styleOrFunction: TStyleSet | ((theme: Theme) => TStyleSet)): (options?: UseStylesOptions) => {
     [key in keyof TStyleSet]: string;
 };

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.ts
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.ts
@@ -45,7 +45,7 @@ export type UseStylesOptions = {
  * @param styleOrFunction - Either a css javascript object, or a function which takes in `ITheme`
  * and returns a css javascript object.
  */
-export function makeStyles<TStyleSet extends { [key: string]: IStyle }>(
+export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle }>(
   styleOrFunction: TStyleSet | ((theme: Theme) => TStyleSet),
 ): (options?: UseStylesOptions) => { [key in keyof TStyleSet]: string } {
   // Create graph of inputs to map to output.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18145
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Issue #18145 describes an issue with `makeStyles` where it didn't work if you used `I***Styles` interface as the `TStyleSet` template since they didn't extend from `{ [key: string]: IStyle }`, even if the actual interface adhered to that restriction. This PR fixes this issue by improving the types in `makeStyles` themselves so we can use it with our `I***Styles` interfaces without sweeping changes to the repo but we still maintain the type safe guards of the old types.

For further information on this refer to the investigation in [this codesandbox](https://codesandbox.io/s/investigation-on-makestyles-typings-issue-18145-h15cv?file=/src/index.tsx).