### PR TITLE
babel-make-styles support call expression

### DIFF
--- a/change/@fluentui-babel-make-styles-c224de0e-1ef8-488f-b2a4-3409d5c48edd.json
+++ b/change/@fluentui-babel-make-styles-c224de0e-1ef8-488f-b2a4-3409d5c48edd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for call expression on babel make-styles transformer",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/function-mixin/code.ts
+++ b/packages/babel-make-styles/__fixtures__/function-mixin/code.ts
@@ -1,0 +1,6 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+import { createMixin } from './mixins';
+
+export const useStyles = makeStyles({
+  avatar: createMixin({ display: 'block', opacity: '0' }),
+});

--- a/packages/babel-make-styles/__fixtures__/function-mixin/mixins.ts
+++ b/packages/babel-make-styles/__fixtures__/function-mixin/mixins.ts
@@ -1,0 +1,9 @@
+import { MakeStyles, MakeStylesStyleRule } from '@fluentui/make-styles';
+import { Theme } from '@fluentui/react-theme';
+
+export const createMixin = (rule: MakeStyles): MakeStylesStyleRule<Theme> => {
+  return theme => ({
+    color: theme.alias.color.brand.brandBackground,
+    ...rule,
+  });
+};

--- a/packages/babel-make-styles/__fixtures__/function-mixin/output.ts
+++ b/packages/babel-make-styles/__fixtures__/function-mixin/output.ts
@@ -1,0 +1,9 @@
+import { __styles } from '@fluentui/react-make-styles';
+import { createMixin } from './mixins';
+export const useStyles = __styles({
+  avatar: {
+    sj55zd: ['', 'f1qa0pc1', '.f1qa0pc1{color:var(--alias-color-brand-brandBackground);}'],
+    mc9l5x: ['', 'ftgm304', '.ftgm304{display:block;}'],
+    abs64n: ['', 'fk73vx1', '.fk73vx1{opacity:0;}'],
+  },
+});

--- a/packages/babel-make-styles/src/plugin.test.ts
+++ b/packages/babel-make-styles/src/plugin.test.ts
@@ -21,27 +21,27 @@ pluginTester({
 
   fixtures: fixturesDir,
   tests: [
-    {
-      title: 'errors: throws on invalid argument type',
-      fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
-      error: /function accepts only an object as a param/,
-    },
-    {
-      title: 'errors: throws on invalid argument count',
-      fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
-      error: /function accepts only a single param/,
-    },
-
-    {
-      title: 'errors: throws on invalid slot',
-      fixture: path.resolve(fixturesDir, 'error-style-method', 'fixture.js'),
-      error: /Object methods are not supported for defining styles/,
-    },
-    {
-      title: 'errors: throws on invalid property',
-      fixture: path.resolve(fixturesDir, 'error-style-property', 'fixture.js'),
-      error: /Object methods are not supported for defining styles/,
-    },
+    // {
+    //   title: 'errors: throws on invalid argument type',
+    //   fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
+    //   error: /function accepts only an object as a param/,
+    // },
+    // {
+    //   title: 'errors: throws on invalid argument count',
+    //   fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
+    //   error: /function accepts only a single param/,
+    // },
+    //
+    // {
+    //   title: 'errors: throws on invalid slot',
+    //   fixture: path.resolve(fixturesDir, 'error-style-method', 'fixture.js'),
+    //   error: /Object methods are not supported for defining styles/,
+    // },
+    // {
+    //   title: 'errors: throws on invalid property',
+    //   fixture: path.resolve(fixturesDir, 'error-style-property', 'fixture.js'),
+    //   error: /Object methods are not supported for defining styles/,
+    // },
   ],
 
   plugin,

--- a/packages/babel-make-styles/src/plugin.test.ts
+++ b/packages/babel-make-styles/src/plugin.test.ts
@@ -21,27 +21,27 @@ pluginTester({
 
   fixtures: fixturesDir,
   tests: [
-    // {
-    //   title: 'errors: throws on invalid argument type',
-    //   fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
-    //   error: /function accepts only an object as a param/,
-    // },
-    // {
-    //   title: 'errors: throws on invalid argument count',
-    //   fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
-    //   error: /function accepts only a single param/,
-    // },
-    //
-    // {
-    //   title: 'errors: throws on invalid slot',
-    //   fixture: path.resolve(fixturesDir, 'error-style-method', 'fixture.js'),
-    //   error: /Object methods are not supported for defining styles/,
-    // },
-    // {
-    //   title: 'errors: throws on invalid property',
-    //   fixture: path.resolve(fixturesDir, 'error-style-property', 'fixture.js'),
-    //   error: /Object methods are not supported for defining styles/,
-    // },
+    {
+      title: 'errors: throws on invalid argument type',
+      fixture: path.resolve(fixturesDir, 'error-argument-type', 'fixture.js'),
+      error: /function accepts only an object as a param/,
+    },
+    {
+      title: 'errors: throws on invalid argument count',
+      fixture: path.resolve(fixturesDir, 'error-argument-count', 'fixture.js'),
+      error: /function accepts only a single param/,
+    },
+
+    {
+      title: 'errors: throws on invalid slot',
+      fixture: path.resolve(fixturesDir, 'error-style-method', 'fixture.js'),
+      error: /Object methods are not supported for defining styles/,
+    },
+    {
+      title: 'errors: throws on invalid property',
+      fixture: path.resolve(fixturesDir, 'error-style-property', 'fixture.js'),
+      error: /Object methods are not supported for defining styles/,
+    },
   ],
 
   plugin,

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -192,6 +192,12 @@ export function evaluatePathsInVM(
       return t.callExpression(hoistedNode as t.ArrowFunctionExpression, [t.identifier(themeVariableName)]);
     }
 
+    // call expressions should be wrapped with IIFE to ensure that "theme" object will be passed without collisions
+    // TODO: right now this only for call expression that returns a function that takes "theme" object as argument
+    if (nodePath.isCallExpression()) {
+      return t.callExpression(hoistedNode as t.CallExpression, [t.identifier(themeVariableName)]);
+    }
+
     return hoistedNode;
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #17973
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds support for call expressions on `@fluentui/babel-make-styles` to ensure SSR for reusable style rule.

**Objs**: *This implementation only solves a single issue of declaring support for call expressions that returns a function which takes "theme" object as an agument, a better implementation must be provided for future support*. 