### PR TITLE
react-aria adds @fluentui/keyboard-key

### DIFF
--- a/change/@fluentui-react-aria-0499d663-ddfb-4709-be9b-452b64b9e864.json
+++ b/change/@fluentui-react-aria-0499d663-ddfb-4709-be9b-452b64b9e864.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds @fluentui/keyboard-key due to legacy",
+  "packageName": "@fluentui/react-aria",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-aria/bundle-size/Default.fixture.js
+++ b/packages/react-aria/bundle-size/Default.fixture.js
@@ -1,0 +1,7 @@
+import { useARIAButton } from '@fluentui/react-aria';
+
+console.log(useARIAButton);
+
+export default {
+  name: 'ARIA - Default',
+};

--- a/packages/react-aria/etc/react-aria.api.md
+++ b/packages/react-aria/etc/react-aria.api.md
@@ -7,12 +7,6 @@
 import { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
-// @internal (undocumented)
-export const _KeyboardEventKeys: {
-    readonly SPACE_BAR: " ";
-    readonly ENTER: "Enter";
-};
-
 // @public
 export function useARIAButton(shorthand: ObjectShorthandProps<React_2.ButtonHTMLAttributes<HTMLElement>>): ObjectShorthandProps<React_2.ButtonHTMLAttributes<HTMLElement>>;
 

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -40,6 +40,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
+    "@fluentui/keyboard-key": "^0.3.2",
     "@fluentui/react-make-styles": "^9.0.0-alpha.42",
     "@fluentui/react-utilities": "^9.0.0-alpha.29",
     "tslib": "^2.1.0"

--- a/packages/react-aria/src/hooks/useARIAButton.test.tsx
+++ b/packages/react-aria/src/hooks/useARIAButton.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { useARIAButton, _KeyboardEventKeys } from './useARIAButton';
+import { useARIAButton } from './useARIAButton';
+import { EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
 import { renderHook } from '@testing-library/react-hooks';
 import { fireEvent, screen, render } from '@testing-library/react';
 import { getSlots, ObjectShorthandProps } from '@fluentui/react-utilities';
@@ -59,7 +60,7 @@ describe('useARIAButton', () => {
     const { result } = renderHook(() => useARIAButton({ as: 'div', onClick: handleClick }));
     const { slots, slotProps } = getSlots(result.current, []);
     render(<slots.root data-testid="div" {...slotProps.root} />);
-    fireEvent.keyUp(screen.getByTestId('div'), { key: _KeyboardEventKeys.SPACE_BAR });
+    fireEvent.keyUp(screen.getByTestId('div'), { keyCode: SpacebarKey });
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
@@ -68,7 +69,7 @@ describe('useARIAButton', () => {
     const { result } = renderHook(() => useARIAButton({ as: 'div', onClick: handleClick }));
     const { slots, slotProps } = getSlots(result.current, []);
     render(<slots.root data-testid="div" {...slotProps.root} />);
-    fireEvent.keyDown(screen.getByTestId('div'), { key: _KeyboardEventKeys.ENTER });
+    fireEvent.keyDown(screen.getByTestId('div'), { keyCode: EnterKey });
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
@@ -94,7 +95,7 @@ describe('useARIAButton', () => {
         <slots.root data-testid="div" {...slotProps.root} />
       </div>,
     );
-    fireEvent.keyUp(screen.getByTestId('div'), { key: _KeyboardEventKeys.SPACE_BAR });
+    fireEvent.keyUp(screen.getByTestId('div'), { key: SpacebarKey });
     expect(handleClick).toHaveBeenCalledTimes(0);
   });
 
@@ -107,7 +108,7 @@ describe('useARIAButton', () => {
         <slots.root data-testid="div" {...slotProps.root} />
       </div>,
     );
-    fireEvent.keyDown(screen.getByTestId('div'), { key: _KeyboardEventKeys.ENTER });
+    fireEvent.keyDown(screen.getByTestId('div'), { key: EnterKey });
     expect(handleClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-aria/src/hooks/useARIAButton.ts
+++ b/packages/react-aria/src/hooks/useARIAButton.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { ObjectShorthandProps, useEventCallback } from '@fluentui/react-utilities';
-
-/** @internal */
-export const _KeyboardEventKeys = {
-  SPACE_BAR: ' ',
-  ENTER: 'Enter',
-} as const;
+import { getCode, SpacebarKey, EnterKey } from '@fluentui/keyboard-key';
 
 /**
  * button keyboard handling, role, disabled and tabIndex implementation that ensures ARIA spec
@@ -30,41 +25,43 @@ export function useARIAButton(
   });
 
   const onKeyDownHandler = useEventCallback((ev: React.KeyboardEvent<HTMLElement>) => {
+    const code = getCode(ev);
     if (typeof onKeyDown === 'function') {
       onKeyDown(ev);
     }
     if (ev.isDefaultPrevented()) {
       return;
     }
-    if (disabled && (ev.key === _KeyboardEventKeys.ENTER || ev.key === _KeyboardEventKeys.SPACE_BAR)) {
+    if (disabled && (code === EnterKey || code === SpacebarKey)) {
       ev.preventDefault();
       ev.stopPropagation();
       return;
     }
-    if (ev.key === _KeyboardEventKeys.SPACE_BAR) {
+    if (code === SpacebarKey) {
       ev.preventDefault();
       return;
     }
     // If enter is pressed, activate the button
-    else if (ev.key === _KeyboardEventKeys.ENTER) {
+    else if (code === EnterKey) {
       ev.preventDefault();
       ev.currentTarget.click();
     }
   });
 
   const onKeyupHandler = useEventCallback((ev: React.KeyboardEvent<HTMLElement>) => {
+    const code = getCode(ev);
     if (typeof onKeyUp === 'function') {
       onKeyUp(ev);
     }
     if (ev.isDefaultPrevented()) {
       return;
     }
-    if (disabled && (ev.key === _KeyboardEventKeys.ENTER || ev.key === _KeyboardEventKeys.SPACE_BAR)) {
+    if (disabled && (code === EnterKey || code === SpacebarKey)) {
       ev.preventDefault();
       ev.stopPropagation();
       return;
     }
-    if (ev.key === _KeyboardEventKeys.SPACE_BAR) {
+    if (code === SpacebarKey) {
       ev.preventDefault();
       ev.currentTarget.click();
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The current implementation of `react-aria` `useARIAButton` hook uses `key` instead of `keyCode` to identify keyboard pressed during events.

At the moment our conformance tests are based on `keyCode` implementation, which is causing some issues with the current implementation. To ensure conformance This PR adds `@fluentui/keyboard-key` as dependency to ensure `keyCode` usage
