### PR TITLE
feat(Menu): Add MenuTriggerChildProps as contract for children

### DIFF
--- a/change/@fluentui-react-menu-5d87c89c-45c2-462f-aaa2-0f9ca22d8803.json
+++ b/change/@fluentui-react-menu-5d87c89c-45c2-462f-aaa2-0f9ca22d8803.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add MenuTriggerChildProps interface",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -228,6 +228,10 @@ export interface MenuState extends MenuProps {
 // @public
 export const MenuTrigger: React_2.FunctionComponent<MenuTriggerProps & React_2.RefAttributes<HTMLElement>>;
 
+// @public
+export interface MenuTriggerChildProps extends Required<Pick<React_2.HTMLAttributes<HTMLElement>, 'onClick' | 'onMouseEnter' | 'onContextMenu' | 'onKeyDown' | 'onBlur' | 'aria-haspopup' | 'aria-expanded' | 'id'>> {
+}
+
 // @public (undocumented)
 export const MenuTriggerContextProvider: React_2.Provider<boolean>;
 

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -100,7 +100,7 @@ export const CustomTrigger = () => {
   return (
     <>
       <button onClick={() => setOpen(true)}>Custom trigger</button>
-      <Menu position="below" open={open} onOpenChange={onOpenChange}>
+      <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger>
           <CustomMenuTrigger />
         </MenuTrigger>

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -86,7 +86,7 @@ export const ControlledPopup = () => {
 const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, Partial<MenuTriggerChildProps>>((props, ref) => {
   return (
     <button {...props} ref={ref}>
-      Toggle menu
+      Custom Trigger
     </button>
   );
 });
@@ -98,21 +98,18 @@ export const CustomTrigger = () => {
   };
 
   return (
-    <>
-      <button onClick={() => setOpen(true)}>Custom Trigger</button>
-      <Menu open={open} onOpenChange={onOpenChange}>
-        <MenuTrigger>
-          <CustomMenuTrigger />
-        </MenuTrigger>
+    <Menu open={open} onOpenChange={onOpenChange}>
+      <MenuTrigger>
+        <CustomMenuTrigger />
+      </MenuTrigger>
 
-        <MenuList>
-          <MenuItem>New </MenuItem>
-          <MenuItem>New Window</MenuItem>
-          <MenuItem disabled>Open File</MenuItem>
-          <MenuItem>Open Folder</MenuItem>
-        </MenuList>
-      </Menu>
-    </>
+      <MenuList>
+        <MenuItem>New </MenuItem>
+        <MenuItem>New Window</MenuItem>
+        <MenuItem disabled>Open File</MenuItem>
+        <MenuItem>Open Folder</MenuItem>
+      </MenuList>
+    </Menu>
   );
 };
 

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -99,7 +99,7 @@ export const CustomTrigger = () => {
 
   return (
     <>
-      <button onClick={() => setOpen(true)}>Custom trigger</button>
+      <button onClick={() => setOpen(true)}>Custom Trigger</button>
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger>
           <CustomMenuTrigger />

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -10,6 +10,7 @@ import {
   MenuDivider,
   MenuGroupHeader,
   MenuProps,
+  MenuTriggerChildProps,
 } from './index';
 import { boolean } from '@storybook/addon-knobs';
 
@@ -82,6 +83,14 @@ export const ControlledPopup = () => {
   );
 };
 
+const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, Partial<MenuTriggerChildProps>>((props, ref) => {
+  return (
+    <button {...props} ref={ref}>
+      Toggle menu
+    </button>
+  );
+});
+
 export const CustomTrigger = () => {
   const [open, setOpen] = React.useState(false);
   const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
@@ -90,10 +99,10 @@ export const CustomTrigger = () => {
 
   return (
     <>
-      <button onClick={() => setOpen(true)}>Custom Trigger</button>
-      <Menu open={open} onOpenChange={onOpenChange}>
+      <button onClick={() => setOpen(true)}>Custom trigger</button>
+      <Menu position="below" open={open} onOpenChange={onOpenChange}>
         <MenuTrigger>
-          <button>Toggle menu</button>
+          <CustomMenuTrigger />
         </MenuTrigger>
 
         <MenuList>

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -11,6 +11,17 @@ export interface MenuTriggerProps {
 }
 
 /**
+ * Props that are passed to the child of the MenuTrigger when cloned to ensure correct behaviour for the Menu
+ */
+export interface MenuTriggerChildProps
+  extends Required<
+    Pick<
+      React.HTMLAttributes<HTMLElement>,
+      'onClick' | 'onMouseEnter' | 'onContextMenu' | 'onKeyDown' | 'onBlur' | 'aria-haspopup' | 'aria-expanded' | 'id'
+    >
+  > {}
+
+/**
  * {@docCategory MenuTrigger }
  */
 export interface MenuTriggerState extends MenuTriggerProps {

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useMergedRefs, useEventCallback, shouldPreventDefaultOnKeyDown } from '@fluentui/react-utilities';
 import { getCode, keyboardKey } from '@fluentui/keyboard-key';
-import { MenuTriggerState } from './MenuTrigger.types';
+import { MenuTriggerChildProps, MenuTriggerState } from './MenuTrigger.types';
 import { useMenuContext } from '../../contexts/menuContext';
 import { isOutsideMenu } from '../../utils/index';
 
@@ -92,21 +92,29 @@ export const useTriggerElement = (state: UseTriggerElementState): MenuTriggerSta
   });
 
   const disabled = child.props?.disabled;
-  const triggerProps: Partial<React.HTMLAttributes<HTMLElement>> = {
+  const triggerProps: MenuTriggerChildProps = {
     'aria-haspopup': true,
     'aria-expanded': open,
     id: triggerId,
-    ...(child.props || {}),
+    // spread props here because below event handlers must handle original prop
+    ...child.props,
 
-    // These handlers should always handle the child's props
-    ...(!disabled && {
-      // These handlers should always handle the child's original handlers
-      onClick,
-      onMouseEnter,
-      onContextMenu,
-      onKeyDown,
-      onBlur,
-    }),
+    ...(!disabled
+      ? {
+          onClick,
+          onMouseEnter,
+          onContextMenu,
+          onKeyDown,
+          onBlur,
+        }
+      : // Spread disabled event handlers to implement contract and avoid specific disabled logic in handlers
+        {
+          onClick: () => null,
+          onMouseEnter: () => null,
+          onContextMenu: () => null,
+          onKeyDown: () => null,
+          onBlur: () => null,
+        }),
   };
 
   state.children = React.cloneElement(child, {

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -8,6 +8,8 @@ import { isOutsideMenu } from '../../utils/index';
 // Helper type to select on parts of state the hook uses
 type UseTriggerElementState = Pick<MenuTriggerState, 'children'>;
 
+const noop = () => null;
+
 /**
  * Adds the necessary props to the trigger element
  *
@@ -109,11 +111,11 @@ export const useTriggerElement = (state: UseTriggerElementState): MenuTriggerSta
         }
       : // Spread disabled event handlers to implement contract and avoid specific disabled logic in handlers
         {
-          onClick: () => null,
-          onMouseEnter: () => null,
-          onContextMenu: () => null,
-          onKeyDown: () => null,
-          onBlur: () => null,
+          onClick: noop,
+          onMouseEnter: noop,
+          onContextMenu: noop,
+          onKeyDown: noop,
+          onBlur: noop,
         }),
   };
 


### PR DESCRIPTION
Adds a new type `MenuTriggerChildProps` which can be used to create
custom triggers for `Menu`. Also adds a story to document usage
