### PR TITLE
Adding default generic type to makeStyles so autocomplete works in scenarios where you don't specify the generic.

### DIFF
--- a/change/@fluentui-react-fd83a9d9-4981-421c-b530-530e04a0d597.json
+++ b/change/@fluentui-react-fd83a9d9-4981-421c-b530-530e04a0d597.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding default generic type to makeStyles so autocomplete works in scenarios where you don't specify the generic.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8649,6 +8649,8 @@ export class ListPeoplePickerBase extends MemberListPeoplePicker {
 // @public
 export function makeStyles<TStyleSet extends {
     [key in keyof TStyleSet]: IStyle;
+} = {
+    [key: string]: IStyle;
 }>(styleOrFunction: TStyleSet | ((theme: Theme) => TStyleSet)): (options?: UseStylesOptions) => {
     [key in keyof TStyleSet]: string;
 };

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.ts
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.ts
@@ -45,7 +45,7 @@ export type UseStylesOptions = {
  * @param styleOrFunction - Either a css javascript object, or a function which takes in `ITheme`
  * and returns a css javascript object.
  */
-export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle }>(
+export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle } = { [key: string]: IStyle }>(
   styleOrFunction: TStyleSet | ((theme: Theme) => TStyleSet),
 ): (options?: UseStylesOptions) => { [key in keyof TStyleSet]: string } {
   // Create graph of inputs to map to output.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18423
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#18376 fixed an issue with the typings of `makeStyles` to make it work with `I***Styles` interfaces but removed all ability to use autocomplete without specifying the generic in the process. This PR fixes the issue by making the default for the generic be of type `{ [key: string]: IStyle }` if the generic is not specified.