### PR TITLE
Custom Accessibility changes for Stacked Bar and Multi Stacked bar Chart

### DIFF
--- a/change/@fluentui-react-charting-59e83514-1905-4121-b1e6-af29a84362f3.json
+++ b/change/@fluentui-react-charting-59e83514-1905-4121-b1e6-af29a84362f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stacked bar chart and multi stacked bar chart custom accessibility changes, for chart title, chart data text and CallOut.",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-7a4bebbe-72d7-4860-97d8-62ac550013a5.json
+++ b/change/@fluentui-react-charting-7a4bebbe-72d7-4860-97d8-62ac550013a5.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Stacked bar chart and multi stacked bar chart custom accessibility changes, for chart title, chart data text and CallOut.",
-  "packageName": "@fluentui/react-charting",
-  "email": "v-scharde@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-charting-7a4bebbe-72d7-4860-97d8-62ac550013a5.json
+++ b/change/@fluentui-react-charting-7a4bebbe-72d7-4860-97d8-62ac550013a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stacked bar chart and multi stacked bar chart custom accessibility changes, for chart title, chart data text and CallOut.",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-20fd0ca9-98b7-4667-8454-e97d8caa5a2c.json
+++ b/change/@fluentui-react-examples-20fd0ca9-98b7-4667-8454-e97d8caa5a2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stacked bar chart and multi stacked bar chart custom accessibility changes, for chart title, chart data text and CallOut.",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -214,7 +214,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     const x = chartData.horizontalBarChartdata!.x;
     const y = chartData.horizontalBarChartdata!.y;
 
-    const accessibilityData = this._getAccessibleDataObject(chartData.chartDataAccessibilityData);
+    const accessibilityData = this._getAccessibleDataObject(data.chartDataAccessibilityData!);
     switch (chartDataMode) {
       case 'default':
         const chartDataText: string = x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -3,6 +3,7 @@ import { classNamesFunction, getId } from '@fluentui/react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { ILegend, Legends } from '../Legends/index';
 import {
+  IAccessibilityProps,
   IChartDataPoint,
   IChartProps,
   IMultiStackedBarChartProps,
@@ -20,11 +21,6 @@ export interface IRefArrayData {
   refElement?: SVGGElement;
 }
 
-export interface IIndexData {
-  lengthOfChartData?: number;
-  indexValOfRect?: number;
-}
-
 export interface IMultiStackedBarChartState {
   isCalloutVisible: boolean;
   refArray: IRefArrayData[];
@@ -38,8 +34,7 @@ export interface IMultiStackedBarChartState {
   xCalloutValue?: string;
   yCalloutValue?: string;
   dataPointCalloutProps?: IChartDataPoint;
-  lengthOfChartData: number;
-  indexValOfRect: number;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarChartProps, IMultiStackedBarChartState> {
@@ -65,8 +60,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       isLegendSelected: false,
       xCalloutValue: '',
       yCalloutValue: '',
-      lengthOfChartData: 1,
-      indexValOfRect: 1,
     };
     this._onLeave = this._onLeave.bind(this);
     this._onBarLeave = this._onBarLeave.bind(this);
@@ -100,7 +93,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       return <div key={index}>{singleChartBars}</div>;
     });
 
-    const barSeriesLabel: string = `Bar series ${this.state.indexValOfRect} of ${this.state.lengthOfChartData}`;
     return (
       <div className={this._classNames.root}>
         {bars}
@@ -115,9 +107,9 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           id={this._calloutId}
           onDismiss={this._closeCallout}
           {...this.props.calloutProps!}
+          {...this._getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false)}
         >
           <>
-            <div className={this._classNames.visuallyHidden}>{barSeriesLabel}</div>
             {this.props.onRenderCalloutPerDataPoint ? (
               this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
             ) : (
@@ -174,10 +166,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         href: href,
       });
 
-      const indexDetails: IIndexData = {
-        indexValOfRect: index,
-        lengthOfChartData: data.chartData!.length!,
-      };
       return (
         <g
           key={index}
@@ -186,17 +174,13 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             this._refCallback(e, point.legend!);
           }}
           data-is-focusable={!this.props.hideTooltip}
-          onFocus={this._onBarFocus.bind(this, pointData, color, point, indexDetails)}
+          onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}
           role="img"
           aria-label="Multi stacked bar chart"
-          onMouseOver={
-            point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point, indexDetails)
-          }
-          onMouseMove={
-            point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point, indexDetails)
-          }
+          onMouseOver={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
+          onMouseMove={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
           onMouseLeave={point.placeHolder ? undefined : this._onBarLeave}
           onClick={href ? (point.placeHolder ? undefined : this._redirectToUrl.bind(this, href)) : point.onClick}
         >
@@ -221,41 +205,25 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     const hideNumber = hideRatio === undefined ? false : hideRatio;
     const showRatio = !hideNumber && data!.chartData!.length === 2;
     const showNumber = !hideNumber && data!.chartData!.length === 1;
-    const titleAriaLabel = this.props.ariaLabel
-      ? this.props.ariaLabel
-      : `Bar chart depicting about ${data!.chartTitle}`;
     const chartDataVal: number = data!.chartData![0].data ? data!.chartData![0].data : 0;
-    let numberAriaLabel: string = '';
-    if (showRatio) {
-      numberAriaLabel = !hideDenominator ? `number ${chartDataVal} of ${total}` : `number ${total}`;
-    }
-    if (showNumber) {
-      numberAriaLabel = `number ${chartDataVal}`;
-    }
 
     return (
       <div className={this._classNames.singleChartRoot}>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div
-                data-is-focusable={true}
-                role="text"
-                aria-label={titleAriaLabel}
-                aria-labelledby={this.props.ariaLabelledBy}
-                aria-describedby={this.props.ariaDescribedBy}
-              >
+              <div {...this._getAccessibleDataObject(data!.chartTitleAccessibilityData)}>
                 <strong>{data!.chartTitle}</strong>
               </div>
             )}
             {showRatio && (
-              <div data-is-focusable={showRatio} role="text" aria-label={numberAriaLabel}>
+              <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
                 <strong>{chartDataVal}</strong>
                 {!hideDenominator && <span>/{total}</span>}
               </div>
             )}
             {showNumber && (
-              <div data-is-focusable={showNumber} role="text" aria-label={numberAriaLabel}>
+              <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
                 <strong>{data!.chartData![0].data}</strong>
               </div>
             )}
@@ -270,7 +238,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     );
   }
 
-  private _onBarFocus(pointData: number, color: string, point: IChartDataPoint, indexDetails: IIndexData): void {
+  private _onBarFocus(pointData: number, color: string, point: IChartDataPoint): void {
     if (
       this.state.isLegendSelected === false ||
       (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!)
@@ -286,8 +254,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             xCalloutValue: point.xAxisCalloutData!,
             yCalloutValue: point.yAxisCalloutData!,
             dataPointCalloutProps: point,
-            indexValOfRect: indexDetails.indexValOfRect! + 1,
-            lengthOfChartData: indexDetails.lengthOfChartData!,
+            callOutAccessibilityData: point.callOutAccessibilityData!,
           });
         }
       });
@@ -421,7 +388,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     pointData: number,
     color: string,
     point: IChartDataPoint,
-    indexDetails: IIndexData,
     mouseEvent: React.MouseEvent<SVGPathElement>,
   ): void {
     mouseEvent.persist();
@@ -439,8 +405,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         xCalloutValue: point.xAxisCalloutData!,
         yCalloutValue: point.yAxisCalloutData!,
         dataPointCalloutProps: point,
-        indexValOfRect: indexDetails.indexValOfRect! + 1,
-        lengthOfChartData: indexDetails.lengthOfChartData!,
+        callOutAccessibilityData: point.callOutAccessibilityData!,
       });
     }
   }
@@ -459,5 +424,20 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _getAccessibleDataObject = (
+    accessibleData?: IAccessibilityProps,
+    role: string = 'text',
+    isDataFocusable: boolean = true,
+  ) => {
+    accessibleData = accessibleData ?? {};
+    return {
+      role,
+      'data-is-focusable': isDataFocusable,
+      'aria-label': accessibleData!.ariaLabel,
+      'aria-labelledby': accessibleData!.ariaLabelledBy,
+      'aria-describedby': accessibleData!.ariaDescribedBy,
+    };
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -50,10 +50,5 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
     noData: {
       cursor: href ? 'pointer' : 'default',
     },
-    visuallyHidden: {
-      position: 'absolute',
-      fontSize: '0 !important',
-      clip: 'rect(0, 0, 0, 0)',
-    },
   };
 };

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -96,21 +96,6 @@ export interface IMultiStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
-
-  /**
-   * Accessible label text for title of the multi stacked bar chart.
-   */
-  ariaLabel?: string;
-
-  /**
-   * ID of the element which contains label text for the title of the multi stacked bar chart.
-   */
-  ariaLabelledBy?: string;
-
-  /**
-   * ID of the element which contains the description for the title of the multi stacked bar chart.
-   */
-  ariaDescribedBy?: string;
 }
 
 export interface IMultiStackedBarChartStyleProps {
@@ -195,9 +180,4 @@ export interface IMultiStackedBarChartStyles {
    * Style for stacked bar chart with no data
    */
   noData: IStyle;
-
-  /**
-   * Style for accessibility content. Only screen readers will "see" the content
-   */
-  visuallyHidden: IStyle;
 }

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -99,10 +99,5 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
         } as IStyle,
       },
     },
-    visuallyHidden: {
-      position: 'absolute',
-      fontSize: '0 !important',
-      clip: 'rect(0, 0, 0, 0)',
-    },
   };
 };

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -125,21 +125,6 @@ export interface IStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
-
-  /**
-   * Accessible label text for title of the multi stacked bar chart.
-   */
-  ariaLabel?: string;
-
-  /**
-   * ID of the element which contains label text for the title of the multi stacked bar chart.
-   */
-  ariaLabelledBy?: string;
-
-  /**
-   * ID of the element which contains the description for the title of the multi stacked bar chart.
-   */
-  ariaDescribedBy?: string;
 }
 
 export interface IStackedBarChartStyleProps {
@@ -254,9 +239,4 @@ export interface IStackedBarChartStyles {
    * Style for the target triangle
    */
   target: IStyle;
-
-  /**
-   * Style for accessibility content. Only screen readers will "see" the content
-   */
-  visuallyHidden: IStyle;
 }

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               }
         >
           <div
-            aria-label="Bar chart depicting about Monitored"
             data-is-focusable={true}
             role="text"
           >
@@ -61,7 +60,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -191,7 +189,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               }
         >
           <div
-            aria-label="Bar chart depicting about Unmonitored"
             data-is-focusable={true}
             role="text"
           >
@@ -200,7 +197,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -405,7 +401,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               }
         >
           <div
-            aria-label="Bar chart depicting about Monitored"
             data-is-focusable={true}
             role="text"
           >
@@ -414,7 +409,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </strong>
           </div>
           <div
-            aria-label="number 63"
             data-is-focusable={true}
             role="text"
           >
@@ -540,7 +534,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               }
         >
           <div
-            aria-label="Bar chart depicting about Unmonitored"
             data-is-focusable={true}
             role="text"
           >
@@ -549,7 +542,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </strong>
           </div>
           <div
-            aria-label="number 63"
             data-is-focusable={true}
             role="text"
           >
@@ -750,7 +742,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               }
         >
           <div
-            aria-label="Bar chart depicting about Monitored"
             data-is-focusable={true}
             role="text"
           >
@@ -759,7 +750,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -889,7 +879,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               }
         >
           <div
-            aria-label="Bar chart depicting about Unmonitored"
             data-is-focusable={true}
             role="text"
           >
@@ -898,7 +887,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -1049,7 +1037,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               }
         >
           <div
-            aria-label="Bar chart depicting about Monitored"
             data-is-focusable={true}
             role="text"
           >
@@ -1175,7 +1162,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               }
         >
           <div
-            aria-label="Bar chart depicting about Unmonitored"
             data-is-focusable={true}
             role="text"
           >
@@ -1184,7 +1170,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -1568,7 +1553,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               }
         >
           <div
-            aria-label="Bar chart depicting about Monitored"
             data-is-focusable={true}
             role="text"
           >
@@ -1577,7 +1561,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >
@@ -1707,7 +1690,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               }
         >
           <div
-            aria-label="Bar chart depicting about Unmonitored"
             data-is-focusable={true}
             role="text"
           >
@@ -1716,7 +1698,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </strong>
           </div>
           <div
-            aria-label="number 40 of 63"
             data-is-focusable={true}
             role="text"
           >

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -50,7 +49,6 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
         </strong>
       </div>
       <div
-        aria-label="number 40 of 63"
         data-is-focusable={true}
         role="text"
       >
@@ -211,7 +209,6 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -220,7 +217,6 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         </strong>
       </div>
       <div
-        aria-label="number 40 of 63"
         data-is-focusable={true}
         role="text"
       >
@@ -381,7 +377,6 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -390,7 +385,6 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         </strong>
       </div>
       <div
-        aria-label="number 63"
         data-is-focusable={true}
         role="text"
       >
@@ -537,7 +531,6 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -546,7 +539,6 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         </strong>
       </div>
       <div
-        aria-label="number 40 of 63"
         data-is-focusable={true}
         role="text"
       >
@@ -707,7 +699,6 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -846,7 +837,6 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >
@@ -855,7 +845,6 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         </strong>
       </div>
       <div
-        aria-label="number 40 of 63"
         data-is-focusable={true}
         role="text"
       >
@@ -1016,7 +1005,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
           }
     >
       <div
-        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
         data-is-focusable={true}
         role="text"
       >

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -125,11 +125,6 @@ export interface IChartDataPoint {
   yAxisCalloutData?: string;
 
   /**
-   * Accessibility data for chart data
-   */
-  chartDataAccessibilityData?: IAccessibilityProps;
-
-  /**
    * Accessibility data for callout
    */
   callOutAccessibilityData?: IAccessibilityProps;
@@ -337,6 +332,11 @@ export interface IChartProps {
    * data for the points in the chart
    */
   chartData?: IChartDataPoint[];
+
+  /**
+   * Accessibility data for chart data
+   */
+  chartDataAccessibilityData?: IAccessibilityProps;
 
   /**
    * data for the points in the line chart

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
@@ -6,7 +6,8 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
   const data: IChartProps[] = [
     {
       chartTitle: 'one',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about one' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about one' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 1543 of 15000' },
       chartData: [
         {
           legend: 'one',
@@ -14,14 +15,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.tealDark,
           xAxisCalloutData: '2021/06/10',
           yAxisCalloutData: '41%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 1543 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart one 2021/06/10 41%' },
         },
       ],
     },
     {
       chartTitle: 'two',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about two' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about two' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 800 of 15000' },
       chartData: [
         {
           legend: 'two',
@@ -29,14 +30,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.purple,
           xAxisCalloutData: '2021/06/11',
           yAxisCalloutData: '52%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 800 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart two 2021/06/11 52%' },
         },
       ],
     },
     {
       chartTitle: 'three',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about three' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about three' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 8888 of 15000' },
       chartData: [
         {
           legend: 'three',
@@ -44,14 +45,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.redDark,
           xAxisCalloutData: '2021/06/12',
           yAxisCalloutData: '63%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 8888 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart three 2021/06/12 63%' },
         },
       ],
     },
     {
       chartTitle: 'four',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about four' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about four' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 15888 of 15000' },
       chartData: [
         {
           legend: 'four',
@@ -59,14 +60,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.themeDarkAlt,
           xAxisCalloutData: '2021/06/13',
           yAxisCalloutData: '74%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 15888 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart four 2021/06/13 74%' },
         },
       ],
     },
     {
       chartTitle: 'five',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about five' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about five' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 11444 of 15000' },
       chartData: [
         {
           legend: 'five',
@@ -74,14 +75,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.themePrimary,
           xAxisCalloutData: '2021/06/14',
           yAxisCalloutData: '85%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 11444 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart five 2021/06/14 85%' },
         },
       ],
     },
     {
       chartTitle: 'six',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about six' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about six' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 14000 of 15000' },
       chartData: [
         {
           legend: 'six',
@@ -89,14 +90,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.greenDark,
           xAxisCalloutData: '2021/06/15',
           yAxisCalloutData: '96%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 14000 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart six 2021/06/15 96%' },
         },
       ],
     },
     {
       chartTitle: 'seven',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about seven' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about seven' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 9855 of 15000' },
       chartData: [
         {
           legend: 'seven',
@@ -104,14 +105,14 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.accent,
           xAxisCalloutData: '2021/06/16',
           yAxisCalloutData: '98%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 9855 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart seven 2021/06/16 98%' },
         },
       ],
     },
     {
       chartTitle: 'eight',
-      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about eight' },
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about eight' },
+      chartDataAccessibilityData: { ariaLabel: 'Data 4250 of 15000' },
       chartData: [
         {
           legend: 'eight',
@@ -119,7 +120,6 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
           color: DefaultPalette.blueLight,
           xAxisCalloutData: '2021/06/17',
           yAxisCalloutData: '99%',
-          chartDataAccessibilityData: { ariaLabel: 'Data 4250 of 15000' },
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart eight 2021/06/17 99%' },
         },
       ],

--- a/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { IChartDataPoint, MultiStackedBarChart, IChartProps } from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+
+export const MultiStackedBarChartCustomAccessibilityExample: React.FunctionComponent<{}> = () => {
+  const firstChartPoints: IChartDataPoint[] = [
+    {
+      legend: 'Debit card numbers (EU and USA)',
+      data: 40,
+      color: DefaultPalette.red,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '40%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 1 of 5 2020/04/30 40%' },
+    },
+    {
+      legend: 'Passport numbers (USA)',
+      data: 23,
+      color: DefaultPalette.green,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '23%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 2 of 5 2020/04/30 23%' },
+    },
+    {
+      legend: 'Social security numbers',
+      data: 35,
+      color: DefaultPalette.yellow,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '35%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 3 of 5 2020/04/30 35%' },
+    },
+    {
+      legend: 'Credit card numbers',
+      data: 87,
+      color: DefaultPalette.blueLight,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '87%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 4 of 5 2020/04/30 87%' },
+    },
+    {
+      legend: 'Tax identification numbers (USA)',
+      data: 87,
+      color: DefaultPalette.black,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '87%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 5 of 5 2020/04/30 87%' },
+    },
+  ];
+  const firstChartPoints1: IChartDataPoint[] = [
+    {
+      legend: 'Debit card numbers (EU and USA)',
+      data: 40,
+      color: DefaultPalette.red,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '40%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 1 of 5 2020/04/30 40%' },
+    },
+    {
+      legend: 'Passport numbers (USA)',
+      data: 56,
+      color: DefaultPalette.green,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '56%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 2 of 5 2020/04/30 56%' },
+    },
+    {
+      legend: 'Social security numbers',
+      data: 35,
+      color: DefaultPalette.yellow,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '35%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 3 of 5 2020/04/30 35%' },
+    },
+    {
+      legend: 'Credit card numbers',
+      data: 92,
+      color: DefaultPalette.blueLight,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '92%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 4 of 5 2020/04/30 92%' },
+    },
+    {
+      legend: 'Tax identification numbers (USA)',
+      data: 87,
+      color: DefaultPalette.black,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '87%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 5 of 5 2020/04/30 87%' },
+    },
+  ];
+
+  const secondChartPoints: IChartDataPoint[] = [
+    {
+      legend: 'Phone Numbers',
+      data: 40,
+      color: DefaultPalette.blue,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '87%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 1 of 2 2020/04/30 87%' },
+    },
+    {
+      legend: 'Credit card Numbers',
+      data: 23,
+      color: DefaultPalette.green,
+      xAxisCalloutData: '2020/04/30',
+      yAxisCalloutData: '87%',
+      callOutAccessibilityData: { ariaLabel: 'Bar series 2 of 2 2020/04/30 87%' },
+    },
+  ];
+
+  const hideRatio: boolean[] = [true, false];
+
+  const hideDenominator: boolean[] = [true, true];
+
+  const data: IChartProps[] = [
+    {
+      chartTitle: 'Monitored',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Monitored' },
+      chartData: firstChartPoints,
+    },
+    {
+      chartTitle: 'Monitored Second Chart',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Monitored Second Chart' },
+      chartData: firstChartPoints1,
+    },
+    {
+      chartTitle: 'Unmonitored',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Unmonitored' },
+      chartDataAccessibilityData: { ariaLabel: 'number 40 out of 63' },
+      chartData: secondChartPoints,
+    },
+  ];
+
+  return (
+    <MultiStackedBarChart
+      data={data}
+      hideDenominator={hideDenominator}
+      hideRatio={hideRatio}
+      width={600}
+      href={'https://developer.microsoft.com/en-us/'}
+      focusZonePropsForLegendsInHoverCard={{ 'aria-label': 'legends Container' }}
+      legendsOverflowText={'OverFlow Items'}
+    />
+  );
+};

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { StackedBarChart, IChartProps, IChartDataPoint } from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+
+export class StackedBarChartCustomAccessibilityExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    const points: IChartDataPoint[] = [
+      {
+        legend: 'first',
+        data: 3000000,
+        color: DefaultPalette.blue,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '40%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1 of 1 2020/04/30 40%' },
+      },
+      { legend: 'second', data: 1, color: DefaultPalette.green },
+    ];
+
+    const data0: IChartProps = {
+      chartTitle: 'Stacked Bar chart example',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Stacked Bar chart example' },
+      chartDataAccessibilityData: { ariaLabel: 'number 3000000 out of 3000001' },
+      chartData: points,
+    };
+
+    const data1: IChartProps = {
+      chartTitle: 'Stacked Bar chart example with ignore fix style',
+      chartTitleAccessibilityData: {
+        ariaLabel: 'Bar chart depicting about Stacked Bar chart example with ignore fix style',
+      },
+      chartData: points,
+    };
+
+    return (
+      <>
+        <StackedBarChart data={data0} href={'https://developer.microsoft.com/en-us/'} ignoreFixStyle={false} />
+        <br />
+        <StackedBarChart
+          data={data1}
+          href={'https://developer.microsoft.com/en-us/'}
+          ignoreFixStyle={true}
+          hideTooltip={true}
+        />
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChartPage.tsx
@@ -14,6 +14,8 @@ import { StackedBarChartDynamicExample } from './StackedBarChart.Dynamic.Example
 import { MultiStackedBarChartExample } from './MultiStackedBarChart.Example';
 import { StackedBarChartBaseBarExample } from './StackedBarChart.BaseBar.Example';
 import { MultiStackedBarChartWithPlaceholderExample } from './MultiStackedBarChartWithPlaceHolder.Example';
+import { StackedBarChartCustomAccessibilityExample } from './StackedBarChart.CustomAccessibility.Example';
+import { MultiStackedBarChartCustomAccessibilityExample } from './MultiStackedBarChart.CustomAccessibility.Example';
 
 const StackedBarChartBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Basic.Example.tsx') as string;
 const StackedBarChartBenchmarkExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Benchmark.Example.tsx') as string;
@@ -22,6 +24,8 @@ const StackedBarChartDynamicExampleCode = require('!raw-loader?esModule=false!@f
 const MultiStackedBarChartExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.Example.tsx') as string;
 const StackedBarChartBaseBarExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/StackedBarChart.BaseBar.Example.tsx') as string;
 const MultiStackedBarChartWithPlaceholderExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChartWithPlaceHolder.Example.tsx') as string;
+const StackedBarChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/StackedBarChart.CustomAccessibility.Example.tsx') as string;
+const MultiStackedBarChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.CustomAccessibility.Example.tsx') as string;
 
 export class StackedBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -46,6 +50,12 @@ export class StackedBarChartPage extends React.Component<IComponentDemoPageProps
             <ExampleCard title="StackedBarChart dynamic" code={StackedBarChartDynamicExampleCode}>
               <StackedBarChartDynamicExample />
             </ExampleCard>
+            <ExampleCard
+              title="StackedBarChart Custom Accessibility"
+              code={StackedBarChartCustomAccessibilityExampleCode}
+            >
+              <StackedBarChartCustomAccessibilityExample />
+            </ExampleCard>
             <ExampleCard title="Multiple StackedBarCharts" code={MultiStackedBarChartExampleCode}>
               <MultiStackedBarChartExample />
             </ExampleCard>
@@ -54,6 +64,12 @@ export class StackedBarChartPage extends React.Component<IComponentDemoPageProps
               code={MultiStackedBarChartWithPlaceholderExampleCode}
             >
               <MultiStackedBarChartWithPlaceholderExample />
+            </ExampleCard>
+            <ExampleCard
+              title="MultiStackedBarChart Custom Accessibility"
+              code={MultiStackedBarChartCustomAccessibilityExampleCode}
+            >
+              <MultiStackedBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Changes are related to Stacked Bar and Multi Stacked Bar custom accessibility

1.  Accessibility Data props added for the chart title, chart data, and Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2.  If the user is sending any custom accessibility data, then that will be used. else only visible data will be read by the narrator.
3.  Custom Accessibility example is added for Stacked Bar chart and Multi Stacked bar chart

**Without Custom Accessibility Data:**
![image](https://user-images.githubusercontent.com/29042635/123441773-d908cf80-d5f1-11eb-9262-22b5780691a1.png)


**With Custom Accessibility Data:**
![image](https://user-images.githubusercontent.com/29042635/123442517-91cf0e80-d5f2-11eb-9ac6-099220523bd8.png)


#### Focus areas to test

(optional)
