### PR TITLE
This ports the change to allow title on menu sections to be an IContextualMenuItem

### DIFF
--- a/change/@fluentui-react-63a89c56-4df9-4cd6-82a6-00f6cdf5cc29.json
+++ b/change/@fluentui-react-63a89c56-4df9-4cd6-82a6-00f6cdf5cc29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "This ports the change to allow title on menu sections to be an IContextualMenuItem to support lang props",
+  "packageName": "@fluentui/react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3415,7 +3415,7 @@ export interface IContextualMenuRenderItem {
 export interface IContextualMenuSection extends React_2.ClassAttributes<any> {
     bottomDivider?: boolean;
     items: IContextualMenuItem[];
-    title?: string;
+    title?: string | IContextualMenuItem;
     topDivider?: boolean;
 }
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -711,19 +711,37 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     let headerItem;
     let groupProps;
     if (sectionProps.title) {
-      // Since title is a user-facing string, it needs to be stripped of whitespace in order to build a valid element ID
-      const id = this._id + sectionProps.title.replace(/\s/g, '');
-      const headerContextualMenuItem: IContextualMenuItem = {
-        key: `section-${sectionProps.title}-title`,
-        itemType: ContextualMenuItemType.Header,
-        text: sectionProps.title,
-        id: id,
-      };
-      groupProps = {
-        role: 'group',
-        'aria-labelledby': id,
-      };
-      headerItem = this._renderHeaderMenuItem(headerContextualMenuItem, menuClassNames, index, hasCheckmarks, hasIcons);
+      let headerContextualMenuItem: IContextualMenuItem | undefined = undefined;
+      let ariaLabellledby = '';
+      if (typeof sectionProps.title === 'string') {
+        // Since title is a user-facing string, it needs to be stripped
+        // of whitespace in order to build a valid element ID
+        const id = this._id + sectionProps.title.replace(/\s/g, '');
+        headerContextualMenuItem = {
+          key: `section-${sectionProps.title}-title`,
+          itemType: ContextualMenuItemType.Header,
+          text: sectionProps.title,
+          id: id,
+        };
+        ariaLabellledby = id;
+      } else {
+        headerContextualMenuItem = sectionProps.title;
+        ariaLabellledby = this._id + sectionProps.title.text?.replace(/\s/g, '');
+      }
+
+      if (headerContextualMenuItem) {
+        groupProps = {
+          role: 'group',
+          'aria-labelledby': ariaLabellledby,
+        };
+        headerItem = this._renderHeaderMenuItem(
+          headerContextualMenuItem,
+          menuClassNames,
+          index,
+          hasCheckmarks,
+          hasIcons,
+        );
+      }
     }
 
     if (sectionProps.items && sectionProps.items.length > 0) {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -692,6 +692,7 @@ describe('ContextualMenu', () => {
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
           key: 'Section1',
+          title: 'TestTitle',
           topDivider: true,
           bottomDivider: true,
           items: [
@@ -712,6 +713,7 @@ describe('ContextualMenu', () => {
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
           key: 'Section1',
+          title: { key: 'title1', text: 'TestTitle' },
           items: [
             {
               text: 'TestText 5',
@@ -731,7 +733,7 @@ describe('ContextualMenu', () => {
     });
 
     const menuItems = document.querySelectorAll('li');
-    expect(menuItems.length).toEqual(8);
+    expect(menuItems.length).toEqual(10);
   });
 
   describe('with links', () => {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -581,7 +581,7 @@ export interface IContextualMenuSection extends React.ClassAttributes<any> {
   /**
    * The optional section title.
    */
-  title?: string;
+  title?: string | IContextualMenuItem;
 
   /**
    * If set to true, the section will display a divider at the top of the section.


### PR DESCRIPTION
This ports the change to allow title on menu sections to be an IContextualMenuItem to support lang props

#### Description of changes

This is simply a port of https://github.com/microsoft/fluentui/pull/15123
