### PR TITLE
Refactor react-accordion makeMergeProps

### DIFF
--- a/change/@fluentui-react-accordion-79b89d31-990b-472d-a2fc-6888a7242d6e.json
+++ b/change/@fluentui-react-accordion-79b89d31-990b-472d-a2fc-6888a7242d6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor from makeMergePropsCompat to makeMergeProps",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -5,9 +5,9 @@
 ```ts
 
 import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentState } from '@fluentui/react-utilities';
 import { Descendant } from '@fluentui/react-utilities';
 import { DescendantContextValue } from '@fluentui/react-utilities';
-import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import { ShorthandProps } from '@fluentui/react-utilities';
 
@@ -23,6 +23,9 @@ export interface AccordionContextValue extends AccordionHeaderCommonProps {
     openItems: number[];
     requestToggle: NonNullable<AccordionProps['onToggle']>;
 }
+
+// @public (undocumented)
+export type AccordionDefaultedProps = 'collapsible' | 'multiple' | 'navigable';
 
 // @public (undocumented)
 export interface AccordionDescendant<ElementType = HTMLElement> extends Descendant<ElementType> {
@@ -45,11 +48,16 @@ export interface AccordionHeaderContextValue {
 }
 
 // @public (undocumented)
+export type AccordionHeaderDefaultedProps = 'size' | 'expandIconPosition' | 'inline' | 'button';
+
+// @public (undocumented)
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';
 
 // @public (undocumented)
 export interface AccordionHeaderProps extends ComponentProps, React_2.HTMLAttributes<HTMLElement> {
     button?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
+    // (undocumented)
+    children?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     expandIcon?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
     expandIconPosition?: AccordionHeaderExpandIconPosition;
     icon?: ShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
@@ -57,29 +65,20 @@ export interface AccordionHeaderProps extends ComponentProps, React_2.HTMLAttrib
     size?: AccordionHeaderSize;
 }
 
+// @public (undocumented)
+export type AccordionHeaderShorthandProps = 'button' | 'expandIcon' | 'icon' | 'children';
+
 // @public
-export const accordionHeaderShorthandProps: readonly ["expandIcon", "button", "children", "icon"];
+export const accordionHeaderShorthandProps: AccordionHeaderShorthandProps[];
 
 // @public (undocumented)
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
 
 // @public (undocumented)
-export interface AccordionHeaderState extends AccordionHeaderProps {
-    button: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
-    // (undocumented)
-    children?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
+export interface AccordionHeaderState extends ComponentState<AccordionHeaderProps, AccordionHeaderShorthandProps, AccordionHeaderDefaultedProps> {
     // (undocumented)
     context: AccordionHeaderContextValue;
-    expandIcon: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
-    // (undocumented)
-    expandIconPosition: AccordionHeaderExpandIconPosition;
-    // (undocumented)
-    icon?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
-    // (undocumented)
-    inline: boolean;
-    ref: React_2.MutableRefObject<HTMLElement>;
-    // (undocumented)
-    size: AccordionHeaderSize;
+    ref: React_2.Ref<HTMLElement>;
 }
 
 // @public (undocumented)
@@ -119,11 +118,11 @@ export interface AccordionItemProps extends ComponentProps, React_2.HTMLAttribut
 export const accordionItemShorthandProps: never[];
 
 // @public (undocumented)
-export interface AccordionItemState extends AccordionItemProps {
+export interface AccordionItemState extends ComponentState<AccordionItemProps> {
     // (undocumented)
     context: AccordionItemContextValue;
     descendants: AccordionItemDescendant[];
-    ref: React_2.MutableRefObject<HTMLElement>;
+    ref: React_2.Ref<HTMLElement>;
     setDescendants: React_2.Dispatch<React_2.SetStateAction<AccordionItemDescendant[]>>;
 }
 
@@ -138,9 +137,9 @@ export interface AccordionPanelProps extends ComponentProps, React_2.HTMLAttribu
 export const accordionPanelShorthandProps: never[];
 
 // @public (undocumented)
-export interface AccordionPanelState extends AccordionPanelProps {
+export interface AccordionPanelState extends ComponentState<AccordionPanelProps> {
     open: boolean;
-    ref: React_2.MutableRefObject<HTMLElement>;
+    ref: React_2.Ref<HTMLElement>;
 }
 
 // @public (undocumented)
@@ -154,20 +153,17 @@ export interface AccordionProps extends ComponentProps, AccordionHeaderCommonPro
     onToggle?(event: React_2.MouseEvent | React_2.KeyboardEvent, index: number): void;
 }
 
+// @public (undocumented)
+export type AccordionShorthandProps = Exclude<AccordionHeaderShorthandProps, 'children'>;
+
 // @public
-export const accordionShorthandProps: readonly ["expandIcon", "button", "icon"];
+export const accordionShorthandProps: AccordionShorthandProps[];
 
 // @public (undocumented)
-export interface AccordionState extends AccordionProps {
-    // (undocumented)
-    collapsible: boolean;
+export interface AccordionState extends ComponentState<AccordionProps, AccordionShorthandProps, AccordionDefaultedProps> {
     context: AccordionContextValue;
     descendants: AccordionDescendant[];
-    // (undocumented)
-    multiple: boolean;
-    // (undocumented)
-    navigable: boolean;
-    ref: React_2.MutableRefObject<HTMLElement>;
+    ref: React_2.Ref<HTMLElement>;
     setDescendants: React_2.Dispatch<React_2.SetStateAction<AccordionDescendant[]>>;
 }
 
@@ -208,7 +204,7 @@ export const useAccordionPanel: (props: AccordionPanelProps, ref: React_2.Ref<HT
 export const useAccordionPanelStyles: (state: AccordionPanelState) => AccordionPanelState;
 
 // @public
-export function useCreateAccordionItemContextValue(state: AccordionItemState): AccordionItemContextValue;
+export function useCreateAccordionItemContextValue(state: AccordionItemState, ref: React_2.RefObject<HTMLElement>): AccordionItemContextValue;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ComponentProps, Descendant } from '@fluentui/react-utilities';
-import { AccordionHeaderProps } from '../AccordionHeader/AccordionHeader.types';
+import { ComponentProps, ComponentState, Descendant } from '@fluentui/react-utilities';
+import { AccordionHeaderProps, AccordionHeaderShorthandProps } from '../AccordionHeader/AccordionHeader.types';
 
 export type AccordionIndex = number | number[];
 
@@ -9,7 +9,7 @@ export type AccordionIndex = number | number[];
  */
 type AccordionHeaderCommonProps = Pick<
   AccordionHeaderProps,
-  'expandIcon' | 'expandIconPosition' | 'icon' | 'button' | 'size' | 'inline'
+  AccordionShorthandProps | 'expandIconPosition' | 'size' | 'inline'
 >;
 export interface AccordionContextValue extends AccordionHeaderCommonProps {
   navigable: boolean;
@@ -47,14 +47,16 @@ export interface AccordionProps extends ComponentProps, AccordionHeaderCommonPro
   onToggle?(event: React.MouseEvent | React.KeyboardEvent, index: number): void;
 }
 
-export interface AccordionState extends AccordionProps {
+export type AccordionShorthandProps = Exclude<AccordionHeaderShorthandProps, 'children'>;
+
+export type AccordionDefaultedProps = 'collapsible' | 'multiple' | 'navigable';
+
+export interface AccordionState
+  extends ComponentState<AccordionProps, AccordionShorthandProps, AccordionDefaultedProps> {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
-  navigable: boolean;
-  multiple: boolean;
-  collapsible: boolean;
+  ref: React.Ref<HTMLElement>;
   /**
    * Internal Context used by Accordion and AccordionItem communication
    */

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -1,15 +1,14 @@
 import * as React from 'react';
-import { makeMergePropsCompat, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
-import { AccordionProps, AccordionState } from './Accordion.types';
+import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
+import { AccordionProps, AccordionShorthandProps, AccordionState } from './Accordion.types';
 import { useCreateAccordionContextValue } from './useAccordionContext';
 
 /**
  * Const listing which props are shorthand props.
  */
-export const accordionShorthandProps = ['expandIcon', 'button', 'icon'] as const;
+export const accordionShorthandProps: AccordionShorthandProps[] = ['expandIcon', 'button', 'icon'];
 
-// eslint-disable-next-line deprecation/deprecation
-const mergeProps = makeMergePropsCompat<AccordionState>({ deepMerge: accordionShorthandProps });
+const mergeProps = makeMergeProps<AccordionState>({ deepMerge: accordionShorthandProps });
 
 /**
  * Returns the props and state required to render the component
@@ -24,12 +23,15 @@ export const useAccordion = (
 ): AccordionState => {
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef(null)),
+      ref,
       collapsible: false,
       multiple: false,
       navigable: false,
+      context: undefined!,
+      descendants: undefined!,
+      setDescendants: undefined!,
     },
-    defaultProps,
+    defaultProps && resolveShorthandProps(defaultProps, accordionShorthandProps),
     resolveShorthandProps(props, accordionShorthandProps),
   );
 

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -27,9 +27,17 @@ export const useAccordion = (
       collapsible: false,
       multiple: false,
       navigable: false,
-      context: undefined!,
-      descendants: undefined!,
-      setDescendants: undefined!,
+      context: {
+        navigable: false,
+        openItems: [],
+        requestToggle() {
+          /* noop */
+        },
+      },
+      descendants: [],
+      setDescendants() {
+        /* noop */
+      },
     },
     defaultProps && resolveShorthandProps(defaultProps, accordionShorthandProps),
     resolveShorthandProps(props, accordionShorthandProps),

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ObjectShorthandProps, ShorthandProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, ShorthandProps } from '@fluentui/react-utilities';
 
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';
@@ -36,25 +36,17 @@ export interface AccordionHeaderProps extends ComponentProps, React.HTMLAttribut
    * Indicates if the AccordionHeader should be rendered inline
    */
   inline?: boolean;
+  children?: ShorthandProps<React.HTMLAttributes<HTMLElement>>;
 }
 
-export interface AccordionHeaderState extends AccordionHeaderProps {
-  size: AccordionHeaderSize;
+export type AccordionHeaderShorthandProps = 'button' | 'expandIcon' | 'icon' | 'children';
+export type AccordionHeaderDefaultedProps = 'size' | 'expandIconPosition' | 'inline' | 'button';
+
+export interface AccordionHeaderState
+  extends ComponentState<AccordionHeaderProps, AccordionHeaderShorthandProps, AccordionHeaderDefaultedProps> {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
-  /**
-   * Expand icon slot when processed by internal state
-   */
-  expandIcon: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-  expandIconPosition: AccordionHeaderExpandIconPosition;
-  icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-  /**
-   * The component to be used as button
-   */
-  button: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-  children?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+  ref: React.Ref<HTMLElement>;
   context: AccordionHeaderContextValue;
-  inline: boolean;
 }

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
@@ -80,7 +80,12 @@ export const useAccordionHeader = (
       as: 'div',
       role: 'heading',
       expandIconPosition: 'start',
-      context: undefined!,
+      context: {
+        disabled: false,
+        open: false,
+        size: 'medium',
+        expandIconPosition: 'start',
+      },
     },
     resolveShorthandProps<AccordionHeaderProps, AccordionHeaderShorthandProps>(
       { button, icon, expandIconPosition, expandIcon, size, inline },

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  makeMergePropsCompat,
+  makeMergeProps,
   resolveShorthandProps,
   useMergedRefs,
   useId,
@@ -9,11 +9,11 @@ import {
   useEventCallback,
 } from '@fluentui/react-utilities';
 import {
-  AccordionHeaderExpandIconPosition,
   AccordionHeaderProps,
   AccordionHeaderSize,
   AccordionHeaderState,
   AccordionHeaderContextValue,
+  AccordionHeaderShorthandProps,
 } from './AccordionHeader.types';
 import {
   useAccordionItemContext,
@@ -28,10 +28,14 @@ import { useContextSelector } from '@fluentui/react-context-selector';
 /**
  * Const listing which props are shorthand props.
  */
-export const accordionHeaderShorthandProps = ['expandIcon', 'button', 'children', 'icon'] as const;
+export const accordionHeaderShorthandProps: AccordionHeaderShorthandProps[] = [
+  'expandIcon',
+  'button',
+  'children',
+  'icon',
+];
 
-// eslint-disable-next-line deprecation/deprecation
-const mergeProps = makeMergePropsCompat<AccordionHeaderState>({ deepMerge: accordionHeaderShorthandProps });
+const mergeProps = makeMergeProps<AccordionHeaderState>({ deepMerge: accordionHeaderShorthandProps });
 
 /**
  * Returns the props and state required to render the component
@@ -53,9 +57,10 @@ export const useAccordionHeader = (
   const size = useContextSelector(AccordionContext, ctx => ctx.size);
   const id = useId('accordion-header-', props.id);
   const panel = useDescendants(accordionItemDescendantContext)[1] as AccordionItemDescendant | undefined;
+  const innerRef = React.useRef<HTMLElement>(null);
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef(null)),
+      ref: useMergedRefs(ref, innerRef),
       size: 'medium' as AccordionHeaderSize,
       inline: false,
       expandIcon: {
@@ -74,10 +79,14 @@ export const useAccordionHeader = (
       },
       as: 'div',
       role: 'heading',
-      expandIconPosition: 'start' as AccordionHeaderExpandIconPosition,
+      expandIconPosition: 'start',
+      context: undefined!,
     },
-    { button, icon, expandIconPosition, expandIcon, size, inline },
-    defaultProps,
+    resolveShorthandProps<AccordionHeaderProps, AccordionHeaderShorthandProps>(
+      { button, icon, expandIconPosition, expandIcon, size, inline },
+      accordionHeaderShorthandProps,
+    ),
+    defaultProps && resolveShorthandProps(defaultProps, accordionHeaderShorthandProps),
     resolveShorthandProps(props, accordionHeaderShorthandProps),
   );
   const originalButtonKeyDown = state.button.onKeyDown;
@@ -96,7 +105,7 @@ export const useAccordionHeader = (
 
   useAccordionItemDescendant(
     {
-      element: state.ref.current,
+      element: innerRef.current,
       id,
     },
     0,

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, Descendant } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, Descendant } from '@fluentui/react-utilities';
 
 export interface AccordionItemContextValue {
   open: boolean;
@@ -14,11 +14,11 @@ export interface AccordionItemProps extends ComponentProps, React.HTMLAttributes
   disabled?: boolean;
 }
 
-export interface AccordionItemState extends AccordionItemProps {
+export interface AccordionItemState extends ComponentState<AccordionItemProps> {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.Ref<HTMLElement>;
   context: AccordionItemContextValue;
   /**
    * Internal Context used by AccordionHeader and AccordionPanel communication

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
-  makeMergePropsCompat,
+  makeMergeProps,
   resolveShorthandProps,
-  useMergedRefs,
   createDescendantContext,
   useDescendant,
   useDescendantsInit,
   DescendantContextValue,
+  useMergedRefs,
 } from '@fluentui/react-utilities';
 import { AccordionItemProps, AccordionItemState, AccordionItemDescendant } from './AccordionItem.types';
 import { useCreateAccordionItemContextValue } from './useAccordionItemContext';
@@ -23,8 +23,7 @@ export const accordionItemDescendantContext: React.Context<
   DescendantContextValue<AccordionItemDescendant<HTMLElement>>
 > = createDescendantContext<AccordionItemDescendant>('AccordionItemDescendantContext');
 
-// eslint-disable-next-line deprecation/deprecation
-const mergeProps = makeMergePropsCompat<AccordionItemState>({ deepMerge: accordionItemShorthandProps });
+const mergeProps = makeMergeProps<AccordionItemState>({ deepMerge: accordionItemShorthandProps });
 
 /**
  * Returns the props and state required to render the component
@@ -37,17 +36,21 @@ export const useAccordionItem = (
   ref: React.Ref<HTMLElement>,
   defaultProps?: AccordionItemProps,
 ): AccordionItemState => {
+  const innerRef = React.useRef<HTMLElement>(null);
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef(null)),
+      ref: useMergedRefs(ref, innerRef),
+      context: undefined!,
+      descendants: undefined!,
+      setDescendants: undefined!,
     },
-    defaultProps,
+    defaultProps && resolveShorthandProps(defaultProps, accordionItemShorthandProps),
     resolveShorthandProps(props, accordionItemShorthandProps),
   );
   const [descendants, setDescendants] = useDescendantsInit<AccordionItemDescendant>();
   state.descendants = descendants;
   state.setDescendants = setDescendants;
-  state.context = useCreateAccordionItemContextValue(state);
+  state.context = useCreateAccordionItemContextValue(state, innerRef);
   const navigable = useContextSelector(AccordionContext, ctx => ctx.navigable);
   const tabsterAttributes = useTabsterAttributes({
     groupper: {},

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItemContext.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItemContext.ts
@@ -17,11 +17,11 @@ export const useAccordionItemContext = () => React.useContext(AccordionItemConte
 /**
  * Creates internal context to be consumed by AccordionHeader and AccordionPanel
  */
-export function useCreateAccordionItemContextValue(state: AccordionItemState) {
+export function useCreateAccordionItemContextValue(state: AccordionItemState, ref: React.RefObject<HTMLElement>) {
   const disabled = state.disabled ?? false;
   // index -1 means context not provided
   const index = useAccordionDescendant({
-    element: state.ref.current,
+    element: ref.current,
     disabled,
   });
   const requestToggle = useContextSelector(AccordionContext, ctx => ctx.requestToggle);

--- a/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 
 export interface AccordionPanelProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {}
 
-export interface AccordionPanelState extends AccordionPanelProps {
+export interface AccordionPanelState extends ComponentState<AccordionPanelProps> {
   /**
    * Ref to the root slot
    */
-  ref: React.MutableRefObject<HTMLElement>;
+  ref: React.Ref<HTMLElement>;
   /**
    * Internal open state, provided by context
    */

--- a/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  makeMergePropsCompat,
-  resolveShorthandProps,
-  useMergedRefs,
-  useId,
-  useDescendants,
-} from '@fluentui/react-utilities';
+import { makeMergeProps, resolveShorthandProps, useMergedRefs, useId, useDescendants } from '@fluentui/react-utilities';
 import { AccordionPanelProps, AccordionPanelState } from './AccordionPanel.types';
 import {
   useAccordionItemContext,
@@ -19,8 +13,7 @@ import {
  */
 export const accordionPanelShorthandProps = [];
 
-// eslint-disable-next-line deprecation/deprecation
-const mergeProps = makeMergePropsCompat<AccordionPanelState>({ deepMerge: accordionPanelShorthandProps });
+const mergeProps = makeMergeProps<AccordionPanelState>({ deepMerge: accordionPanelShorthandProps });
 
 /**
  * Returns the props and state required to render the component
@@ -36,20 +29,21 @@ export const useAccordionPanel = (
   const { open } = useAccordionItemContext();
   const id = useId('accordion-panel-', props.id);
   const header = useDescendants(accordionItemDescendantContext)[0] as AccordionItemDescendant | undefined;
+  const innerRef = React.useRef<HTMLElement>(null);
   const state = mergeProps(
     {
-      ref: useMergedRefs(ref, React.useRef(null)),
+      ref: useMergedRefs(ref, innerRef),
       id,
       open,
       role: 'region',
       'aria-labelledby': header?.id,
     },
-    defaultProps,
+    resolveShorthandProps(defaultProps, accordionPanelShorthandProps),
     resolveShorthandProps(props, accordionPanelShorthandProps),
   );
   useAccordionItemDescendant(
     {
-      element: state.ref.current,
+      element: innerRef.current,
       id,
     },
     1,


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Refactors accordion codebase to use `makeMergeProps` instead of `makeMergePropsCompat`