### PR TITLE
fix: set pointer event to none on children in button component

### DIFF
--- a/change/@fluentui-web-components-f111b326-20fc-4836-a718-8a376030deab.json
+++ b/change/@fluentui-web-components-f111b326-20fc-4836-a718-8a376030deab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set pointer event none on children content",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -90,9 +90,14 @@ export const BaseButtonStyles: ElementStyles = css`
     border: 0;
   }
 
+  .content {
+    pointer-events: none;
+  }
+
   .start,
   .end {
     display: flex;
+    pointer-events: none;
   }
 
   ::slotted(svg) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added `pointer-events: none` on `content`, `start` and `end` classes. The contents were triggering focus-visible on the button when clicked.

#### Focus areas to test

(optional)
