### PR TITLE
[react-northstar] Add DocumentTitle from Prototype section

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Documentation
 - Allow switching to V2 themes in maximized examples @Hirse ([#18292](https://github.com/microsoft/fluentui/pull/18292))
+- Add DocumentTitle from Prototype section @Hirse ([#18539](https://github.com/microsoft/fluentui/pull/18539))
 
 <!--------------------------------[ v0.56.0 ]------------------------------- -->
 ## [v0.56.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.56.0) (2021-05-14)

--- a/packages/fluentui/react-northstar-prototypes/package.json
+++ b/packages/fluentui/react-northstar-prototypes/package.json
@@ -23,6 +23,7 @@
     "moment": "^2.18.1",
     "react": "16.8.6",
     "react-custom-scrollbars": "^4.2.1",
+    "react-document-title": "^2.0.3",
     "react-dom": "16.8.6",
     "react-hook-form": "^5.7.2",
     "react-textarea-autosize": "7.0.4",

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/Prototypes.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/Prototypes.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import DocumentTitle from 'react-document-title';
+
 import { Box, Header, ICSSInJSStyle, Segment } from '@fluentui/react-northstar';
 
 interface PrototypeSectionProps {
@@ -10,27 +12,27 @@ interface ComponentPrototypeProps extends PrototypeSectionProps {
   description?: React.ReactNode;
 }
 
-export const PrototypeSection: React.FunctionComponent<ComponentPrototypeProps> = props => {
-  const { title, children, styles, ...rest } = props;
-  return (
-    <Box styles={{ margin: '20px', ...styles }} {...rest}>
-      {title && <Header as="h1">{title}</Header>}
-      {children}
-    </Box>
-  );
-};
+export const PrototypeSection: React.FunctionComponent<PrototypeSectionProps> = ({ children, styles, title }) => (
+  <Box styles={{ margin: '20px', ...styles }}>
+    <DocumentTitle title={`Fluent UI - ${title || 'Prototype'}`} />
+    <Header as="h1">{title}</Header>
+    {children}
+  </Box>
+);
 
-export const ComponentPrototype: React.FunctionComponent<ComponentPrototypeProps> = props => {
-  const { description, title: header, children, styles, ...rest } = props;
-  return (
-    <Box styles={{ marginTop: '20px', ...styles }} {...rest}>
-      {(header || description) && (
-        <Segment>
-          {header && <Header as="h3">{header}</Header>}
-          {description && <p>{description}</p>}
-        </Segment>
-      )}
-      <Segment>{children}</Segment>
-    </Box>
-  );
-};
+export const ComponentPrototype: React.FunctionComponent<ComponentPrototypeProps> = ({
+  children,
+  description,
+  styles,
+  title,
+}) => (
+  <Box styles={{ marginTop: '20px', ...styles }}>
+    {(title || description) && (
+      <Segment>
+        {title && <Header as="h3">{title}</Header>}
+        {description && <p>{description}</p>}
+      </Segment>
+    )}
+    <Segment>{children}</Segment>
+  </Box>
+);


### PR DESCRIPTION
#### Description of changes
Set the document title from prototype sections.
This change impacts only the docs site.

See for example:
https://fluentsite.z22.web.core.windows.net/0.56.0/prototype-chat-messages

Before:
![image](https://user-images.githubusercontent.com/2564094/121755243-8d233a00-cacb-11eb-8741-ccdd46375b57.png)

After:
![image](https://user-images.githubusercontent.com/2564094/121755266-99a79280-cacb-11eb-9315-cde40eb78eca.png)
