### PR TITLE
fix(MenuItemContent): get vertical prop from context

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,7 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `ChatMessage` badge-bar conflict with focus-border @Hirse ([#18303](https://github.com/microsoft/fluentui/pull/18303))
 - Fix `Dropdown` to pass all positioning props to its inner `Popper` @yuanboxue-amber ([#18457](https://github.com/microsoft/fluentui/pull/18457))
 - Update `Datepicker` today cell background color in dark-v2 theme to increase contrast @yuanboxue-amber ([#18461](https://github.com/microsoft/fluentui/pull/18461))
-- Fix missing `vertical` prop from parent context in `MenuItemContent` ([#18570](https://github.com/microsoft/fluentui/pull/18570))
+- Fix missing `vertical` prop from parent context in `MenuItemContent` @assuncaocharles ([#18570](https://github.com/microsoft/fluentui/pull/18570))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `ChatMessage` badge-bar conflict with focus-border @Hirse ([#18303](https://github.com/microsoft/fluentui/pull/18303))
 - Fix `Dropdown` to pass all positioning props to its inner `Popper` @yuanboxue-amber ([#18457](https://github.com/microsoft/fluentui/pull/18457))
 - Update `Datepicker` today cell background color in dark-v2 theme to increase contrast @yuanboxue-amber ([#18461](https://github.com/microsoft/fluentui/pull/18461))
+- Fix missing `vertical` prop from parent context in `MenuItemContent` ([#18570](https://github.com/microsoft/fluentui/pull/18570))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleVertical.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleVertical.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Menu, MenuItem, MenuItemContent } from '@fluentui/react-northstar';
+
+const MenuExampleVertical = () => (
+  <Menu vertical>
+    <MenuItem>
+      <MenuItemContent>Item 01</MenuItemContent>
+    </MenuItem>
+  </Menu>
+);
+
+export default MenuExampleVertical;

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/index.tsx
@@ -6,6 +6,7 @@ import NonPublicSection from '../../../../components/ComponentDoc/NonPublicSecti
 const Usage = () => (
   <NonPublicSection title="Visual tests">
     <ComponentExample examplePath="components/Menu/Visual/MenuExamplePositioning" />
+    <ComponentExample examplePath="components/Menu/Visual/MenuExampleVertical" />
   </NonPublicSection>
 );
 

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -318,6 +318,7 @@ export const Menu = (React.forwardRef<HTMLUListElement, MenuProps>((props, ref) 
     activeIndex: +activeIndex,
     onItemClick: handleClick,
     onItemSelect: handleSelect,
+    vertical,
     variables,
 
     slotProps: {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
@@ -8,6 +8,7 @@ import {
   useUnhandledProps,
   getElementType,
   childrenExist,
+  useContextSelectors,
 } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import {
@@ -19,6 +20,7 @@ import {
 } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';
 import { Accessibility } from '@fluentui/accessibility';
+import { MenuContext, MenuItemSubscribedValue } from './menuContext';
 
 export interface MenuItemContentProps extends UIComponentProps, ContentComponentProps, ChildrenComponentProps {
   /**
@@ -51,6 +53,10 @@ export const MenuItemContent = (React.forwardRef<HTMLSpanElement, MenuItemConten
   const { setStart, setEnd } = useTelemetry(MenuItemContent.displayName, context.telemetry);
   setStart();
 
+  const parentProps = (useContextSelectors(MenuContext, {
+    vertical: v => v.vertical,
+  }) as unknown) as MenuItemSubscribedValue; // TODO: we should improve typings for the useContextSelectors
+
   const { className, children, design, styles, variables, content, hasMenu, hasIcon, vertical, inSubmenu } = props;
 
   const { classes } = useStyles<MenuItemContentStylesProps>(MenuItemContent.displayName, {
@@ -58,7 +64,7 @@ export const MenuItemContent = (React.forwardRef<HTMLSpanElement, MenuItemConten
     mapPropsToStyles: () => ({
       hasMenu,
       hasIcon,
-      vertical,
+      vertical: vertical || parentProps.vertical,
       inSubmenu,
     }),
     mapPropsToInlineStyles: () => ({

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -6,6 +6,7 @@ import { MenuItemProps } from './MenuItem';
 
 export type MenuContextValue = {
   activeIndex: number;
+  vertical: boolean;
   variables: ComponentVariablesInput;
   onItemClick: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
   onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
@@ -21,7 +22,10 @@ export type MenuContextValue = {
   };
 };
 
-export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemClick' | 'onItemSelect'> & {
+export type MenuItemSubscribedValue = Pick<
+  MenuContextValue,
+  'variables' | 'onItemClick' | 'onItemSelect' | 'vertical'
+> & {
   slotProps: MenuContextValue['slotProps']['item'];
   accessibility: MenuContextValue['behaviors']['item'];
   active: boolean;
@@ -34,6 +38,7 @@ export type MenuDividerSubscribedValue = Pick<MenuContextValue, 'variables'> & {
 
 export const MenuContext = createContext<MenuContextValue>({
   activeIndex: -1,
+  vertical: false,
   variables: {},
   onItemClick: null,
   onItemSelect: null,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17585
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fallback to `vertical` prop from `MenuContext`  if prop is not explicit set in `MenuItemContent`  

#### Focus areas to test

(optional)
