### PR TITLE
fix(Badge): icons alignment

### DIFF
--- a/change/@fluentui-react-badge-515ab507-489c-4a09-ad76-bd72b4b5fe54.json
+++ b/change/@fluentui-react-badge-515ab507-489c-4a09-ad76-bd72b4b5fe54.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(Badge): icons alignment",
+  "packageName": "@fluentui/react-badge",
+  "email": "junioassuncaocharles@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
     borderWidth: theme.global.strokeWidth.thin,
     borderStyle: 'solid',
     fontFamily: theme.global.type.fontFamilies.base,
+    position: 'relative',
   }),
   rootSmallest: {
     width: '6px',
@@ -78,6 +79,8 @@ const useStyles = makeStyles({
   }),
   icon: {
     position: 'absolute',
+    top: 0,
+    bottom: 0,
   },
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix icon alignment for Badge

Before:

<img width="213" alt="Screen Shot 2021-06-17 at 1 41 14 PM" src="https://user-images.githubusercontent.com/8545105/122441484-f7c4f180-cf73-11eb-8882-55f314e26597.png">

After:

<img width="228" alt="Screen Shot 2021-06-17 at 1 35 29 PM" src="https://user-images.githubusercontent.com/8545105/122441512-fdbad280-cf73-11eb-9b4b-aba0c94b4a05.png">


#### Focus areas to test

(optional)
