### PR TITLE
fix(tools): preserve types and tags when running migration on already migrated project

### DIFF
--- a/tools/types.ts
+++ b/tools/types.ts
@@ -6,10 +6,12 @@ type KnownKeys<T> = {
   : never;
 
 type TsOriginalCompilerOptions = import('typescript').CompilerOptions;
-interface CompilerOptions extends Omit<RemoveIndex<TsOriginalCompilerOptions>, 'module' | 'target' | 'jsx'> {
+interface CompilerOptions
+  extends Omit<RemoveIndex<TsOriginalCompilerOptions>, 'module' | 'target' | 'jsx' | 'moduleResolution'> {
   module?: keyof typeof import('typescript').ModuleKind;
   target?: keyof typeof import('typescript').ScriptTarget;
-  jsx?: Lowercase<keyof typeof import('typescript').JsxEmit>;
+  jsx?: 'none' | 'preserve' | 'react' | 'react-native' | 'react-jsx' | 'react-jsxdev';
+  moduleResolution?: 'Node' | 'Classic';
 }
 
 export interface TsConfig {

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -1,6 +1,20 @@
+type RemoveIndex<T extends Record<string, unknown>> = Pick<T, KnownKeys<T>>;
+type KnownKeys<T> = {
+  [K in keyof T]: string extends K ? never : number extends K ? never : K;
+} extends { [_ in keyof T]: infer U }
+  ? U
+  : never;
+
+type TsOriginalCompilerOptions = import('typescript').CompilerOptions;
+interface CompilerOptions extends Omit<RemoveIndex<TsOriginalCompilerOptions>, 'module' | 'target' | 'jsx'> {
+  module?: keyof typeof import('typescript').ModuleKind;
+  target?: keyof typeof import('typescript').ScriptTarget;
+  jsx?: Lowercase<keyof typeof import('typescript').JsxEmit>;
+}
+
 export interface TsConfig {
   extends?: string;
-  compilerOptions: import('typescript').CompilerOptions;
+  compilerOptions: CompilerOptions;
   include?: Array<string>;
   files?: Array<string>;
   exclude?: Array<string>;


### PR DESCRIPTION
…ion generator

#### Pull request checklist

- [x] Addresses an existing issue: implements partially #16889 
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- add `platform:web` to nx.json tags as new organisation classifier (will be used in the future with eslint rule to enforce boundaries)
- fix: migration will preserve additional `types` in package tsconfig.json if present
- tweaks TSconfig interface to match real editor config instead of processed options within tsc compiler 

~TODO:~
- [x] add platform tags to nx.json
- ~[ ] properly provide path source in tsconfig.base.json based on real file system (eg node packages might be written in JS thus `index.js` needs to be provided~ -> not applicable, implement in separate migration generator

#### Focus areas to test

(optional)
