### PR TITLE
fix: scripts package error thrown during test in Windows 10

### DIFF
--- a/scripts/typescript/normalize-import.spec.js
+++ b/scripts/typescript/normalize-import.spec.js
@@ -65,7 +65,7 @@ describe(`normalize-import`, () => {
     const utils = setup();
 
     expect(() => execSync(`node ${utils.scriptPath} --output some/nonexistent/path`, { stdio: 'pipe' })).toThrowError(
-      `some/nonexistent/path doesn't exist`,
+      `/some[\\/]nonexistent[\\/]path doesn't exist/`,
     );
   });
 

--- a/scripts/typescript/normalize-import.spec.js
+++ b/scripts/typescript/normalize-import.spec.js
@@ -64,9 +64,9 @@ describe(`normalize-import`, () => {
   it(`should throw error if provided --output is not a valid directory`, () => {
     const utils = setup();
 
-    expect(() => execSync(`node ${utils.scriptPath} --output some/nonexistent/path`, { stdio: 'pipe' })).toThrowError(
-      `/some[\\/]nonexistent[\\/]path doesn't exist/`,
-    );
+    expect(() =>
+      execSync(`node ${utils.scriptPath} --output /some[\\/]nonexistent[\\/]path doesn't exist/`, { stdio: 'pipe' }),
+    ).toThrowError(`/some[\\/]nonexistent[\\/]path doesn't exist/`);
   });
 
   it(`should replace all relative path import to scoped/absolute path in all files within directory`, () => {

--- a/scripts/typescript/normalize-import.spec.js
+++ b/scripts/typescript/normalize-import.spec.js
@@ -64,9 +64,9 @@ describe(`normalize-import`, () => {
   it(`should throw error if provided --output is not a valid directory`, () => {
     const utils = setup();
 
-    expect(() =>
-      execSync(`node ${utils.scriptPath} --output /some[\\/]nonexistent[\\/]path doesn't exist/`, { stdio: 'pipe' }),
-    ).toThrowError(`/some[\\/]nonexistent[\\/]path doesn't exist/`);
+    expect(() => execSync(`node ${utils.scriptPath} --output some/nonexistent/path`, { stdio: 'pipe' })).toThrowError(
+      /some[/\\]nonexistent[\\/]path doesn't exist/,
+    );
   });
 
   it(`should replace all relative path import to scoped/absolute path in all files within directory`, () => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When running `yarn buildci` on my Windows 10 machine, I kept encountering the error below. This PR fixes the issue by also accounting for Windows machine paths.

![image](https://user-images.githubusercontent.com/8649804/121432975-38978780-c930-11eb-93f9-8639ba9d8733.png)
![image](https://user-images.githubusercontent.com/8649804/121433010-43521c80-c930-11eb-8094-e59f917066d6.png)


