### PR TITLE
Coachmark: now accepts Target type for target prop

### DIFF
--- a/change/@fluentui-react-77ced60f-3927-4b1d-bc1c-a906d0a8f710.json
+++ b/change/@fluentui-react-77ced60f-3927-4b1d-bc1c-a906d0a8f710.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Coachmark: now accepts Target type for target prop.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2647,7 +2647,7 @@ export interface ICoachmarkProps extends React_2.RefAttributes<HTMLDivElement> {
     preventDismissOnLostFocus?: boolean;
     preventFocusOnMount?: boolean;
     styles?: IStyleFunctionOrObject<ICoachmarkStyleProps, ICoachmarkStyles>;
-    target: HTMLElement | string | null;
+    target: Target;
     // @deprecated (undocumented)
     teachingBubbleRef?: ITeachingBubble;
     theme?: ITheme;
@@ -6776,7 +6776,7 @@ export interface IPositioningContainerProps extends IBaseProps<IPositioningConta
     preventDismissOnScroll?: boolean;
     role?: string;
     setInitialFocus?: boolean;
-    target?: HTMLElement | string | MouseEvent | Point | null;
+    target?: Target;
     // @deprecated
     targetPoint?: Point;
     // @deprecated

--- a/packages/react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/react/src/components/Coachmark/Coachmark.types.ts
@@ -3,6 +3,7 @@ import { IStyle, ITheme } from '../../Styling';
 import { IPositioningContainerProps } from './PositioningContainer/PositioningContainer.types';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { ITeachingBubble } from '../../TeachingBubble';
+import { Target } from '@fluentui/react-hooks';
 
 /**
  * {@docCategory Coachmark}
@@ -38,7 +39,7 @@ export interface ICoachmarkProps extends React.RefAttributes<HTMLDivElement> {
   /**
    * The target that the Coachmark should try to position itself based on.
    */
-  target: HTMLElement | string | null;
+  target: Target;
 
   /**
    * Props to pass to the PositioningContainer component. Specify the `directionalHint` to indicate

--- a/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -102,14 +102,12 @@ function usePositionState(
       currentProps!.target = targetRef.current!;
 
       if (target) {
-        // Check if the target is an Element or a MouseEvent and the document contains it or don't check anything else if the target is a Point or Rectangle
-        console.log('getboundingclientrect ', !(target as Element).getBoundingClientRect);
-        console.log('mouseevent ', !(target as MouseEvent).preventDefault);
+        // Check if the target is an Element or a MouseEvent and the document contains it
+        // or don't check anything else if the target is a Point or Rectangle
         if (
           (!(target as Element).getBoundingClientRect && !(target as MouseEvent).preventDefault) ||
           document.body.contains(currentProps!.target as Node)
         ) {
-          console.log('HERE');
           currentProps!.gapSpace = offsetFromTarget;
           const newPositions: IPositionedData = positionElement(
             currentProps!,
@@ -313,9 +311,6 @@ export const PositioningContainer: React.FunctionComponent<IPositioningContainer
   const rootRef = useMergedRefs(forwardedRef, positionedHost);
 
   const [targetRef, targetWindow] = useTarget(props.target, positionedHost);
-  // console.log('targetref ', targetRef);
-  // console.log('targetwindow ', targetWindow);
-
   const getCachedBounds = useCachedBounds(props, targetWindow);
   const [positions, updateAsyncPosition] = usePositionState(
     props,

--- a/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -3,6 +3,7 @@ import { DirectionalHint } from '../../../common/DirectionalHint';
 import { IRefObject, IBaseProps, Point, IRectangle } from '../../../Utilities';
 import { IPositionedData } from '../../../Positioning';
 import { ReactNode } from 'react';
+import { Target } from '@fluentui/react-hooks';
 
 /**
  * {@docCategory Coachmark}
@@ -25,7 +26,7 @@ export interface IPositioningContainerProps
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent | Point | null;
+  target?: Target;
 
   /**
    * How the element should be positioned


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the ability to pass a `Target` type to the `target` prop of `Coachmark`. So various types such as `Rectangle` and `Point` can now be passed as `target` to `Coachmark`.

**Ex:**
![image](https://user-images.githubusercontent.com/8649804/123019721-e02ba580-d385-11eb-919b-a650927720f5.png)

