### PR TITLE
ToggleButton: Removing legacy patterns from converged component.

### DIFF
--- a/change/@fluentui-react-button-53d2b6c5-0e15-4e89-a15f-8c76b5ac878b.json
+++ b/change/@fluentui-react-button-53d2b6c5-0e15-4e89-a15f-8c76b5ac878b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ToggleButton: Removing legacy patterns from converged component.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -198,30 +198,20 @@ export const renderMenuButton: (state: MenuButtonState) => JSX.Element;
 export const ToggleButton: React_2.ForwardRefExoticComponent<ToggleButtonProps & React_2.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
+export type ToggleButtonDefaultedProps = ButtonDefaultedProps;
+
+// @public (undocumented)
 export interface ToggleButtonProps extends ButtonProps {
     checked?: boolean;
     defaultChecked?: boolean;
 }
 
 // @public (undocumented)
-export interface ToggleButtonState extends Omit<ToggleButtonProps, 'children' | 'icon' | 'size'>, ButtonState {
+export type ToggleButtonShorthandProps = ButtonShorthandProps;
+
+// @public (undocumented)
+export interface ToggleButtonState extends ButtonState, ComponentState<ToggleButtonProps, ToggleButtonShorthandProps, ToggleButtonDefaultedProps> {
 }
-
-// @public (undocumented)
-export type ToggleButtonStyleSelectors = ButtonStyleSelectors & {
-    checked?: boolean;
-};
-
-// @public (undocumented)
-export type ToggleButtonTokens = ButtonTokens;
-
-// @public (undocumented)
-export type ToggleButtonVariants = ButtonVariants | 'checked' | 'checkedPrimary' | 'checkedSubtle' | 'checkedTransparent';
-
-// @public (undocumented)
-export type ToggleButtonVariantTokens = Partial<{
-    [variant in ToggleButtonVariants]: Partial<ToggleButtonTokens>;
-}>;
 
 // @public
 export const useButton: (props: ButtonProps, ref: React_2.Ref<HTMLElement>, defaultProps?: ButtonProps | undefined) => ButtonState;
@@ -254,7 +244,7 @@ export const useMenuButtonStyles: (state: MenuButtonState, selectors: MenuButton
 export const useToggleButton: (props: ToggleButtonProps, ref: React_2.Ref<HTMLElement>, defaultProps?: ToggleButtonProps | undefined) => ToggleButtonState;
 
 // @public (undocumented)
-export const useToggleButtonStyles: (state: ToggleButtonState, selectors: ToggleButtonStyleSelectors) => void;
+export const useToggleButtonStyles: (state: ToggleButtonState) => ToggleButtonState;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
@@ -1,6 +1,6 @@
-import { ToggleButton } from './ToggleButton';
-import { isConformant } from '../../common/isConformant';
 import { validateBehavior, ComponentTestFacade, toggleButtonBehaviorDefinition } from '@fluentui/a11y-testing';
+import { isConformant } from '../../common/isConformant';
+import { ToggleButton } from './ToggleButton';
 
 describe('ToggleButton', () => {
   isConformant({

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ToggleButtonProps, ToggleButtonStyleSelectors } from './ToggleButton.types';
+import { ToggleButtonProps } from './ToggleButton.types';
 import { renderToggleButton } from './renderToggleButton';
 import { useToggleButton } from './useToggleButton';
 import { useToggleButtonStyles } from './useToggleButtonStyles';
@@ -11,17 +11,7 @@ import { useToggleButtonStyles } from './useToggleButtonStyles';
 export const ToggleButton = React.forwardRef<HTMLElement, ToggleButtonProps>((props, ref) => {
   const state = useToggleButton(props, ref);
 
-  const styleSelectors: ToggleButtonStyleSelectors = {
-    checked: state.checked,
-    disabled: state.disabled,
-    iconOnly: state.iconOnly,
-    primary: state.primary,
-    size: state.size,
-    subtle: state.subtle,
-    transparent: state.transparent,
-  };
-
-  useToggleButtonStyles(state, styleSelectors);
+  useToggleButtonStyles(state);
 
   return renderToggleButton(state);
 });

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,4 +1,5 @@
-import { ButtonProps, ButtonState, ButtonStyleSelectors, ButtonTokens, ButtonVariants } from '../Button/Button.types';
+import { ComponentState } from '@fluentui/react-utilities';
+import { ButtonDefaultedProps, ButtonProps, ButtonShorthandProps, ButtonState } from '../Button/Button.types';
 
 /**
  * {@docCategory Button}
@@ -24,33 +25,16 @@ export interface ToggleButtonProps extends ButtonProps {
 /**
  * {@docCategory Button}
  */
-export interface ToggleButtonState extends Omit<ToggleButtonProps, 'children' | 'icon' | 'size'>, ButtonState {}
+export type ToggleButtonShorthandProps = ButtonShorthandProps;
 
 /**
  * {@docCategory Button}
  */
-export type ToggleButtonStyleSelectors = ButtonStyleSelectors & { checked?: boolean };
+export type ToggleButtonDefaultedProps = ButtonDefaultedProps;
 
 /**
  * {@docCategory Button}
  */
-export type ToggleButtonTokens = ButtonTokens;
-
-/**
- * {@docCategory Button}
- */
-export type ToggleButtonVariants =
-  | ButtonVariants
-  | 'checked'
-  | 'checkedPrimary'
-  | 'checkedSubtle'
-  | 'checkedTransparent';
-
-/**
- * {@docCategory Button}
- */
-export type ToggleButtonVariantTokens = Partial<
-  {
-    [variant in ToggleButtonVariants]: Partial<ToggleButtonTokens>;
-  }
->;
+export interface ToggleButtonState
+  extends ButtonState,
+    ComponentState<ToggleButtonProps, ToggleButtonShorthandProps, ToggleButtonDefaultedProps> {}

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -162,15 +162,9 @@ const useRootStyles = makeStyles({
 });
 
 export const useToggleButtonStyles = (state: ToggleButtonState): ToggleButtonState => {
-  // Save the classnames used in useButtonStyles and undefine them at the state level so that they are always applied
-  // last.
-  const { className: rootClassName } = state;
-  useButtonStyles(state);
-
   const rootStyles = useRootStyles();
 
   state.className = mergeClasses(
-    state.className,
     state.checked && rootStyles.checked,
     state.checked && state.primary && rootStyles.checkedPrimary,
     state.checked && state.subtle && rootStyles.checkedSubtle,
@@ -179,8 +173,10 @@ export const useToggleButtonStyles = (state: ToggleButtonState): ToggleButtonSta
     state.disabled && state.primary && rootStyles.disabledPrimary,
     state.disabled && state.subtle && rootStyles.disabledSubtle,
     state.disabled && state.transparent && rootStyles.disabledTransparent,
-    rootClassName,
+    state.className,
   );
+
+  useButtonStyles(state);
 
   return state;
 };

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -1,140 +1,133 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { Theme } from '@fluentui/react-theme';
 import { useButtonStyles } from '../Button/useButtonStyles';
-import { ToggleButtonState, ToggleButtonStyleSelectors, ToggleButtonVariantTokens } from './ToggleButton.types';
+import { ToggleButtonState } from './ToggleButton.types';
 
-export const makeToggleButtonTokens = (theme: Theme): ToggleButtonVariantTokens => ({
-  checked: {
+const useRootStyles = makeStyles({
+  checked: theme => ({
     background: theme.alias.color.neutral.neutralBackground1Selected,
+    borderColor: theme.alias.color.neutral.neutralStroke1,
     color: theme.alias.color.neutral.neutralForeground1,
 
-    borderColor: theme.alias.color.neutral.neutralStroke1,
     borderWidth: theme.global.strokeWidth.thin,
 
-    // TODO: spec calls out "shadow 2 __lighter__", are we missing tokens?
-    shadow: theme.alias.shadow.shadow2,
+    boxShadow: theme.alias.shadow.shadow2,
 
-    hovered: {
+    ':hover': {
       background: theme.alias.color.neutral.neutralBackground1Hover,
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
       color: theme.alias.color.neutral.neutralForeground1,
 
-      // TODO: spec calls out "shadow 4 __lighter__", are we missing tokens?
-      shadow: theme.alias.shadow.shadow4,
+      boxShadow: theme.alias.shadow.shadow4,
     },
 
-    pressed: {
+    ':active': {
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
       color: theme.alias.color.neutral.neutralForeground1,
 
-      // TODO: spec calls out "shadow 2 __lighter__", are we missing tokens?
-      shadow: theme.alias.shadow.shadow2,
+      boxShadow: theme.alias.shadow.shadow2,
     },
-  },
-  checkedPrimary: {
+  }),
+  checkedPrimary: theme => ({
     background: theme.alias.color.neutral.brandBackgroundSelected,
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
 
-    // TODO: spec calls out "shadow 2 __brand__", are we missing tokens?
-    shadow: theme.alias.shadow.shadow2,
+    boxShadow: theme.alias.shadow.shadow2,
 
-    hovered: {
+    ':hover': {
       background: theme.alias.color.neutral.brandBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
 
-      // TODO: spec calls out "shadow 4 __brand__", are we missing tokens?
-      shadow: theme.alias.shadow.shadow4,
+      boxShadow: theme.alias.shadow.shadow4,
     },
 
-    pressed: {
+    ':active': {
       background: theme.alias.color.neutral.brandBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundInvertedAccessible,
 
-      // TODO: spec calls out "shadow 2 __brand__", are we missing tokens?
-      shadow: theme.alias.shadow.shadow2,
+      boxShadow: theme.alias.shadow.shadow2,
     },
-  },
-  checkedSubtle: {
+  }),
+  checkedSubtle: theme => ({
     background: theme.alias.color.neutral.subtleBackgroundSelected,
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2BrandSelected,
 
-    shadow: 'none',
+    boxShadow: 'none',
 
-    hovered: {
+    ':hover': {
       background: theme.alias.color.neutral.subtleBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
 
-    pressed: {
+    ':active': {
       background: theme.alias.color.neutral.subtleBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
-  },
-  checkedTransparent: {
+  }),
+  checkedTransparent: theme => ({
     background: theme.alias.color.neutral.transparentBackgroundSelected,
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2BrandSelected,
 
-    shadow: 'none',
+    boxShadow: 'none',
 
-    hovered: {
+    ':hover': {
       background: theme.alias.color.neutral.transparentBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
 
-    pressed: {
+    ':active': {
       background: theme.alias.color.neutral.transparentBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
-  },
-  disabled: {
+  }),
+  disabled: theme => ({
     background: theme.alias.color.neutral.neutralBackgroundDisabled,
     borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
     color: theme.alias.color.neutral.neutralForegroundDisabled,
 
-    shadow: 'none',
+    boxShadow: 'none',
 
-    hovered: {
+    ':hover': {
       background: theme.alias.color.neutral.neutralBackgroundDisabled,
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
 
-    pressed: {
+    ':active': {
       background: theme.alias.color.neutral.neutralBackgroundDisabled,
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
 
-      shadow: 'none',
+      boxShadow: 'none',
     },
-  },
+  }),
   disabledPrimary: {
     borderColor: 'transparent',
 
-    hovered: {
+    ':hover': {
       borderColor: 'transparent',
     },
 
-    pressed: {
+    ':active': {
       borderColor: 'transparent',
     },
   },
@@ -142,12 +135,12 @@ export const makeToggleButtonTokens = (theme: Theme): ToggleButtonVariantTokens 
     background: 'none',
     borderColor: 'transparent',
 
-    hovered: {
+    ':hover': {
       background: 'none',
       borderColor: 'transparent',
     },
 
-    pressed: {
+    ':active': {
       background: 'none',
       borderColor: 'transparent',
     },
@@ -156,227 +149,38 @@ export const makeToggleButtonTokens = (theme: Theme): ToggleButtonVariantTokens 
     background: 'none',
     borderColor: 'transparent',
 
-    hovered: {
+    ':hover': {
       background: 'none',
       borderColor: 'transparent',
     },
 
-    pressed: {
+    ':active': {
       background: 'none',
       borderColor: 'transparent',
     },
   },
 });
 
-const useStyles = makeStyles({
-  rootChecked: theme => {
-    const toggleButtonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: toggleButtonTokens.checked?.background,
-      color: toggleButtonTokens.checked?.color,
-
-      borderColor: toggleButtonTokens.checked?.borderColor,
-      borderWidth: toggleButtonTokens.checked?.borderWidth,
-
-      boxShadow: toggleButtonTokens.checked?.shadow,
-
-      ':hover': {
-        background: toggleButtonTokens.checked?.hovered?.background,
-        borderColor: toggleButtonTokens.checked?.hovered?.borderColor,
-        color: toggleButtonTokens.checked?.hovered?.color,
-
-        boxShadow: toggleButtonTokens.checked?.hovered?.shadow,
-      },
-
-      ':active': {
-        background: toggleButtonTokens.checked?.pressed?.background,
-        borderColor: toggleButtonTokens.checked?.pressed?.borderColor,
-        color: toggleButtonTokens.checked?.pressed?.color,
-
-        boxShadow: toggleButtonTokens.checked?.pressed?.shadow,
-      },
-    };
-  },
-  rootCheckedPrimary: theme => {
-    const toggleButtonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: toggleButtonTokens.checkedPrimary?.background,
-      borderColor: toggleButtonTokens.checkedPrimary?.borderColor,
-      color: toggleButtonTokens.checkedPrimary?.color,
-
-      boxShadow: toggleButtonTokens.checkedPrimary?.shadow,
-
-      ':hover': {
-        background: toggleButtonTokens.checkedPrimary?.hovered?.background,
-        borderColor: toggleButtonTokens.checkedPrimary?.hovered?.borderColor,
-        color: toggleButtonTokens.checkedPrimary?.hovered?.color,
-
-        boxShadow: toggleButtonTokens.checkedPrimary?.hovered?.shadow,
-      },
-
-      ':active': {
-        background: toggleButtonTokens.checkedPrimary?.pressed?.background,
-        borderColor: toggleButtonTokens.checkedPrimary?.pressed?.borderColor,
-        color: toggleButtonTokens.checkedPrimary?.pressed?.color,
-
-        boxShadow: toggleButtonTokens.checkedPrimary?.pressed?.shadow,
-      },
-    };
-  },
-  rootCheckedSubtle: theme => {
-    const toggleButtonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: toggleButtonTokens.checkedSubtle?.background,
-      borderColor: toggleButtonTokens.checkedSubtle?.borderColor,
-      color: toggleButtonTokens.checkedSubtle?.color,
-
-      boxShadow: toggleButtonTokens.checkedSubtle?.shadow,
-
-      ':hover': {
-        background: toggleButtonTokens.checkedSubtle?.hovered?.background,
-        borderColor: toggleButtonTokens.checkedSubtle?.hovered?.borderColor,
-        color: toggleButtonTokens.checkedSubtle?.hovered?.color,
-
-        boxShadow: toggleButtonTokens.checkedSubtle?.hovered?.shadow,
-      },
-
-      ':active': {
-        background: toggleButtonTokens.checkedSubtle?.pressed?.background,
-        borderColor: toggleButtonTokens.checkedSubtle?.pressed?.borderColor,
-        color: toggleButtonTokens.checkedSubtle?.pressed?.color,
-
-        boxShadow: toggleButtonTokens.checkedSubtle?.pressed?.shadow,
-      },
-    };
-  },
-  rootCheckedTransparent: theme => {
-    const toggleButtonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: toggleButtonTokens.checkedTransparent?.background,
-      borderColor: toggleButtonTokens.checkedTransparent?.borderColor,
-      color: toggleButtonTokens.checkedTransparent?.color,
-
-      boxShadow: toggleButtonTokens.checkedTransparent?.shadow,
-
-      ':hover': {
-        background: toggleButtonTokens.checkedTransparent?.hovered?.background,
-        borderColor: toggleButtonTokens.checkedTransparent?.hovered?.borderColor,
-        color: toggleButtonTokens.checkedTransparent?.hovered?.color,
-
-        boxShadow: toggleButtonTokens.checkedTransparent?.hovered?.shadow,
-      },
-
-      ':active': {
-        background: toggleButtonTokens.checkedTransparent?.pressed?.background,
-        borderColor: toggleButtonTokens.checkedTransparent?.pressed?.borderColor,
-        color: toggleButtonTokens.checkedTransparent?.pressed?.color,
-
-        boxShadow: toggleButtonTokens.checkedTransparent?.pressed?.shadow,
-      },
-    };
-  },
-  rootDisabled: theme => {
-    const toggleButtonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: toggleButtonTokens.disabled?.background,
-      borderColor: toggleButtonTokens.disabled?.borderColor,
-      color: toggleButtonTokens.disabled?.color,
-
-      boxShadow: toggleButtonTokens.disabled?.shadow,
-
-      ':hover': {
-        background: toggleButtonTokens.disabled?.hovered?.background,
-        borderColor: toggleButtonTokens.disabled?.hovered?.borderColor,
-        color: toggleButtonTokens.disabled?.hovered?.color,
-
-        boxShadow: toggleButtonTokens.disabled?.hovered?.shadow,
-      },
-
-      ':active': {
-        background: toggleButtonTokens.disabled?.pressed?.background,
-        borderColor: toggleButtonTokens.disabled?.pressed?.borderColor,
-        color: toggleButtonTokens.disabled?.pressed?.color,
-
-        boxShadow: toggleButtonTokens.disabled?.pressed?.shadow,
-      },
-    };
-  },
-  rootDisabledPrimary: theme => {
-    const buttonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      borderColor: buttonTokens.disabledPrimary?.borderColor,
-
-      ':hover': {
-        borderColor: buttonTokens.disabledPrimary?.hovered?.borderColor,
-      },
-
-      ':active': {
-        borderColor: buttonTokens.disabledPrimary?.pressed?.borderColor,
-      },
-    };
-  },
-  rootDisabledSubtle: theme => {
-    const buttonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: buttonTokens.disabledSubtle?.background,
-      borderColor: buttonTokens.disabledSubtle?.borderColor,
-
-      ':hover': {
-        background: buttonTokens.disabledSubtle?.hovered?.background,
-        borderColor: buttonTokens.disabledSubtle?.hovered?.borderColor,
-      },
-
-      ':active': {
-        background: buttonTokens.disabledSubtle?.pressed?.background,
-        borderColor: buttonTokens.disabledSubtle?.pressed?.borderColor,
-      },
-    };
-  },
-  rootDisabledTransparent: theme => {
-    const buttonTokens = makeToggleButtonTokens(theme);
-
-    return {
-      background: buttonTokens.disabledTransparent?.background,
-      borderColor: buttonTokens.disabledTransparent?.borderColor,
-
-      ':hover': {
-        background: buttonTokens.disabledTransparent?.hovered?.background,
-        borderColor: buttonTokens.disabledTransparent?.hovered?.borderColor,
-      },
-
-      ':active': {
-        background: buttonTokens.disabledTransparent?.pressed?.background,
-        borderColor: buttonTokens.disabledTransparent?.pressed?.borderColor,
-      },
-    };
-  },
-});
-
-export const useToggleButtonStyles = (state: ToggleButtonState, selectors: ToggleButtonStyleSelectors) => {
+export const useToggleButtonStyles = (state: ToggleButtonState): ToggleButtonState => {
   // Save the classnames used in useButtonStyles and undefine them at the state level so that they are always applied
   // last.
   const { className: rootClassName } = state;
   useButtonStyles(state);
 
-  const styles = useStyles();
+  const rootStyles = useRootStyles();
 
   state.className = mergeClasses(
     state.className,
-    selectors.checked && styles.rootChecked,
-    selectors.checked && selectors.primary && styles.rootCheckedPrimary,
-    selectors.checked && selectors.subtle && styles.rootCheckedSubtle,
-    selectors.checked && selectors.transparent && styles.rootCheckedTransparent,
-    selectors.disabled && styles.rootDisabled,
-    selectors.disabled && selectors.primary && styles.rootDisabledPrimary,
-    selectors.disabled && selectors.subtle && styles.rootDisabledSubtle,
-    selectors.disabled && selectors.transparent && styles.rootDisabledTransparent,
+    state.checked && rootStyles.checked,
+    state.checked && state.primary && rootStyles.checkedPrimary,
+    state.checked && state.subtle && rootStyles.checkedSubtle,
+    state.checked && state.transparent && rootStyles.checkedTransparent,
+    state.disabled && rootStyles.disabled,
+    state.disabled && state.primary && rootStyles.disabledPrimary,
+    state.disabled && state.subtle && rootStyles.disabledSubtle,
+    state.disabled && state.transparent && rootStyles.disabledTransparent,
     rootClassName,
   );
+
+  return state;
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes part of #17555 and #18379
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Follow-up of #18468, #18497 and #18498.

This PR removes the legacy patterns that were being used in the `ToggleButton` component in `@fluentui/react-button`, instead opting for using the patterns adopted by other converged components such as `Avatar` in `@fluentui/react-avatar`.
