### PR TITLE
Updated colorCell style to fix vertical alignment bug in SwatchColorPicker

### DIFF
--- a/change/@fluentui-react-21171906-3dee-475e-afba-8e2349b7cbdd.json
+++ b/change/@fluentui-react-21171906-3dee-475e-afba-8e2349b7cbdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "react-button: Removing last remnants of legacy patterns (#18519)",
+  "packageName": "@fluentui/react",
+  "email": "bhadiyadranancy@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-21171906-3dee-475e-afba-8e2349b7cbdd.json
+++ b/change/@fluentui-react-21171906-3dee-475e-afba-8e2349b7cbdd.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "react-button: Removing last remnants of legacy patterns (#18519)",
+  "comment": "SwatchColorPicker: Updated colorCell style to fix vertical alignment bug",
   "packageName": "@fluentui/react",
   "email": "bhadiyadranancy@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-examples-ccceef25-10f8-4ce0-9db6-80ab12f3cd81.json
+++ b/change/@fluentui-react-examples-ccceef25-10f8-4ce0-9db6-80ab12f3cd81.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "react-button: Removing last remnants of legacy patterns (#18519)",
+  "packageName": "@fluentui/react-examples",
+  "email": "bhadiyadranancy@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-examples-ccceef25-10f8-4ce0-9db6-80ab12f3cd81.json
+++ b/change/@fluentui-react-examples-ccceef25-10f8-4ce0-9db6-80ab12f3cd81.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "react-button: Removing last remnants of legacy patterns (#18519)",
+  "comment": "SwatchColorPicker: Updated colorCell style to fix vertical alignment bug",
   "packageName": "@fluentui/react-examples",
   "email": "bhadiyadranancy@gmail.com",
   "dependentChangeType": "none"

--- a/packages/react-examples/src/react/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -86,6 +86,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -257,6 +258,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -428,6 +430,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -599,6 +602,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -770,6 +774,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -988,6 +993,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1148,6 +1154,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1308,6 +1315,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1468,6 +1476,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1628,6 +1637,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1835,6 +1845,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -1995,6 +2006,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2155,6 +2167,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2315,6 +2328,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2475,6 +2489,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2692,6 +2707,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2863,6 +2879,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3034,6 +3051,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3205,6 +3223,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3380,6 +3399,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3551,6 +3571,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3722,6 +3743,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3893,6 +3915,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4068,6 +4091,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4239,6 +4263,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4410,6 +4435,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4581,6 +4607,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4805,6 +4832,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -4981,6 +5009,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5157,6 +5186,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5333,6 +5363,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5509,6 +5540,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
+                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {

--- a/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -59,6 +59,7 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
         border: 'none',
         height: height,
         width: width,
+        verticalAlign: 'top',
       },
       !circle && {
         selectors: {

--- a/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -253,6 +254,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -424,6 +426,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -595,6 +598,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -770,6 +774,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -941,6 +946,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1112,6 +1118,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1283,6 +1290,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1458,6 +1466,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1629,6 +1638,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1800,6 +1810,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1971,6 +1982,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
+                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17974
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added `verticalAlign` in `colorCell` style 

#### Focus areas to test

(optional)
