### PR TITLE
Azure-themes combobox selectedstate fix

### DIFF
--- a/change/@uifabric-azure-themes-6741018f-69a5-4dfc-bdd4-d8c10372866d.json
+++ b/change/@uifabric-azure-themes-6741018f-69a5-4dfc-bdd4-d8c10372866d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox multi-select selected state fix",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
@@ -97,6 +97,12 @@ export const ComboBoxStyles = (theme: ITheme): Partial<IComboBoxStyles> => {
         '.is-checked': {
           backgroundColor: semanticColors.listItemBackgroundChecked,
         },
+        '.ms-Checkbox.is-checked': {
+          backgroundColor: StyleConstants.transparent,
+        },
+        '.ms-Checkbox.is-checked:hover': {
+          backgroundColor: semanticColors.menuItemBackgroundHovered,
+        },
         '.is-disabled': {
           color: semanticColors.disabledBodyText,
         },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue:
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Removed multi-select combo box selected state. Single select state is-selected state maintains background color. 

Before: 
![image](https://user-images.githubusercontent.com/30805892/123136838-5fba8280-d421-11eb-83be-bc67ca874a69.png)

After: 
![image](https://user-images.githubusercontent.com/30805892/123136626-241fb880-d421-11eb-87e2-b943f64cb655.png)


All sub-themes:
![image](https://user-images.githubusercontent.com/30805892/123137068-985a5c00-d421-11eb-95dd-6b6ad267729c.png)
![image](https://user-images.githubusercontent.com/30805892/123137145-ad36ef80-d421-11eb-8669-32ef373c890d.png)
![image](https://user-images.githubusercontent.com/30805892/123137239-c0e25600-d421-11eb-9ff4-a96d0e563063.png)

Cherry picking to 8.0 IS NOT NEEDED, I do not see the same bug in 8.0
