### PR TITLE
fix(eslint-plugin): properly resolve configs for projects that use so…

### DIFF
--- a/change/@fluentui-eslint-plugin-02074c28-c278-4781-b198-7336a400cfd5.json
+++ b/change/@fluentui-eslint-plugin-02074c28-c278-4781-b198-7336a400cfd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(eslint-plugin): properly resolve configs for projects that use solution kind of TS config",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -126,18 +126,57 @@ module.exports = {
     const tsGlob = '**/*.{ts,tsx}';
     let tsFiles = [`src/${tsGlob}`];
     tsconfigPath = tsconfigPath || path.join(process.cwd(), 'tsconfig.json');
-    if (fs.existsSync(tsconfigPath)) {
-      // Note that this way of reading tsconfig does not account for extends, but that's okay since
-      // typically include will not be specified that way
-      const tsconfig = jju.parse(fs.readFileSync(tsconfigPath).toString());
-      if (tsconfig.include) {
-        tsFiles = /** @type {string[]} */ (tsconfig.include).map(
-          includePath => `${includePath.replace(/\*.*/, '')}/${tsGlob}`,
-        );
-      } else if (tsconfig.compilerOptions && tsconfig.compilerOptions.rootDir) {
-        tsFiles = [`${tsconfig.compilerOptions.rootDir}/${tsGlob}`];
-      }
+
+    if (!fs.existsSync(tsconfigPath)) {
+      return [];
     }
+
+    /**
+       * Note that this way of reading tsconfig does not account for extends, but that's okay since
+       * typically include will not be specified that way
+       *
+       * @type {{
+          extends: string[];
+          include: string[];
+          excludes: string[];
+          compilerOptions: Record<string,unknown>;
+          references?: Array<{path:string}>
+          }}
+       */
+    const tsconfig = jju.parse(fs.readFileSync(tsconfigPath).toString());
+
+    // if project is using solution TS style config (process references)
+    if (tsconfig.references) {
+      return [
+        {
+          files: [tsGlob],
+          parserOptions: {
+            project: tsconfig.references.map(refConfig => path.join(process.cwd(), refConfig.path)),
+          },
+          rules,
+        },
+      ];
+    }
+
+    if (tsconfig.include) {
+      tsFiles = /** @type {string[]} */ (tsconfig.include).map(
+        includePath => `${includePath.replace(/\*.*/, '')}/${tsGlob}`,
+      );
+    } else if (tsconfig.compilerOptions && tsconfig.compilerOptions.rootDir) {
+      tsFiles = [`${tsconfig.compilerOptions.rootDir}/${tsGlob}`];
+    }
+
+    // properly resolve invalid slashes in path and preserve initial relative `./` used in tsconfigs
+    tsFiles = tsFiles.map(fileGlob => {
+      const isRelativePath = !path.isAbsolute(fileGlob);
+      const normalized = path.normalize(fileGlob);
+
+      if (isRelativePath) {
+        return './' + normalized;
+      }
+
+      return normalized;
+    });
 
     return [
       {

--- a/tools/.eslintrc.json
+++ b/tools/.eslintrc.json
@@ -1,8 +1,7 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/node"],
+  "root": true,
   "rules": {
-    // In nx run nx-workspace-tools:lint this is resolved relative to the repo root
-    "import/no-extraneous-dependencies": ["error", { "packageDir": ["."] }]
-  },
-  "root": true
+    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../"] }]
+  }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -489,7 +489,8 @@
         "lint": {
           "executor": "@nrwl/workspace:run-commands",
           "options": {
-            "command": "eslint tools/**/*.ts"
+            "command": "eslint **/*.ts",
+            "cwd": "tools"
           }
         },
         "type-check": {


### PR DESCRIPTION
…lution kind of TS config

#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

**Before:**
- with current setup linting was not working in editors within `/tools` project
- while debugging I found out our dynamic config provided invalid paths for `file` property (double slash etc)

**After:**
- linting now works consistently within `/tools` project from CLI and Editor
- files are properly normalized

#### Focus areas to test

(optional)
