### PR TITLE
fix(TableCell): set height so divider has some height ref

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableCellStyles.ts
@@ -28,6 +28,10 @@ export const tableCellStyles: ComponentSlotStylesPrepared<TableCellStylesProps, 
   content: ({ props: p }): ICSSInJSStyle => {
     return {
       alignSelf: 'center',
+      height: '100%',
+      '> *': {
+        height: '100%',
+      },
       ...(p.truncateContent && {
         display: 'block',
         overflow: 'hidden',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17691
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix `TableCell` to give some height ref for `Divider`  when used inside 

#### Focus areas to test

(optional)
