### PR TITLE
feat(tools): implement storybook updates for migration generator

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -331,7 +331,6 @@ describe('migrate-converged-pkg generator', () => {
       };
     }
 
-    // eslint-disable-next-line @fluentui/max-len
     it(`should move stories from react-examples package to local package within sourceRoot`, async () => {
       const { pathToStoriesWithinReactExamples, getMovedStoriesData } = setup();
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -237,6 +237,8 @@ describe('migrate-converged-pkg generator', () => {
           ],
         }
       `);
+
+      /* eslint-disable @fluentui/max-len */
       expect(tree.read(`${projectStorybookConfigPath}/main.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "const rootMain = require('../../../.storybook/main');
 
@@ -250,6 +252,8 @@ describe('migrate-converged-pkg generator', () => {
         },
         });"
       `);
+      /* eslint-enable @fluentui/max-len */
+
       expect(tree.read(`${projectStorybookConfigPath}/preview.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "import * as rootPreview from '../../../.storybook/preview';
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -23,8 +23,8 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
  * TASK:
  * 1. migrate to typescript path aliases - #18343 ✅
  * 2. migrate to use standard jest powered by TS path aliases - #18368 ✅
- * 3. bootstrap new storybook config
- * 4. collocate all package stories from `react-examples`
+ * 3. bootstrap new storybook config - #18394 ✅
+ * 4. collocate all package stories from `react-examples` - #18394 ✅
  * 5. update npm scripts (setup docs task to run api-extractor for local changes verification)
  */
 
@@ -171,32 +171,6 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
   return tree;
 }
 
-function getReactExamplesProjectConfig(tree: Tree, options: NormalizedSchema) {
-  return readProjectConfiguration(tree, `@${options.workspaceConfig.npmScope}/react-examples`);
-}
-
-function deleteProjectFolderInReactExamples(tree: Tree, options: NormalizedSchema) {
-  const reactExamplesConfig = getReactExamplesProjectConfig(tree, options);
-  const pathToStoriesWithinReactExamples = `${reactExamplesConfig.root}/src/${options.normalizedPkgName}`;
-
-  tree.delete(pathToStoriesWithinReactExamples);
-
-  userLog.push(
-    { type: 'warn', message: `NOTE: Deleting ${reactExamplesConfig.root}/src/${options.normalizedPkgName}` },
-    { type: 'warn', message: `      - Please update your moved stories to follow standard storybook format\n` },
-  );
-
-  return tree;
-}
-
-function printUserLogs(logs: typeof userLog) {
-  logger.log(`${'='.repeat(80)}\n`);
-
-  logs.forEach(log => logger[log.type](log.message));
-
-  logger.log(`${'='.repeat(80)}\n`);
-}
-
 function moveStorybookFromReactExamples(tree: Tree, options: NormalizedSchema) {
   const reactExamplesConfig = getReactExamplesProjectConfig(tree, options);
   const pathToStoriesWithinReactExamples = `${reactExamplesConfig.root}/src/${options.normalizedPkgName}`;
@@ -228,8 +202,22 @@ function moveStorybookFromReactExamples(tree: Tree, options: NormalizedSchema) {
   return tree;
 }
 
-function splitPathFragments(filePath: string) {
-  return filePath.split(path.sep);
+function getReactExamplesProjectConfig(tree: Tree, options: NormalizedSchema) {
+  return readProjectConfiguration(tree, `@${options.workspaceConfig.npmScope}/react-examples`);
+}
+
+function deleteProjectFolderInReactExamples(tree: Tree, options: NormalizedSchema) {
+  const reactExamplesConfig = getReactExamplesProjectConfig(tree, options);
+  const pathToStoriesWithinReactExamples = `${reactExamplesConfig.root}/src/${options.normalizedPkgName}`;
+
+  tree.delete(pathToStoriesWithinReactExamples);
+
+  userLog.push(
+    { type: 'warn', message: `NOTE: Deleting ${reactExamplesConfig.root}/src/${options.normalizedPkgName}` },
+    { type: 'warn', message: `      - Please update your moved stories to follow standard storybook format\n` },
+  );
+
+  return tree;
 }
 
 function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
@@ -272,4 +260,16 @@ function updatedBaseTsConfig(tree: Tree, options: NormalizedSchema) {
 
     return json;
   });
+}
+
+function printUserLogs(logs: typeof userLog) {
+  logger.log(`${'='.repeat(80)}\n`);
+
+  logs.forEach(log => logger[log.type](log.message));
+
+  logger.log(`${'='.repeat(80)}\n`);
+}
+
+function splitPathFragments(filePath: string) {
+  return filePath.split(path.sep);
 }

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -186,11 +186,21 @@ function moveStorybookFromReactExamples(tree: Tree, options: NormalizedSchema) {
   storyPaths.forEach(originPath => {
     const pathSegments = splitPathFragments(originPath);
     const fileName = pathSegments[pathSegments.length - 1];
+    const componentName = fileName.replace(/\.stories\.tsx?$/, '');
     let contents = tree.read(originPath)?.toString('utf-8');
 
-    contents = contents?.replace(options.name, './index');
-
     if (contents) {
+      contents = contents.replace(options.name, './index');
+      contents =
+        contents +
+        '\n\n' +
+        stripIndents`
+        export default {
+            title: 'Components/${componentName}',
+            component: ${componentName},
+        }
+      `;
+
       tree.write(joinPathFragments(options.projectConfig.root, 'src', fileName), contents);
 
       return;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Partially implements #16889
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

This is 3rd phase for implementing migration generator with nx:

TASK:

- ~migrate to typescript path aliases~
- ~migrate to use standard jest powered by TS path aliases~
- bootstrap new storybook config ( THIS PR ✅ )
- collocate all package stories from react-examples ( THIS PR ✅ )
- update npm scripts (setup docs task to run api-extractor for local changes verification)

#### Focus areas to test

(optional)
