### PR TITLE
Removing image dependency from react-examples package

### DIFF
--- a/change/@fluentui-react-examples-0efe6f0a-3913-4fc7-9838-e45a827108a3.json
+++ b/change/@fluentui-react-examples-0efe6f0a-3913-4fc7-9838-e45a827108a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removing image dependency from react-examples package.",
+  "packageName": "@fluentui/react-examples",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -52,7 +52,6 @@
     "@fluentui/react-focus": "^8.1.4",
     "@fluentui/react-hooks": "^8.2.2",
     "@fluentui/react-icons-mdl2": "^1.1.3",
-    "@fluentui/react-image": "^9.0.0-alpha.45",
     "@fluentui/react-label": "^9.0.0-alpha.9",
     "@fluentui/react-link": "^9.0.0-alpha.47",
     "@fluentui/react-make-styles": "^9.0.0-alpha.42",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removing unused `@fluentui/react-image` dependency from `@fluentui/react-examples` that happened after a bad merge with master in #18614.