### PR TITLE
Bug 111881: UnifiedPicker: Backspace does not work for recipients in pop out window

### DIFF
--- a/change/@fluentui-react-experiments-2d78d84b-e392-4d77-9619-42110f62351d.json
+++ b/change/@fluentui-react-experiments-2d78d84b-e392-4d77-9619-42110f62351d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "unifiedpicker: make backspace delete work for pop out windows",
+  "packageName": "@fluentui/react-experiments",
+  "email": "litong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -363,7 +363,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           input &&
           input.current &&
           !input.current.isValueSelected &&
-          input.current.inputElement === document.activeElement &&
+          input.current.inputElement === ev.currentTarget.ownerDocument.activeElement &&
           (input.current as Autofill).cursorLocation === 0
         ) {
           const indexToRemove = selectedItems.length - 1;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #111881
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Problem: when in pop out window mode, user cannot use backspace key to delete recipients

Issue: when determining whether to process the delete, unifiedpicker checks whether the input has focus.  It compares against 
 document.activeElement.  When in pop out window, the parent window drives the child window so 'document' refers to the parent document.  We need to test against the child focused element.

Fix: check for focus using the event element's reference document.

#### Focus areas to test

Backspace key in unifiedpicker when hosted in various document environments.
