### PR TITLE
feat(tools): add --stats flag and update nx workspace config

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -11,6 +11,7 @@ import {
   visitNotIgnoredFiles,
   logger,
   writeJson,
+  updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { serializeJson } from '@nrwl/workspace';
 import { updateJestConfig } from '@nrwl/jest/src/generators/jest-project/lib/update-jestconfig';
@@ -29,12 +30,25 @@ import { MigrateConvergedPkgGeneratorSchema } from './schema';
  * 5. update npm scripts (setup docs task to run api-extractor for local changes verification) - #18403 ✅
  */
 
+interface ProjectConfiguration extends ReturnType<typeof readProjectConfiguration> {}
+
+interface AssertedSchema extends MigrateConvergedPkgGeneratorSchema {
+  name: string;
+}
+
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 
 type UserLog = Array<{ type: keyof typeof logger; message: string }>;
 
 export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorSchema) {
   const userLog: UserLog = [];
+
+  if (schema.stats) {
+    printStats(tree, schema);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
   validateUserInput(tree, schema);
 
   const options = normalizeOptions(tree, schema);
@@ -57,6 +71,8 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
   // 5. update package npm scripts
   updateNpmScripts(tree, options);
   updateApiExtractorForLocalBuilds(tree, options);
+
+  updateNxWorkspace(tree, options);
 
   formatFiles(tree);
 
@@ -146,7 +162,7 @@ const templates = {
   },
 };
 
-function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+function normalizeOptions(host: Tree, options: AssertedSchema) {
   const defaults = {};
   const workspaceConfig = readWorkspaceConfiguration(host);
   const projectConfig = readProjectConfiguration(host, options.name);
@@ -177,21 +193,71 @@ function normalizeOptions(host: Tree, options: MigrateConvergedPkgGeneratorSchem
   };
 }
 
-function validateUserInput(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+function validateUserInput(tree: Tree, options: MigrateConvergedPkgGeneratorSchema): asserts options is AssertedSchema {
   if (!options.name) {
     throw new Error(`--name cannot be empty. Please provide name of the package.`);
   }
 
   const projectConfig = readProjectConfiguration(tree, options.name);
-  const packageJson = readJson<PackageJson>(tree, joinPathFragments(projectConfig.root, 'package.json'));
 
-  const isPackageConverged = packageJson.version.startsWith('9.');
-
-  if (!isPackageConverged) {
+  if (!isPackageConverged(tree, projectConfig)) {
     throw new Error(
       `${options.name} is not converged package. Make sure to run the migration on packages with version 9.x.x`,
     );
   }
+}
+
+function printStats(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
+  const allProjects = getProjects(tree);
+  const stats = {
+    migrated: [] as Array<ProjectConfiguration & { projectName: string }>,
+    notMigrated: [] as Array<ProjectConfiguration & { projectName: string }>,
+  };
+
+  allProjects.forEach((project, projectName) => {
+    if (!isPackageConverged(tree, project)) {
+      return;
+    }
+
+    if (isProjectMigrated(project)) {
+      stats.migrated.push({ projectName, ...project });
+
+      return;
+    }
+    stats.notMigrated.push({ projectName, ...project });
+  });
+
+  logger.info('Convergence DX migration stats:');
+  logger.info('='.repeat(80));
+
+  logger.info(`Migrated (${stats.migrated.length}):`);
+  logger.info(stats.migrated.map(projectStat => `- ${projectStat.projectName}`).join('\n'));
+
+  logger.info('='.repeat(80));
+  logger.info(`Not migrated (${stats.notMigrated.length}):`);
+  logger.info(stats.notMigrated.map(projectStat => `- ${projectStat.projectName}`).join('\n'));
+
+  return tree;
+}
+
+function isPackageConverged(tree: Tree, project: ProjectConfiguration) {
+  const packageJson = readJson<PackageJson>(tree, joinPathFragments(project.root, 'package.json'));
+  return packageJson.version.startsWith('9.');
+}
+
+function isProjectMigrated<T extends ProjectConfiguration>(
+  project: T,
+): project is T & Required<Pick<ProjectConfiguration, 'tags' | 'sourceRoot'>> {
+  // eslint-disable-next-line eqeqeq
+  return project.sourceRoot != null && Boolean(project.tags?.includes('vNext'));
+}
+
+function updateNxWorkspace(tree: Tree, options: NormalizedSchema) {
+  updateProjectConfiguration(tree, options.name, {
+    ...options.projectConfig,
+    sourceRoot: joinPathFragments(options.projectConfig.root, 'src'),
+    tags: [...(options.projectConfig.tags ?? []), 'vNext'],
+  });
 
   return tree;
 }

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -13,7 +13,11 @@
       },
       "x-prompt": "Which converged package would you like migrate to new DX? (ex: @fluentui/react-menu)",
       "pattern": "^[a-zA-Z].*$"
+    },
+    "stats": {
+      "type": "boolean",
+      "description": "Get statistics for how many projects have been migrated"
     }
   },
-  "required": ["name"]
+  "required": []
 }

--- a/tools/generators/migrate-converged-pkg/schema.ts
+++ b/tools/generators/migrate-converged-pkg/schema.ts
@@ -2,5 +2,9 @@ export interface MigrateConvergedPkgGeneratorSchema {
   /**
    * Library name
    */
-  name: string;
+  name?: string;
+  /**
+   * Get statistics for how many projects have been migrated
+   */
+  stats?: boolean;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes partially #16889 
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- updates nx workspace with proper `srcRoot` and adds `vNext` tag to migrated project
- adds stats flag

```sh
yarn nx workspace-generator  migrate-converged-pkg --stats
```

↓↓↓

![2021-06-08 at 16 53](https://user-images.githubusercontent.com/1223799/121208140-20fdc780-c87a-11eb-9a00-95958374d2a8.png)


#### Focus areas to test

(optional)
