### PR TITLE
fix(MenuButton): stop propagation avoiding navigating between cells

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Let focus-border inherit border-radius from `ChatMessage` @Hirse ([#18305](https://github.com/microsoft/fluentui/pull/18305))
 - Add Default Foreground5 and Foreground6 for v2 theme and v2 dark theme @yuanboxue-amber ([#18451](https://github.com/microsoft/fluentui/pull/18451))
 - Add `compact`-prop to `Chat` (and `ChatMessage`) that displays the Chat in compact density @Hirse ([#18334](https://github.com/microsoft/fluentui/pull/18334))
+- Fix `MenuButton` to avoid arrow keys to move to cells inside a table @assuncaocharles ([#18663](https://github.com/microsoft/fluentui/pull/18663))
 
 ### Performance
 

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -239,6 +239,12 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
         handleOpenChange(e, false);
       }
     },
+    onKeyDown: (e: React.KeyboardEvent, itemProps: MenuItemProps) => {
+      _.invoke(predefinedProps, 'onKeyDown', e, itemProps);
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowLeft') {
+        e.stopPropagation();
+      }
+    },
   });
 
   const content = Menu.create(menu, {

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -241,7 +241,7 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     },
     onKeyDown: (e: React.KeyboardEvent, itemProps: MenuItemProps) => {
       _.invoke(predefinedProps, 'onKeyDown', e, itemProps);
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowLeft') {
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         e.stopPropagation();
       }
     },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18067
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Prevents navigation to cell when navigating in submenu inside table

#### Focus areas to test

(optional)
