### PR TITLE
Update BASE_URL to remove depreacted CDN

### DIFF
--- a/change/@fluentui-react-examples-8842ffa2-bda1-47a6-b881-fd4a79d73d48.json
+++ b/change/@fluentui-react-examples-8842ffa2-bda1-47a6-b881-fd4a79d73d48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@fluentui/react-examples",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-experiments-db6edf7a-d90c-4b04-a77b-c63d3d16a991.json
+++ b/change/@uifabric-experiments-db6edf7a-d90c-4b04-a77b-c63d3d16a991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@uifabric/experiments",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-file-type-icons-33350302-0979-4321-929d-5734fb274d20.json
+++ b/change/@uifabric-file-type-icons-33350302-0979-4321-929d-5734fb274d20.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-icons-7b8385c1-1a80-460b-bd89-82127b8ab387.json
+++ b/change/@uifabric-icons-7b8385c1-1a80-460b-bd89-82127b8ab387.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update BASE_URL to remove depreacted CDN",
+  "packageName": "@uifabric/icons",
+  "email": "bekaise@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { registerIcons, IIconOptions } from '@uifabric/styling';
 
 const ASSET_CDN_BASE_URL =
-  'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/office-ui-fabric-react-assets/foldericons';
+  'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/office-ui-fabric-react-assets/foldericons';
 
 export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, options?: Partial<IIconOptions>): void {
   registerIcons(

--- a/packages/file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
+++ b/packages/file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
@@ -90,10 +90,10 @@ describe('Returns correct element for custom CDN url', () => {
         size: 96,
         extension: 'docx',
       },
-      'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/',
+      'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types-fluent/',
     );
     expect(elm).toEqual(
-      '<img src="https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/96/docx.svg" alt="" />',
+      '<img src="https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types-fluent/96/docx.svg" alt="" />',
     );
   });
 });

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20210115.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -20,7 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/icons/';
+const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: IIconOptions): void {
   [

--- a/packages/react-examples/src/experiments/TilesList/TilesList.Document.Example.tsx
+++ b/packages/react-examples/src/experiments/TilesList/TilesList.Document.Example.tsx
@@ -223,7 +223,7 @@ export class TilesListDocumentExample extends React.Component<
         invokeSelection={true}
         foreground={
           <img
-            src={`https://spoprod-a.akamaihd.net/files/odsp-next-prod_2018-04-06_20180406.004/odsp-media/images/itemtypes/${imgSize}/docx.png`}
+            src={`https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/item-types/${imgSize}/docx.png`}
             style={{
               display: 'block',
               width: `${imgSize}px`,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We are shifting to no longer use akamaihd for hosting these assets inside of OneDrive.

This change updates the default URL to point to the location on the new CDN location.

This is a backport of https://github.com/microsoft/fluentui/pull/18615

#### Focus areas to test

Icon loading