### PR TITLE
Make codesandbox build use Node 12

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -7,5 +7,6 @@
     "packages/fluentui/react-bindings",
     "packages/fluentui/react-northstar"
   ],
-  "sandboxes": ["u0e3w", "/apps/codesandbox-react-template", "/apps/codesandbox-react-northstar-template"]
+  "sandboxes": ["u0e3w", "/apps/codesandbox-react-template", "/apps/codesandbox-react-northstar-template"],
+  "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,12 +1,6 @@
 {
   "buildCommand": "build:min",
-  "packages": [
-    "packages/react",
-    "packages/react-button",
-    "packages/react-icons-mdl2",
-    "packages/fluentui/react-bindings",
-    "packages/fluentui/react-northstar"
-  ],
-  "sandboxes": ["u0e3w", "/apps/codesandbox-react-template", "/apps/codesandbox-react-northstar-template"],
+  "packages": ["packages/react", "packages/fluentui/react-bindings", "packages/fluentui/react-northstar"],
+  "sandboxes": ["/apps/codesandbox-react-template", "/apps/codesandbox-react-northstar-template"],
   "node": "12"
 }


### PR DESCRIPTION
The codesandbox build step has been failing due to using Node 10 by default. Switch it to use Node 12.