### PR TITLE
Charting: CherryPick #18619. Accessibility changes for multistackebar chart #18619

### DIFF
--- a/change/@uifabric-charting-4a0b5e05-c3b1-44ce-8501-7866c58c433a.json
+++ b/change/@uifabric-charting-4a0b5e05-c3b1-44ce-8501-7866c58c433a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility changes for MultiStackedBar chart, narrator will read the visible content from CallOut hover card",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -168,6 +168,12 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         xScale = createNumericXAxis(XAxisParams);
     }
 
+    /*
+     * To enable wrapping of x axis tick values or to disaply complete x axis tick values,
+     * we need to calculate how much space it needed to render the text.
+     * No need to re-calculate every time the chart renders and same time need to get an update. So using setState.
+     * Required space will be calculated first time chart rendering and if any width/height of chart updated.
+     * */
     if (this.props.wrapXAxisLables || this.props.showXAxisLablesTooltip) {
       const wrapLabelProps = {
         node: this.xAxisElement,
@@ -206,15 +212,18 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       className: this.props.className,
       isRtl: this._isRtl,
     });
+
     const svgDimensions = {
       width: this.state.containerWidth,
       height: this.state.containerHeight,
     };
+
     const children = this.props.children({
       ...this.state,
       xScale,
       yScale,
     });
+
     let focusDirection;
     if (this.props.focusZoneDirection === FocusZoneDirection.vertical) {
       focusDirection = this.props.focusZoneDirection;
@@ -411,11 +420,16 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
     }
   }
 
+  /**
+   * When screen resizes, along with screen, chart also auto adjusted.
+   * This method used to adjust height and width of the charts.
+   */
   private _fitParentContainer(): void {
     const { containerWidth, containerHeight } = this.state;
     this._reqID = requestAnimationFrame(() => {
       let legendContainerHeight;
       if (this.props.hideLegend) {
+        // If there is no legend, need not to allocate some space from total chart space.
         legendContainerHeight = 0;
       } else {
         const legendContainerComputedStyles = getComputedStyle(this.legendContainer);
@@ -441,6 +455,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
     });
   }
 
+  // Call back to the chart.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _getData = (xScale: any, yScale: any) => {
     this.props.getGraphData &&

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -50,5 +50,10 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
     noData: {
       cursor: href ? 'pointer' : 'default',
     },
+    visuallyHidden: {
+      position: 'absolute',
+      fontSize: '0 !important',
+      clip: 'rect(0, 0, 0, 0)',
+    },
   };
 };

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -96,6 +96,21 @@ export interface IMultiStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * Accessible label text for title of the multi stacked bar chart.
+   */
+  ariaLabel?: string;
+
+  /**
+   * ID of the element which contains label text for the title of the multi stacked bar chart.
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * ID of the element which contains the description for the title of the multi stacked bar chart.
+   */
+  ariaDescribedBy?: string;
 }
 
 export interface IMultiStackedBarChartStyleProps {
@@ -180,4 +195,9 @@ export interface IMultiStackedBarChartStyles {
    * Style for stacked bar chart with no data
    */
   noData: IStyle;
+
+  /**
+   * Style for accessibility content. Only screen readers will "see" the content
+   */
+  visuallyHidden: IStyle;
 }

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -9,6 +9,12 @@ import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { ChartHoverCard } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IStackedBarChartStyleProps, IStackedBarChartStyles>();
+
+export interface IIndexData {
+  lengthOfChartData?: number;
+  indexValOfRect?: number;
+}
+
 export interface IStackedBarChartState {
   isCalloutVisible: boolean;
   selectedLegendTitle: string;
@@ -21,6 +27,8 @@ export interface IStackedBarChartState {
   xCalloutValue?: string;
   yCalloutValue?: string;
   dataPointCalloutProps?: IChartDataPoint;
+  indexValOfRect: number;
+  lengthOfChartData: number;
 }
 
 export class StackedBarChartBase extends React.Component<IStackedBarChartProps, IStackedBarChartState> {
@@ -46,6 +54,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       isLegendSelected: false,
       xCalloutValue: '',
       yCalloutValue: '',
+      indexValOfRect: 1,
+      lengthOfChartData: 1,
     };
     this._refArray = [];
     this._onLeave = this._onLeave.bind(this);
@@ -97,38 +107,57 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       targetColor: targetData ? targetData.color : '',
       targetRatio,
     });
+
+    const titleAriaLabel = this.props.ariaLabel
+      ? this.props.ariaLabel
+      : `Bar chart depicting about ${data!.chartTitle}`;
+    const chartDataVal: number = data!.chartData![0].data ? data!.chartData![0].data : 0;
+    let numberAriaLabel: string = '';
+    if (showRatio) {
+      numberAriaLabel = !this.props.hideDenominator ? `number ${chartDataVal} of ${total}` : `number ${total}`;
+    }
+    if (showNumber) {
+      numberAriaLabel = `number ${chartDataVal}`;
+    }
+    const barSeriesLabel: string = `Bar series ${this.state.indexValOfRect} of ${this.state.lengthOfChartData}`;
     return (
       <div className={this._classNames.root}>
-        <div className={this._classNames.chartTitle}>
-          {data!.chartTitle && (
-            <div>
-              <strong>{data!.chartTitle}</strong>
-            </div>
-          )}
-          {showRatio && (
-            <div>
-              <span className={this._classNames.ratioNumerator}>
-                {data!.chartData![0].data ? data!.chartData![0].data : 0}
-              </span>
-              {!this.props.hideDenominator && (
-                <span>
-                  /<span className={this._classNames.ratioDenominator}>{total}</span>
-                </span>
-              )}
-            </div>
-          )}
-          {showNumber && (
-            <div>
-              <strong>{data!.chartData![0].data}</strong>
-            </div>
-          )}
-        </div>
-        {(benchmarkData || targetData) && (
-          <div className={this._classNames.benchmarkContainer}>
-            {benchmarkData && <div className={this._classNames.benchmark} />}
-            {targetData && <div className={this._classNames.target} />}
+        <FocusZone direction={FocusZoneDirection.horizontal}>
+          <div className={this._classNames.chartTitle}>
+            {data!.chartTitle && (
+              <div data-is-focusable={true} role="text" aria-label={titleAriaLabel}>
+                <strong>{data!.chartTitle}</strong>
+              </div>
+            )}
+            {showRatio && (
+              <div
+                role="text"
+                data-is-focusable={showRatio}
+                aria-label={numberAriaLabel}
+                aria-labelledby={this.props.ariaLabelledBy}
+                aria-describedby={this.props.ariaDescribedBy}
+              >
+                <span className={this._classNames.ratioNumerator}>{chartDataVal}</span>
+                {!this.props.hideDenominator && (
+                  <span>
+                    /<span className={this._classNames.ratioDenominator}>{total}</span>
+                  </span>
+                )}
+              </div>
+            )}
+            {showNumber && (
+              <div role="text" data-is-focusable={showNumber} aria-label={numberAriaLabel}>
+                <strong>{data!.chartData![0].data}</strong>
+              </div>
+            )}
           </div>
-        )}
+          {(benchmarkData || targetData) && (
+            <div className={this._classNames.benchmarkContainer}>
+              {benchmarkData && <div className={this._classNames.benchmark} role="text" />}
+              {targetData && <div className={this._classNames.target} role="text" />}
+            </div>
+          )}
+        </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
             <svg className={this._classNames.chart}>
@@ -144,15 +173,18 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
                 onDismiss={this._closeCallout}
                 {...this.props.calloutProps!}
               >
-                {this.props.onRenderCalloutPerDataPoint ? (
-                  this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
-                ) : (
-                  <ChartHoverCard
-                    Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.selectedLegendTitle}
-                    YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard}
-                    color={this.state.color}
-                  />
-                )}
+                <>
+                  <div className={this._classNames.visuallyHidden}>{barSeriesLabel}</div>
+                  {this.props.onRenderCalloutPerDataPoint ? (
+                    this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
+                  ) : (
+                    <ChartHoverCard
+                      Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.selectedLegendTitle}
+                      YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard}
+                      color={this.state.color}
+                    />
+                  )}
+                </>
               </Callout>
             </svg>
           </div>
@@ -191,6 +223,11 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     let value = 0;
 
     const bars = data.chartData!.map((point: IChartDataPoint, index: number) => {
+      const indexDetails: IIndexData = {
+        indexValOfRect: index,
+        lengthOfChartData: data.chartData!.length!,
+      };
+
       const color: string = point.color ? point.color : defaultPalette[Math.floor(Math.random() * 4 + 1)];
       const pointData = point.data ? point.data : 0;
       // mapping data to the format Legends component needs
@@ -247,13 +284,13 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
             this._refCallback(e, legend.title);
           }}
           data-is-focusable={!this.props.hideTooltip}
-          onFocus={this._onBarFocus.bind(this, pointData, color, point)}
+          onFocus={this._onBarFocus.bind(this, pointData, color, point, indexDetails)}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}
           aria-label="Stacked bar chart"
           role="img"
-          onMouseOver={this._onBarHover.bind(this, pointData, color, point)}
-          onMouseMove={this._onBarHover.bind(this, pointData, color, point)}
+          onMouseOver={this._onBarHover.bind(this, pointData, color, point, indexDetails)}
+          onMouseMove={this._onBarHover.bind(this, pointData, color, point, indexDetails)}
           onMouseLeave={this._onBarLeave}
           pointerEvents="all"
           onClick={this.props.href ? this._redirectToUrl.bind(this, this.props.href!) : point.onClick}
@@ -289,7 +326,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     ];
   }
 
-  private _onBarFocus(pointData: number, color: string, point: IChartDataPoint): void {
+  private _onBarFocus(pointData: number, color: string, point: IChartDataPoint, indexDetails: IIndexData): void {
     if (
       this.state.isLegendSelected === false ||
       (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!)
@@ -305,6 +342,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
             xCalloutValue: point.xAxisCalloutData!,
             yCalloutValue: point.yAxisCalloutData!,
             dataPointCalloutProps: point,
+            indexValOfRect: indexDetails.indexValOfRect! + 1,
+            lengthOfChartData: indexDetails.lengthOfChartData!,
           });
         }
       });
@@ -378,6 +417,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     pointData: number,
     color: string,
     point: IChartDataPoint,
+    indexDetails: IIndexData,
     mouseEvent: React.MouseEvent<SVGPathElement>,
   ): void {
     mouseEvent.persist();
@@ -394,6 +434,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         xCalloutValue: point.xAxisCalloutData!,
         yCalloutValue: point.yAxisCalloutData!,
         dataPointCalloutProps: point,
+        indexValOfRect: indexDetails.indexValOfRect! + 1,
+        lengthOfChartData: indexDetails.lengthOfChartData!,
       });
     }
   }

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -99,5 +99,10 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
         } as IStyle,
       },
     },
+    visuallyHidden: {
+      position: 'absolute',
+      fontSize: '0 !important',
+      clip: 'rect(0, 0, 0, 0)',
+    },
   };
 };

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -125,6 +125,21 @@ export interface IStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * Accessible label text for title of the multi stacked bar chart.
+   */
+  ariaLabel?: string;
+
+  /**
+   * ID of the element which contains label text for the title of the multi stacked bar chart.
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * ID of the element which contains the description for the title of the multi stacked bar chart.
+   */
+  ariaDescribedBy?: string;
 }
 
 export interface IStackedBarChartStyleProps {
@@ -239,4 +254,9 @@ export interface IStackedBarChartStyles {
    * Style for the target triangle
    */
   target: IStyle;
+
+  /**
+   * Style for accessibility content. Only screen readers will "see" the content
+   */
+  visuallyHidden: IStyle;
 }

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -333,13 +333,21 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             <div
               aria-label="Legends"
               className=
+                  ms-FocusZone
                   ms-OverflowSet
+                  &:focus {
+                    outline: none;
+                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
+              data-focuszone-id="FocusZone5"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>
@@ -385,7 +393,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone21"
+        data-focuszone-id="FocusZone24"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -430,7 +438,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone22"
+        data-focuszone-id="FocusZone25"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -446,7 +454,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout20"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -473,7 +481,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout20"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -520,7 +528,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone23"
+        data-focuszone-id="FocusZone26"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -565,7 +573,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone24"
+        data-focuszone-id="FocusZone27"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -581,7 +589,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout20"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -608,7 +616,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout20"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -678,13 +686,21 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             <div
               aria-label="Legends"
               className=
+                  ms-FocusZone
                   ms-OverflowSet
+                  &:focus {
+                    outline: none;
+                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
+              data-focuszone-id="FocusZone28"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>
@@ -730,7 +746,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone6"
+        data-focuszone-id="FocusZone7"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -779,7 +795,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone8"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -795,7 +811,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout5"
+              aria-labelledby="callout6"
               className=
 
                   {
@@ -822,7 +838,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout5"
+              aria-labelledby="callout6"
               className=
 
                   {
@@ -869,7 +885,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone8"
+        data-focuszone-id="FocusZone9"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -918,7 +934,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone9"
+        data-focuszone-id="FocusZone10"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -934,7 +950,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout5"
+              aria-labelledby="callout6"
               className=
 
                   {
@@ -961,7 +977,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout5"
+              aria-labelledby="callout6"
               className=
 
                   {
@@ -1029,7 +1045,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone16"
+        data-focuszone-id="FocusZone18"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1065,7 +1081,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone17"
+        data-focuszone-id="FocusZone19"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1081,7 +1097,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout17"
               className=
 
                   {
@@ -1108,7 +1124,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout17"
               className=
 
                   {
@@ -1155,7 +1171,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone18"
+        data-focuszone-id="FocusZone20"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1204,7 +1220,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone19"
+        data-focuszone-id="FocusZone21"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1220,7 +1236,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout17"
               className=
 
                   {
@@ -1247,7 +1263,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout17"
               className=
 
                   {
@@ -1317,13 +1333,21 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             <div
               aria-label="Legends"
               className=
+                  ms-FocusZone
                   ms-OverflowSet
+                  &:focus {
+                    outline: none;
+                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
+              data-focuszone-id="FocusZone22"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
               role="listbox"
             >
               <div
@@ -1384,9 +1408,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
 
                         {
                           background-color: #e81123;
+                          background-image: ;
                           border-color: #e81123;
                           border: 1px solid;
-                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1473,9 +1497,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
 
                         {
                           background-color: #107c10;
+                          background-image: ;
                           border-color: #107c10;
                           border: 1px solid;
-                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1548,7 +1572,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone11"
+        data-focuszone-id="FocusZone12"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1597,7 +1621,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone12"
+        data-focuszone-id="FocusZone13"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1613,7 +1637,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout10"
+              aria-labelledby="callout11"
               className=
 
                   {
@@ -1640,7 +1664,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout10"
+              aria-labelledby="callout11"
               className=
 
                   {
@@ -1687,7 +1711,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone13"
+        data-focuszone-id="FocusZone14"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1736,7 +1760,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone14"
+        data-focuszone-id="FocusZone15"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1752,7 +1776,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout10"
+              aria-labelledby="callout11"
               className=
 
                   {
@@ -1779,7 +1803,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout10"
+              aria-labelledby="callout11"
               className=
 
                   {
@@ -1849,13 +1873,21 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             <div
               aria-label="Legends"
               className=
+                  ms-FocusZone
                   ms-OverflowSet
+                  &:focus {
+                    outline: none;
+                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
+              data-focuszone-id="FocusZone16"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -28,35 +28,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
-            }
-      >
-        <div>
-          <strong>
-            Monitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
-        </div>
-      </div>
-      <div
-        className=
             ms-FocusZone
             &:focus {
               outline: none;
@@ -66,112 +37,42 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
       >
-        <div>
-          <svg
-            className=
+        <div
+          className=
 
-                {
-                  height: 16px;
-                  width: 100%;
-                }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Monitored"
+            data-is-focusable={true}
+            role="text"
           >
-            <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
-              className=
-
-                  {
-                    cursor: default;
-                    opacity: ;
-                    stroke-width: 2px;
-                    stroke: #ffffff;
-                  }
-              data-is-focusable={true}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onMouseLeave={[Function]}
-              onMouseMove={[Function]}
-              onMouseOver={[Function]}
-              role="img"
-            >
-              <rect
-                fill="#e81123"
-                height={16}
-                width="63.49206349206349%"
-                x="0%"
-                y={0}
-              />
-            </g>
-            <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
-              className=
-
-                  {
-                    cursor: default;
-                    opacity: ;
-                    stroke-width: 2px;
-                    stroke: #ffffff;
-                  }
-              data-is-focusable={true}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onMouseLeave={[Function]}
-              onMouseMove={[Function]}
-              onMouseOver={[Function]}
-              role="img"
-            >
-              <rect
-                fill="#107c10"
-                height={16}
-                width="36.507936507936506%"
-                x="63.49206349206349%"
-                y={0}
-              />
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      className=
-
-          {
-            display: flex;
-            flex-direction: column;
-            margin-bottom: 16px;
-            width: 100%;
-          }
-    >
-      <div
-        className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
-            }
-      >
-        <div>
-          <strong>
-            Unmonitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+            <strong>
+              Monitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -214,6 +115,145 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               role="img"
             >
               <rect
+                fill="#e81123"
+                height={16}
+                width="63.49206349206349%"
+                x="0%"
+                y={0}
+              />
+            </g>
+            <g
+              aria-label="Multi stacked bar chart"
+              aria-labelledby="callout0"
+              className=
+
+                  {
+                    cursor: default;
+                    opacity: ;
+                    stroke-width: 2px;
+                    stroke: #ffffff;
+                  }
+              data-is-focusable={true}
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseMove={[Function]}
+              onMouseOver={[Function]}
+              role="img"
+            >
+              <rect
+                fill="#107c10"
+                height={16}
+                width="36.507936507936506%"
+                x="63.49206349206349%"
+                y={0}
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      className=
+
+          {
+            display: flex;
+            flex-direction: column;
+            margin-bottom: 16px;
+            width: 100%;
+          }
+    >
+      <div
+        className=
+            ms-FocusZone
+            &:focus {
+              outline: none;
+            }
+        data-focuszone-id="FocusZone3"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+      >
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Unmonitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Unmonitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className=
+            ms-FocusZone
+            &:focus {
+              outline: none;
+            }
+        data-focuszone-id="FocusZone4"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+      >
+        <div>
+          <svg
+            className=
+
+                {
+                  height: 16px;
+                  width: 100%;
+                }
+          >
+            <g
+              aria-label="Multi stacked bar chart"
+              aria-labelledby="callout0"
+              className=
+
+                  {
+                    cursor: default;
+                    opacity: ;
+                    stroke-width: 2px;
+                    stroke: #ffffff;
+                  }
+              data-is-focusable={true}
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseMove={[Function]}
+              onMouseOver={[Function]}
+              role="img"
+            >
+              <rect
                 fill="#0078d4"
                 height={16}
                 width="63.49206349206349%"
@@ -293,21 +333,13 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             <div
               aria-label="Legends"
               className=
-                  ms-FocusZone
                   ms-OverflowSet
-                  &:focus {
-                    outline: none;
-                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
-              data-focuszone-id="FocusZone3"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>
@@ -349,27 +381,47 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone21"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Monitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Monitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Monitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+          </div>
         </div>
       </div>
       <div
@@ -378,7 +430,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone16"
+        data-focuszone-id="FocusZone22"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -394,7 +446,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout20"
               className=
 
                   {
@@ -421,7 +473,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout20"
               className=
 
                   {
@@ -464,27 +516,47 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone23"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Unmonitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Unmonitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Unmonitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+          </div>
         </div>
       </div>
       <div
@@ -493,7 +565,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone17"
+        data-focuszone-id="FocusZone24"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -509,7 +581,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout20"
               className=
 
                   {
@@ -536,7 +608,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-labelledby="callout20"
               className=
 
                   {
@@ -606,21 +678,13 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             <div
               aria-label="Legends"
               className=
-                  ms-FocusZone
                   ms-OverflowSet
-                  &:focus {
-                    outline: none;
-                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
-              data-focuszone-id="FocusZone18"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>
@@ -662,31 +726,51 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone6"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Monitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Monitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Monitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -695,7 +779,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone5"
+        data-focuszone-id="FocusZone7"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -711,7 +795,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout4"
+              aria-labelledby="callout5"
               className=
 
                   {
@@ -738,7 +822,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout4"
+              aria-labelledby="callout5"
               className=
 
                   {
@@ -781,31 +865,51 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone8"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Unmonitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Unmonitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Unmonitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -814,7 +918,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone6"
+        data-focuszone-id="FocusZone9"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -830,7 +934,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout4"
+              aria-labelledby="callout5"
               className=
 
                   {
@@ -857,7 +961,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout4"
+              aria-labelledby="callout5"
               className=
 
                   {
@@ -921,22 +1025,38 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone16"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Monitored
-          </strong>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Monitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Monitored
+            </strong>
+          </div>
         </div>
       </div>
       <div
@@ -945,7 +1065,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone12"
+        data-focuszone-id="FocusZone17"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -961,7 +1081,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -988,7 +1108,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -1031,31 +1151,51 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone18"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Unmonitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Unmonitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Unmonitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1064,7 +1204,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone13"
+        data-focuszone-id="FocusZone19"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1080,7 +1220,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -1107,7 +1247,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -1177,21 +1317,13 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             <div
               aria-label="Legends"
               className=
-                  ms-FocusZone
                   ms-OverflowSet
-                  &:focus {
-                    outline: none;
-                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
-              data-focuszone-id="FocusZone14"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
               role="listbox"
             >
               <div
@@ -1252,9 +1384,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
 
                         {
                           background-color: #e81123;
-                          background-image: ;
                           border-color: #e81123;
                           border: 1px solid;
+                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1341,9 +1473,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
 
                         {
                           background-color: #107c10;
-                          background-image: ;
                           border-color: #107c10;
                           border: 1px solid;
+                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1412,31 +1544,51 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone11"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Monitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Monitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Monitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1445,7 +1597,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone8"
+        data-focuszone-id="FocusZone12"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1461,7 +1613,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout7"
+              aria-labelledby="callout10"
               className=
 
                   {
@@ -1488,7 +1640,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout7"
+              aria-labelledby="callout10"
               className=
 
                   {
@@ -1531,31 +1683,51 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
     >
       <div
         className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              justify-content: space-between;
-              margin-bottom: 5px;
+            ms-FocusZone
+            &:focus {
+              outline: none;
             }
+        data-focuszone-id="FocusZone13"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
       >
-        <div>
-          <strong>
-            Unmonitored
-          </strong>
-        </div>
-        <div>
-          <strong>
-            40
-          </strong>
-          <span>
-            /
-            63
-          </span>
+        <div
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                justify-content: space-between;
+                margin-bottom: 5px;
+              }
+        >
+          <div
+            aria-label="Bar chart depicting about Unmonitored"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              Unmonitored
+            </strong>
+          </div>
+          <div
+            aria-label="number 40 of 63"
+            data-is-focusable={true}
+            role="text"
+          >
+            <strong>
+              40
+            </strong>
+            <span>
+              /
+              63
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1564,7 +1736,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone9"
+        data-focuszone-id="FocusZone14"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1580,7 +1752,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout7"
+              aria-labelledby="callout10"
               className=
 
                   {
@@ -1607,7 +1779,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout7"
+              aria-labelledby="callout10"
               className=
 
                   {
@@ -1677,21 +1849,13 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             <div
               aria-label="Legends"
               className=
-                  ms-FocusZone
                   ms-OverflowSet
-                  &:focus {
-                    outline: none;
-                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
-              data-focuszone-id="FocusZone10"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
               role="listbox"
             />
           </div>

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -17,49 +17,69 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
-    </div>
-    <div>
-      <span
-        className=
+    <div
+      className=
 
-            {
-              color: #000000;
-              font-size: 12px;
-              font-weight: 600;
-            }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
       >
-        40
-      </span>
-      <span>
-        /
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
+      <div
+        aria-label="number 40 of 63"
+        data-is-focusable={true}
+        role="text"
+      >
         <span
           className=
 
               {
                 color: #000000;
                 font-size: 12px;
-                opacity: 0.6;
+                font-weight: 600;
               }
         >
-          63
+          40
         </span>
-      </span>
+        <span>
+          /
+          <span
+            className=
+
+                {
+                  color: #000000;
+                  font-size: 12px;
+                  opacity: 0.6;
+                }
+          >
+            63
+          </span>
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -68,7 +88,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone1"
+    data-focuszone-id="FocusZone2"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -167,49 +187,69 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone19"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
-    </div>
-    <div>
-      <span
-        className=
+    <div
+      className=
 
-            {
-              color: #000000;
-              font-size: 12px;
-              font-weight: 600;
-            }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
       >
-        40
-      </span>
-      <span>
-        /
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
+      <div
+        aria-label="number 40 of 63"
+        data-is-focusable={true}
+        role="text"
+      >
         <span
           className=
 
               {
                 color: #000000;
                 font-size: 12px;
-                opacity: 0.6;
+                font-weight: 600;
               }
         >
-          63
+          40
         </span>
-      </span>
+        <span>
+          /
+          <span
+            className=
+
+                {
+                  color: #000000;
+                  font-size: 12px;
+                  opacity: 0.6;
+                }
+          >
+            63
+          </span>
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -218,7 +258,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone14"
+    data-focuszone-id="FocusZone20"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -236,7 +276,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout13"
+            aria-labelledby="callout18"
             className=
 
                 {
@@ -264,7 +304,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout13"
+            aria-labelledby="callout18"
             className=
 
                 {
@@ -317,35 +357,55 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone13"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
-    </div>
-    <div>
-      <span
-        className=
+    <div
+      className=
 
-            {
-              color: #000000;
-              font-size: 12px;
-              font-weight: 600;
-            }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
       >
-        40
-      </span>
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
+      <div
+        aria-label="number 63"
+        data-is-focusable={true}
+        role="text"
+      >
+        <span
+          className=
+
+              {
+                color: #000000;
+                font-size: 12px;
+                font-weight: 600;
+              }
+        >
+          40
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -354,7 +414,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone9"
+    data-focuszone-id="FocusZone14"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -372,7 +432,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout8"
+            aria-labelledby="callout12"
             className=
 
                 {
@@ -400,7 +460,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout8"
+            aria-labelledby="callout12"
             className=
 
                 {
@@ -453,49 +513,69 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone4"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
-    </div>
-    <div>
-      <span
-        className=
+    <div
+      className=
 
-            {
-              color: #000000;
-              font-size: 12px;
-              font-weight: 600;
-            }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
       >
-        40
-      </span>
-      <span>
-        /
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
+      <div
+        aria-label="number 40 of 63"
+        data-is-focusable={true}
+        role="text"
+      >
         <span
           className=
 
               {
                 color: #000000;
                 font-size: 12px;
-                opacity: 0.6;
+                font-weight: 600;
               }
         >
-          63
+          40
         </span>
-      </span>
+        <span>
+          /
+          <span
+            className=
+
+                {
+                  color: #000000;
+                  font-size: 12px;
+                  opacity: 0.6;
+                }
+          >
+            63
+          </span>
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -504,7 +584,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone3"
+    data-focuszone-id="FocusZone5"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -522,7 +602,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout2"
+            aria-labelledby="callout3"
             className=
 
                 {
@@ -550,7 +630,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout2"
+            aria-labelledby="callout3"
             className=
 
                 {
@@ -603,22 +683,38 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone10"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
+    <div
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
+      >
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
     </div>
   </div>
   <div
@@ -627,7 +723,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone7"
+    data-focuszone-id="FocusZone11"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -645,7 +741,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout6"
+            aria-labelledby="callout9"
             className=
 
                 {
@@ -673,7 +769,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout6"
+            aria-labelledby="callout9"
             className=
 
                 {
@@ -726,49 +822,69 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone7"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
-    </div>
-    <div>
-      <span
-        className=
+    <div
+      className=
 
-            {
-              color: #000000;
-              font-size: 12px;
-              font-weight: 600;
-            }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
       >
-        40
-      </span>
-      <span>
-        /
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
+      <div
+        aria-label="number 40 of 63"
+        data-is-focusable={true}
+        role="text"
+      >
         <span
           className=
 
               {
                 color: #000000;
                 font-size: 12px;
-                opacity: 0.6;
+                font-weight: 600;
               }
         >
-          63
+          40
         </span>
-      </span>
+        <span>
+          /
+          <span
+            className=
+
+                {
+                  color: #000000;
+                  font-size: 12px;
+                  opacity: 0.6;
+                }
+          >
+            63
+          </span>
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -777,7 +893,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -795,7 +911,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout4"
+            aria-labelledby="callout6"
             className=
 
                 {
@@ -823,7 +939,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout4"
+            aria-labelledby="callout6"
             className=
 
                 {
@@ -876,22 +992,38 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
 >
   <div
     className=
-
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 12px;
-          font-weight: 400;
-          justify-content: space-between;
-          margin-bottom: 5px;
+        ms-FocusZone
+        &:focus {
+          outline: none;
         }
+    data-focuszone-id="FocusZone16"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
   >
-    <div>
-      <strong>
-        Stacked bar chart 2nd example
-      </strong>
+    <div
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            justify-content: space-between;
+            margin-bottom: 5px;
+          }
+    >
+      <div
+        aria-label="Bar chart depicting about Stacked bar chart 2nd example"
+        data-is-focusable={true}
+        role="text"
+      >
+        <strong>
+          Stacked bar chart 2nd example
+        </strong>
+      </div>
     </div>
   </div>
   <div
@@ -900,7 +1032,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone11"
+    data-focuszone-id="FocusZone17"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -918,7 +1050,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout10"
+            aria-labelledby="callout15"
             className=
 
                 {
@@ -946,7 +1078,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout10"
+            aria-labelledby="callout15"
             className=
 
                 {
@@ -1019,21 +1151,13 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             <div
               aria-label="Legends"
               className=
-                  ms-FocusZone
                   ms-OverflowSet
-                  &:focus {
-                    outline: none;
-                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
-              data-focuszone-id="FocusZone12"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
               role="listbox"
             >
               <div
@@ -1094,9 +1218,9 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
 
                         {
                           background-color: #5c005c;
-                          background-image: ;
                           border-color: #5c005c;
                           border: 1px solid;
+                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1183,9 +1307,9 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
 
                         {
                           background-color: #e81123;
-                          background-image: ;
                           border-color: #e81123;
                           border: 1px solid;
+                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone19"
+    data-focuszone-id="FocusZone20"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -258,7 +258,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone20"
+    data-focuszone-id="FocusZone21"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -276,7 +276,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout18"
+            aria-labelledby="callout19"
             className=
 
                 {
@@ -304,7 +304,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout18"
+            aria-labelledby="callout19"
             className=
 
                 {
@@ -1151,13 +1151,21 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             <div
               aria-label="Legends"
               className=
+                  ms-FocusZone
                   ms-OverflowSet
+                  &:focus {
+                    outline: none;
+                  }
                   {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: unset;
                     position: relative;
                   }
+              data-focuszone-id="FocusZone18"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
               role="listbox"
             >
               <div
@@ -1218,9 +1226,9 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
 
                         {
                           background-color: #5c005c;
+                          background-image: ;
                           border-color: #5c005c;
                           border: 1px solid;
-                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;
@@ -1307,9 +1315,9 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
 
                         {
                           background-color: #e81123;
+                          background-image: ;
                           border-color: #e81123;
                           border: 1px solid;
-                          content: ;
                           height: 12px;
                           margin-right: 8px;
                           opacity: ;


### PR DESCRIPTION
#### Pull request checklist
- [ ] Include a change request file using `$ yarn change`

### Original description
**Cherry pick of** [18619](https://github.com/microsoft/fluentui/pull/18619)

#### Description of changes
Changes are related to MultiStackedBar accessibility
1. Label of the bar will be read as "Bar chart depicting about **Label** "
2. For rectangles, it will read as "Bar series **IndexOfRect** 0f **TotalLength**"
    ex. for 1st bar out of 5, it will read as "Bas Series 1 of 5" along with the content of CallOut hover card

**Before Changes:**
1. For Label
![image](https://user-images.githubusercontent.com/29042635/122547767-27482c80-d04e-11eb-82a7-433ce31a5644.png)

2. For Rectangle
![image](https://user-images.githubusercontent.com/29042635/122548060-80b05b80-d04e-11eb-9c5c-baaa578954c9.png)

**After Change:**
1. For Label
![image](https://user-images.githubusercontent.com/29042635/122548260-bf461600-d04e-11eb-9cbb-e7c189d6d328.png)

2. For Rectangle
![image](https://user-images.githubusercontent.com/29042635/122548352-e00e6b80-d04e-11eb-89fe-a3d73ffe9fba.png)

#### Focus areas to test
1. MultiStackedBar chart accessibility 

