### PR TITLE
fix(Menu): Do not open submenus without mousemove, other a11y changes

### DIFF
--- a/change/@fluentui-react-menu-b529e230-2994-422a-9eea-f0a8dcf2df83.json
+++ b/change/@fluentui-react-menu-b529e230-2994-422a-9eea-f0a8dcf2df83.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Menu): Do not open submenus without mousemove, other a11y changes",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -25,14 +25,36 @@ describe('Menu', () => {
         .get(menuTriggerSelector)
         .click()
         .get(menuSelector)
+        .should('be.visible');
+    });
+
+    it('should focus first menu item on down arrow when focus is on the trigger', () => {
+      cy.loadStory(menuStoriesTitle, defaultStory)
+        .get(menuTriggerSelector)
+        .click()
+        .get(menuSelector)
         .should('be.visible')
+        .get(menuTriggerSelector)
+        .type('{downarrow}')
         .get(menuItemSelector)
         .first()
         .should('be.focused');
     });
 
+    it('should close menu on escape when focus is on the trigger', () => {
+      cy.loadStory(menuStoriesTitle, defaultStory)
+        .get(menuTriggerSelector)
+        .click()
+        .get(menuSelector)
+        .should('be.visible')
+        .get(menuTriggerSelector)
+        .type('{esc}')
+        .get(menuSelector)
+        .should('not.exist');
+    });
+
     ['downarrow', 'enter', ' '].forEach(key => {
-      it(`should open menu with ${key === ' ' ? 'space' : key}`, () => {
+      it(`should open menu with ${key === ' ' ? 'space' : key} and focus first menuitem`, () => {
         cy.loadStory(menuStoriesTitle, defaultStory)
           .get(menuTriggerSelector)
           .focus()
@@ -235,7 +257,7 @@ describe('Menu', () => {
   });
 
   // [nestedMenuStory, nestedMenuControlledStory].forEach(story => {
-  [nestedMenuStory].forEach(story => {
+  [nestedMenuStory, nestedMenuControlledStory].forEach(story => {
     describe(`Nested Menus (${story.includes('Controlled') ? 'Controlled' : 'Uncontrolled'})`, () => {
       it('should open on trigger hover', () => {
         cy.loadStory(menuStoriesTitle, story)
@@ -243,7 +265,7 @@ describe('Menu', () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).trigger('mouseover');
+            cy.get(menuTriggerSelector).trigger('mousemove');
           })
           .get(menuSelector)
           .should('have.length', 2);
@@ -270,17 +292,30 @@ describe('Menu', () => {
 
       it('should close on mouse enter parent menu', () => {
         // mocking the clock due to setTimeout used for mouseenter and mouseleave
-        cy.clock();
         cy.loadStory(menuStoriesTitle, story).get(menuTriggerSelector).click();
 
         cy.get(menuSelector).within(() => {
-          cy.get(menuTriggerSelector).trigger('mouseover');
-          cy.tick(defaultMouseOverDelay);
-          cy.get(menuTriggerSelector).trigger('mouseout');
+          cy.get(menuTriggerSelector).trigger('mousemove');
         });
+        cy.get(menuSelector).should('have.length', 2);
 
+        // Mouseout is necessary because internally it will set a flag
+        cy.get(menuSelector)
+          .eq(0)
+          .within(() => {
+            cy.get(menuTriggerSelector).trigger('mouseout');
+          });
+
+        // move mouse over first element in nested menu
+        cy.get(menuSelector)
+          .eq(1)
+          .within(() => {
+            cy.get(menuItemSelector).eq(0).trigger('mouseover');
+          });
+
+        // move mouse back to the first element in the root menu
         cy.get(menuItemSelector).first().trigger('mouseover');
-        cy.tick(defaultMouseOverDelay);
+        cy.get(menuSelector).should('have.length', 1);
       });
 
       it('should focus first menuitem in an open submenu with right arrow from the trigger', () => {

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -287,11 +287,45 @@ describe('Menu', () => {
     expect(getByRole('menuitemcheckbox').getAttribute('aria-checked')).toEqual('true');
   });
 
-  it('should open nested menu with mouse enter', () => {
+  it('should open nested menu with mouse move', () => {
     // Arrange
     jest.useFakeTimers();
     const expected = 'visible';
     const { getByRole, getByText } = render(
+      <Menu open>
+        <MenuTrigger>
+          <button>Menu trigger</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <Menu>
+              <MenuTrigger>
+                <MenuItem>Item</MenuItem>
+              </MenuTrigger>
+              <MenuList>
+                <MenuItem>{expected}</MenuItem>
+              </MenuList>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    // Act
+    act(() => {
+      fireEvent.mouseMove(getByRole('menuitem'));
+      jest.runOnlyPendingTimers();
+    });
+
+    // Assert
+    getByText(expected);
+  });
+
+  it('should not open nested menu with mouseenter without mousemove', () => {
+    // Arrange
+    jest.useFakeTimers();
+    const expected = 'hidden';
+    const { getByRole, queryByText } = render(
       <Menu open>
         <MenuTrigger>
           <button>Menu trigger</button>
@@ -318,7 +352,52 @@ describe('Menu', () => {
     });
 
     // Assert
-    getByText(expected);
+    expect(queryByText(expected)).toBeNull();
+  });
+
+  it('should not open nested menu mousemove after first mousemove event', () => {
+    // Arrange
+    jest.useFakeTimers();
+    const expected = 'hidden';
+    const { getByText, queryByText } = render(
+      <Menu open>
+        <MenuTrigger>
+          <button>Menu trigger</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <Menu>
+              <MenuTrigger>
+                <MenuItem>Trigger</MenuItem>
+              </MenuTrigger>
+              <MenuList>
+                <MenuItem>{expected}</MenuItem>
+              </MenuList>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    // Act
+    act(() => {
+      // open menu
+      fireEvent.mouseMove(getByText('Trigger'));
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      // close menu
+      fireEvent.mouseLeave(getByText('Trigger'));
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      // fail to open again with mouse mouve
+      fireEvent.mouseMove(getByText('Trigger'));
+      jest.runOnlyPendingTimers();
+    });
+
+    // Assert
+    expect(queryByText(expected)).toBeNull();
   });
 
   it('should close open nested menu when mouse enters another menuitem', () => {

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -156,9 +156,9 @@ const useMenuOpenState = (state: MenuState) => {
       e.persist();
     }
 
-    if (e.type === 'mouseleave' || e.type === 'mouseenter' || e.type === MENU_ENTER_EVENT) {
+    if (e.type === 'mouseleave' || e.type === 'mouseenter' || e.type === 'mousemove' || e.type === MENU_ENTER_EVENT) {
       if (state.triggerRef.current?.contains(e.target as HTMLElement)) {
-        enteringTriggerRef.current = e.type === 'mouseenter';
+        enteringTriggerRef.current = e.type === 'mouseenter' || e.type === 'mousemove';
       }
 
       setOpenTimeout.current = setTimeout(() => trySetOpen(e, data), state.hoverDelay);
@@ -213,11 +213,13 @@ const useMenuOpenState = (state: MenuState) => {
   }, [findPrevFocusable, state.triggerRef]);
 
   React.useEffect(() => {
-    if (open) {
-      focusFirst();
+    if (!shouldHandleKeyboadRef.current) {
+      return;
     }
 
-    if (shouldHandleKeyboadRef.current && !open) {
+    if (open) {
+      focusFirst();
+    } else {
       if (shouldHandleTabRef.current && !state.isSubmenu) {
         pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
       } else {

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { getCode, ArrowLeftKey, TabKey } from '@fluentui/keyboard-key';
+import { getCode, ArrowLeftKey, TabKey, ArrowRightKey } from '@fluentui/keyboard-key';
 import { makeMergeProps, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 import { useMenuContext } from '../../contexts/menuContext';
 import { dispatchMenuEnterEvent } from '../../utils/index';
+import { useFluent } from '@fluentui/react-shared-contexts';
 
 const mergeProps = makeMergeProps<MenuPopoverState>({});
 
@@ -28,6 +29,9 @@ export const useMenuPopover = (
   const isSubmenu = useMenuContext(context => context.isSubmenu);
   const canDispatchCustomEventRef = React.useRef(true);
   const throttleDispatchTimerRef = React.useRef(0);
+
+  const { dir } = useFluent();
+  const CloseArrowKey = dir === 'ltr' ? ArrowLeftKey : ArrowRightKey;
 
   // use DOM listener since react events propagate up the react tree
   // no need to do `contains` logic as menus are all positioned in different portals
@@ -80,7 +84,7 @@ export const useMenuPopover = (
 
   state.onKeyDown = useEventCallback((e: React.KeyboardEvent<HTMLElement>) => {
     const keyCode = getCode(e);
-    if (keyCode === 27 /* Escape */ || (isSubmenu && keyCode === ArrowLeftKey)) {
+    if (keyCode === 27 /* Escape */ || (isSubmenu && keyCode === CloseArrowKey)) {
       if (popoverRef.current?.contains(e.target as HTMLElement)) {
         setOpen(e, { open: false, keyboard: true });
       }

--- a/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`MenuTrigger renders a default state 1`] = `
   onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  onMouseMove={[Function]}
 >
   Menu trigger
 </button>

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.test.tsx
@@ -83,7 +83,6 @@ describe('useTriggerElement', () => {
 
     it.each([
       ['click', true, fireEvent.click, {}],
-      ['mouseenter', true, fireEvent.mouseEnter, {}],
       ['mouseleave', false, fireEvent.mouseLeave, {}],
     ])('should on %s event call setOpen with %s ', (_, expectedValue, triggerEvent, eventOptions?) => {
       // Arrange
@@ -101,10 +100,59 @@ describe('useTriggerElement', () => {
       expect(spy).toHaveBeenCalledWith(expect.anything(), { open: expectedValue, keyboard: false });
     });
 
+    it('should only open the menu on first mousemove event', () => {
+      // Arrange
+      const spy = jest.fn();
+      mockUseMenuContext({ setOpen: spy, openOnHover: true });
+      const triggerButton = <button>Trigger button</button>;
+      const { result } = renderHook(() => useTriggerElement({ children: triggerButton }));
+
+      // Act
+      const { getByRole } = render(result.current.children);
+      fireEvent.mouseMove(getByRole('button'));
+      fireEvent.mouseMove(getByRole('button'));
+
+      // Assert
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(expect.anything(), { open: true, keyboard: false });
+    });
+
+    it('should open the menu on with mouseenter after mouseover', () => {
+      // Arrange
+      const spy = jest.fn();
+      mockUseMenuContext({ setOpen: spy, openOnHover: true });
+      const triggerButton = <button>Trigger button</button>;
+      const { result } = renderHook(() => useTriggerElement({ children: triggerButton }));
+
+      // Act
+      const { getByRole } = render(result.current.children);
+      fireEvent.mouseMove(getByRole('button'));
+      fireEvent.mouseEnter(getByRole('button'));
+
+      // Assert
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenNthCalledWith(1, expect.anything(), { open: true, keyboard: false });
+      expect(spy).toHaveBeenNthCalledWith(2, expect.anything(), { open: true, keyboard: false });
+    });
+
+    it('should not open the menu on with mouseenter before mouseover', () => {
+      // Arrange
+      const spy = jest.fn();
+      mockUseMenuContext({ setOpen: spy, openOnHover: true });
+      const triggerButton = <button>Trigger button</button>;
+      const { result } = renderHook(() => useTriggerElement({ children: triggerButton }));
+
+      // Act
+      const { getByRole } = render(result.current.children);
+      fireEvent.mouseEnter(getByRole('button'));
+
+      // Assert
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+
     it.each([
       ['click', fireEvent.click],
       ['mouseenter', fireEvent.mouseEnter],
-      ['blur', fireEvent.blur],
     ])('should not call setOpen on %s when element is disabled', (_, triggerEvent) => {
       // Arrange
       const spy = jest.fn();

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { getCode, ArrowRightKey, ArrowDownKey } from '@fluentui/keyboard-key';
+import { getCode, ArrowRightKey, ArrowDownKey, ArrowLeftKey } from '@fluentui/keyboard-key';
 import { useMergedRefs, useEventCallback, shouldPreventDefaultOnKeyDown } from '@fluentui/react-utilities';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { useMenuContext } from '../../contexts/menuContext';
 import { MenuTriggerChildProps, MenuTriggerState } from './MenuTrigger.types';
+import { useFluent } from '@fluentui/react-shared-contexts';
 
 const noop = () => null;
 
@@ -26,6 +27,10 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
   }, [findFirstFocusable, menuPopoverRef]);
 
   const openedWithKeyboardRef = React.useRef(false);
+  const hasMouseMoved = React.useRef(false);
+
+  const { dir } = useFluent();
+  const OpenArrowKey = dir === 'ltr' ? ArrowRightKey : ArrowLeftKey;
 
   // TODO also need to warn on React.Fragment usage
   const child = React.Children.only(state.children);
@@ -55,12 +60,16 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
 
     const keyCode = getCode(e);
 
-    if (!openOnContext && ((isSubmenu && keyCode === ArrowRightKey) || (!isSubmenu && keyCode === ArrowDownKey))) {
+    if (!openOnContext && ((isSubmenu && keyCode === OpenArrowKey) || (!isSubmenu && keyCode === ArrowDownKey))) {
       setOpen(e, { open: true, keyboard: true });
     }
 
+    if (keyCode === 27 /* Escape */ && !isSubmenu) {
+      setOpen(e, { open: false, keyboard: true });
+    }
+
     // if menu is already open, can't rely on effects to focus
-    if (open && keyCode === ArrowRightKey && isSubmenu) {
+    if (open && keyCode === OpenArrowKey && isSubmenu) {
       focusFirst();
     }
 
@@ -72,11 +81,21 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
   });
 
   const onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
-    if (openOnHover) {
+    if (openOnHover && hasMouseMoved.current) {
       setOpen(e, { open: true, keyboard: false });
     }
 
     child.props?.onMouseEnter?.(e);
+  });
+
+  // Opening a menu when a mouse hasn't moved and just entering the trigger is a bad a11y experience
+  // First time open the mouse using mousemove and then continue with mouseenter
+  // Only use once to determine that the user is using the mouse since it is an expensive event to handle
+  const onMouseMove = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (openOnHover && !hasMouseMoved.current) {
+      setOpen(e, { open: true, keyboard: false });
+      hasMouseMoved.current = true;
+    }
   });
 
   const onMouseLeave = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
@@ -100,6 +119,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
           onMouseLeave,
           onContextMenu,
           onKeyDown,
+          onMouseMove,
         }
       : // Spread disabled event handlers to implement contract and avoid specific disabled logic in handlers
         {
@@ -108,6 +128,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
           onMouseLeave: noop,
           onContextMenu: noop,
           onKeyDown: noop,
+          onMouseMove: noop,
         }),
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #18319
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`MenuTrigger` should not open a menu on hover until one `mousemove` event is detected. This means that hover menus will not open just because the mouse landed on it by chance.

Before:
![qnxZIs4GCp](https://user-images.githubusercontent.com/20744592/122538983-6747e900-d027-11eb-8cdf-fc8372d3baea.gif)

After:
![hEeK1iteDX](https://user-images.githubusercontent.com/20744592/122538488-e557c000-d026-11eb-9222-1b2bf97c1716.gif)

Opening the menu with mouse click will no longer focus the first menu item

Before:
![WfbdQUqQtB](https://user-images.githubusercontent.com/20744592/122539367-cf96ca80-d027-11eb-8076-5e74ee4a84f9.gif)

After:
![1qlcsx6c4g](https://user-images.githubusercontent.com/20744592/122539290-b857dd00-d027-11eb-80c0-43a295986a34.gif)


#### Focus areas to test

(optional)
