### PR TITLE
Bug 115853: Recipients: Dragging recipient to well shows drop allowed but does not drop

### DIFF
--- a/change/@fluentui-react-experiments-04ab1a5a-a1c8-4a56-a269-09e97812b7b6.json
+++ b/change/@fluentui-react-experiments-04ab1a5a-a1c8-4a56-a269-09e97812b7b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "allow dragging plain text into unifiedpicker input",
+  "packageName": "@fluentui/react-experiments",
+  "email": "litong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -180,15 +180,21 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     isInDropAction = false;
   };
 
+  const _hasRecipientType = (event?: React.DragEvent<HTMLDivElement>) => {
+    return !!event?.dataTransfer.types.includes(customClipboardType!);
+  };
+
   const _onDragOverAutofill = (event?: React.DragEvent<HTMLDivElement>) => {
-    if (autofillDragDropEnabled) {
+    if (autofillDragDropEnabled && _hasRecipientType(event)) {
       event?.preventDefault();
     }
   };
 
   const _onDropAutoFill = (event?: React.DragEvent<HTMLDivElement>) => {
     isInDropAction = true;
-    event?.preventDefault();
+    if (_hasRecipientType(event)) {
+      event?.preventDefault();
+    }
     if (onDropAutoFill) {
       onDropAutoFill(event);
     } else {

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -180,8 +180,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     isInDropAction = false;
   };
 
-  const _hasRecipientType = (event?: React.DragEvent<HTMLDivElement>) => {
-    return !!event?.dataTransfer.types.includes(customClipboardType!);
+  const _hasRecipientType = (event?: React.DragEvent<HTMLDivElement> | DragEvent) => {
+    return !!event?.dataTransfer?.types.includes(customClipboardType!);
   };
 
   const _onDragOverAutofill = (event?: React.DragEvent<HTMLDivElement>) => {
@@ -205,6 +205,16 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const _canDrop = (dropContext?: IDragDropContext, dragContext?: IDragDropContext): boolean => {
     return defaultDragDropEnabled && !focusedItemIndices.includes(dropContext!.index);
+  };
+
+  const _onDragOver = (item?: any, event?: DragEvent) => {
+    if (event && event.dataTransfer) {
+      if (_hasRecipientType(event)) {
+        event.dataTransfer.dropEffect = 'move';
+      } else {
+        event.dataTransfer.dropEffect = 'none';
+      }
+    }
   };
 
   const _onDropList = (item?: any, event?: DragEvent): void => {
@@ -309,6 +319,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDrop: _onDropList,
     onDragStart: _onDragStart,
     onDragEnd: _onDragEnd,
+    onDragOver: _onDragOver,
   };
 
   const _onSuggestionSelected = React.useCallback(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #115853
- [x] Include a change request file using `$ yarn change`

Defect: Cannot drag text into recipient field, drop effect shows can drop but nothing happens.  Input field is blocked from handling dragdrop.

Fix: Only prevent default for recipient type drag objects and let input field handle default dragdrop behavior.  When dragging over recipients, show correct drop effect ie only recipient types are allowed to be dropped.

#### Focus areas to test

dragdrop in unifiedpicker of text, recipients, and other types
