### PR TITLE
Details list group not rendering fix

### DIFF
--- a/change/@fluentui-react-72c29a12-f5b8-40c0-914f-1b9b7c60506c.json
+++ b/change/@fluentui-react-72c29a12-f5b8-40c0-914f-1b9b7c60506c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "(GroupedList) fixed getGroupHeight when group has children",
+  "comment": "(GroupedList) fixed getGroupHeight function returning wrong height for groups with children",
   "packageName": "@fluentui/react",
   "email": "karlo.sudec@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-72c29a12-f5b8-40c0-914f-1b9b7c60506c.json
+++ b/change/@fluentui-react-72c29a12-f5b8-40c0-914f-1b9b7c60506c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "(GroupedList) fixed getGroupHeight when group has children",
+  "packageName": "@fluentui/react",
+  "email": "karlo.sudec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -287,7 +287,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   private _getDefaultGroupItemLimit = (group: IGroup): number => {
-    return group.count;
+    return group.children && group.children.length > 0 ? group.children.length : group.count;
   };
 
   private _getGroupItemLimit = (group: IGroup): number => {

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -288,7 +288,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getDefaultGroupItemLimit = (group: IGroup): number => {
     return group.count;
-    return group.children && group.children.length > 0 ? group.children.length : group.count;
   };
 
   private _getGroupItemLimit = (group: IGroup): number => {

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -287,6 +287,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   private _getDefaultGroupItemLimit = (group: IGroup): number => {
+    return group.count;
     return group.children && group.children.length > 0 ? group.children.length : group.count;
   };
 
@@ -300,8 +301,9 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
+    const rowCount = group.children?.length > 0 ? group.children.length : this._getGroupItemLimit(group);
 
-    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupItemLimit(group));
+    return rowHeight + (group.isCollapsed ? 0 : rowHeight * rowCount);
   };
 
   private _getPageHeight: IListProps['getPageHeight'] = (itemIndex: number) => {

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -287,7 +287,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   private _getDefaultGroupItemLimit = (group: IGroup): number => {
-    return group.count;
+    return group.children && group.children.length > 0 ? group.children.length : group.count;
   };
 
   private _getGroupItemLimit = (group: IGroup): number => {
@@ -300,10 +300,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
-    const rowCount =
-      group.children && group.children.length > 0 ? group.children.length : this._getGroupItemLimit(group);
 
-    return rowHeight + (group.isCollapsed ? 0 : rowHeight * rowCount);
+    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupItemLimit(group));
   };
 
   private _getPageHeight: IListProps['getPageHeight'] = (itemIndex: number) => {

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -300,7 +300,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
-    const rowCount = group.children?.length > 0 ? group.children.length : this._getGroupItemLimit(group);
+    const rowCount =
+      group.children && group.children.length > 0 ? group.children.length : this._getGroupItemLimit(group);
 
     return rowHeight + (group.isCollapsed ? 0 : rowHeight * rowCount);
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18336
- [x] Include a change request file using `$ yarn change`

#### Description of changes

getGroupHeight function in GroupedList base was returning wrong height if a group had children. Now it returns height of children groups, or height of  items if there's no children.

#### Focus areas to test

Everything that relies on group height prop.
