### PR TITLE
Revert "chore: enable Jest aliases for converged packages (#18337)"

### DIFF
--- a/change/@fluentui-babel-make-styles-83e13a25-e639-4d60-868a-c563a1177c3a.json
+++ b/change/@fluentui-babel-make-styles-83e13a25-e639-4d60-868a-c563a1177c3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-make-styles-7b63899d-2539-45d0-85c2-cdf84dd60c74.json
+++ b/change/@fluentui-jest-serializer-make-styles-7b63899d-2539-45d0-85c2-cdf84dd60c74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-fcf6a285-db68-427f-aa0d-502e211e29ec.json
+++ b/change/@fluentui-make-styles-fcf6a285-db68-427f-aa0d-502e211e29ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-825f1cae-c8b5-42bd-874a-4bc60db0df9c.json
+++ b/change/@fluentui-react-accordion-825f1cae-c8b5-42bd-874a-4bc60db0df9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-8ad79140-6446-445d-8d27-2efd29a01c33.json
+++ b/change/@fluentui-react-avatar-8ad79140-6446-445d-8d27-2efd29a01c33.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-3721f797-a1dc-4682-b782-7b639e77379e.json
+++ b/change/@fluentui-react-badge-3721f797-a1dc-4682-b782-7b639e77379e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-7d224452-eead-452a-a3bf-d24f941f27da.json
+++ b/change/@fluentui-react-button-7d224452-eead-452a-a3bf-d24f941f27da.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-ea5a1725-78f5-441a-b171-9ee6eba42c3a.json
+++ b/change/@fluentui-react-context-selector-ea5a1725-78f5-441a-b171-9ee6eba42c3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-eecc5e62-fa04-41c4-8fd5-5601a198e1e1.json
+++ b/change/@fluentui-react-divider-eecc5e62-fa04-41c4-8fd5-5601a198e1e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-divider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-c35fb515-1794-437c-8ec1-94a51d93234a.json
+++ b/change/@fluentui-react-image-c35fb515-1794-437c-8ec1-94a51d93234a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-04c32bfd-a404-40c4-8d66-f76c4c956a07.json
+++ b/change/@fluentui-react-label-04c32bfd-a404-40c4-8d66-f76c4c956a07.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-label",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-b403e8bf-d667-4326-b111-7d085ef7c5dc.json
+++ b/change/@fluentui-react-link-b403e8bf-d667-4326-b111-7d085ef7c5dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-e471079d-16ae-4417-a6d8-8edcf0d0fe4d.json
+++ b/change/@fluentui-react-make-styles-e471079d-16ae-4417-a6d8-8edcf0d0fe4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-3c5747c0-24e5-42f1-a57e-06a0321b5b66.json
+++ b/change/@fluentui-react-popover-3c5747c0-24e5-42f1-a57e-06a0321b5b66.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-e38d0f09-192e-4546-99dc-d1c1b41b6270.json
+++ b/change/@fluentui-react-portal-e38d0f09-192e-4546-99dc-d1c1b41b6270.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-758cb772-3f63-470a-b84f-e71c68f4f275.json
+++ b/change/@fluentui-react-positioning-758cb772-3f63-470a-b84f-e71c68f4f275.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-adb39ac2-88c0-4fcd-8dac-8d81c125267e.json
+++ b/change/@fluentui-react-provider-adb39ac2-88c0-4fcd-8dac-8d81c125267e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-3fd9ab72-4787-4326-abdd-6f32c1b99a34.json
+++ b/change/@fluentui-react-shared-contexts-3fd9ab72-4787-4326-abdd-6f32c1b99a34.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-6a31c8ae-470a-4fbf-be46-00f6b02871e0.json
+++ b/change/@fluentui-react-tabster-6a31c8ae-470a-4fbf-be46-00f6b02871e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-tabster",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-724f4052-74f9-43b7-a6b6-0a1c97ca5805.json
+++ b/change/@fluentui-react-text-724f4052-74f9-43b7-a6b6-0a1c97ca5805.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-text",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-7b049922-1584-4f30-89bd-599042ff13bc.json
+++ b/change/@fluentui-react-theme-7b049922-1584-4f30-89bd-599042ff13bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-theme",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-provider-cef4eb94-deb4-433b-a0c2-23372f98e77a.json
+++ b/change/@fluentui-react-theme-provider-cef4eb94-deb4-433b-a0c2-23372f98e77a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-bf58344f-2ccd-4028-91be-9c4f3dbd7a9f.json
+++ b/change/@fluentui-react-tooltip-bf58344f-2ccd-4028-91be-9c4f3dbd7a9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-9c88574e-f68f-4359-8e86-62e015abad1a.json
+++ b/change/@fluentui-react-utilities-9c88574e-f68f-4359-8e86-62e015abad1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert \"chore: enable Jest aliases for converged packages (#18337)\"",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-make-styles/jest.config.js
+++ b/packages/babel-make-styles/jest.config.js
@@ -1,7 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig({});
 
 module.exports = config;

--- a/packages/jest-serializer-make-styles/jest.config.js
+++ b/packages/jest-serializer-make-styles/jest.config.js
@@ -1,6 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
 module.exports = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFilesAfterEnv: ['./jest-setup.js'],
 });

--- a/packages/make-styles/jest.config.js
+++ b/packages/make-styles/jest.config.js
@@ -1,7 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig();
 
 module.exports = config;

--- a/packages/react-accordion/jest.config.js
+++ b/packages/react-accordion/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-avatar/jest.config.js
+++ b/packages/react-avatar/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-badge/jest.config.js
+++ b/packages/react-badge/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-button/jest.config.js
+++ b/packages/react-button/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-context-selector/jest.config.js
+++ b/packages/react-context-selector/jest.config.js
@@ -1,8 +1,7 @@
-const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
+const { createConfig, resolveMergeStylesSerializer } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });
 

--- a/packages/react-divider/jest.config.js
+++ b/packages/react-divider/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-image/jest.config.js
+++ b/packages/react-image/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-label/jest.config.js
+++ b/packages/react-label/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-link/jest.config.js
+++ b/packages/react-link/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-make-styles/jest.config.js
+++ b/packages/react-make-styles/jest.config.js
@@ -1,7 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig();
 
 module.exports = config;

--- a/packages/react-popover/jest.config.js
+++ b/packages/react-popover/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-portal/jest.config.js
+++ b/packages/react-portal/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-positioning/jest.config.js
+++ b/packages/react-positioning/jest.config.js
@@ -1,7 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig({});
 
 module.exports = config;

--- a/packages/react-provider/jest.config.js
+++ b/packages/react-provider/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-shared-contexts/jest.config.js
+++ b/packages/react-shared-contexts/jest.config.js
@@ -1,6 +1,5 @@
 let path = require('path');
 let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 module.exports = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });

--- a/packages/react-tabster/jest.config.js
+++ b/packages/react-tabster/jest.config.js
@@ -1,7 +1,5 @@
 const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig({});
 
 module.exports = config;

--- a/packages/react-text/jest.config.js
+++ b/packages/react-text/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-theme-provider/jest.config.js
+++ b/packages/react-theme-provider/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-theme/jest.config.js
+++ b/packages/react-theme/jest.config.js
@@ -1,7 +1,5 @@
 let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 
-const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
-});
+const config = createConfig();
 
 module.exports = config;

--- a/packages/react-tooltip/jest.config.js
+++ b/packages/react-tooltip/jest.config.js
@@ -2,7 +2,6 @@ const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 });

--- a/packages/react-utilities/jest.config.js
+++ b/packages/react-utilities/jest.config.js
@@ -2,7 +2,6 @@ let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 let path = require('path');
 
 const config = createConfig({
-  moduleNameMapper: require('lerna-alias').jest(),
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 });
 


### PR DESCRIPTION
#### Description of changes

This PR reverts #18337, it was designed as a temporary workaround for tests before #16889 will be completed, however it causes problem with Jest watch mode in some packages:

```
  ● Test suite failed to run

    Configuration error:

    Could not locate module @fluentui/scripts mapped as:
    office-ui-fabric-react\scripts\src\index.

    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^@fluentui\/scripts$/": "office-ui-fabric-react\scripts\src\index"
      },
      "resolver": null
    }
```

This happens because `@fluentui/scripts` are a part of Lerna project: 
https://github.com/microsoft/fluentui/blob/fa961304d6ba90927e57abe23359e0cf9eaf66a9/lerna.json#L2

But are configured in a different way and don't have `src/index` as an entrypoint. To implement it properly we will need to do something like: https://github.com/microsoft/fluentui/blob/fa961304d6ba90927e57abe23359e0cf9eaf66a9/scripts/webpack/getResolveAlias.js#L22-L28

That is definitely too much. Let's wait for #18337.

