### PR TITLE
TooltipHost: avoid <div> cannot be descendant of <p> error

### DIFF
--- a/change/@fluentui-react-03dde553-6e57-4be4-99d6-0951f1f1e47d.json
+++ b/change/@fluentui-react-03dde553-6e57-4be4-99d6-0951f1f1e47d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "TooltipHost: replace div with span",
+  "packageName": "@fluentui/react",
+  "email": "hantatsang@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-12ada8cd-78a1-443f-8c95-c1d01e1f2b24.json
+++ b/change/@fluentui-web-components-12ada8cd-78a1-443f-8c95-c1d01e1f2b24.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@fluentui/web-components",
+  "email": "hantatsang@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -291,7 +291,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                   onMouseLeave={[Function]}
                 >
                   TestText3
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -367,7 +367,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -380,7 +380,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                   onMouseLeave={[Function]}
                 >
                   TestText4
-                </div>
+                </span>
               </span>
             </li>
           </ol>
@@ -496,7 +496,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -509,7 +509,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText1
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -585,7 +585,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -598,7 +598,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText2
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -674,7 +674,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -687,7 +687,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText3
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -763,7 +763,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -776,7 +776,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText4
-                </div>
+                </span>
               </span>
             </li>
           </ol>
@@ -892,7 +892,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -905,7 +905,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText1
-                </div>
+                </span>
               </span>
               <span>
                 *
@@ -954,7 +954,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -967,7 +967,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText2
-                </div>
+                </span>
               </span>
               <span>
                 *
@@ -1016,7 +1016,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -1029,7 +1029,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText3
-                </div>
+                </span>
               </span>
               <span>
                 *
@@ -1078,7 +1078,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -1091,7 +1091,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText4
-                </div>
+                </span>
               </span>
             </li>
           </ol>
@@ -1207,7 +1207,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -1220,7 +1220,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                   onMouseLeave={[Function]}
                 >
                   TestText1
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -1952,7 +1952,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -1965,7 +1965,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText3
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -2041,7 +2041,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -2054,7 +2054,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                   onMouseLeave={[Function]}
                 >
                   TestText4
-                </div>
+                </span>
               </span>
             </li>
           </ol>
@@ -2170,7 +2170,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -2183,7 +2183,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                   onMouseLeave={[Function]}
                 >
                   TestText1
-                </div>
+                </span>
               </span>
               <i
                 aria-hidden={true}
@@ -2451,7 +2451,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                       cursor: default;
                     }
               >
-                <div
+                <span
                   className=
                       ms-TooltipHost
                       {
@@ -2464,7 +2464,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                   onMouseLeave={[Function]}
                 >
                   TestText4
-                </div>
+                </span>
               </span>
             </li>
           </ol>

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Persona renders Persona children correctly 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -133,7 +133,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -317,7 +317,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -330,7 +330,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -516,7 +516,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -529,7 +529,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -696,7 +696,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -709,7 +709,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1136,7 +1136,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1149,7 +1149,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1164,7 +1164,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1177,7 +1177,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1193,7 +1193,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1206,7 +1206,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1222,7 +1222,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1235,7 +1235,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>
@@ -1323,7 +1323,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1336,7 +1336,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1351,7 +1351,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1364,7 +1364,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1380,7 +1380,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1393,7 +1393,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1409,7 +1409,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1422,7 +1422,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>
@@ -1645,7 +1645,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1658,7 +1658,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1673,7 +1673,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1686,7 +1686,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1702,7 +1702,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1715,7 +1715,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1731,7 +1731,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1744,7 +1744,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>

--- a/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -152,7 +152,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -319,7 +319,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -332,7 +332,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Persona renders Persona children correctly 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -133,7 +133,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -317,7 +317,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -330,7 +330,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -516,7 +516,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -529,7 +529,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -696,7 +696,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -709,7 +709,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onMouseLeave={[Function]}
       >
         Kat Larrson
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1136,7 +1136,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1149,7 +1149,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1164,7 +1164,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1177,7 +1177,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1193,7 +1193,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1206,7 +1206,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1222,7 +1222,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1235,7 +1235,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>
@@ -1323,7 +1323,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1336,7 +1336,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1351,7 +1351,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1364,7 +1364,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1380,7 +1380,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1393,7 +1393,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1409,7 +1409,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1422,7 +1422,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>
@@ -1645,7 +1645,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1658,7 +1658,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Swapnil Vaibhav
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1673,7 +1673,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1686,7 +1686,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Software Engineer
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1702,7 +1702,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1715,7 +1715,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         In a meeting
-      </div>
+      </span>
     </div>
     <div
       className=
@@ -1731,7 +1731,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           }
       dir="auto"
     >
-      <div
+      <span
         className=
             ms-TooltipHost
             {
@@ -1744,7 +1744,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onMouseLeave={[Function]}
       >
         Available at 4:00pm
-      </div>
+      </span>
     </div>
   </div>
 </div>

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -90,7 +90,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
     const ariaDescribedBy = setAriaDescribedBy && isTooltipVisible && isContentPresent ? tooltipId : undefined;
 
     return (
-      <div
+      <span
         className={this._classNames.root}
         ref={this._tooltipHost}
         {...{ onFocusCapture: this._onTooltipMouseEnter }}
@@ -120,11 +120,11 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
           />
         )}
         {isAriaPlaceholderRendered && (
-          <div id={tooltipId} style={hiddenContentStyle as React.CSSProperties}>
+          <span id={tooltipId} style={hiddenContentStyle as React.CSSProperties}>
             {content}
-          </div>
+          </span>
         )}
-      </div>
+      </span>
     );
   }
 

--- a/packages/react/src/components/Tooltip/TooltipHost.test.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.test.tsx
@@ -61,7 +61,7 @@ describe('TooltipHost', () => {
       />,
     );
 
-    component.find('div').simulate('mouseenter');
+    component.find('span').simulate('mouseenter');
 
     const tooltip = component.find('TooltipBase');
 
@@ -104,7 +104,7 @@ describe('TooltipHost', () => {
     );
 
     // simulate mouse enter to trigger use of calloutProps
-    component.find('div').simulate('mouseenter');
+    component.find('span').simulate('mouseenter');
 
     expect(onTooltipToggleCalled).toEqual(true);
     expect(calloutPropsBefore).toEqual(calloutProps);

--- a/packages/react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TooltipHost renders correctly 1`] = `
-<div
+<span
   className=
       ms-TooltipHost
       {

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                       }
                   dir="auto"
                 >
-                  <div
+                  <span
                     className=
                         ms-TooltipHost
                         {
@@ -380,7 +380,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onMouseLeave={[Function]}
                   >
                     Annie Lindqvist
-                  </div>
+                  </span>
                 </div>
                 <div
                   className=
@@ -396,7 +396,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                       }
                   dir="auto"
                 >
-                  <div
+                  <span
                     className=
                         ms-TooltipHost
                         {
@@ -409,7 +409,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onMouseLeave={[Function]}
                   >
                     Designer
-                  </div>
+                  </span>
                 </div>
                 <div
                   className=
@@ -425,7 +425,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                       }
                   dir="auto"
                 >
-                  <div
+                  <span
                     className=
                         ms-TooltipHost
                         {
@@ -438,7 +438,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onMouseLeave={[Function]}
                   >
                     In a meeting
-                  </div>
+                  </span>
                 </div>
                 <div
                   className=
@@ -454,7 +454,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                       }
                   dir="auto"
                 >
-                  <div
+                  <span
                     className=
                         ms-TooltipHost
                         {
@@ -467,7 +467,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onMouseLeave={[Function]}
                   >
                     Available at 4:00pm
-                  </div>
+                  </span>
                 </div>
               </div>
             </div>

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -53,42 +53,14 @@ import { TreeView } from '@microsoft/fast-foundation';
 // @internal (undocumented)
 export const AccentButtonStyles: ElementStyles;
 
-// Warning: (ae-forgotten-export) The symbol "SwatchFamilyResolver" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "FillSwatchFamily" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "accentFill" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFill: SwatchFamilyResolver<FillSwatchFamily>;
-
-// Warning: (ae-forgotten-export) The symbol "SwatchRecipe" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "accentFillActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillActive: SwatchRecipe;
-
 // @public
 export const accentFillActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
 export const accentFillFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentFillHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillHover: SwatchRecipe;
-
 // @public
 export const accentFillHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentFillLarge" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillLarge: SwatchFamilyResolver<FillSwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "accentFillLargeActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillLargeActive: SwatchRecipe;
 
 // @public
 export const accentFillLargeActiveBehavior: CSSCustomPropertyBehavior;
@@ -96,68 +68,23 @@ export const accentFillLargeActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const accentFillLargeFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentFillLargeHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillLargeHover: SwatchRecipe;
-
 // @public
 export const accentFillLargeHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentFillLargeRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillLargeRest: SwatchRecipe;
 
 // @public
 export const accentFillLargeRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentFillLargeSelected" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillLargeSelected: SwatchRecipe;
-
 // @public
 export const accentFillLargeSelectedBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentFillRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillRest: SwatchRecipe;
 
 // @public
 export const accentFillRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentFillSelected" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentFillSelected: SwatchRecipe;
-
 // @public
 export const accentFillSelectedBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentForeground" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForeground: SwatchFamilyResolver;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundActive: SwatchRecipe;
-
 // @public
 export const accentForegroundActiveBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundCut" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const accentForegroundCut: SwatchRecipe;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundCutLarge" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const accentForegroundCutLarge: SwatchRecipe;
 
 // @public
 export const accentForegroundCutRestBehavior: CSSCustomPropertyBehavior;
@@ -165,23 +92,8 @@ export const accentForegroundCutRestBehavior: CSSCustomPropertyBehavior;
 // @public
 export const accentForegroundFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundHover: SwatchRecipe;
-
 // @public
 export const accentForegroundHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundLarge" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundLarge: SwatchFamilyResolver;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundLargeActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundLargeActive: SwatchRecipe;
 
 // @public
 export const accentForegroundLargeActiveBehavior: CSSCustomPropertyBehavior;
@@ -189,26 +101,11 @@ export const accentForegroundLargeActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const accentForegroundLargeFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundLargeHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundLargeHover: SwatchRecipe;
-
 // @public
 export const accentForegroundLargeHoverBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundLargeRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundLargeRest: SwatchRecipe;
-
 // @public
 export const accentForegroundLargeRestBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "accentForegroundRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const accentForegroundRest: SwatchRecipe;
 
 // @public
 export const accentForegroundRestBehavior: CSSCustomPropertyBehavior;
@@ -267,9 +164,6 @@ export type ComboboxAppearance = SelectAppearance;
 
 // @public
 export const ComboboxStyles: import("@microsoft/fast-element").ElementStyles;
-
-// @public
-export function createColorPalette(baseColor: any): string[];
 
 // @public
 export const DataGridCellStyles: import("@microsoft/fast-element").ElementStyles;
@@ -813,9 +707,6 @@ export const inlineEndBehavior: CSSCustomPropertyBehavior;
 // @public
 export const inlineStartBehavior: CSSCustomPropertyBehavior;
 
-// @public (undocumented)
-export function isDarkMode(designSystem: DesignSystem): boolean;
-
 // Warning: (ae-internal-missing-underscore) The name "LightweightButtonStyles" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -830,34 +721,14 @@ export const MenuItemStyles: import("@microsoft/fast-element").ElementStyles;
 // @public
 export const MenuStyles: import("@microsoft/fast-element").ElementStyles;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralContrastFill" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralContrastFill: SwatchFamilyResolver;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralContrastFillActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralContrastFillActive: SwatchRecipe;
-
 // @public
 export const neutralContrastFillActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
 export const neutralContrastFillFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralContrastFillHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralContrastFillHover: SwatchRecipe;
-
 // @public
 export const neutralContrastFillHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralContrastFillRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralContrastFillRest: SwatchRecipe;
 
 // @public
 export const neutralContrastFillRestBehavior: CSSCustomPropertyBehavior;
@@ -865,38 +736,11 @@ export const neutralContrastFillRestBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralContrastForegroundRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralDividerRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralDividerRest: SwatchRecipe;
-
 // @public
 export const neutralDividerRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-forgotten-export) The symbol "ColorRecipe" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "neutralFill" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFill: ColorRecipe<FillSwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillActive: SwatchRecipe;
-
 // @public
 export const neutralFillActiveBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-forgotten-export) The symbol "Swatch" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "neutralFillCard" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export function neutralFillCard(designSystem: DesignSystem): Swatch;
-
-// Warning: (ae-forgotten-export) The symbol "SwatchResolver" needs to be exported by the entry point index.d.ts
-//
-// @internal (undocumented)
-export function neutralFillCard(backgroundResolver: SwatchResolver): SwatchResolver;
 
 // @public
 export const neutralFillCardRestBehavior: CSSCustomPropertyBehavior;
@@ -904,23 +748,8 @@ export const neutralFillCardRestBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralFillFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillHover: SwatchRecipe;
-
 // @public
 export const neutralFillHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillInput" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillInput: ColorRecipe<FillSwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillInputActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillInputActive: SwatchRecipe;
 
 // @public
 export const neutralFillInputActiveBehavior: CSSCustomPropertyBehavior;
@@ -928,52 +757,17 @@ export const neutralFillInputActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralFillInputFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillInputHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillInputHover: SwatchRecipe;
-
 // @public
 export const neutralFillInputHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillInputRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillInputRest: SwatchRecipe;
 
 // @public
 export const neutralFillInputRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillInputSelected" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillInputSelected: SwatchRecipe;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillRest: SwatchRecipe;
-
 // @public
 export const neutralFillRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillSelected" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillSelected: SwatchRecipe;
-
 // @public
 export const neutralFillSelectedBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillStealth" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillStealth: ColorRecipe<FillSwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillStealthActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillStealthActive: ColorRecipe<Swatch>;
 
 // @public
 export const neutralFillStealthActiveBehavior: CSSCustomPropertyBehavior;
@@ -981,39 +775,14 @@ export const neutralFillStealthActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralFillStealthFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillStealthHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillStealthHover: ColorRecipe<Swatch>;
-
 // @public
 export const neutralFillStealthHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillStealthRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillStealthRest: ColorRecipe<Swatch>;
 
 // @public
 export const neutralFillStealthRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillStealthSelected" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillStealthSelected: ColorRecipe<Swatch>;
-
 // @public
 export const neutralFillStealthSelectedBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillToggle" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillToggle: SwatchFamilyResolver;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillToggleActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillToggleActive: SwatchRecipe;
 
 // @public
 export const neutralFillToggleActiveBehavior: CSSCustomPropertyBehavior;
@@ -1021,48 +790,17 @@ export const neutralFillToggleActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralFillToggleFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFillToggleHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillToggleHover: SwatchRecipe;
-
 // @public
 export const neutralFillToggleHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralFillToggleRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFillToggleRest: SwatchRecipe;
 
 // @public
 export const neutralFillToggleRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralFocus" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralFocus: ColorRecipe<Swatch>;
-
 // @public
 export const neutralFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-forgotten-export) The symbol "DesignSystemResolver" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "neutralFocusInnerAccent" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export function neutralFocusInnerAccent(accentFillColor: DesignSystemResolver<string>): DesignSystemResolver<string>;
-
 // @public
 export const neutralFocusInnerAccentBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralForeground" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralForeground: SwatchFamilyResolver;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralForegroundActive: SwatchRecipe;
 
 // @public
 export const neutralForegroundActiveBehavior: CSSCustomPropertyBehavior;
@@ -1070,87 +808,32 @@ export const neutralForegroundActiveBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralForegroundFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundHint" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralForegroundHint: SwatchRecipe;
-
 // @public
 export const neutralForegroundHintBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundHintLarge" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralForegroundHintLarge: SwatchRecipe;
 
 // @public
 export const neutralForegroundHintLargeBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralForegroundHover: SwatchRecipe;
-
 // @public
 export const neutralForegroundHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralForegroundRest: SwatchRecipe;
 
 // @public
 export const neutralForegroundRestBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundToggle" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralForegroundToggle: SwatchRecipe;
-
 // @public
 export const neutralForegroundToggleBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralForegroundToggleLarge" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralForegroundToggleLarge: SwatchRecipe;
 
 // @public
 export const neutralForegroundToggleLargeBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerCard" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerCard: ColorRecipe<Swatch>;
-
 // @public
 export const neutralLayerCardBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerCardContainer" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerCardContainer: ColorRecipe<Swatch>;
 
 // @public
 export const neutralLayerCardContainerBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerFloating" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerFloating: ColorRecipe<Swatch>;
-
 // @public
 export const neutralLayerFloatingBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerL1" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerL1: ColorRecipe<Swatch>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerL1Alt" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerL1Alt: ColorRecipe<Swatch>;
 
 // @public
 export const neutralLayerL1AltBehavior: CSSCustomPropertyBehavior;
@@ -1158,79 +841,23 @@ export const neutralLayerL1AltBehavior: CSSCustomPropertyBehavior;
 // @public
 export const neutralLayerL1Behavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerL2" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerL2: ColorRecipe<Swatch>;
-
 // @public
 export const neutralLayerL2Behavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerL3" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerL3: ColorRecipe<Swatch>;
 
 // @public
 export const neutralLayerL3Behavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralLayerL4" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const neutralLayerL4: ColorRecipe<Swatch>;
-
 // @public
 export const neutralLayerL4Behavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-forgotten-export) The symbol "SwatchFamily" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-missing-underscore) The name "neutralOutline" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutline: ColorRecipe<SwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineActive: SwatchRecipe;
 
 // @public
 export const neutralOutlineActiveBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineContrast" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineContrast: ColorRecipe<SwatchFamily>;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineContrastActive" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineContrastActive: SwatchRecipe;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineContrastHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineContrastHover: SwatchRecipe;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineContrastRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineContrastRest: SwatchRecipe;
-
 // @public
 export const neutralOutlineFocusBehavior: CSSCustomPropertyBehavior;
 
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineHover" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineHover: SwatchRecipe;
-
 // @public
 export const neutralOutlineHoverBehavior: CSSCustomPropertyBehavior;
-
-// Warning: (ae-internal-missing-underscore) The name "neutralOutlineRest" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export const neutralOutlineRest: SwatchRecipe;
 
 // @public
 export const neutralOutlineRestBehavior: CSSCustomPropertyBehavior;
@@ -1248,22 +875,6 @@ export const OptionStyles: import("@microsoft/fast-element").ElementStyles;
 //
 // @internal (undocumented)
 export const OutlineButtonStyles: ElementStyles;
-
-// @public
-export type Palette = Swatch[];
-
-// Warning: (ae-internal-missing-underscore) The name "palette" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal @deprecated
-export function palette(paletteType: PaletteType): DesignSystemResolver<Palette>;
-
-// @public @deprecated
-export enum PaletteType {
-    // (undocumented)
-    accent = "accent",
-    // (undocumented)
-    neutral = "neutral"
-}
 
 // @public
 export function parseColorString(color: string): ColorRGBA64;
@@ -1294,14 +905,6 @@ export const SliderLabelStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const SliderStyles: import("@microsoft/fast-element").ElementStyles;
-
-// @public
-export enum StandardLuminance {
-    // (undocumented)
-    DarkMode = 0.23,
-    // (undocumented)
-    LightMode = 1
-}
 
 // Warning: (ae-internal-missing-underscore) The name "StealthButtonStyles" should be prefixed with an underscore because the declaration is marked as @internal
 //


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17696
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Reading https://github.com/microsoft/fluentui/issues/17696#issuecomment-833879364, I decided to change the container element of `TooltipHost` from `div` to `span`.

I checked the snapshots and Storybook for the components that have snapshots changed, everything looks fine but I may be missing more detailed inspections. Please advise.

#### Focus areas to test

(optional)
