### PR TITLE
Change as prop to only accept IntrinsicElements

### DIFF
--- a/change/@fluentui-react-utilities-2871cb30-1605-40d4-b3d9-d48c5598b9fe.json
+++ b/change/@fluentui-react-utilities-2871cb30-1605-40d4-b3d9-d48c5598b9fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change as prop to only accept IntrinsicElements",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -45,7 +45,7 @@ export const colProperties: Record<string, number>;
 // @public (undocumented)
 export interface ComponentProps {
     // (undocumented)
-    as?: React_2.ElementType;
+    as?: keyof JSX.IntrinsicElements;
     // (undocumented)
     children?: React_2.ReactNode;
     // (undocumented)

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -147,7 +147,8 @@ export type MergePropsOptions<TState> = {
 export const nullRender: () => null;
 
 // @public (undocumented)
-export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps & Omit<ComponentProps, 'children'> & {
+export type ObjectShorthandProps<TProps extends ComponentProps = {}> = Omit<TProps, 'children' | 'as'> & {
+    as?: React_2.ElementType;
     children?: TProps['children'] | ShorthandRenderFunction<TProps>;
 };
 

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -31,10 +31,10 @@ export type ShorthandProps<TProps extends ComponentProps = {}> =
   | undefined
   | ObjectShorthandProps<TProps>;
 
-export type ObjectShorthandProps<TProps extends ComponentProps = {}> = TProps &
-  Omit<ComponentProps, 'children'> & {
-    children?: TProps['children'] | ShorthandRenderFunction<TProps>;
-  };
+export type ObjectShorthandProps<TProps extends ComponentProps = {}> = Omit<TProps, 'children' | 'as'> & {
+  as?: React.ElementType;
+  children?: TProps['children'] | ShorthandRenderFunction<TProps>;
+};
 
 export interface BaseSlots {
   root: React.ElementType;

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -12,7 +12,7 @@ export type GenericDictionary = Record<string, any>;
 export type ClassDictionary = Record<string, string>;
 
 export interface ComponentProps {
-  as?: React.ElementType;
+  as?: keyof JSX.IntrinsicElements;
   className?: string;
   children?: React.ReactNode;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Following approved  [as prop RFC](https://github.com/microsoft/fluentui/blob/master/rfcs/convergence/as-prop.md), changes `ComponentProps` to only accept Intrinsic elements
