### PR TITLE
fix(Nav): update chevron icon styles to adapt to text spacing

### DIFF
--- a/change/@fluentui-react-cb654f7d-01c0-4f3f-b21f-9897f972c396.json
+++ b/change/@fluentui-react-cb654f7d-01c0-4f3f-b21f-9897f972c396.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Nav chevron icon styles to adapt to text spacing",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-06f683f4-1725-4f75-a900-a6c1cc89317f.json
+++ b/change/@fluentui-react-examples-06f683f4-1725-4f75-a900-a6c1cc89317f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot updates for Nav icon style changes",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -148,7 +148,8 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        display: inline-block;
+                        align-items: center;
+                        display: inline-flex;
                         font-family: "FabricMDL2Icons";
                         font-size: 12px;
                         font-style: normal;

--- a/packages/react-examples/src/react/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -143,7 +143,8 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        display: inline-block;
+                        align-items: center;
+                        display: inline-flex;
                         font-family: "FabricMDL2Icons";
                         font-size: 12px;
                         font-style: normal;
@@ -375,7 +376,8 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        display: inline-block;
+                        align-items: center;
+                        display: inline-flex;
                         font-family: "FabricMDL2Icons";
                         font-size: 12px;
                         font-style: normal;

--- a/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Wrapped.Example.tsx.shot
@@ -149,7 +149,8 @@ exports[`Component Examples renders Nav.Wrapped.Example.tsx correctly 1`] = `
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        display: inline-block;
+                        align-items: center;
+                        display: inline-flex;
                         font-family: "FabricMDL2Icons";
                         font-size: 12px;
                         font-style: normal;

--- a/packages/react/src/components/Nav/Nav.styles.ts
+++ b/packages/react/src/components/Nav/Nav.styles.ts
@@ -217,7 +217,10 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
       {
         position: 'absolute',
         left: '8px',
+        top: '1px',
         height: navHeight,
+        display: 'inline-flex',
+        alignItems: 'center',
         lineHeight: `${navHeight}px`,
         fontSize: fonts.small.fontSize,
         transition: 'transform .1s linear',

--- a/packages/react/src/components/Nav/Nav.styles.ts
+++ b/packages/react/src/components/Nav/Nav.styles.ts
@@ -219,6 +219,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         left: '8px',
         top: '1px',
         height: navHeight,
+        // inline-flex prevents the chevron from shifting with custom line height styles
         display: 'inline-flex',
         alignItems: 'center',
         lineHeight: `${navHeight}px`,

--- a/packages/react/src/components/Nav/Nav.styles.ts
+++ b/packages/react/src/components/Nav/Nav.styles.ts
@@ -217,7 +217,6 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
       {
         position: 'absolute',
         left: '8px',
-        top: '1px',
         height: navHeight,
         // inline-flex prevents the chevron from shifting with custom line height styles
         display: 'inline-flex',

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -104,7 +104,6 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                   line-height: 44px;
                   position: absolute;
                   speak: none;
-                  top: 1px;
                   transform: rotate(-180deg);
                   transition: transform .1s linear;
                 }

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -93,7 +93,8 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  display: inline-block;
+                  align-items: center;
+                  display: inline-flex;
                   font-family: "FabricMDL2Icons";
                   font-size: 12px;
                   font-style: normal;
@@ -103,6 +104,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                   line-height: 44px;
                   position: absolute;
                   speak: none;
+                  top: 1px;
                   transform: rotate(-180deg);
                   transition: transform .1s linear;
                 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18103 and [11490](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/11490)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates the chevron icon styles within Nav to inline-flex, so applying a custom line height doesn't break the icon alignment.

I put the changefile as minor instead of patch b/c it seemed more appropriate for changing styles.