### PR TITLE
Remove boolean from ShorthandProps type

### DIFF
--- a/change/@fluentui-react-button-11d7da9d-37b9-444b-9f8e-ba77797d90a1.json
+++ b/change/@fluentui-react-button-11d7da9d-37b9-444b-9f8e-ba77797d90a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Temporary typing fix for children prop",
+  "packageName": "@fluentui/react-button",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-51c9605b-0dc2-4b1f-ac39-eccb2757a62c.json
+++ b/change/@fluentui-react-examples-51c9605b-0dc2-4b1f-ac39-eccb2757a62c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Avatar ActiveAnimation story",
+  "packageName": "@fluentui/react-examples",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-69106440-0dab-4f76-afbb-42b041985a9a.json
+++ b/change/@fluentui-react-label-69106440-0dab-4f76-afbb-42b041985a9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix type of required prop after change to ShorthandProp type definition",
+  "packageName": "@fluentui/react-label",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-e6d8ec1b-4e76-41a8-b44a-2507bbe6fdff.json
+++ b/change/@fluentui-react-utilities-e6d8ec1b-4e76-41a8-b44a-2507bbe6fdff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove boolean from ShorthandProps type",
+  "packageName": "@fluentui/react-utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -17,6 +17,7 @@ export type ButtonDefaultedProps = 'icon' | 'size';
 
 // @public (undocumented)
 export type ButtonProps = ComponentProps & React_2.ButtonHTMLAttributes<HTMLElement> & {
+    children?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     icon?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     disabled?: boolean;
     iconPosition?: 'before' | 'after';

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -6,6 +6,9 @@ import { ComponentProps, ComponentState, ShorthandProps } from '@fluentui/react-
  */
 export type ButtonProps = ComponentProps &
   React.ButtonHTMLAttributes<HTMLElement> & {
+    // Temporarily declare children as a shorthand slot until #18471 is fixed
+    children?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
+
     /**
      * Icon slot that, if specified, renders an icon either before or after the `children` as specified by the
      * `iconPosition` prop.

--- a/packages/react-examples/src/react-avatar/Avatar/Avatar.stories.tsx
+++ b/packages/react-examples/src/react-avatar/Avatar/Avatar.stories.tsx
@@ -185,8 +185,8 @@ export const ActiveAnimation = () => {
             active={active ? 'active' : 'inactive'}
             activeDisplay={activeDisplay}
             name={examples.name[10]}
-            image={display === 'image' && examples.image[10]}
-            icon={display === 'icon' && <ContactIcon />}
+            image={display === 'image' ? examples.image[10] : undefined}
+            icon={display === 'icon' ? <ContactIcon /> : undefined}
           />
         </div>
         <Stack tokens={{ childrenGap: 8, maxWidth: 220 }}>

--- a/packages/react-label/etc/react-label.api.md
+++ b/packages/react-label/etc/react-label.api.md
@@ -24,13 +24,19 @@ export interface LabelProps extends ComponentProps, React_2.LabelHTMLAttributes<
 }
 
 // @public
+export interface LabelPropsResolved extends LabelProps {
+    // (undocumented)
+    required?: ShorthandProps<ComponentProps>;
+}
+
+// @public
 export type LabelShorthandProps = 'required';
 
 // @public
 export const labelShorthandProps: LabelShorthandProps[];
 
 // @public
-export interface LabelState extends ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
+export interface LabelState extends ComponentState<LabelPropsResolved, LabelShorthandProps, LabelDefaultedProps> {
     ref: React_2.Ref<HTMLElement>;
 }
 

--- a/packages/react-label/etc/react-label.api.md
+++ b/packages/react-label/etc/react-label.api.md
@@ -6,6 +6,7 @@
 
 import { ComponentProps } from '@fluentui/react-utilities';
 import { ComponentState } from '@fluentui/react-utilities';
+import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
 
@@ -24,20 +25,15 @@ export interface LabelProps extends ComponentProps, React_2.LabelHTMLAttributes<
 }
 
 // @public
-export interface LabelPropsResolved extends LabelProps {
-    // (undocumented)
-    required?: ShorthandProps<ComponentProps>;
-}
-
-// @public
 export type LabelShorthandProps = 'required';
 
 // @public
 export const labelShorthandProps: LabelShorthandProps[];
 
 // @public
-export interface LabelState extends ComponentState<LabelPropsResolved, LabelShorthandProps, LabelDefaultedProps> {
+export interface LabelState extends ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
     ref: React_2.Ref<HTMLElement>;
+    required?: ObjectShorthandProps<ComponentProps>;
 }
 
 // @public

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -33,6 +33,13 @@ export interface LabelProps extends ComponentProps, React.LabelHTMLAttributes<HT
 }
 
 /**
+ * (Internal) LabelProps after the required prop has been resolved from a boolean to a string
+ */
+export interface LabelPropsResolved extends LabelProps {
+  required?: ShorthandProps<ComponentProps>;
+}
+
+/**
  * Names of the shorthand properties in LabelProps
  * {@docCategory Label}
  */
@@ -48,7 +55,7 @@ export type LabelDefaultedProps = 'size';
  * State used in rendering Label
  * {@docCategory Label}
  */
-export interface LabelState extends ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
+export interface LabelState extends ComponentState<LabelPropsResolved, LabelShorthandProps, LabelDefaultedProps> {
   /**
    * Ref to the root element
    */

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState, ShorthandProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
 
 /**
  * Label Props
@@ -33,13 +33,6 @@ export interface LabelProps extends ComponentProps, React.LabelHTMLAttributes<HT
 }
 
 /**
- * (Internal) LabelProps after the required prop has been resolved from a boolean to a string
- */
-export interface LabelPropsResolved extends LabelProps {
-  required?: ShorthandProps<ComponentProps>;
-}
-
-/**
  * Names of the shorthand properties in LabelProps
  * {@docCategory Label}
  */
@@ -55,9 +48,14 @@ export type LabelDefaultedProps = 'size';
  * State used in rendering Label
  * {@docCategory Label}
  */
-export interface LabelState extends ComponentState<LabelPropsResolved, LabelShorthandProps, LabelDefaultedProps> {
+export interface LabelState extends ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
   /**
    * Ref to the root element
    */
   ref: React.Ref<HTMLElement>;
+
+  /**
+   * The required prop resolved to a slot object
+   */
+  required?: ObjectShorthandProps<ComponentProps>;
 }

--- a/packages/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-label/src/components/Label/useLabel.tsx
@@ -52,7 +52,7 @@ const resolveLabelShorthandProps = (props: LabelProps) => {
     propsNormalized = { ...props, required: undefined };
   } else {
     // TypeScript needs a nudge to figure out that props.required won't be a boolean here
-    propsNormalized = props as typeof props & { required?: typeof props.required };
+    propsNormalized = props as LabelProps & { required?: Exclude<LabelProps['required'], boolean> };
   }
 
   return resolveShorthandProps(propsNormalized, labelShorthandProps);

--- a/packages/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-label/src/components/Label/useLabel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { LabelProps, LabelShorthandProps, LabelState } from './Label.types';
+import { LabelProps, LabelPropsResolved, LabelShorthandProps, LabelState } from './Label.types';
 
 /**
  * Array of all shorthand properties listed in LabelShorthandProps
@@ -51,5 +51,5 @@ const resolveLabelShorthandProps = (props: LabelProps) => {
     props = { ...props, required: undefined };
   }
 
-  return resolveShorthandProps(props, labelShorthandProps);
+  return resolveShorthandProps(props as LabelPropsResolved, labelShorthandProps);
 };

--- a/packages/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-label/src/components/Label/useLabel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { LabelProps, LabelPropsResolved, LabelShorthandProps, LabelState } from './Label.types';
+import { LabelProps, LabelShorthandProps, LabelState } from './Label.types';
 
 /**
  * Array of all shorthand properties listed in LabelShorthandProps
@@ -45,11 +45,15 @@ export const useLabel = (props: LabelProps, ref: React.Ref<HTMLElement>, default
  * or a custom required text.
  */
 const resolveLabelShorthandProps = (props: LabelProps) => {
+  let propsNormalized;
   if (props.required === true) {
-    props = { ...props, required: { children: '*' } };
+    propsNormalized = { ...props, required: { children: '*' } };
   } else if (props.required === false) {
-    props = { ...props, required: undefined };
+    propsNormalized = { ...props, required: undefined };
+  } else {
+    // TypeScript needs a nudge to figure out that props.required won't be a boolean here
+    propsNormalized = props as typeof props & { required?: typeof props.required };
   }
 
-  return resolveShorthandProps(props as LabelPropsResolved, labelShorthandProps);
+  return resolveShorthandProps(propsNormalized, labelShorthandProps);
 };

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -186,7 +186,7 @@ export const resolveShorthandProps: <TProps, TShorthandPropNames extends keyof T
 export const selectProperties: Record<string, number>;
 
 // @public (undocumented)
-export type ShorthandProps<TProps extends ComponentProps = {}> = React_2.ReactChild | React_2.ReactNodeArray | React_2.ReactPortal | boolean | number | null | undefined | ObjectShorthandProps<TProps>;
+export type ShorthandProps<TProps extends ComponentProps = {}> = React_2.ReactChild | React_2.ReactNodeArray | React_2.ReactPortal | number | null | undefined | ObjectShorthandProps<TProps>;
 
 // @public (undocumented)
 export type ShorthandRenderFunction<TProps> = (Component: React_2.ElementType<TProps>, props: TProps) => React_2.ReactNode;

--- a/packages/react-utilities/src/compose/resolveShorthandProps.test.tsx
+++ b/packages/react-utilities/src/compose/resolveShorthandProps.test.tsx
@@ -27,13 +27,6 @@ describe('resolveShorthandProps', () => {
     expect(resolvedProps).toEqual({ slotA: { children: <div>hello</div> } });
   });
 
-  it('resolves false', () => {
-    const props: TestProps = { slotA: false };
-    const resolvedProps = resolveShorthandProps(props, testShorthandProps);
-
-    expect(resolvedProps).toEqual({ slotA: { children: false } });
-  });
-
   it('resolves a number', () => {
     const props: TestProps = { slotA: 42 };
     const resolvedProps = resolveShorthandProps(props, testShorthandProps);

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -25,7 +25,6 @@ export type ShorthandProps<TProps extends ComponentProps = {}> =
   | React.ReactChild
   | React.ReactNodeArray
   | React.ReactPortal
-  | boolean
   | number
   | null
   | undefined


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove boolean as an allowed type of ShorthandProps.

#### Background
Currently setting a shorthand slot to `true` or `false` will render the slot's element, but not render any children. This is confusing and possibly not what one would expect. It would be reasonable to expect that setting a slot to `false` would cause it to not render at all (which isn't the case). And there's no reasonable expectation of what would happen when setting the slot to true.

For example, `<Button icon={false}>...</Button>` will render the icon slot with nothing in it, and the button will have a blank space for the icon. This is likely not what was intended.

Also see the change in [Avatar.stories.tsx](https://github.com/microsoft/fluentui/pull/18521/files#diff-9fcb50f2001881eb0755f6caa26b70f83dbdbd1d3812b6d7cc8e882a3c189a7d) to see an example of a boolean value in a slot causing incorrect behavior.

Given the confusing nature of having a shorthand be boolean, and questionable benefits, it seems best to remove boolean as a possible type for ShorthandProps. If there is some legitimate reason to have the slot's children be a boolean, it can still be written "longhand" as `slot={{ children: false }}`
