### PR TITLE
fix(PositioningContainer): add z-index if not using Layer

### DIFF
--- a/change/@fluentui-react-e6122318-3fe5-4416-9863-289d383dacc4.json
+++ b/change/@fluentui-react-e6122318-3fe5-4416-9863-289d383dacc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add explicit z-index to PositiningContainer with doNotLayer=true",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IPositioningContainerProps } from './PositioningContainer.types';
 import { getClassNames } from './PositioningContainer.styles';
+import { ZIndexes } from '../../../Styling';
 import { Layer } from '../../../Layer';
 
 // Utilites/Helpers
@@ -320,7 +321,7 @@ export const PositioningContainer: React.FunctionComponent<IPositioningContainer
     return null;
   }
 
-  const { className, positioningContainerWidth, positioningContainerMaxHeight, children } = props;
+  const { className, doNotLayer, positioningContainerWidth, positioningContainerMaxHeight, children } = props;
 
   const styles = getClassNames();
 
@@ -341,6 +342,7 @@ export const PositioningContainer: React.FunctionComponent<IPositioningContainer
           className,
           directionalClassName,
           !!positioningContainerWidth && { width: positioningContainerWidth },
+          doNotLayer && { zIndex: ZIndexes.Layer },
         )}
         style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
         // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
@@ -357,7 +359,7 @@ export const PositioningContainer: React.FunctionComponent<IPositioningContainer
     </div>
   );
 
-  return props.doNotLayer ? content : <Layer>{content}</Layer>;
+  return doNotLayer ? content : <Layer>{content}</Layer>;
 });
 PositioningContainer.displayName = 'PositioningContainer';
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Related to #18495, adds the same z-index fix for Coachmark's PositioningContainer when it has doNotLayer="true"
