### PR TITLE
feat(tools): add migration generator user input validations

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -61,6 +61,7 @@ describe('migrate-converged-pkg generator', () => {
       });
 
       await expect(generator(tree, options)).rejects.toMatchInlineSnapshot(
+        // eslint-disable-next-line @fluentui/max-len
         `[Error: @proj/react-dummy is not converged package. Make sure to run the migration on packages with version 9.x.x]`,
       );
     });

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -41,18 +41,28 @@ describe('migrate-converged-pkg generator', () => {
   });
 
   describe('general', () => {
-    it.skip(`should throw error if provided name doesn't match existing package`, async () => {
-      expect(readProjectConfiguration(tree, '@proj/non-existent-lib')).toThrowErrorMatchingInlineSnapshot();
+    it(`should throw error if name is empty`, async () => {
+      await expect(generator(tree, { name: '' })).rejects.toMatchInlineSnapshot(
+        `[Error: --name cannot be empty. Please provide name of the package.]`,
+      );
     });
 
-    it.skip(`should throw error if user wants migrate non converged package`, async () => {
+    it(`should throw error if provided name doesn't match existing package`, async () => {
+      await expect(generator(tree, { name: '@proj/non-existent-lib' })).rejects.toMatchInlineSnapshot(
+        `[Error: Cannot find configuration for '@proj/non-existent-lib' in /workspace.json.]`,
+      );
+    });
+
+    it(`should throw error if user wants migrate non converged package`, async () => {
       const projectConfig = readProjectConfiguration(tree, options.name);
-      updateJson(tree, `${projectConfig.root}/tsconfig.json`, json => {
+      updateJson(tree, `${projectConfig.root}/package.json`, json => {
         json.version = '8.0.0';
         return json;
       });
 
-      expect(await generator(tree, options)).rejects.toMatchInlineSnapshot();
+      await expect(generator(tree, options)).rejects.toMatchInlineSnapshot(
+        `[Error: @proj/react-dummy is not converged package. Make sure to run the migration on packages with version 9.x.x]`,
+      );
     });
   });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -32,6 +32,8 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 
 export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorSchema) {
+  validateUserInput(tree, schema);
+
   const options = normalizeOptions(tree, schema);
 
   // 1. update TsConfigs
@@ -172,6 +174,25 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
       },
     },
   };
+}
+
+function validateUserInput(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+  if (!Boolean(options.name)) {
+    throw new Error(`--name cannot be empty. Please provide name of the package.`);
+  }
+
+  const projectConfig = readProjectConfiguration(tree, options.name);
+  const packageJson = readJson<PackageJson>(tree, joinPathFragments(projectConfig.root, 'package.json'));
+
+  const isPackageConverged = packageJson.version.startsWith('9.');
+
+  if (!isPackageConverged) {
+    throw new Error(
+      `${options.name} is not converged package. Make sure to run the migration on packages with version 9.x.x`,
+    );
+  }
+
+  return tree;
 }
 
 function updateNpmScripts(tree: Tree, options: NormalizedSchema) {

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -177,7 +177,7 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
 }
 
 function validateUserInput(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
-  if (!Boolean(options.name)) {
+  if (!options.name) {
     throw new Error(`--name cannot be empty. Please provide name of the package.`);
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Partially implements #16889
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

This is last phase for implementing migration generator with nx:

TASK:

- ~migrate to typescript path aliases~
- ~migrate to use standard jest powered by TS path aliases~
- ~bootstrap new storybook config~
- ~collocate all package stories from react-examples~
- ~update npm scripts (setup docs task to run api-extractor for local changes verification)~
- add user input validation (THIS PR ✅)

#### Focus areas to test

(optional)
