### PR TITLE
Add Default Foreground5 and Foreground6 for v2 theme and v2 dark theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))
 - Add `inline` to `ChatMessage`'s `actionMenu` prop that allows actionMenu to be rendered either inline or attached to body @yuanboxue-amber ([#18147](https://github.com/microsoft/fluentui/pull/18147))
 - Let focus-border inherit border-radius from `ChatMessage` @Hirse ([#18305](https://github.com/microsoft/fluentui/pull/18305))
+- Add Default Foreground5 and Foreground6 for v2 theme and v2 dark theme @yuanboxue-amber ([#18451](https://github.com/microsoft/fluentui/pull/18451))
 
 ### Performance
 

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/siteVariables.ts
@@ -9,7 +9,9 @@ export const colorScheme = {
     foreground2: colors.grey['310'],
     foreground3: colors.white,
     foreground4: colors.white,
-    foreground7: colors.white, // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1
+    foreground5: colors.grey['450'],
+    foreground6: colors.grey['550'],
+    foreground7: colors.white,
 
     background: colors.grey['700'],
     background1: colors.grey['750'],

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/siteVariables.ts
@@ -54,7 +54,9 @@ export const colorScheme = {
     foreground2: colors.grey['450'],
     foreground3: colors.white,
     foreground4: colors.white,
-    foreground7: colors.grey['750'], // 5 and 6 are missing to keep foreground7 name consistent with teams-theme-v1
+    foreground5: colors.grey['100'],
+    foreground6: colors.grey['200'],
+    foreground7: colors.grey['750'],
 
     background: colors.white,
     background1: colors.grey['25'],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Currently in v2 default scheme, foreground5 and foreground6 is missing. So it's pulling colors from v1.
This PR adds default foreground5 and 6 to v2 light/dark theme.
<img width="1363" alt="Screenshot 2021-06-03 at 12 30 03" src="https://user-images.githubusercontent.com/28751745/120777764-ed433a80-c525-11eb-8233-9d4e2162da13.png">

#### Focus areas to test

(optional)
