### PR TITLE
Fix on restore focus ctx menu

### DIFF
--- a/change/@fluentui-react-0351eb0b-f667-4c0a-a6c7-9abe81e9dab8.json
+++ b/change/@fluentui-react-0351eb0b-f667-4c0a-a6c7-9abe81e9dab8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing onRestoreFocus merge issue between v7/V8",
+  "packageName": "@fluentui/react",
+  "email": "pagaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -513,7 +513,9 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   }
 
   private _tryFocusPreviousActiveElement = (options: IPopupRestoreFocusParams) => {
-    if (options && options.documentContainsFocus && this._previousActiveElement) {
+    if (this.props.onRestoreFocus) {
+      this.props.onRestoreFocus(options);
+    } else if (options && options.documentContainsFocus && this._previousActiveElement) {
       // Make sure that the focus method actually exists
       // In some cases the object might exist but not be a real element.
       // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.


### PR DESCRIPTION
#### Pull request checklist

- [* ] Addresses an existing issue: Fixes #18433
- [ *] Include a change request file using `$ yarn change`

#### Description of changes

Seems while merging the code from react-internal ContextualMenu package to fluentUI following piece of code got missed.
Re-adding back as the documentation of OnRestoreFocus (which wasn't updated) also hints that it got accidently removed.

#### Focus areas to test
ContextualMenu
