### PR TITLE
fix(Datepicker): update 'today' cell background color in dark-v2 theme to increase contrast

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `useAutoControlled` to use updated state @assuncaocharles ([#18338](https://github.com/microsoft/fluentui/pull/18338))
 - Fix RTL version of `NumberListIcon` @notandrew ([#18310](https://github.com/microsoft/fluentui/pull/18310))
 - Fix `ChatMessage` badge-bar conflict with focus-border @Hirse ([#18303](https://github.com/microsoft/fluentui/pull/18303))
+- Update `Datepicker` today cell background color in dark-v2 theme to increase contrast @yuanboxue-amber ([#18461](https://github.com/microsoft/fluentui/pull/18461))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
@@ -1,2 +1,3 @@
 export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
+export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Datepicker/datepickerCalendarCellButtonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Datepicker/datepickerCalendarCellButtonVariables.ts
@@ -1,0 +1,7 @@
+import { DatepickerVariables } from '../../../teams/components/Datepicker/datepickerVariables';
+
+export const datepickerCalendarCellButtonVariables = (siteVars): Partial<DatepickerVariables> => {
+  return {
+    calendarCellTodayBackgroundColor: siteVars.colorScheme.brand.background,
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #18077
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`Datepicker`'s 'today' cell uses **default backgroundFocus** as background color. But it does not have enough contrast in dark-v2 theme:
<img width="540" alt="Screenshot 2021-06-07 at 11 40 22" src="https://user-images.githubusercontent.com/28751745/120995292-8d4acf00-c785-11eb-9073-b00fc0a4acd8.png">

This PR added override in dark-v2 theme, with **default background** as background color:
<img width="572" alt="Screenshot 2021-06-07 at 11 39 44" src="https://user-images.githubusercontent.com/28751745/120995369-a05d9f00-c785-11eb-85a6-01f98ac011b0.png">
based on the suggestions in the original issue

#### Focus areas to test

(optional)
