### PR TITLE
SearchBox - Resolving onChanged bug in SearchBox component

### DIFF
--- a/change/@fluentui-react-8d007e58-7ef5-42a2-86b9-68bd891feea1.json
+++ b/change/@fluentui-react-8d007e58-7ef5-42a2-86b9-68bd891feea1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing onChanged regression within SearchBox component.",
+  "packageName": "@fluentui/react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -63,9 +63,9 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     props.value,
     defaultValue,
     React.useCallback(
-      ev => {
-        onChange?.(ev.target.value, ev);
-        onChanged?.(ev.target.value);
+      (ev: React.ChangeEvent<HTMLInputElement> | undefined) => {
+        onChange?.(ev, ev?.target.value);
+        onChanged?.(ev?.target.value);
       },
       [onChange, onChanged],
     ),

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -31,17 +31,10 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
   HTMLDivElement,
   ISearchBoxProps
 >((props, forwardedRef) => {
-  const { defaultValue = '' } = props;
-  const [hasFocus, setHasFocus] = React.useState(false);
-  const [uncastValue, setValue] = useControllableValue(props.value, defaultValue, props.onChange);
-  const value = String(uncastValue);
-  const rootElementRef = React.useRef<HTMLDivElement>(null);
-  const inputElementRef = React.useRef<HTMLInputElement>(null);
-  const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
-  const id = useId(COMPONENT_NAME, props.id);
   const {
     ariaLabel,
     className,
+    defaultValue = '',
     disabled,
     underlined,
     styles,
@@ -60,7 +53,28 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     onKeyDown: customOnKeyDown,
     iconProps,
     role,
+    onChange,
+    // eslint-disable-next-line deprecation/deprecation
+    onChanged,
   } = props;
+
+  const [hasFocus, setHasFocus] = React.useState(false);
+  const [uncastValue, setValue] = useControllableValue(
+    props.value,
+    defaultValue,
+    React.useCallback(
+      ev => {
+        onChange?.(ev.target.value, ev);
+        onChanged?.(ev.target.value);
+      },
+      [onChange, onChanged],
+    ),
+  );
+  const value = String(uncastValue);
+  const rootElementRef = React.useRef<HTMLDivElement>(null);
+  const inputElementRef = React.useRef<HTMLInputElement>(null);
+  const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
+  const id = useId(COMPONENT_NAME, props.id);
 
   const { onClick: customOnClearClick } = clearButtonProps;
 

--- a/packages/react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, ReactTestRenderer } from 'react-test-renderer';
+import { ReactTestRenderer } from 'react-test-renderer';
 import { create } from '@fluentui/utilities/lib/test';
 import { mount, ReactWrapper } from 'enzyme';
 import { SearchBox } from './SearchBox';

--- a/packages/react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactTestRenderer } from 'react-test-renderer';
+import { act, ReactTestRenderer } from 'react-test-renderer';
 import { create } from '@fluentui/utilities/lib/test';
 import { mount, ReactWrapper } from 'enzyme';
 import { SearchBox } from './SearchBox';
@@ -171,6 +171,30 @@ describe('SearchBox', () => {
     wrapper = mount(<SearchBox value={0 as any} />);
     // this is not allowed per typings, but users might do it anyway
     expect(wrapper.find('input').getDOMNode().getAttribute('value')).toBe('0');
+  });
+
+  it('handles onChange', () => {
+    const onChange = jest.fn();
+
+    act(() => {
+      wrapper = mount(<SearchBox onChange={onChange} />);
+      expect(onChange).toHaveBeenCalledTimes(0);
+
+      wrapper.find('input').simulate('change', { target: { value: 'New value' } });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('handles onChanged', () => {
+    const onChanged = jest.fn();
+
+    wrapper = mount(<SearchBox onChanged={onChanged} />);
+    expect(onChanged).toHaveBeenCalledTimes(0);
+
+    wrapper.find('input').simulate('change', { target: { value: 'New value' } });
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
   it('invokes onEscape callback on escape keydown', () => {

--- a/packages/react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.test.tsx
@@ -176,14 +176,12 @@ describe('SearchBox', () => {
   it('handles onChange', () => {
     const onChange = jest.fn();
 
-    act(() => {
-      wrapper = mount(<SearchBox onChange={onChange} />);
-      expect(onChange).toHaveBeenCalledTimes(0);
+    wrapper = mount(<SearchBox onChange={onChange} />);
+    expect(onChange).toHaveBeenCalledTimes(0);
 
-      wrapper.find('input').simulate('change', { target: { value: 'New value' } });
+    wrapper.find('input').simulate('change', { target: { value: 'New value' } });
 
-      expect(onChange).toHaveBeenCalledTimes(1);
-    });
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it('handles onChanged', () => {


### PR DESCRIPTION
#### Pull request checklist
- [X] Addresses an existing issue: Fixes #18714
- [X] Include a change request file using `$ yarn change`

#### Description of changes
* Fixing a regression in V8's **SearchBox** which caused the deprecated `onChanged` prop to break.
* Adding tests for SearchBox's `onChanged` and `onChange` props.
