### PR TITLE
Ignore contentPosition in compact density

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -119,9 +119,9 @@ export const ChatItem: ComponentWithAs<'li', ChatItemProps> & FluentComponentSta
 
     return (
       <ChatItemContextProvider value={{ attached }}>
-        {contentPosition === 'start' && gutterElement}
+        {(contentPosition === 'start' || density === 'compact') && gutterElement}
         {messageElement}
-        {contentPosition === 'end' && gutterElement}
+        {contentPosition === 'end' && density === 'comfy' && gutterElement}
       </ChatItemContextProvider>
     );
   };


### PR DESCRIPTION
Ignore the value of the `contentPosition`-prop in ChatItem when `density` is set to `'compact'` as a value of `'end'` causes a broken layout:
![image](https://user-images.githubusercontent.com/2564094/123475951-f7021000-d5b0-11eb-9c17-c73cf1e20fed.png)
