### PR TITLE
Pivot Component - Add additional prop to customize focus behavior

### DIFF
--- a/change/@fluentui-react-cce21862-638d-4a53-aac4-65218b449886.json
+++ b/change/@fluentui-react-cce21862-638d-4a53-aac4-65218b449886.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added additional prop for focus zone direction",
+  "packageName": "@fluentui/react",
+  "email": "nikolenkoanton92@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-cce21862-638d-4a53-aac4-65218b449886.json
+++ b/change/@fluentui-react-cce21862-638d-4a53-aac4-65218b449886.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added additional prop for focus zone direction",
+  "comment": "Added focusZoneProps to the Pivot component to have ability be more customized",
   "packageName": "@fluentui/react",
   "email": "nikolenkoanton92@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6623,6 +6623,7 @@ export interface IPivotProps extends React_2.HTMLAttributes<HTMLDivElement>, Rea
     className?: string;
     componentRef?: React_2.RefObject<IPivot>;
     defaultSelectedKey?: string;
+    focusZoneProps?: IFocusZoneProps;
     getTabId?: (itemKey: string, index: number) => string;
     headersOnly?: boolean;
     linkFormat?: PivotLinkFormatType;

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -244,7 +244,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
           componentRef={focusZoneRef}
-          className={classNames.root}
+          className={css(classNames.root)}
           role="tablist"
           direction={FocusZoneDirection.horizontal}
           {...focusZoneProps}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -244,7 +244,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
           componentRef={focusZoneRef}
-          className={css(classNames.root)}
+          className={css(classNames.root, focusZoneProps.className)}
           role="tablist"
           direction={FocusZoneDirection.horizontal}
           {...focusZoneProps}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -247,7 +247,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
           role="tablist"
           direction={FocusZoneDirection.horizontal}
           {...focusZoneProps}
-          className={css(classNames.root, focusZoneProps.className)}
+          className={css(classNames.root, focusZoneProps?.className)}
         >
           {items}
           {overflowBehavior === 'menu' && (

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -244,10 +244,10 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
           componentRef={focusZoneRef}
-          className={css(classNames.root, focusZoneProps.className)}
           role="tablist"
           direction={FocusZoneDirection.horizontal}
           {...focusZoneProps}
+          className={css(classNames.root, focusZoneProps.className)}
         >
           {items}
           {overflowBehavior === 'menu' && (

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -3,7 +3,7 @@ import { useControllableValue, useId } from '@fluentui/react-hooks';
 import { classNamesFunction, css, divProperties, getNativeProps, getRTL, KeyCodes, warn } from '@fluentui/utilities';
 import { CommandButton, IButton } from '../../Button';
 import { useOverflow } from '../../utilities/useOverflow';
-import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
+import { FocusZone, IFocusZone, FocusZoneDirection } from '../../FocusZone';
 import { DirectionalHint, IContextualMenuProps } from '../ContextualMenu/ContextualMenu.types';
 import { Icon } from '../Icon/Icon';
 import { IPivot, IPivotItemProps, IPivotProps, IPivotStyleProps, IPivotStyles, PivotItem } from './index';
@@ -65,7 +65,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
 
     const [selectedKey, setSelectedKey] = useControllableValue(props.selectedKey, props.defaultSelectedKey);
 
-    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, focusZoneDirection } = props;
+    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, focusZoneProps } = props;
 
     let classNames: { [key in keyof IPivotStyles]: string };
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
@@ -244,9 +244,10 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
           componentRef={focusZoneRef}
-          direction={focusZoneDirection}
           className={classNames.root}
           role="tablist"
+          direction={FocusZoneDirection.horizontal}
+          {...focusZoneProps}
         >
           {items}
           {overflowBehavior === 'menu' && (

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -65,7 +65,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
 
     const [selectedKey, setSelectedKey] = useControllableValue(props.selectedKey, props.defaultSelectedKey);
 
-    const { componentRef, theme, linkSize, linkFormat, overflowBehavior } = props;
+    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, focusZoneDirection } = props;
 
     let classNames: { [key in keyof IPivotStyles]: string };
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
@@ -244,7 +244,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
           componentRef={focusZoneRef}
-          direction={FocusZoneDirection.horizontal}
+          direction={focusZoneDirection}
           className={classNames.root}
           role="tablist"
         >

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -91,7 +91,7 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
   getTabId?: (itemKey: string, index: number) => string;
 
   /**
-   * Focus zone props
+   * Props passed to the `FocusZone` component used as the root of `Pivot`.
    */
   focusZoneProps?: IFocusZoneProps;
 }

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IStyle, ITheme } from '@fluentui/style-utilities';
 import { IStyleFunctionOrObject } from '@fluentui/utilities';
 import { PivotItem } from './PivotItem';
-import { FocusZoneDirection } from '../../FocusZone';
+import { IFocusZoneProps } from '../../FocusZone';
 
 /**
  * {@docCategory Pivot}
@@ -91,10 +91,9 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
   getTabId?: (itemKey: string, index: number) => string;
 
   /**
-   * Use this prop if you would like to override default behaviour of horizontal tabbing.
-   * @default FocusZoneDirection.horizontal
+   * Focus zone props
    */
-  focusZoneDirection?: FocusZoneDirection.horizontal;
+  focusZoneProps?: IFocusZoneProps;
 }
 
 /**

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IStyle, ITheme } from '@fluentui/style-utilities';
 import { IStyleFunctionOrObject } from '@fluentui/utilities';
 import { PivotItem } from './PivotItem';
+import { FocusZoneDirection } from '../../FocusZone';
 
 /**
  * {@docCategory Pivot}
@@ -88,6 +89,12 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
+
+  /**
+   * Use this prop if you would like to override default behaviour of horizontal tabbing.
+   * @default FocusZoneDirection.horizontal
+   */
+  focusZoneDirection?: FocusZoneDirection.horizontal;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

As part of our internal component we are using vertical tabs. This additional prop should help us customize the direction of the focus to address some of the accessibility issue.
It also can be good starting point to address this(https://github.com/microsoft/fluentui/issues/3593) request in the future.

#### Focus areas to test
N/A