### PR TITLE
fix(Dropdown): passes all positioning props to Popper

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `useAutoControlled` to use updated state @assuncaocharles ([#18338](https://github.com/microsoft/fluentui/pull/18338))
 - Fix RTL version of `NumberListIcon` @notandrew ([#18310](https://github.com/microsoft/fluentui/pull/18310))
 - Fix `ChatMessage` badge-bar conflict with focus-border @Hirse ([#18303](https://github.com/microsoft/fluentui/pull/18303))
+- Fix `Dropdown` to pass all positioning props to its inner `Popper` @yuanboxue-amber ([#18457](https://github.com/microsoft/fluentui/pull/18457))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -376,7 +376,6 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
   setStart();
 
   const {
-    align,
     'aria-labelledby': ariaLabelledby,
     'aria-invalid': ariaInvalid,
     clearable,
@@ -404,8 +403,6 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
     loading,
     loadingMessage,
     placeholder,
-    position,
-    offset,
     renderItem,
     renderSelectedItem,
     search,
@@ -413,12 +410,22 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
     styles,
     toggleIndicator,
     triggerButton,
+    variables,
+  } = props;
+
+  const {
+    align,
+    flipBoundary,
+    overflowBoundary,
+    popperRef,
+    position,
+    positionFixed,
+    offset,
     unstable_disableTether,
     unstable_pinned,
     autoSize,
-    variables,
-  } = props;
-  const [list, positioningProps] = partitionPopperPropsFromShorthand(props.list);
+  } = props; // PositioningProps passed directly to Dropdown
+  const [list, positioningProps] = partitionPopperPropsFromShorthand(props.list); // PositioningProps passed to Dropdown `list` prop's `popper` key
 
   const buttonRef = React.useRef<HTMLElement>();
   const inputRef = React.useRef<HTMLInputElement | undefined>() as React.MutableRefObject<HTMLInputElement | undefined>;
@@ -488,7 +495,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
       isFromKeyboard,
       multiple,
       open,
-      position,
+      position: positioningProps?.position ?? position,
       search: !!search,
       hasItemsSelected: value.length > 0,
     }),
@@ -646,15 +653,20 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
         }}
       >
         <Popper
-          align={align}
-          position={position}
-          offset={offset}
           rtl={context.rtl}
           enabled={open}
           targetRef={containerRef}
+          positioningDependencies={[items.length]}
+          // positioning props:
+          align={align}
+          flipBoundary={flipBoundary}
+          overflowBoundary={overflowBoundary}
+          popperRef={popperRef}
+          position={position}
+          positionFixed={positionFixed}
+          offset={offset}
           unstable_disableTether={unstable_disableTether}
           unstable_pinned={unstable_pinned}
-          positioningDependencies={[items.length]}
           autoSize={autoSize}
           {...positioningProps}
         >
@@ -1647,7 +1659,6 @@ Dropdown.propTypes = {
     content: false,
   }),
   activeSelectedIndex: PropTypes.number,
-  align: PropTypes.oneOf(ALIGNMENTS),
   checkable: PropTypes.bool,
   checkableIndicator: customPropTypes.shorthandAllowingChildren,
   clearable: PropTypes.bool,
@@ -1676,10 +1687,6 @@ Dropdown.propTypes = {
   moveFocusOnTab: PropTypes.bool,
   multiple: PropTypes.bool,
   noResultsMessage: customPropTypes.itemShorthand,
-  offset: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.arrayOf(PropTypes.number) as PropTypes.Requireable<[number, number]>,
-  ]),
   onOpenChange: PropTypes.func,
   onSearchQueryChange: PropTypes.func,
   onBlur: PropTypes.func,
@@ -1688,7 +1695,6 @@ Dropdown.propTypes = {
   onHighlightedIndexChange: PropTypes.func,
   open: PropTypes.bool,
   placeholder: PropTypes.string,
-  position: PropTypes.oneOf(POSITIONS),
   renderItem: PropTypes.func,
   renderSelectedItem: PropTypes.func,
   search: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
@@ -1696,13 +1702,32 @@ Dropdown.propTypes = {
   searchInput: customPropTypes.itemShorthand,
   toggleIndicator: customPropTypes.shorthandAllowingChildren,
   triggerButton: customPropTypes.itemShorthand,
-  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
-  unstable_pinned: PropTypes.bool,
-  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
   value: PropTypes.oneOfType([customPropTypes.itemShorthand, customPropTypes.collectionShorthand]),
   'aria-labelledby': PropTypes.string,
   'aria-invalid': PropTypes.bool,
   a11ySelectedItemsMessage: PropTypes.string,
+  // positioning props
+  align: PropTypes.oneOf(ALIGNMENTS),
+  flipBoundary: PropTypes.oneOfType([
+    PropTypes.object as PropTypes.Requireable<HTMLElement>,
+    PropTypes.arrayOf(PropTypes.object) as PropTypes.Requireable<HTMLElement[]>,
+    PropTypes.oneOf<'clippingParents' | 'window' | 'scrollParent'>(['clippingParents', 'window', 'scrollParent']),
+  ]),
+  overflowBoundary: PropTypes.oneOfType([
+    PropTypes.object as PropTypes.Requireable<HTMLElement>,
+    PropTypes.arrayOf(PropTypes.object) as PropTypes.Requireable<HTMLElement[]>,
+    PropTypes.oneOf<'clippingParents' | 'window' | 'scrollParent'>(['clippingParents', 'window', 'scrollParent']),
+  ]),
+  popperRef: customPropTypes.ref,
+  position: PropTypes.oneOf(POSITIONS),
+  positionFixed: PropTypes.bool,
+  offset: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.number) as PropTypes.Requireable<[number, number]>,
+  ]),
+  unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
+  unstable_pinned: PropTypes.bool,
+  autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
 };
 Dropdown.handledProps = Object.keys(Dropdown.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -5,6 +5,7 @@ import { renderDropdown, items, getItemIdRegexByIndex } from './test-utils';
 import { Dropdown } from 'src/components/Dropdown/Dropdown';
 import { dropdownSelectedItemSlotClassNames } from 'src/components/Dropdown/DropdownSelectedItem';
 import { implementsShorthandProp, isConformant } from 'test/specs/commonTests';
+import { implementsPopperProps } from 'test/specs/commonTests/implementsPopperProps';
 import { findIntrinsicElement } from 'test/utils';
 import { DropdownItemProps } from 'src/components/Dropdown/DropdownItem';
 import { ShorthandValue } from 'src/types';
@@ -20,8 +21,13 @@ describe('Dropdown', () => {
     constructorName: 'Dropdown',
     autoControlledProps: ['highlightedIndex', 'open', 'searchQuery', 'activeSelectedIndex', 'value'],
   });
+
   implementsShorthandProp(Dropdown)('list', List, {
     implementsPopper: true,
+    requiredProps: { open: true },
+  });
+
+  implementsPopperProps(Dropdown, {
     requiredProps: { open: true },
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`Dropdown` component has 2 sets of positioning props that can be passed to its inner `Popper` component to position dropdown list.
1. the positioning props directly on `Dropdown`, for example its `align`, `position` prop
2. the positioning props on `Dropdown`'s `list` prop's `popper` property.

Before this fix, some of the props in the 1st set is not passed to Popper. This PR fixes it and adds UT

#### Focus areas to test

(optional)
