### PR TITLE
feat(tools): implement npm scripts updates for migration generator

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -398,21 +398,33 @@ describe('migrate-converged-pkg generator', () => {
     });
   });
 
-  describe.skip('package.json updates', () => {
-    it(`should update npm scripts`, async () => {
+  describe('package.json updates', () => {
+    it(`should update package npm scripts`, async () => {
       const projectConfig = readProjectConfiguration(tree, options.name);
       let pkgJson = readJson(tree, `${projectConfig.root}/package.json`);
 
-      expect(pkgJson).toMatchInlineSnapshot();
+      expect(pkgJson.scripts).toMatchInlineSnapshot(`
+        Object {
+          "build": "just-scripts build",
+          "clean": "just-scripts clean",
+          "code-style": "just-scripts code-style",
+          "just": "just-scripts",
+          "lint": "just-scripts lint",
+          "start": "just-scripts dev:storybook",
+          "start-test": "just-scripts jest-watch",
+          "test": "just-scripts test",
+          "update-snapshots": "just-scripts jest -u",
+        }
+      `);
 
       await generator(tree, options);
 
       pkgJson = readJson(tree, `${projectConfig.root}/package.json`);
 
-      expect(pkgJson).toEqual({
+      expect(pkgJson.scripts).toEqual({
         docs: 'api-extractor run --config=config/api-extractor.local.json --local',
         // eslint-disable-next-line @fluentui/max-len
-        'build:local': `tsc -p . --module esnext --emitDeclarationOnly && node config/normalize-import --output dist/${projectConfig.root}/src && yarn docs`,
+        'build:local': `tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/${projectConfig.root}/src && yarn docs`,
         build: 'just-scripts build',
         clean: 'just-scripts clean',
         'code-style': 'just-scripts code-style',
@@ -422,6 +434,16 @@ describe('migrate-converged-pkg generator', () => {
         storybook: 'start-storybook',
         test: 'jest',
       });
+    });
+
+    it(`should create api-extractor.local.json for scripts:docs task consumption`, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+
+      expect(tree.exists(`${projectConfig.root}/config/api-extractor.local.json`)).toBeFalsy();
+
+      await generator(tree, options);
+
+      expect(tree.exists(`${projectConfig.root}/config/api-extractor.local.json`)).toBeTruthy();
     });
   });
 });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -10,6 +10,7 @@ import {
   stripIndents,
   visitNotIgnoredFiles,
   logger,
+  writeJson,
 } from '@nrwl/devkit';
 import { serializeJson } from '@nrwl/workspace';
 import { updateJestConfig } from '@nrwl/jest/src/generators/jest-project/lib/update-jestconfig';
@@ -25,7 +26,7 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
  * 2. migrate to use standard jest powered by TS path aliases - #18368 ✅
  * 3. bootstrap new storybook config - #18394 ✅
  * 4. collocate all package stories from `react-examples` - #18394 ✅
- * 5. update npm scripts (setup docs task to run api-extractor for local changes verification)
+ * 5. update npm scripts (setup docs task to run api-extractor for local changes verification) - #18394 ✅
  */
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
@@ -48,6 +49,10 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
   moveStorybookFromReactExamples(tree, options);
   deleteProjectFolderInReactExamples(tree, options);
 
+  // 5. update package npm scripts
+  updateNpmScripts(tree, options);
+  updateApiExtractorForLocalBuilds(tree, options);
+
   formatFiles(tree);
 
   return () => {
@@ -60,6 +65,11 @@ const userLog: Array<{ type: keyof typeof logger; message: string }> = [];
 // ==== helpers ====
 
 const templates = {
+  apiExtractor: {
+    $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
+    extends: './api-extractor.json',
+    mainEntryPointFilePath: '<projectFolder>/dist/<unscopedPackageName>/src/index.d.ts',
+  },
   tsconfig: {
     extends: '../../tsconfig.base.json',
     compilerOptions: {
@@ -148,6 +158,7 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
      */
     normalizedPkgName: options.name.replace(`@${workspaceConfig.npmScope}/`, ''),
     paths: {
+      configRoot: joinPathFragments(projectConfig.root, 'config'),
       packageJson: joinPathFragments(projectConfig.root, 'package.json'),
       tsconfig: joinPathFragments(projectConfig.root, 'tsconfig.json'),
       jestConfig: joinPathFragments(projectConfig.root, 'jest.config.js'),
@@ -161,6 +172,32 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
       },
     },
   };
+}
+
+function updateNpmScripts(tree: Tree, options: NormalizedSchema) {
+  updateJson(tree, options.paths.packageJson, json => {
+    delete json.scripts['update-snapshots'];
+    delete json.scripts['start-test'];
+
+    json.scripts.docs = 'api-extractor run --config=config/api-extractor.local.json --local';
+    json.scripts[
+      'build:local'
+      // eslint-disable-next-line @fluentui/max-len
+    ] = `tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/${options.projectConfig.root}/src && yarn docs`;
+    json.scripts.storybook = 'start-storybook';
+    json.scripts.start = 'storybook';
+    json.scripts.test = 'jest';
+
+    return json;
+  });
+
+  return tree;
+}
+
+function updateApiExtractorForLocalBuilds(tree: Tree, options: NormalizedSchema) {
+  writeJson(tree, joinPathFragments(options.paths.configRoot, 'api-extractor.local.json'), templates.apiExtractor);
+
+  return tree;
 }
 
 function setupStorybook(tree: Tree, options: NormalizedSchema) {

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -26,7 +26,7 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
  * 2. migrate to use standard jest powered by TS path aliases - #18368 ✅
  * 3. bootstrap new storybook config - #18394 ✅
  * 4. collocate all package stories from `react-examples` - #18394 ✅
- * 5. update npm scripts (setup docs task to run api-extractor for local changes verification) - #18394 ✅
+ * 5. update npm scripts (setup docs task to run api-extractor for local changes verification) - #18403 ✅
  */
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: implements partially #16889
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

 - depends on https://github.com/microsoft/fluentui/pull/18401

This is 4th phase for implementing migration generator with nx:

TASK:

- ~migrate to typescript path aliases~
- ~migrate to use standard jest powered by TS path aliases~
- ~bootstrap new storybook config~
- ~collocate all package stories from react-examples~
- update npm scripts (setup docs task to run api-extractor for local changes verification) ( THIS PR ✅ )

#### Focus areas to test

(optional)
