### PR TITLE
Update BASE_URL to remove depreacted CDN

### DIFF
--- a/change/@uifabric-icons-7b8385c1-1a80-460b-bd89-82127b8ab387.json
+++ b/change/@uifabric-icons-7b8385c1-1a80-460b-bd89-82127b8ab387.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@uifabric/icons",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -20,7 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/icons/';
+const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: IIconOptions): void {
   [


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We are shifting to no longer use akamaihd for hosting these assets inside of OneDrive.

This change updates the default URL to point to the location on the new CDN location.

This PR is a backport of https://github.com/microsoft/fluentui/pull/18615

#### Focus areas to test

Icon loading