### PR TITLE
Add cxe-red as codeowner for most remaining v8 components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,30 +128,30 @@ packages/react/src/components/ActivityItem/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Announced/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Breadcrumb/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Button/ @microsoft/cxe-red @khmakoto
-packages/react/src/components/Calendar/ @lorejoh12 @pompomon
+packages/react/src/components/Calendar/ @lorejoh12
 packages/react/src/components/CalendarDayGrid/ @lorejoh12
 packages/react/src/components/Callout/ @microsoft/cxe-red
 packages/react/src/components/Check/ @microsoft/cxe-red @ThomasMichon @khmakoto
 packages/react/src/components/Checkbox/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/ChoiceGroup/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Coachmark/ @leddie24
+packages/react/src/components/Coachmark/ @microsoft/cxe-red @leddie24
 packages/react/src/components/ColorPicker/ @microsoft/cxe-red @ecraig12345
 packages/react/src/components/ComboBox/ @microsoft/cxe-red
 packages/react/src/components/CommandBar/ @microsoft/cxe-red
 packages/react/src/components/ContextualMenu/ @microsoft/cxe-red
-packages/react/src/components/DatePicker/ @lorejoh12 @pompomon
+packages/react/src/components/DatePicker/ @lorejoh12
 packages/react/src/components/DetailsList/ @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/Dialog/ @microsoft/cxe-red
-packages/react/src/components/DocumentCard/ @yiminwu
+packages/react/src/components/DocumentCard/ @microsoft/cxe-red @yiminwu
 packages/react/src/components/Dropdown/ @microsoft/cxe-red
-packages/react/src/components/Fabric/ @dzearing
-packages/react/src/components/Facepile/ @markionium @mtennoe
+packages/react/src/components/Fabric/ @microsoft/cxe-red @dzearing
+packages/react/src/components/Facepile/ @microsoft/cxe-red @markionium @mtennoe
 packages/react/src/components/FolderCover/ @microsoft/cxe-red @ThomasMichon @bigbadcapers
 packages/react/src/components/FocusTrapZone/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/GroupedList/ @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/HoverCard/ @microsoft/cxe-red @Jahnp @Vitalius1
 packages/react/src/components/Icon/ @microsoft/cxe-red @dzearing @ecraig12345
-packages/react/src/components/Image/ @dzearing
+packages/react/src/components/Image/ @microsoft/cxe-red @dzearing
 packages/react/src/components/Label/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Layer/ @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/Link/ @microsoft/cxe-red @khmakoto
@@ -163,9 +163,8 @@ packages/react/src/components/Nav/ @microsoft/cxe-red @ecraig12345
 packages/react/src/components/OverflowSet/ @microsoft/cxe-red
 packages/react/src/components/Overlay/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Panel/ @microsoft/cxe-red @khmakoto
-packages/react/src/components/Persona/ @markionium @mtennoe
-packages/react/src/components/PersonaCoin/ @mtennoe @markionium
-packages/react/src/components/Persona/PersonaConsts.tsx @mtennoe
+packages/react/src/components/Persona/ @microsoft/cxe-red @markionium @mtennoe
+packages/react/src/components/PersonaCoin/ @microsoft/cxe-red @mtennoe @markionium
 packages/react/src/components/pickers/ @microsoft/cxe-red
 packages/react/src/components/Pivot/ @microsoft/cxe-red @behowell
 packages/react/src/components/Popup/ @microsoft/cxe-red
@@ -188,10 +187,9 @@ packages/react/src/components/Tooltip/ @microsoft/cxe-red @behowell
 packages/react/src/components/WeeklyDayPicker/ @lorejoh12
 
 ## Theming and styling
-packages/react/src/utilities/ThemeProvider @dzearing
+packages/react/src/utilities/ThemeProvider @microsoft/cxe-red @dzearing
 
 ## Experiments
-packages/react-experiments/src/components/Pagination/ @caradong
 packages/react-experiments/src/components/Signals/ @ThomasMichon
 packages/react-experiments/src/components/Tile/ @ThomasMichon
 packages/react-experiments/src/components/TileList/ @ThomasMichon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,26 +124,21 @@ packages/react-tooltip/ @microsoft/cxe-red @behowell
 packages/react-label/ @microsoft/cxe-red @sopranopillow
 
 ## Components
+packages/react @microsoft/cxe-red
 packages/react/src/components/ActivityItem/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Announced/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Breadcrumb/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Button/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Calendar/ @lorejoh12
 packages/react/src/components/CalendarDayGrid/ @lorejoh12
-packages/react/src/components/Callout/ @microsoft/cxe-red
 packages/react/src/components/Check/ @microsoft/cxe-red @ThomasMichon @khmakoto
 packages/react/src/components/Checkbox/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/ChoiceGroup/ @microsoft/cxe-red @ecraig12345
 packages/react/src/components/Coachmark/ @microsoft/cxe-red @leddie24
 packages/react/src/components/ColorPicker/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/ComboBox/ @microsoft/cxe-red
-packages/react/src/components/CommandBar/ @microsoft/cxe-red
-packages/react/src/components/ContextualMenu/ @microsoft/cxe-red
 packages/react/src/components/DatePicker/ @lorejoh12
 packages/react/src/components/DetailsList/ @microsoft/cxe-red @ThomasMichon
-packages/react/src/components/Dialog/ @microsoft/cxe-red
 packages/react/src/components/DocumentCard/ @microsoft/cxe-red @yiminwu
-packages/react/src/components/Dropdown/ @microsoft/cxe-red
 packages/react/src/components/Fabric/ @microsoft/cxe-red @dzearing
 packages/react/src/components/Facepile/ @microsoft/cxe-red @markionium @mtennoe
 packages/react/src/components/FolderCover/ @microsoft/cxe-red @ThomasMichon @bigbadcapers
@@ -158,28 +153,17 @@ packages/react/src/components/Link/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/List/ @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/MarqueeSelection/ @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/MessageBar/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Modal/ @microsoft/cxe-red
 packages/react/src/components/Nav/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/OverflowSet/ @microsoft/cxe-red
 packages/react/src/components/Overlay/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Panel/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Persona/ @microsoft/cxe-red @markionium @mtennoe
 packages/react/src/components/PersonaCoin/ @microsoft/cxe-red @mtennoe @markionium
-packages/react/src/components/pickers/ @microsoft/cxe-red
 packages/react/src/components/Pivot/ @microsoft/cxe-red @behowell
-packages/react/src/components/Popup/ @microsoft/cxe-red
-packages/react/src/components/ProgressIndicator/ @microsoft/cxe-red
-packages/react/src/components/Rating/ @microsoft/cxe-red
-packages/react/src/components/ResizeGroup/ @microsoft/cxe-red
 packages/react/src/components/SearchBox/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Separator/ @microsoft/cxe-red
 packages/react/src/components/Shimmer/ @microsoft/cxe-red @Vitalius1
-packages/react/src/components/Slider/ @microsoft/cxe-red
 packages/react/src/components/SpinButton/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Spinner/ @microsoft/cxe-red
 packages/react/src/components/Stack/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/SwatchColorPicker/ @microsoft/cxe-red @ecraig12345
-packages/react/src/components/TeachingBubble/ @microsoft/cxe-red
 packages/react/src/components/Text/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/TextField/ @microsoft/cxe-red @ecraig12345
 packages/react/src/components/Toggle/ @microsoft/cxe-red @khmakoto


### PR DESCRIPTION
Add `@microsoft/cxe-red` as generic codeowner for all of `packages/react`, and remove per-component entries where there were no additional codeowners. (For example, the TextField entry stays because it's owned by `@microsoft/cxe-red @ecraig12345`, but the Callout entry was removed because it's only owned by `@microsoft/cxe-red`, which is now covered by the package-wide rule.)

Remove `@caradong` as codeowner of Pagination as she appears to no longer be at Microsoft.

Remove @pompomon as codeowner of v8 date-related components. I'm pretty sure this was added during a previous convergence effort (which included using the same utilities in v8/v0) but is no longer relevant--please let me know if that's incorrect.

I'd also propose the following (currently implemented in this PR) but open to suggestions: 
Add `@microsoft/cxe-red` to the codeowners list for most v8 components that still only had an individual codeowner. This is because most of the listed owners are no longer working on those components and/or haven't been active on github reviews in a long time. I left the date-related ones owned by only @lorejoh12 since he's still active, but open to adding cxe-red there too if people prefer.