### PR TITLE
doc(react-theme): Improve alias color tokens story

### DIFF
--- a/change/@fluentui-react-theme-209009d0-fbfa-4842-8937-d2b3c35a51ae.json
+++ b/change/@fluentui-react-theme-209009d0-fbfa-4842-8937-d2b3c35a51ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "doc(react-theme): Improve alias color tokens story",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-theme/src/themes/AliasColor.stories.tsx
+++ b/packages/react-theme/src/themes/AliasColor.stories.tsx
@@ -15,6 +15,7 @@ import {
   teamsDarkTheme,
   teamsHighContrastTheme,
   teamsLightTheme,
+  webDarkTheme,
   Theme,
 } from '../index';
 import { ColorRampItem } from './ColorRamp.stories';
@@ -22,7 +23,8 @@ import { ColorRampItem } from './ColorRamp.stories';
 // FIXME: hardcoded theme
 const theme = {
   light: teamsLightTheme,
-  dark: teamsDarkTheme,
+  dark: webDarkTheme,
+  teamsDark: teamsDarkTheme,
   highContrast: teamsHighContrastTheme,
 };
 
@@ -114,23 +116,39 @@ export const AliasColors = () => {
           ))}
       </div>
 
-      <div>{activeColor}</div>
-      <div>
-        <div style={{ display: 'flex' }}>
-          <h3 style={{ flex: `0 0 ${COLUMN_WIDTH}px`, padding: '1em', margin: 0 }}>Design Token</h3>
-          <h3 style={{ flex: `0 0 ${COLUMN_WIDTH}px`, padding: '1em', margin: 0 }}>Light</h3>
-          <h3 style={{ flex: `0 0 ${COLUMN_WIDTH}px`, padding: '1em', margin: 0 }}>Dark</h3>
-          <h3 style={{ flex: `0 0 ${COLUMN_WIDTH}px`, padding: '1em', margin: 0 }}>High Contrast</h3>
-        </div>
+      <div
+        style={{
+          display: 'inline-grid',
+          gridTemplateColumns: 'repeat(5, auto)',
+          columnGap: '1em',
+          alignItems: 'center',
+        }}
+      >
+        <h3 key="hrToken" style={{ padding: '1em', margin: 0 }}>
+          Design Token
+        </h3>
+        <h3 key="hrLight" style={{ padding: '1em', margin: 0 }}>
+          Light
+        </h3>
+        <h3 key="hrDark" style={{ padding: '1em', margin: 0 }}>
+          Dark
+        </h3>
+        <h3 key="hrTeamsDark" style={{ padding: '1em', margin: 0 }}>
+          Teams Dark
+        </h3>
+        <h3 key="hrHC" style={{ padding: '1em', margin: 0 }}>
+          High Contrast
+        </h3>
         {Object.keys(theme.light.alias.color?.[activeColor] ?? []).map(
-          (name: keyof (SharedColorTokens | NeutralColorTokens | BackgroundColorTokens | BrandColorTokens)) => (
-            <div key={name} style={{ display: 'flex' }}>
-              <div style={{ flex: `0 0 ${COLUMN_WIDTH}px`, padding: '1em', fontWeight: 'bold' }}>{name}</div>
-              <ColorRampItem value={theme.light.alias.color[activeColor][name]} />
-              <ColorRampItem value={theme.dark.alias.color[activeColor][name]} />
-              <ColorRampItem value={theme.highContrast.alias.color[activeColor][name]} />
-            </div>
-          ),
+          (name: keyof (SharedColorTokens | NeutralColorTokens | BackgroundColorTokens | BrandColorTokens)) => [
+            <div key={`${name}Token`} style={{ padding: '0 1em', fontWeight: 'bold' }}>
+              {name}
+            </div>,
+            <ColorRampItem key={`${name}Light`} value={theme.light.alias.color[activeColor][name]} />,
+            <ColorRampItem key={`${name}Dark`} value={theme.dark.alias.color[activeColor][name]} />,
+            <ColorRampItem key={`${name}TeamsDark`} value={theme.teamsDark.alias.color[activeColor][name]} />,
+            <ColorRampItem key={`${name}HC`} value={theme.highContrast.alias.color[activeColor][name]} />,
+          ],
         )}
       </div>
     </>

--- a/packages/react-theme/src/themes/AliasColor.stories.tsx
+++ b/packages/react-theme/src/themes/AliasColor.stories.tsx
@@ -121,7 +121,7 @@ export const AliasColors = () => {
           display: 'inline-grid',
           gridTemplateColumns: 'repeat(5, auto)',
           columnGap: '1em',
-          alignItems: 'center',
+          alignItems: 'stretch',
         }}
       >
         <h3 key="hrToken" style={{ padding: '1em', margin: 0 }}>
@@ -141,7 +141,10 @@ export const AliasColors = () => {
         </h3>
         {Object.keys(theme.light.alias.color?.[activeColor] ?? []).map(
           (name: keyof (SharedColorTokens | NeutralColorTokens | BackgroundColorTokens | BrandColorTokens)) => [
-            <div key={`${name}Token`} style={{ padding: '0 1em', fontWeight: 'bold' }}>
+            <div
+              key={`${name}Token`}
+              style={{ padding: '0 1em', fontWeight: 'bold', display: 'flex', alignItems: 'center' }}
+            >
               {name}
             </div>,
             <ColorRampItem key={`${name}Light`} value={theme.light.alias.color[activeColor][name]} />,

--- a/packages/react-theme/src/themes/ColorRamp.stories.tsx
+++ b/packages/react-theme/src/themes/ColorRamp.stories.tsx
@@ -6,6 +6,8 @@
 // @ts-nocheck
 
 import * as React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { TinyColor } from '@ctrl/tinycolor';
 
 export type ColorRampProps = {
@@ -21,23 +23,48 @@ export type ColorRampItemProps = {
   value?: string;
 };
 
+const alphaStyle = {
+  backgroundImage:
+    'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)',
+};
+
 export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props => {
-  const color = new TinyColor(props.value);
-  const isDark = color.isDark();
-  const isTransparent = color.getAlpha() < 0.5;
+  const divRef = React.useRef();
+  const [rawColorValue, setRawColorValue] = React.useState();
+
+  useIsomorphicLayoutEffect(() => {
+    const computedStyle = window.getComputedStyle(divRef.current);
+    const elementColor = computedStyle.getPropertyValue('background-color');
+    const color = new TinyColor(elementColor);
+    const isDark = color.isDark();
+    const isTransparent = color.getAlpha() < 0.5;
+    divRef.current.style.color = isTransparent ? '#000' : isDark ? '#fff' : '#000';
+
+    const cssVar = props.value?.match(/^var\((.+)\)$/);
+    if (cssVar) {
+      const colorValue = computedStyle.getPropertyValue(cssVar[1]);
+      if (colorValue) {
+        setRawColorValue(colorValue);
+      }
+    }
+  }, [props.value]);
+
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        padding: '1.5vh',
-        background: props.value,
-        color: isTransparent ? '#000' : isDark ? '#fff' : '#000',
-        width: 250,
-      }}
-    >
-      {props.name && <span>{props.name}</span>}
-      {props.value && <span>{props.value}</span>}
+    <div style={alphaStyle}>
+      <div
+        ref={divRef}
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: '1.5vh',
+          background: props.value,
+          width: 250,
+        }}
+      >
+        {props.name && <span>{props.name}</span>}
+        {props.value && <span>{props.value}</span>}
+        {rawColorValue && <span>{rawColorValue}</span>}
+      </div>
     </div>
   );
 };

--- a/packages/react-theme/src/themes/ColorRamp.stories.tsx
+++ b/packages/react-theme/src/themes/ColorRamp.stories.tsx
@@ -47,7 +47,7 @@ export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props 
         setRawColorValue(colorValue);
       }
     }
-  }, [props.value]);
+  });
 
   return (
     <div style={alphaStyle}>
@@ -58,7 +58,10 @@ export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props 
           justifyContent: 'space-between',
           padding: '1.5vh',
           background: props.value,
-          width: 250,
+          width: '300px',
+          boxSizing: 'border-box',
+          alignItems: 'center',
+          height: '100%',
         }}
       >
         {props.name && <span>{props.name}</span>}

--- a/packages/react-theme/src/themes/ColorRamp.stories.tsx
+++ b/packages/react-theme/src/themes/ColorRamp.stories.tsx
@@ -30,7 +30,10 @@ const alphaStyle = {
 
 export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props => {
   const divRef = React.useRef();
+  const cssVar = React.useRef();
   const [rawColorValue, setRawColorValue] = React.useState();
+
+  cssVar.current = props.value?.match(/^var\((.+)\)$/)?.[1];
 
   useIsomorphicLayoutEffect(() => {
     const computedStyle = window.getComputedStyle(divRef.current);
@@ -40,9 +43,8 @@ export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props 
     const isTransparent = color.getAlpha() < 0.5;
     divRef.current.style.color = isTransparent ? '#000' : isDark ? '#fff' : '#000';
 
-    const cssVar = props.value?.match(/^var\((.+)\)$/);
-    if (cssVar) {
-      const colorValue = computedStyle.getPropertyValue(cssVar[1]);
+    if (cssVar.current) {
+      const colorValue = computedStyle.getPropertyValue(cssVar.current);
       if (colorValue) {
         setRawColorValue(colorValue);
       }
@@ -65,7 +67,7 @@ export const ColorRampItem: React.FunctionComponent<ColorRampItemProps> = props 
         }}
       >
         {props.name && <span>{props.name}</span>}
-        {props.value && <span>{props.value}</span>}
+        {props.value && <span>{cssVar.current ?? props.value}</span>}
         {rawColorValue && <span>{rawColorValue}</span>}
       </div>
     </div>


### PR DESCRIPTION
Improve alias color tokens story based on feedback:
- use dark text on light backgrounds
- add `teamsDark` theme
- show raw color values for css vars
- add chessboard background for transparent colors

#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Before
![image](https://user-images.githubusercontent.com/9615899/122446621-2908e600-cfa3-11eb-837b-972f2a007b41.png)

#### After
![image](https://user-images.githubusercontent.com/9615899/122545109-c3ae0700-d02d-11eb-8cf9-54a5fa0c8760.png)


