### PR TITLE
CompoundButton: Removing legacy patterns from converged component

### DIFF
--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -111,40 +111,23 @@ export interface CheckedState {
 export const CompoundButton: React_2.ForwardRefExoticComponent<CompoundButtonProps & React_2.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
+export type CompoundButtonDefaultedProps = ButtonDefaultedProps | 'contentContainer' | 'secondaryContent';
+
+// @public (undocumented)
 export interface CompoundButtonProps extends ButtonProps {
     contentContainer?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     secondaryContent?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
 }
 
+// @public (undocumented)
+export type CompoundButtonShorthandProps = ButtonShorthandProps | 'contentContainer' | 'secondaryContent';
+
 // @public
 export const compoundButtonShorthandProps: readonly ["children", "contentContainer", "icon", "secondaryContent"];
 
 // @public (undocumented)
-export interface CompoundButtonState extends Omit<CompoundButtonProps, 'children' | 'icon' | 'size'>, ButtonState {
-    // (undocumented)
-    contentContainer?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
-    // (undocumented)
-    secondaryContent?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
+export interface CompoundButtonState extends ButtonState, ComponentState<CompoundButtonProps, CompoundButtonShorthandProps, CompoundButtonDefaultedProps> {
 }
-
-// @public (undocumented)
-export type CompoundButtonStyleSelectors = ButtonStyleSelectors;
-
-// Warning: (ae-forgotten-export) The symbol "CompoundButtonBaseTokens" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export type CompoundButtonTokens = ButtonTokens & CompoundButtonBaseTokens & {
-    hovered: Partial<CompoundButtonBaseTokens>;
-    pressed: Partial<CompoundButtonBaseTokens>;
-};
-
-// @public (undocumented)
-export type CompoundButtonVariants = ButtonVariants;
-
-// @public (undocumented)
-export type CompoundButtonVariantTokens = Partial<{
-    [variant in CompoundButtonVariants]: Partial<CompoundButtonTokens>;
-}>;
 
 // @public
 export const MenuButton: React_2.FunctionComponent<MenuButtonProps & React_2.RefAttributes<HTMLElement>>;
@@ -230,7 +213,7 @@ export const useButton: (props: ButtonProps, ref: React_2.Ref<HTMLElement>, defa
 export const useButtonState: (state: ButtonState) => ButtonState;
 
 // @public (undocumented)
-export const useButtonStyles: (state: ButtonState) => void;
+export const useButtonStyles: (state: ButtonState) => ButtonState;
 
 // @public
 export const useChecked: <TState extends CheckedState>(state: TState) => void;
@@ -239,7 +222,7 @@ export const useChecked: <TState extends CheckedState>(state: TState) => void;
 export const useCompoundButton: (props: CompoundButtonProps, ref: React_2.Ref<HTMLElement>, defaultProps?: CompoundButtonProps | undefined) => CompoundButtonState;
 
 // @public (undocumented)
-export const useCompoundButtonStyles: (state: CompoundButtonState, selectors: CompoundButtonStyleSelectors) => void;
+export const useCompoundButtonStyles: (state: CompoundButtonState) => CompoundButtonState;
 
 // @public
 export const useMenuButton: (props: MenuButtonProps, ref: React_2.Ref<HTMLElement>, defaultProps?: MenuButtonProps | undefined) => MenuButtonState;

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -18,7 +18,9 @@ export const useButton = (props: ButtonProps, ref: React.Ref<HTMLElement>, defau
     {
       ref,
       as: 'button',
+      // Slots
       icon: { as: 'span' },
+      // Props
       size: 'medium',
     },
     defaultProps && resolveShorthandProps(defaultProps, buttonShorthandProps),

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -288,7 +288,7 @@ const useIconStyles = makeStyles({
   },
 });
 
-export const useButtonStyles = (state: ButtonState) => {
+export const useButtonStyles = (state: ButtonState): ButtonState => {
   const rootStyles = useRootStyles();
   const rootIconOnlyStyles = useRootIconOnlyStyles();
   const childrenStyles = useChildrenStyles();
@@ -314,4 +314,6 @@ export const useButtonStyles = (state: ButtonState) => {
   }
 
   state.icon.className = mergeClasses(iconStyles.base, iconStyles[state.size], state.icon.className);
+
+  return state;
 };

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButtonProps, CompoundButtonStyleSelectors } from './CompoundButton.types';
+import { CompoundButtonProps } from './CompoundButton.types';
 import { renderCompoundButton } from './renderCompoundButton';
 import { useCompoundButton } from './useCompoundButton';
 import { useCompoundButtonStyles } from './useCompoundButtonStyles';
@@ -11,16 +11,7 @@ import { useCompoundButtonStyles } from './useCompoundButtonStyles';
 export const CompoundButton = React.forwardRef<HTMLElement, CompoundButtonProps>((props, ref) => {
   const state = useCompoundButton(props, ref);
 
-  const styleSelectors: CompoundButtonStyleSelectors = {
-    disabled: state.disabled,
-    iconOnly: state.iconOnly,
-    primary: state.primary,
-    size: state.size,
-    subtle: state.subtle,
-    transparent: state.transparent,
-  };
-
-  useCompoundButtonStyles(state, styleSelectors);
+  useCompoundButtonStyles(state);
 
   return renderCompoundButton(state);
 });

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
-import { ButtonProps, ButtonState, ButtonStyleSelectors, ButtonTokens, ButtonVariants } from '../Button/Button.types';
+import { ComponentState, ShorthandProps } from '@fluentui/react-utilities';
+import { ButtonDefaultedProps, ButtonProps, ButtonShorthandProps, ButtonState } from '../Button/Button.types';
 
 /**
  * {@docCategory Button}
@@ -20,42 +20,16 @@ export interface CompoundButtonProps extends ButtonProps {
 /**
  * {@docCategory Button}
  */
-export interface CompoundButtonState extends Omit<CompoundButtonProps, 'children' | 'icon' | 'size'>, ButtonState {
-  contentContainer?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-  secondaryContent?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-}
+export type CompoundButtonShorthandProps = ButtonShorthandProps | 'contentContainer' | 'secondaryContent';
 
 /**
  * {@docCategory Button}
  */
-export type CompoundButtonStyleSelectors = ButtonStyleSelectors;
-
-type CompoundButtonBaseTokens = {
-  secondaryContentColor: string;
-  secondaryContentFontSize: string;
-  secondaryContentFontWeight: string | number;
-  secondaryContentGap: string;
-};
+export type CompoundButtonDefaultedProps = ButtonDefaultedProps | 'contentContainer' | 'secondaryContent';
 
 /**
  * {@docCategory Button}
  */
-export type CompoundButtonTokens = ButtonTokens &
-  CompoundButtonBaseTokens & {
-    hovered: Partial<CompoundButtonBaseTokens>;
-    pressed: Partial<CompoundButtonBaseTokens>;
-  };
-
-/**
- * {@docCategory Button}
- */
-export type CompoundButtonVariants = ButtonVariants;
-
-/**
- * {@docCategory Button}
- */
-export type CompoundButtonVariantTokens = Partial<
-  {
-    [variant in CompoundButtonVariants]: Partial<CompoundButtonTokens>;
-  }
->;
+export interface CompoundButtonState
+  extends ButtonState,
+    ComponentState<CompoundButtonProps, CompoundButtonShorthandProps, CompoundButtonDefaultedProps> {}

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -1,15 +1,14 @@
 import * as React from 'react';
-import { makeMergePropsCompat, resolveShorthandProps } from '@fluentui/react-utilities';
-import { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
+import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
 import { useButtonState } from '../Button/useButtonState';
+import { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
 
 /**
  * Consts listing which props are shorthand props.
  */
 export const compoundButtonShorthandProps = ['children', 'contentContainer', 'icon', 'secondaryContent'] as const;
 
-// eslint-disable-next-line deprecation/deprecation
-const mergeProps = makeMergePropsCompat<CompoundButtonState>({
+const mergeProps = makeMergeProps<CompoundButtonState>({
   deepMerge: compoundButtonShorthandProps,
 });
 
@@ -27,10 +26,10 @@ export const useCompoundButton = (
       as: 'button',
       // Slots inherited from Button
       icon: { as: 'span' },
-      loader: { as: 'span' },
       // Slots exclusive to CompoundButton
       contentContainer: { as: 'span', children: null },
       secondaryContent: { as: 'span' },
+      // Props
       size: 'medium',
     },
     defaultProps && resolveShorthandProps(defaultProps, compoundButtonShorthandProps),

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -1,356 +1,224 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { Theme } from '@fluentui/react-theme';
 import { buttonSpacing, useButtonStyles } from '../Button/useButtonStyles';
-import { CompoundButtonState, CompoundButtonStyleSelectors, CompoundButtonVariantTokens } from './CompoundButton.types';
+import { CompoundButtonState } from './CompoundButton.types';
 
 const CompoundButtonClassNames = {
   secondaryContent: 'CompoundButton-secondaryContent',
 };
 
-export const makeCompoundButtonTokens = (theme: Theme): CompoundButtonVariantTokens => ({
-  base: {
-    // root tokens
+const useRootStyles = makeStyles({
+  base: theme => ({
+    gap: buttonSpacing.large,
+
     height: 'auto',
-    paddingX: buttonSpacing.large,
-    paddingY: buttonSpacing.large,
 
-    // icon tokens
-    iconFontSize: '40px',
-    iconSpacing: buttonSpacing.large,
-    iconHeight: '40px',
-    iconWidth: '40px',
-
-    // secondary content tokens
-    secondaryContentColor: theme.alias.color.neutral.neutralForeground2,
-    secondaryContentFontSize: theme.global.type.fontSizes.base[200],
-    secondaryContentFontWeight: theme.global.type.fontWeights.regular,
-    secondaryContentGap: buttonSpacing.smaller,
-
-    hovered: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2Hover,
+    [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+      color: theme.alias.color.neutral.neutralForeground2,
     },
 
-    pressed: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2Pressed,
+    ':hover': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2Hover,
+      },
     },
-  },
+
+    ':active': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2Pressed,
+      },
+    },
+  }),
   small: {
-    paddingX: buttonSpacing.medium,
-    paddingY: buttonSpacing.medium,
-
-    fontSize: theme.global.type.fontSizes.base[300],
-    lineHeight: theme.global.type.lineHeights.base[300],
+    padding: `${buttonSpacing.medium} ${buttonSpacing.medium}`,
+  },
+  medium: {
+    padding: `${buttonSpacing.large} ${buttonSpacing.large}`,
   },
   large: {
-    paddingX: buttonSpacing.larger,
-    paddingY: buttonSpacing.larger,
+    padding: `${buttonSpacing.larger} ${buttonSpacing.larger}`,
+  },
+  primary: theme => ({
+    [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+      color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
+    },
 
-    secondaryContentFontSize: theme.global.type.fontSizes.base[300],
-  },
-  iconOnly: {
-    maxWidth: '52px',
-    minWidth: '52px',
-  },
-  iconOnlySmall: {
+    ':hover': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
+      },
+    },
+
+    ':active': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
+      },
+    },
+  }),
+  subtle: theme => ({
+    [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+      color: theme.alias.color.neutral.neutralForeground2,
+    },
+
+    ':hover': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2BrandHover,
+      },
+    },
+
+    ':active': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2BrandPressed,
+      },
+    },
+  }),
+  transparent: theme => ({
+    [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+      color: theme.alias.color.neutral.neutralForeground2,
+    },
+
+    ':hover': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2BrandHover,
+      },
+    },
+
+    ':active': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForeground2BrandPressed,
+      },
+    },
+  }),
+  disabled: theme => ({
+    [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+      color: theme.alias.color.neutral.neutralForegroundDisabled,
+    },
+
+    ':hover': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForegroundDisabled,
+      },
+    },
+
+    ':active': {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: theme.alias.color.neutral.neutralForegroundDisabled,
+      },
+    },
+  }),
+});
+
+const useRootIconOnlyStyles = makeStyles({
+  small: {
     maxWidth: '48px',
     minWidth: '48px',
   },
-  iconOnlyLarge: {
+  medium: {
+    maxWidth: '52px',
+    minWidth: '52px',
+  },
+  large: {
     maxWidth: '56px',
     minWidth: '56px',
   },
-  primary: {
-    secondaryContentColor: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
+});
 
-    hovered: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
-    },
+const useChildrenStyles = makeStyles({
+  small: theme => ({
+    fontSize: theme.global.type.fontSizes.base[300],
+    lineHeight: theme.global.type.lineHeights.base[300],
+  }),
+  medium: theme => ({
+    fontSize: theme.global.type.fontSizes.base[300],
+    lineHeight: theme.global.type.lineHeights.base[300],
+  }),
+  large: theme => ({
+    fontSize: theme.global.type.fontSizes.base[400],
+    lineHeight: theme.global.type.lineHeights.base[400],
+  }),
+});
 
-    pressed: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
-    },
-  },
-  subtle: {
-    secondaryContentColor: theme.alias.color.neutral.neutralForeground2,
-
-    hovered: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2BrandHover,
-    },
-
-    pressed: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2BrandPressed,
-    },
-  },
-  transparent: {
-    secondaryContentColor: theme.alias.color.neutral.neutralForeground2,
-
-    hovered: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2BrandHover,
-    },
-
-    pressed: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForeground2BrandPressed,
-    },
-  },
-  disabled: {
-    secondaryContentColor: theme.alias.color.neutral.neutralForegroundDisabled,
-
-    hovered: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForegroundDisabled,
-    },
-
-    pressed: {
-      secondaryContentColor: theme.alias.color.neutral.neutralForegroundDisabled,
-    },
+const useIconStyles = makeStyles({
+  base: {
+    fontSize: '40px',
+    height: '40px',
+    width: '40px',
   },
 });
 
-const useStyles = makeStyles({
-  root: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      gap: compoundButtonTokens.base?.iconSpacing,
-      height: compoundButtonTokens.base?.height,
-      padding: `${compoundButtonTokens.base?.paddingY} ${compoundButtonTokens.base?.paddingX}`,
-
-      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: compoundButtonTokens.base?.secondaryContentColor,
-      },
-
-      ':hover': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.base?.hovered?.secondaryContentColor,
-        },
-      },
-
-      ':active': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.base?.pressed?.secondaryContentColor,
-        },
-      },
-    };
-  },
-  rootPrimary: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: compoundButtonTokens.primary?.secondaryContentColor,
-      },
-
-      ':hover': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.primary?.hovered?.secondaryContentColor,
-        },
-      },
-
-      ':active': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.primary?.pressed?.secondaryContentColor,
-        },
-      },
-    };
-  },
-  rootSubtle: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: compoundButtonTokens.subtle?.secondaryContentColor,
-      },
-
-      ':hover': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.subtle?.hovered?.secondaryContentColor,
-        },
-      },
-
-      ':active': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.subtle?.pressed?.secondaryContentColor,
-        },
-      },
-    };
-  },
-  rootTransparent: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: compoundButtonTokens.transparent?.secondaryContentColor,
-      },
-
-      ':hover': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.transparent?.hovered?.secondaryContentColor,
-        },
-      },
-
-      ':active': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.transparent?.pressed?.secondaryContentColor,
-        },
-      },
-    };
-  },
-  rootDisabled: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: compoundButtonTokens.disabled?.secondaryContentColor,
-      },
-
-      ':hover': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.disabled?.hovered?.secondaryContentColor,
-        },
-      },
-
-      ':active': {
-        [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-          color: compoundButtonTokens.disabled?.pressed?.secondaryContentColor,
-        },
-      },
-    };
-  },
-  rootSmall: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      padding: `${compoundButtonTokens.small?.paddingY} ${compoundButtonTokens.small?.paddingX}`,
-    };
-  },
-  rootLarge: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      padding: `${compoundButtonTokens.large?.paddingY} ${compoundButtonTokens.large?.paddingX}`,
-    };
-  },
-  rootIconOnly: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      maxWidth: compoundButtonTokens.iconOnly?.maxWidth,
-      minWidth: compoundButtonTokens.iconOnly?.minWidth,
-    };
-  },
-  rootIconOnlySmall: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      maxWidth: compoundButtonTokens.iconOnlySmall?.maxWidth,
-      minWidth: compoundButtonTokens.iconOnlySmall?.minWidth,
-    };
-  },
-  rootIconOnlyLarge: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      maxWidth: compoundButtonTokens.iconOnlyLarge?.maxWidth,
-      minWidth: compoundButtonTokens.iconOnlyLarge?.minWidth,
-    };
-  },
-  childrenSmall: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      fontSize: compoundButtonTokens.small?.fontSize,
-      lineHeight: compoundButtonTokens.small?.lineHeight,
-    };
-  },
-  icon: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      fontSize: compoundButtonTokens.base?.iconFontSize,
-      height: compoundButtonTokens.base?.iconHeight,
-      width: compoundButtonTokens.base?.iconWidth,
-    };
-  },
-  contentContainer: {
+const useContentContainerStyles = makeStyles({
+  base: {
     display: 'flex',
     flexDirection: 'column',
     textAlign: 'left',
   },
-  secondaryContent: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      lineHeight: '100%',
-
-      fontSize: compoundButtonTokens.base?.secondaryContentFontSize,
-      fontWeight: compoundButtonTokens.base?.secondaryContentFontWeight,
-      marginTop: compoundButtonTokens.base?.secondaryContentGap,
-    };
-  },
-  secondaryContentLarge: theme => {
-    const compoundButtonTokens = makeCompoundButtonTokens(theme);
-
-    return {
-      fontSize: compoundButtonTokens.large?.secondaryContentFontSize,
-    };
-  },
 });
 
-export const useCompoundButtonStyles = (state: CompoundButtonState, selectors: CompoundButtonStyleSelectors) => {
+const useSecondaryContentStyles = makeStyles({
+  base: theme => ({
+    lineHeight: '100%',
+    marginTop: buttonSpacing.smaller,
+
+    fontWeight: theme.global.type.fontWeights.regular,
+  }),
+  small: theme => ({
+    fontSize: theme.global.type.fontSizes.base[200],
+  }),
+  medium: theme => ({
+    fontSize: theme.global.type.fontSizes.base[200],
+  }),
+  large: theme => ({
+    fontSize: theme.global.type.fontSizes.base[300],
+  }),
+});
+
+export const useCompoundButtonStyles = (state: CompoundButtonState): CompoundButtonState => {
   // Save the classnames used in useButtonStyles and undefine them at the state level so that they are always applied
   // last.
   const {
     className: rootClassName,
     children: { className: childrenClassName } = { className: undefined },
-    icon: { className: iconClassName } = { className: undefined },
+    icon: { className: iconClassName },
   } = state;
   state.className = undefined;
   if (state.children) {
     state.children.className = undefined;
   }
-  if (state.icon) {
-    state.icon.className = undefined;
-  }
+  state.icon.className = undefined;
   useButtonStyles(state);
 
-  const styles = useStyles();
+  const rootStyles = useRootStyles();
+  const rootIconOnlyStyles = useRootIconOnlyStyles();
+  const childrenStyles = useChildrenStyles();
+  const iconStyles = useIconStyles();
+  const contentContainerStyles = useContentContainerStyles();
+  const secondaryContentStyles = useSecondaryContentStyles();
 
   state.className = mergeClasses(
     state.className,
-    styles.root,
-    selectors.primary && styles.rootPrimary,
-    selectors.subtle && styles.rootSubtle,
-    selectors.transparent && styles.rootTransparent,
-    selectors.disabled && styles.rootDisabled,
-    selectors.size === 'small' && styles.rootSmall,
-    selectors.size === 'large' && styles.rootLarge,
-    selectors.iconOnly && styles.rootIconOnly,
-    selectors.iconOnly && selectors.size === 'small' && styles.rootIconOnlySmall,
-    selectors.iconOnly && selectors.size === 'large' && styles.rootIconOnlyLarge,
+    rootStyles.base,
+    rootStyles[state.size],
+    state.primary && rootStyles.primary,
+    state.subtle && rootStyles.subtle,
+    state.transparent && rootStyles.transparent,
+    state.disabled && rootStyles.disabled,
+    state.iconOnly && rootIconOnlyStyles[state.size],
     rootClassName,
   );
 
   if (state.children) {
-    state.children.className = mergeClasses(
-      state.children.className,
-      selectors.size === 'small' && styles.childrenSmall,
-      childrenClassName,
-    );
+    state.children.className = mergeClasses(state.children.className, childrenStyles[state.size], childrenClassName);
   }
 
-  if (state.icon) {
-    state.icon.className = mergeClasses(state.icon.className, styles.icon, iconClassName);
-  }
+  state.icon.className = mergeClasses(state.icon.className, iconStyles.base, iconClassName);
 
-  if (state.contentContainer) {
-    state.contentContainer.className = mergeClasses(styles.contentContainer, state.contentContainer.className);
-  }
+  state.contentContainer.className = mergeClasses(contentContainerStyles.base, state.contentContainer.className);
 
-  if (state.secondaryContent) {
-    state.secondaryContent.className = mergeClasses(
-      CompoundButtonClassNames.secondaryContent,
-      styles.secondaryContent,
-      selectors.size === 'large' && styles.secondaryContentLarge,
-      state.secondaryContent.className,
-    );
-  }
+  state.secondaryContent.className = mergeClasses(
+    CompoundButtonClassNames.secondaryContent,
+    secondaryContentStyles.base,
+    secondaryContentStyles[state.size],
+    state.secondaryContent.className,
+  );
+
+  return state;
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes part of #17555 and #18379
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Follow-up of #18468.

This PR removes the legacy patterns that were being used in the `CompoundButton` component in `@fluentui/react-button`, instead opting for using the patterns adopted by other converged components such as `Avatar` in `@fluentui/react-avatar`.

PRs to update `MenuButton` and `ToggleButton` will follow.
