### PR TITLE
feat(Menu): Allow custom and virtual popover target

### DIFF
--- a/change/@fluentui-react-menu-45e2f117-af8f-472c-80c9-303392bf6753.json
+++ b/change/@fluentui-react-menu-45e2f117-af8f-472c-80c9-303392bf6753.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(Menu): Allow custom and virtual popover target",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-ee22c13a-daa7-4278-96ed-5d924e05669f.json
+++ b/change/@fluentui-react-positioning-ee22c13a-daa7-4278-96ed-5d924e05669f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(usePopperMouseTarget): Reusable hook to manage the state of a virtual popper element",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -12,6 +12,7 @@ const nestedMenuStory = 'NestedSubmenus';
 const nestedMenuControlledStory = 'NestedSubmenusControlled';
 
 const menuStoriesTitle = 'Components/Menu';
+const defaultMouseOverDelay = 250;
 
 describe('Menu', () => {
   before(() => {
@@ -274,12 +275,12 @@ describe('Menu', () => {
 
         cy.get(menuSelector).within(() => {
           cy.get(menuTriggerSelector).trigger('mouseover');
-          cy.tick(0);
+          cy.tick(defaultMouseOverDelay);
           cy.get(menuTriggerSelector).trigger('mouseout');
         });
 
         cy.get(menuItemSelector).first().trigger('mouseover');
-        cy.tick(0);
+        cy.tick(defaultMouseOverDelay);
       });
 
       it('should focus first menuitem in an open submenu with right arrow from the trigger', () => {

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -11,6 +11,7 @@ import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import { PositioningProps } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
+import { usePopperMouseTarget } from '@fluentui/react-positioning';
 
 // @public
 export const Menu: React_2.FC<MenuProps>;
@@ -210,9 +211,10 @@ export interface MenuPopoverState extends ComponentState<MenuPopoverProps>, Pick
 }
 
 // @public
-export interface MenuProps extends MenuListProps, Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset'> {
-    children: [JSX.Element, JSX.Element];
+export interface MenuProps extends MenuListProps, Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset' | 'target'> {
+    children: [JSX.Element, JSX.Element] | JSX.Element;
     defaultOpen?: boolean;
+    hoverDelay?: number;
     inline?: boolean;
     menuPopup?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     onOpenChange?: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
@@ -220,6 +222,7 @@ export interface MenuProps extends MenuListProps, Pick<PositioningProps, 'positi
     openOnContext?: boolean;
     // (undocumented)
     openOnHover?: boolean;
+    persistOnItemClick?: boolean;
 }
 
 // @public (undocumented)
@@ -230,13 +233,14 @@ export const menuShorthandProps: (keyof MenuProps)[];
 
 // @public (undocumented)
 export interface MenuState extends MenuProps {
+    contextTarget: ReturnType<typeof usePopperMouseTarget>[0];
     isSubmenu: boolean;
     menuPopover: React_2.ReactNode;
     menuPopoverRef: React_2.MutableRefObject<HTMLElement>;
     menuTrigger: React_2.ReactNode;
     open: boolean;
-    persistOnItemClick?: boolean;
     ref: React_2.MutableRefObject<HTMLElement>;
+    setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
     setOpen: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
     triggerId: string;
     triggerRef: React_2.MutableRefObject<HTMLElement>;

--- a/packages/react-menu/src/Menu.stories.tsx
+++ b/packages/react-menu/src/Menu.stories.tsx
@@ -150,6 +150,32 @@ export const CustomTrigger = () => {
   );
 };
 
+export const CustomTarget = () => {
+  const [open, setOpen] = React.useState(false);
+  const [target, setTarget] = React.useState<HTMLButtonElement | null>(null);
+  const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
+    setOpen(data.open);
+  };
+
+  return (
+    <>
+      <button ref={setTarget} onClick={() => setOpen(s => !s)}>
+        Custom Target
+      </button>
+      <Menu open={open} onOpenChange={onOpenChange} target={target}>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>New </MenuItem>
+            <MenuItem>New Window</MenuItem>
+            <MenuItem disabled>Open File</MenuItem>
+            <MenuItem>Open Folder</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </>
+  );
+};
+
 export const MenuTriggerInteractions = () => {
   const context = boolean('context', false);
   const hover = boolean('hover', false);

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
-import { PositioningProps } from '@fluentui/react-positioning';
+import { PositioningProps, usePopperMouseTarget } from '@fluentui/react-positioning';
 import { MenuListProps } from '../MenuList/index';
 
 /**
@@ -9,12 +9,12 @@ import { MenuListProps } from '../MenuList/index';
  */
 export interface MenuProps
   extends MenuListProps,
-    Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset'> {
+    Pick<PositioningProps, 'position' | 'align' | 'coverTarget' | 'offset' | 'target'> {
   /**
-   * Explicitly require children
+   * Can contain two children including {@see MenuTrigger} and {@see MenuPopover}
+   * Alternatively can only contain {@see MenuPopover} if using a custom {@see target}
    */
-
-  children: [JSX.Element, JSX.Element];
+  children: [JSX.Element, JSX.Element] | JSX.Element;
   /**
    * Whether the popup is open
    */
@@ -51,6 +51,16 @@ export interface MenuProps
    * This option is disregarded for submenus
    */
   inline?: boolean;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnItemClick?: boolean;
+
+  /**
+   * Sets the delay for mouse open/close for the popover one mouse enter/leave
+   */
+  hoverDelay?: number;
 }
 
 /**
@@ -103,9 +113,14 @@ export interface MenuState extends MenuProps {
   isSubmenu: boolean;
 
   /**
-   * Do not dismiss the menu when a menu item is clicked
+   * Anchors the popper to the mouse click for context events
    */
-  persistOnItemClick?: boolean;
+  contextTarget: ReturnType<typeof usePopperMouseTarget>[0];
+
+  /**
+   * A callback to set the target of the popper to the mouse click for context events
+   */
+  setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
 }
 
 /**

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { usePopper } from '@fluentui/react-positioning';
+import { usePopperMouseTarget, usePopper } from '@fluentui/react-positioning';
 import {
   makeMergePropsCompat,
   resolveShorthandProps,
@@ -43,6 +43,7 @@ export const useMenu = (props: MenuProps, defaultProps?: MenuProps): MenuState =
       position: isSubmenu ? 'after' : 'below',
       align: isSubmenu ? 'top' : 'start',
       openOnHover: isSubmenu,
+      hoverDelay: 250,
       triggerId,
     },
     defaultProps,
@@ -59,13 +60,24 @@ export const useMenu = (props: MenuProps, defaultProps?: MenuProps): MenuState =
     console.warn('Menu can only take one MenuTrigger and one MenuList as children');
   }
 
+  const [contextTarget, setContextTarget] = usePopperMouseTarget();
+  state.setContextTarget = setContextTarget;
+  state.contextTarget = contextTarget;
+
+  if (!state.target && state.openOnContext && state.contextTarget) {
+    state.target = state.contextTarget;
+  }
+
   const { targetRef: triggerRef, containerRef: menuPopoverRef } = usePopper({
     align: state.align,
     position: state.position,
     coverTarget: state.coverTarget,
+    offset: state.offset,
+    target: state.target,
   });
   state.menuPopoverRef = menuPopoverRef;
   state.triggerRef = triggerRef;
+
   children.forEach(child => {
     if (child.type === MenuTrigger) {
       state.menuTrigger = child;
@@ -112,9 +124,17 @@ const useMenuOpenState = (state: MenuState) => {
 
   const [open, setOpen] = useControllableValue(state.open, state.defaultOpen);
   state.open = open !== undefined ? open : state.open;
+
   const trySetOpen = useEventCallback((e: MenuOpenEvents, data: MenuOpenChangeData) => {
     const event = e instanceof CustomEvent && e.type === MENU_ENTER_EVENT ? e.detail.nativeEvent : e;
     onOpenChange?.(event, { ...data });
+    if (data.open && e.type === 'contextmenu') {
+      state.setContextTarget(e as React.MouseEvent);
+    }
+
+    if (!data.open) {
+      state.setContextTarget(undefined);
+    }
 
     if (data.keyboard) {
       shouldHandleKeyboadRef.current = true;
@@ -131,12 +151,17 @@ const useMenuOpenState = (state: MenuState) => {
 
   state.setOpen = useEventCallback((e: MenuOpenEvents, data: MenuOpenChangeData) => {
     clearTimeout(setOpenTimeout.current);
-    if (e.type === 'mouseleave' || e.type === 'mouseenter') {
+    if (!(e instanceof Event) && e.persist) {
+      // < React 17 still uses pooled synthetic events
+      e.persist();
+    }
+
+    if (e.type === 'mouseleave' || e.type === 'mouseenter' || e.type === MENU_ENTER_EVENT) {
       if (state.triggerRef.current?.contains(e.target as HTMLElement)) {
         enteringTriggerRef.current = e.type === 'mouseenter';
       }
-      // TODO #18315 setTimeout for now to make it easier to consistently call onOpenChange once for each state change
-      setOpenTimeout.current = setTimeout(() => trySetOpen(e, data));
+
+      setOpenTimeout.current = setTimeout(() => trySetOpen(e, data), state.hoverDelay);
     } else {
       trySetOpen(e, data);
     }

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -43,7 +43,7 @@ export const useMenu = (props: MenuProps, defaultProps?: MenuProps): MenuState =
       position: isSubmenu ? 'after' : 'below',
       align: isSubmenu ? 'top' : 'start',
       openOnHover: isSubmenu,
-      hoverDelay: 250,
+      hoverDelay: 500,
       triggerId,
     },
     defaultProps,

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -43,7 +43,7 @@ export const useMenuPopover = (
             dispatchMenuEnterEvent(popoverRef.current as HTMLElement, e);
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore #16889 Node setTimeout type leaking
-            throttleDispatchTimerRef.current = setTimeout(() => (canDispatchCustomEventRef.current = true), 500);
+            throttleDispatchTimerRef.current = setTimeout(() => (canDispatchCustomEventRef.current = true), 250);
           }
         });
       }

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -25,7 +25,6 @@ export const useMenuPopover = (
   const popoverRef = useMenuContext(context => context.menuPopoverRef);
   const setOpen = useMenuContext(context => context.setOpen);
   const openOnHover = useMenuContext(context => context.openOnHover);
-  const openOnContext = useMenuContext(context => context.openOnContext);
   const isSubmenu = useMenuContext(context => context.isSubmenu);
   const canDispatchCustomEventRef = React.useRef(true);
   const throttleDispatchTimerRef = React.useRef(0);
@@ -72,7 +71,7 @@ export const useMenuPopover = (
   const { onMouseEnter: onMouseEnterOriginal, onKeyDown: onKeyDownOriginal } = state;
 
   state.onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
-    if (openOnHover && !openOnContext) {
+    if (openOnHover) {
       setOpen(e, { open: true, keyboard: false });
     }
 

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -72,7 +72,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
   });
 
   const onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
-    if (openOnHover && !openOnContext) {
+    if (openOnHover) {
       setOpen(e, { open: true, keyboard: false });
     }
 
@@ -80,7 +80,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
   });
 
   const onMouseLeave = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
-    if (openOnHover && !openOnContext) {
+    if (openOnHover) {
       setOpen(e, { open: false, keyboard: false });
     }
 

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -75,6 +75,9 @@ export function usePopper(options?: PopperOptions): {
     arrowRef: React_2.MutableRefObject<any>;
 };
 
+// @public
+export const usePopperMouseTarget: (initialState?: PopperJs.VirtualElement | undefined) => readonly [PopperJs.VirtualElement | undefined, (event: React_2.MouseEvent | MouseEvent | undefined | null) => void];
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -76,7 +76,7 @@ export function usePopper(options?: PopperOptions): {
 };
 
 // @public
-export const usePopperMouseTarget: (initialState?: PopperJs.VirtualElement | undefined) => readonly [PopperJs.VirtualElement | undefined, (event: React_2.MouseEvent | MouseEvent | undefined | null) => void];
+export const usePopperMouseTarget: (initialState?: PopperJs.VirtualElement | (() => PopperJs.VirtualElement) | undefined) => readonly [PopperJs.VirtualElement | undefined, (event: React_2.MouseEvent | MouseEvent | undefined | null) => void];
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-positioning/src/index.ts
+++ b/packages/react-positioning/src/index.ts
@@ -1,3 +1,4 @@
 export * from './usePopper';
 export * from './createVirtualElementFromClick';
+export * from './usePopperMouseTarget';
 export * from './types';

--- a/packages/react-positioning/src/usePopperMouseTarget.ts
+++ b/packages/react-positioning/src/usePopperMouseTarget.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { createVirtualElementFromClick } from './createVirtualElementFromClick';
+import * as PopperJs from '@popperjs/core';
+
+/**
+ * A state hook that manages a popper virtual element from mouseevents.
+ * Useful for scenarios where a component needs to be positioned by mouse click (e.g. contextmenu)
+ * React synthetic events are not persisted by this hook
+ * @returns state and dispatcher for a Popper virtual element that uses native/synthetic mouse events
+ */
+export const usePopperMouseTarget = (initialState?: PopperJs.VirtualElement | (() => PopperJs.VirtualElement)) => {
+  const [virtualElement, setVirtualElement] = React.useState<PopperJs.VirtualElement | undefined>(initialState);
+
+  const setVirtualMouseTarget = (event: React.MouseEvent | MouseEvent | undefined | null) => {
+    if (event === undefined || event === null) {
+      setVirtualElement(undefined);
+      return;
+    }
+
+    let mouseevent: MouseEvent;
+    if (!(event instanceof MouseEvent)) {
+      mouseevent = event.nativeEvent;
+    } else {
+      mouseevent = event;
+    }
+
+    if (!(mouseevent instanceof MouseEvent) && process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.error('usePopperMouseTarget should only be used with MouseEvent');
+    }
+
+    const contextTarget = createVirtualElementFromClick(mouseevent);
+    setVirtualElement(contextTarget);
+  };
+
+  return [virtualElement, setVirtualMouseTarget] as const;
+};

--- a/packages/react-positioning/src/usePopperMouseTarget.ts
+++ b/packages/react-positioning/src/usePopperMouseTarget.ts
@@ -6,6 +6,8 @@ import * as PopperJs from '@popperjs/core';
  * A state hook that manages a popper virtual element from mouseevents.
  * Useful for scenarios where a component needs to be positioned by mouse click (e.g. contextmenu)
  * React synthetic events are not persisted by this hook
+ *
+ * @param initialState - initializes a user provided state similare to useState
  * @returns state and dispatcher for a Popper virtual element that uses native/synthetic mouse events
  */
 export const usePopperMouseTarget = (initialState?: PopperJs.VirtualElement | (() => PopperJs.VirtualElement)) => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #18316 #18315
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Since #18464 aligns with `Popover` API pattern. Leverages the pattern used in `Popover` to support custom targets and real context menu targets. A reusable `usePopperMouseTarget` hook as a util manage the state of a popper virtual element. Will convert `Popover` to use this in a follow up PR.

Removes current constraint that context and hover cannot be used together

Adds `hoverDelay` prop for open and dismiss on mouse over events. This delay has a default of 500ms as in design spec

#### Focus areas to test

(optional)
