### PR TITLE
fix(ColorPicker example): label text was overly verbose and contained role and instruction text

### DIFF
--- a/change/@fluentui-react-9be574bf-e7e7-4af5-8fd3-d4dd815b6f3c.json
+++ b/change/@fluentui-react-9be574bf-e7e7-4af5-8fd3-d4dd815b6f3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add better comments to ColorPicker ariaLabel properties in type file",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-examples-79622e1f-06b6-4bbd-9061-cf8b62db0d5d.json
+++ b/change/@fluentui-react-examples-79622e1f-06b6-4bbd-9061-cf8b62db0d5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix arla-label text in ColorPicker example for better accessibility (no code change)",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/ColorPicker/ColorPicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/ColorPicker/ColorPicker.Basic.Example.tsx
@@ -44,11 +44,11 @@ export const ColorPickerBasicExample: React.FunctionComponent = () => {
         // If your app is localized, you MUST provide the `strings` prop with localized strings.
         strings={{
           // By default, the sliders will use the text field labels as their aria labels.
-          // If you'd like to provide more detailed instructions, you can use these props.
-          alphaAriaLabel: 'Alpha slider: Use left and right arrow keys to change value, hold shift for a larger jump',
-          transparencyAriaLabel:
-            'Transparency slider: Use left and right arrow keys to change value, hold shift for a larger jump',
-          hueAriaLabel: 'Hue slider: Use left and right arrow keys to change value, hold shift for a larger jump',
+          // Previously this example had more detailed instructions in the labels, but this is
+          // a bad practice and not recommended. Labels should be concise, and match visible text when possible.
+          alphaAriaLabel: 'Alpha channel',
+          transparencyAriaLabel: 'Transparency',
+          hueAriaLabel: 'Hue',
         }}
       />
 

--- a/packages/react-examples/src/react/ColorPicker/ColorPicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/ColorPicker/ColorPicker.Basic.Example.tsx
@@ -46,8 +46,6 @@ export const ColorPickerBasicExample: React.FunctionComponent = () => {
           // By default, the sliders will use the text field labels as their aria labels.
           // Previously this example had more detailed instructions in the labels, but this is
           // a bad practice and not recommended. Labels should be concise, and match visible text when possible.
-          alphaAriaLabel: 'Alpha channel',
-          transparencyAriaLabel: 'Transparency',
           hueAriaLabel: 'Hue',
         }}
       />

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -165,7 +165,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               }
         >
           <div
-            aria-label="Hue slider: Use left and right arrow keys to change value, hold shift for a larger jump"
+            aria-label="Hue"
             aria-valuemax={359}
             aria-valuemin={0}
             aria-valuenow={0}
@@ -215,7 +215,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             />
           </div>
           <div
-            aria-label="Alpha slider: Use left and right arrow keys to change value, hold shift for a larger jump"
+            aria-label="Alpha channel"
             aria-valuemax={100}
             aria-valuemin={0}
             aria-valuenow={100}

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -215,7 +215,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             />
           </div>
           <div
-            aria-label="Alpha channel"
+            aria-label="Alpha"
             aria-valuemax={100}
             aria-valuemin={0}
             aria-valuenow={100}

--- a/packages/react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/react/src/components/ColorPicker/ColorPicker.types.ts
@@ -158,11 +158,13 @@ export interface IColorPickerStrings {
 
   /**
    * Customized aria-label for the alpha slider.
+   * This overrides the visible text label, and should be used with extreme care (and very rarely).
    */
   alphaAriaLabel?: string;
 
   /**
    * Customized aria-label for the transparency slider.
+   * This overrides the visible text label, and should be used with extreme care (and very rarely).
    */
   transparencyAriaLabel?: string;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

A separate a11y bug made me realize that the label text for the color picker sliders was pretty awful, so this PR fixes it 😂. I'm guessing some tester filed a really, really bad bug in the past.
