### PR TITLE
SearchBox to show icon on focus

### DIFF
--- a/apps/vr-tests/src/stories/SearchBox.stories.tsx
+++ b/apps/vr-tests/src/stories/SearchBox.stories.tsx
@@ -42,4 +42,13 @@ storiesOf('SearchBox', module)
       </Fabric>
     ),
     { rtl: true },
+  )
+  .addStory(
+    'ShowIcon',
+    () => (
+      <Fabric className="testWrapper">
+        <SearchBox placeholder="Search" showIcon={true} defaultValue="Test" />
+      </Fabric>
+    ),
+    { rtl: true },
   );

--- a/change/@fluentui-react-2ef6965f-113f-40f4-97f7-223fe87516ef.json
+++ b/change/@fluentui-react-2ef6965f-113f-40f4-97f7-223fe87516ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: show icon on focus",
+  "packageName": "@fluentui/react",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7068,6 +7068,7 @@ export interface ISearchBoxProps extends React_2.InputHTMLAttributes<HTMLInputEl
     onSearch?: (newValue: any) => void;
     placeholder?: string;
     role?: string;
+    showIcon?: boolean;
     styles?: IStyleFunctionOrObject<ISearchBoxStyleProps, ISearchBoxStyles>;
     theme?: ITheme;
     underlined?: boolean;
@@ -7086,6 +7087,8 @@ export interface ISearchBoxStyleProps {
     hasFocus?: boolean;
     // (undocumented)
     hasInput?: boolean;
+    // (undocumented)
+    showIcon?: boolean;
     // (undocumented)
     theme: ITheme;
     // (undocumented)

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -52,6 +52,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     theme,
     clearButtonProps = defaultClearButtonProps,
     disableAnimation = false,
+    showIcon = false,
     onClear: customOnClear,
     onBlur: customOnBlur,
     onEscape: customOnEscape,
@@ -71,6 +72,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     disabled,
     hasInput: value.length > 0,
     disableAnimation,
+    showIcon,
   });
 
   const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(props, inputProperties, [

--- a/packages/react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.styles.tsx
@@ -19,7 +19,7 @@ const GlobalClassNames = {
 };
 
 export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
-  const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
+  const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation, showIcon } = props;
   const { palette, fonts, semanticColors, effects } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -91,6 +91,18 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
           underlined ? 'borderBottom' : 'border',
         ),
       ],
+      showIcon && [
+        {
+          selectors: {
+            [`:hover .${classNames.iconContainer}`]: {
+              width: 32,
+            },
+            [`:hover .${classNames.icon}`]: {
+              opacity: 1,
+            },
+          },
+        },
+      ],
       disabled && [
         'is-disabled',
         {
@@ -143,6 +155,10 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       !disableAnimation && {
         transition: `width ${AnimationVariables.durationValue1}`,
       },
+      showIcon &&
+        hasFocus && {
+          width: 32,
+        },
     ],
     icon: [
       classNames.icon,
@@ -155,6 +171,10 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       !disableAnimation && {
         transition: `opacity ${AnimationVariables.durationValue1} 0s`,
       },
+      showIcon &&
+        hasFocus && {
+          opacity: 1,
+        },
     ],
     clearButton: [
       classNames.clearButton,

--- a/packages/react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react/src/components/SearchBox/SearchBox.types.ts
@@ -122,6 +122,12 @@ export interface ISearchBoxProps
    * @defaultvalue false
    */
   disableAnimation?: boolean;
+
+  /**
+   * Whether or not to make the icon visible on focus
+   * @defaultvalue false
+   */
+  showIcon?: boolean;
 }
 
 /**
@@ -135,6 +141,7 @@ export interface ISearchBoxStyleProps {
   underlined?: boolean;
   hasInput?: boolean;
   disableAnimation?: boolean;
+  showIcon?: boolean;
 }
 
 /**

--- a/packages/react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react/src/components/SearchBox/SearchBox.types.ts
@@ -124,7 +124,7 @@ export interface ISearchBoxProps
   disableAnimation?: boolean;
 
   /**
-   * Whether or not to make the icon visible on focus
+   * Whether or not to make the icon be always visible (it hides by default when the search box is focused).
    * @defaultvalue false
    */
   showIcon?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8782 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Added a new prop `showIcon` with `false` as default value, that will enable for the icon to be visible on focus (changes were done based on the workaround provided in the issue).

#### Focus areas to test

SearchBox icon that should be visible if the prop is set
