### PR TITLE
Update BASE_URL to remove depreacted CDN

### DIFF
--- a/change/@fluentui-font-icons-mdl2-5e34f524-ecb9-42fe-b0e4-d36385e591a8.json
+++ b/change/@fluentui-font-icons-mdl2-5e34f524-ecb9-42fe-b0e4-d36385e591a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-6dfaeea4-eaeb-475f-b134-4c078244bf32.json
+++ b/change/@fluentui-react-examples-6dfaeea4-eaeb-475f-b134-4c078244bf32.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update fabric-cdn urls",
+  "packageName": "@fluentui/react-examples",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-0f9d58c0-a55d-4fd5-bec2-cb20a24f6d6c.json
+++ b/change/@fluentui-react-experiments-0f9d58c0-a55d-4fd5-bec2-cb20a24f6d6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update fabric-cdn urls",
+  "packageName": "@fluentui/react-experiments",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-ee0f06b1-41ec-4bb5-8589-8984afc410e5.json
+++ b/change/@fluentui-react-file-type-icons-ee0f06b1-41ec-4bb5-8589-8984afc410e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update fabric-cdn urls",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -20,7 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/icons/';
+const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: IIconOptions): void {
   [

--- a/packages/react-examples/src/react-experiments/TilesList/TilesList.Document.Example.tsx
+++ b/packages/react-examples/src/react-experiments/TilesList/TilesList.Document.Example.tsx
@@ -223,7 +223,7 @@ export class TilesListDocumentExample extends React.Component<
         invokeSelection={true}
         foreground={
           <img
-            src={`https://spoprod-a.akamaihd.net/files/odsp-next-prod_2018-04-06_20180406.004/odsp-media/images/itemtypes/${imgSize}/docx.png`}
+            src={`https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types/${imgSize}/docx.png`}
             style={{
               display: 'block',
               width: `${imgSize}px`,

--- a/packages/react-experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/react-experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { registerIcons, IIconOptions } from '@fluentui/style-utilities';
 
 const ASSET_CDN_BASE_URL =
-  'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/office-ui-fabric-react-assets/foldericons';
+  'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/office-ui-fabric-react-assets/foldericons';
 
 export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, options?: Partial<IIconOptions>): void {
   registerIcons(

--- a/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
@@ -90,10 +90,10 @@ describe('Returns correct element for custom CDN url', () => {
         size: 96,
         extension: 'docx',
       },
-      'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/',
+      'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types-fluent/',
     );
     expect(elm).toEqual(
-      '<img src="https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/96/docx.svg" alt="" />',
+      '<img src="https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types-fluent/96/docx.svg" alt="" />',
     );
   });
 });

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20210115.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We are shifting to no longer use akamaihd for hosting these assets inside of OneDrive.

This change updates the default URL to point to the location on the new CDN location.

#### Focus areas to test

Icon loading