### PR TITLE
fix(PeoplePicker): remove tooltip within suggestions dropdown, add no-tooltip option to Persona

### DIFF
--- a/change/@fluentui-react-b3fc9c8f-3200-4150-aef2-bb6f55200609.json
+++ b/change/@fluentui-react-b3fc9c8f-3200-4150-aef2-bb6f55200609.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Persona to make tooltip optional, update PeoplePicker to not show tooltip",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-10be9e19-f696-46e4-a062-b2622e51d9fe.json
+++ b/change/@fluentui-react-examples-10be9e19-f696-46e4-a062-b2622e51d9fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update PeoplePicker List example to show wrapped suggestion text",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import { IPersonaProps, IPersonaStyles } from '@fluentui/react/lib/Persona';
 import {
   IBasePickerSuggestionsProps,
   ListPeoplePicker,
@@ -25,7 +25,7 @@ const checkboxStyles = {
   },
 };
 
-const personaStyles = {
+const personaStyles: Partial<IPersonaStyles> = {
   root: {
     height: 'auto',
   },

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { IBasePickerSuggestionsProps, ListPeoplePicker, ValidationState } from '@fluentui/react/lib/Pickers';
+import {
+  IBasePickerSuggestionsProps,
+  ListPeoplePicker,
+  ValidationState,
+  PeoplePickerItemSuggestion,
+} from '@fluentui/react/lib/Pickers';
 import { people, mru } from '@fluentui/example-data';
 
 const suggestionProps: IBasePickerSuggestionsProps = {
@@ -17,6 +22,20 @@ const suggestionProps: IBasePickerSuggestionsProps = {
 const checkboxStyles = {
   root: {
     marginTop: 10,
+  },
+};
+
+const personaStyles = {
+  root: {
+    height: 'auto',
+  },
+  secondaryText: {
+    height: 'auto',
+    whiteSpace: 'normal',
+  },
+  primaryText: {
+    height: 'auto',
+    whiteSpace: 'normal',
   },
 };
 
@@ -87,6 +106,15 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
     setDelayResults(!delayResults);
   };
 
+  const onRenderSuggestionItem = (personaProps: IPersonaProps, suggestionsProps: IBasePickerSuggestionsProps) => {
+    return (
+      <PeoplePickerItemSuggestion
+        personaProps={{ ...personaProps, styles: personaStyles }}
+        suggestionsProps={suggestionsProps}
+      />
+    );
+  };
+
   return (
     <div>
       <ListPeoplePicker
@@ -102,6 +130,8 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
         removeButtonAriaLabel={'Remove'}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
+        // eslint-disable-next-line react/jsx-no-bind
+        onRenderSuggestionsItem={onRenderSuggestionItem}
         onValidateInput={validateInput}
         inputProps={{
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.doc.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.doc.tsx
@@ -33,7 +33,7 @@ export const PeoplePickerPageProps: IDocPageProps = {
       view: <PeoplePickerCompactExample />,
     },
     {
-      title: 'List People Picker',
+      title: 'List People Picker with Wrapped Item text',
       code: PeoplePickerListExampleCode,
       view: <PeoplePickerListExample />,
     },

--- a/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
+++ b/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
@@ -14,4 +14,6 @@ pickerCalloutProps={{ doNotLayer: true }}
 ```
 
 #### Truncation
-By default, the PeoplePicker truncates suggestion item text instead of wrapping to a new line. This is done without displaying a tooltip to avoid having nested popups. If truncation is not desired, the PeoplePicker item styles can be modified to wrap text, as demonstrated in the List example.
+By default, the PeoplePicker truncates item text in the dropdown instead of wrapping to a new line. To avoid losing meaningful information, keeping option text short is recommended, especially since localizing to different languages may increase the character count. Tooltips are not shown for truncated text within the dropdown to avoid nested popups and the usability and accessibility issues they cause.
+
+Wrapping to two lines is often better than truncating, and the List People Picker example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
+++ b/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
@@ -5,8 +5,13 @@
 
 ### Accessibility
 
+#### Mobile Accessibility
+
 PeoplePicker dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the PeoplePicker inline unless it is in an overflow container. To do so, set the following property on the PeoplePicker:
 
 ```js
 pickerCalloutProps={{ doNotLayer: true }}
 ```
+
+#### Truncation
+By default, the PeoplePicker truncates suggestion item text instead of wrapping to a new line. This is done without displaying a tooltip to avoid having nested popups. If truncation is not desired, the PeoplePicker item styles can be modified to wrap text, as demonstrated in the List example.

--- a/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
+++ b/packages/react-examples/src/react/PeoplePicker/docs/PeoplePickerBestPractices.md
@@ -14,6 +14,7 @@ pickerCalloutProps={{ doNotLayer: true }}
 ```
 
 #### Truncation
-By default, the PeoplePicker truncates item text in the dropdown instead of wrapping to a new line. To avoid losing meaningful information, keeping option text short is recommended, especially since localizing to different languages may increase the character count. Tooltips are not shown for truncated text within the dropdown to avoid nested popups and the usability and accessibility issues they cause.
 
-Wrapping to two lines is often better than truncating, and the List People Picker example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.
+By default, the PeoplePicker truncates item text in the dropdown instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended. Tooltips are not shown for truncated text within the dropdown to avoid nested popups and the usability and accessibility issues they cause.
+
+The List People Picker example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/Persona/docs/PersonaBestPractices.md
+++ b/packages/react-examples/src/react/Persona/docs/PersonaBestPractices.md
@@ -11,4 +11,10 @@
 
 ### Accessibility
 
+#### Color
+
 The presence indicator for small personas of size 32 or less only uses color to indicate the current status. This can result in poor accessibility for anyone who has trouble perceiving color. If you use the presence indicator on small personas, we recommend adding a text alternative as we do in our examples.
+
+#### Tooltips
+
+By default, the Persona truncates text and displays a tooltip with the full text. If a tooltip is not desired (e.g. the Persona is used within a dropdown), the `showOverflowTooltip` property can be set to false.

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6530,6 +6530,7 @@ export interface IPersonaSharedProps extends React_2.HTMLAttributes<HTMLDivEleme
     primaryText?: string;
     secondaryText?: string;
     showInitialsUntilImageLoads?: boolean;
+    showOverflowTooltip?: boolean;
     // (undocumented)
     showSecondaryText?: boolean;
     showUnknownPersonaCoin?: boolean;

--- a/packages/react/src/components/Persona/Persona.base.tsx
+++ b/packages/react/src/components/Persona/Persona.base.tsx
@@ -99,7 +99,7 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
                 </TooltipHost>
               );
             }
-          : (): JSX.Element => <>{text}</>
+          : () => <>{text}</>
         : undefined;
     };
 

--- a/packages/react/src/components/Persona/Persona.base.tsx
+++ b/packages/react/src/components/Persona/Persona.base.tsx
@@ -25,6 +25,7 @@ const DEFAULT_PROPS = {
   size: PersonaSize.size48,
   presence: PersonaPresenceEnum.none,
   imageAlt: '',
+  showOverflowTooltip: true,
 };
 
 function useDebugWarnings(props: IPersonaProps) {
@@ -82,21 +83,23 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
      * to make it independent of the type of text passed
      * @param text - text to render
      */
-    const onRenderText = (text: string | undefined): IRenderFunction<IPersonaProps> | undefined => {
+    const onRenderText = (text: string | undefined, tooltip = true): IRenderFunction<IPersonaProps> | undefined => {
       // return default render behavior for valid text or undefined
       return text
-        ? (): JSX.Element => {
-            // default onRender behavior
-            return (
-              <TooltipHost
-                content={text}
-                overflowMode={TooltipOverflowMode.Parent}
-                directionalHint={DirectionalHint.topLeftEdge}
-              >
-                {text}
-              </TooltipHost>
-            );
-          }
+        ? tooltip
+          ? (): JSX.Element => {
+              // default onRender behavior
+              return (
+                <TooltipHost
+                  content={text}
+                  overflowMode={TooltipOverflowMode.Parent}
+                  directionalHint={DirectionalHint.topLeftEdge}
+                >
+                  {text}
+                </TooltipHost>
+              );
+            }
+          : (): JSX.Element => <>{text}</>
         : undefined;
     };
 
@@ -105,10 +108,10 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
     };
 
     // wrapping default render behavior based on various props properties
-    const onInternalRenderPrimaryText = onRenderText(getText());
-    const onInternalRenderSecondaryText = onRenderText(props.secondaryText);
-    const onInternalRenderTertiaryText = onRenderText(props.tertiaryText);
-    const onInternalRenderOptionalText = onRenderText(props.optionalText);
+    const onInternalRenderPrimaryText = onRenderText(getText(), props.showOverflowTooltip);
+    const onInternalRenderSecondaryText = onRenderText(props.secondaryText, props.showOverflowTooltip);
+    const onInternalRenderTertiaryText = onRenderText(props.tertiaryText, props.showOverflowTooltip);
+    const onInternalRenderOptionalText = onRenderText(props.optionalText, props.showOverflowTooltip);
 
     const {
       hidePersonaDetails,

--- a/packages/react/src/components/Persona/Persona.types.ts
+++ b/packages/react/src/components/Persona/Persona.types.ts
@@ -126,6 +126,12 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<HTMLDivElement
   secondaryText?: string;
 
   /**
+   * Controls whether clipped overflow text should render in a tooltip
+   * @defaultvalue true
+   */
+  showOverflowTooltip?: boolean;
+
+  /**
    * Tertiary text to display, usually the status of the user.
    * The tertiary text will only be shown when using size72 or size100.
    */

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
@@ -31,6 +31,7 @@ export const PeoplePickerItemSuggestionBase = (props: IPeoplePickerItemSuggestio
         styles={personaStyles}
         className={classNames.personaWrapper}
         showSecondaryText={!compact}
+        showOverflowTooltip={false}
         {...personaProps}
       />
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [11882](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11882)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, the tooltip/truncation behavior in Persona means we have tooltips within the dropdown of PeoplePicker. To fix that, I've made these changes:
- Add a `showOverflowTooltip` prop to Persona that defaults to `true` (the current behavior)
- Set `showOverflowTooltip` to false on the Persona used within PeoplePicker
- Update the List example of PeoplePicker to demo styles for wrapping text instead of truncating
- Add docs wording to Persona and PeoplePicker about the changes
