### PR TITLE
refactor(react-popover): apply controls setup based on SB authoring RFC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,6 +126,7 @@ packages/react-tabs/ @microsoft/cxe-red @behowell
 packages/react-toggle/ @microsoft/cxe-red @behowell
 packages/react-tooltip/ @microsoft/cxe-red @behowell
 packages/react-label/ @microsoft/cxe-red @sopranopillow
+packages/react-popover/ @teams-prg
 
 ## Components
 packages/react @microsoft/cxe-red

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,13 @@
 import { withFluentProvider, withStrictMode } from '@fluentui/react-storybook';
 import 'cypress-storybook/react';
 
+/** @type {NonNullable<import('@storybook/react').Story['decorators']>} */
 export const decorators = [withFluentProvider, withStrictMode];
+
+/** @type {import('@storybook/react').Parameters} */
+export const parameters = {
+  controls: {
+    disable: true,
+    expanded: true,
+  },
+};

--- a/change/@fluentui-react-popover-bc78ecd6-737f-4918-a194-1e54e3645c5a.json
+++ b/change/@fluentui-react-popover-bc78ecd6-737f-4918-a194-1e54e3645c5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-popover): apply controls setup based on SB authoring RFC",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-popover/.storybook/preview.js
+++ b/packages/react-popover/.storybook/preview.js
@@ -1,4 +1,7 @@
 import * as rootPreview from '../../../.storybook/preview';
 
+/** @type {typeof rootPreview.decorators} */
 export const decorators = [...rootPreview.decorators];
-export const parameters = { layout: 'centered' };
+
+/** @type {typeof rootPreview.parameters} */
+export const parameters = { ...rootPreview.parameters, layout: 'centered' };

--- a/packages/react-popover/src/Popover.stories.tsx
+++ b/packages/react-popover/src/Popover.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from './index';
+import { ArgTypes, Meta, Parameters } from '@storybook/react';
 
 const ExampleContent = () => {
   return (
@@ -27,23 +28,21 @@ export const Default = (props: PopoverProps) => (
     </PopoverSurface>
   </Popover>
 );
-
+// @FIXME - remove manually specified argTypes once `react-components` package will use new storybook setup(DX)
+// https://github.com/microsoft/fluentui/issues/18514
 Default.argTypes = {
   open: {
     defaultValue: false,
     control: 'boolean',
   },
-
   openOnContext: {
     defaultValue: false,
     control: 'boolean',
   },
-
   openOnHover: {
     defaultValue: false,
     control: 'boolean',
   },
-
   position: {
     type: { name: 'string', required: false },
     control: {
@@ -51,7 +50,6 @@ Default.argTypes = {
       options: ['above', 'below', 'before', 'after'],
     },
   },
-
   align: {
     type: { name: 'string', required: false },
     control: {
@@ -59,7 +57,6 @@ Default.argTypes = {
       options: ['top', 'bottom', 'start', 'end', 'center'],
     },
   },
-
   size: {
     type: { name: 'string', required: false },
     control: {
@@ -67,12 +64,16 @@ Default.argTypes = {
       options: ['small', 'medium', 'large'],
     },
   },
-
   trapFocus: {
     defaultValue: true,
     control: 'boolean',
   },
-};
+} as ArgTypes;
+Default.parameters = {
+  controls: {
+    disable: false,
+  },
+} as Parameters;
 
 export const AnchorToTarget = () => {
   const [target, setTarget] = React.useState<HTMLButtonElement | null>();
@@ -98,10 +99,10 @@ export const AnchorToTarget = () => {
 
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
-  const onOpenChange: PopoverProps['onOpenChange'] = (_, data) => setOpen(data.open || false);
+  const handleOpenChange: PopoverProps['onOpenChange'] = (_, data) => setOpen(data.open || false);
 
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger>
         <button>Controlled trigger</button>
       </PopoverTrigger>
@@ -115,6 +116,7 @@ export const Controlled = () => {
 export const WithCustomTrigger = () => {
   const [open, setOpen] = React.useState(false);
   const [target, setTarget] = React.useState<HTMLElement | null>(null);
+
   const onClick = () => setOpen(s => !s);
   const onOpenChange: PopoverProps['onOpenChange'] = (_, data) => setOpen(data.open || false);
 
@@ -206,4 +208,4 @@ export const InternalUpdateContent = () => {
 export default {
   title: 'Components/Popover',
   component: Popover,
-};
+} as Meta;

--- a/packages/react-popover/tsconfig.json
+++ b/packages/react-popover/tsconfig.json
@@ -12,6 +12,6 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
   }
 }

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -118,7 +118,7 @@ describe('migrate-converged-pkg generator', () => {
           outDir: 'dist',
           preserveConstEnums: true,
           target: 'ES5',
-          types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
+          types: ['jest', 'custom-global', 'inline-style-expand-shorthand', 'storybook__addons'],
         },
         extends: '../../tsconfig.base.json',
         include: ['src'],
@@ -141,6 +141,7 @@ describe('migrate-converged-pkg generator', () => {
         'jest',
         'custom-global',
         'inline-style-expand-shorthand',
+        'storybook__addons',
         '@testing-library/jest-dom',
         'foo-bar',
       ]);
@@ -304,7 +305,11 @@ describe('migrate-converged-pkg generator', () => {
       expect(tree.read(`${projectStorybookConfigPath}/preview.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "import * as rootPreview from '../../../.storybook/preview';
 
-        export const decorators = [...rootPreview.decorators];"
+        /** @type {typeof rootPreview.decorators} */
+        export const decorators = [...rootPreview.decorators];
+
+        /** @type {typeof rootPreview.parameters} */
+        export const parameters = { ...rootPreview.parameters };"
       `);
     });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -107,7 +107,7 @@ const templates = {
       importHelpers: true,
       noUnusedLocals: true,
       preserveConstEnums: true,
-      types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
+      types: ['jest', 'custom-global', 'inline-style-expand-shorthand', 'storybook__addons'],
     } as TsConfig['compilerOptions'],
   },
   jest: (options: { pkgName: string }) => stripIndents`
@@ -152,7 +152,11 @@ const templates = {
     preview: stripIndents`
       import * as rootPreview from '../../../.storybook/preview';
 
+      /** @type {typeof rootPreview.decorators} */
       export const decorators = [...rootPreview.decorators];
+
+      /** @type {typeof rootPreview.parameters} */
+      export const parameters = { ...rootPreview.parameters };
     `,
     tsconfig: {
       extends: '../tsconfig.json',

--- a/typings/storybook__addons/index.d.ts
+++ b/typings/storybook__addons/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions extension for @storybook/addons 6.0.18
+// Project: https://github.com/storybookjs/storybook/tree/next/lib/addons
+// Definitions by: Martin Hochel
+// Definitions: N/A
+// TypeScript Version: 3.1
+
+import { Parameters } from '@storybook/addons';
+
+declare module '@storybook/addons' {
+  // PUBLIC API - extended definitions
+  export interface Parameters extends ParametersExtended {}
+
+  // =====
+  interface ParametersExtended {
+    controls?: ControlsParameters & DisableControl;
+  }
+
+  interface ControlsParameters {
+    sort?: 'alpha' | 'requiredFirst' | 'none';
+    expanded?: boolean;
+    presetColors?: Array<string | { color: string; title?: string }>;
+    hideNoControlsWarning?: boolean;
+  }
+
+  type DisableControl = { disable?: boolean };
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Implements #18455 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- implements initial RFC for authoring storybook for react-popover and root storybook config
- updates nx migration generator

**TODO Martin:**

- [x] check if those manual argTypes won't be needed for react-components storybook as that is using react-examples preview.js and friends. If they will be needed add them back -> create followup issue -> ref that issue to those manual args definitions

#### Focus areas to test

(optional)
