### PR TITLE
Charting: CherryPick #18687: Accessibility changes for Horizontal Bar Chart #18687

### DIFF
--- a/change/@fluentui-react-examples-77bff388-3761-4482-99c7-a78610b11b0b.json
+++ b/change/@fluentui-react-examples-77bff388-3761-4482-99c7-a78610b11b0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Horizontal bar accessibility changes: all accesibility data needs to pass as props, else narrator will read visible data as it is",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-b3c85ac4-ea5a-49c3-a6d8-ad67b31f07e3.json
+++ b/change/@fluentui-react-examples-b3c85ac4-ea5a-49c3-a6d8-ad67b31f07e3.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Horizontal bar accessibility changes: all accesibility data needs to pass as props, else narrator will read visible data as it is",
-  "packageName": "@fluentui/react-examples",
-  "email": "v-scharde@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-examples-b3c85ac4-ea5a-49c3-a6d8-ad67b31f07e3.json
+++ b/change/@fluentui-react-examples-b3c85ac4-ea5a-49c3-a6d8-ad67b31f07e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Horizontal bar accessibility changes: all accesibility data needs to pass as props, else narrator will read visible data as it is",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-5c101b77-d0e0-47f5-852c-9fc8a760f8b2.json
+++ b/change/@uifabric-charting-5c101b77-d0e0-47f5-852c-9fc8a760f8b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Horizontal bar accessibility changes: all accesibility data needs to pass as props, else narrator will read visible data as it is",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNamesFunction, find, getId } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
 import {
+  IAccessibilityProps,
   IChartProps,
   IHorizontalBarChartProps,
   IHorizontalBarChartStyleProps,
@@ -25,6 +26,7 @@ export interface IHorizontalBarChartState {
   xCalloutValue?: string;
   yCalloutValue?: string;
   barCalloutProps?: IChartDataPoint;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartProps, IHorizontalBarChartState> {
@@ -63,34 +65,43 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     const { palette } = theme!;
     let datapoint: number | undefined = 0;
     return (
-      <FocusZone direction={FocusZoneDirection.vertical}>
-        <div className={this._classNames.root}>
-          {data!.map((points: IChartProps, index: number) => {
-            if (points.chartData && points.chartData![0] && points.chartData![0].horizontalBarChartdata!.x) {
-              datapoint = points.chartData![0].horizontalBarChartdata!.x;
-            } else {
-              datapoint = 0;
-            }
-            points.chartData![1] = {
-              legend: '',
-              horizontalBarChartdata: {
-                x: points.chartData![0].horizontalBarChartdata!.y - datapoint!,
-                y: points.chartData![0].horizontalBarChartdata!.y,
-              },
-              color: palette.neutralTertiaryAlt,
-            };
+      <div className={this._classNames.root}>
+        {data!.map((points: IChartProps, index: number) => {
+          if (points.chartData && points.chartData![0] && points.chartData![0].horizontalBarChartdata!.x) {
+            datapoint = points.chartData![0].horizontalBarChartdata!.x;
+          } else {
+            datapoint = 0;
+          }
+          points.chartData![1] = {
+            legend: '',
+            horizontalBarChartdata: {
+              x: points.chartData![0].horizontalBarChartdata!.y - datapoint!,
+              y: points.chartData![0].horizontalBarChartdata!.y,
+            },
+            color: palette.neutralTertiaryAlt,
+          };
 
-            const chartDataText = this._getChartDataText(points!);
-            const bars = this._createBars(points!, palette);
-            const keyVal = this._uniqLineText + '_' + index;
-            return (
-              <div key={index} className={this._classNames.items}>
-                <div className={this._classNames.items}>
+          const chartDataText = this._getChartDataText(points!);
+          const bars = this._createBars(points!, palette);
+          const keyVal = this._uniqLineText + '_' + index;
+          return (
+            <div key={index} className={this._classNames.items}>
+              <div className={this._classNames.items}>
+                <FocusZone direction={FocusZoneDirection.horizontal}>
                   <div className={this._classNames.chartTitle}>
-                    {points!.chartTitle && <div className={this._classNames.chartDataText}>{points!.chartTitle}</div>}
+                    {points!.chartTitle && (
+                      <div
+                        className={this._classNames.chartDataText}
+                        {...this._getAccessibleDataObject(points!.chartTitleAccessibilityData)}
+                      >
+                        {points!.chartTitle}
+                      </div>
+                    )}
                     {chartDataText}
                   </div>
-                  {points!.chartData![0].data && this._createBenchmark(points!)}
+                </FocusZone>
+                {points!.chartData![0].data && this._createBenchmark(points!)}
+                <FocusZone direction={FocusZoneDirection.horizontal}>
                   <svg className={this._classNames.chart}>
                     <g
                       id={keyVal}
@@ -130,21 +141,24 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                       {bars}
                     </g>
                   </svg>
-                </div>
+                </FocusZone>
               </div>
-            );
-          })}
-          <Callout
-            target={this.state.refSelected}
-            coverTarget={true}
-            isBeakVisible={false}
-            gapSpace={30}
-            hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
-            directionalHint={DirectionalHint.rightTopEdge}
-            id={this._calloutId}
-            onDismiss={this._closeCallout}
-            {...this.props.calloutProps!}
-          >
+            </div>
+          );
+        })}
+        <Callout
+          target={this.state.refSelected}
+          coverTarget={true}
+          isBeakVisible={false}
+          gapSpace={30}
+          hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
+          directionalHint={DirectionalHint.rightTopEdge}
+          id={this._calloutId}
+          onDismiss={this._closeCallout}
+          {...this.props.calloutProps!}
+          {...this._getAccessibleDataObject(this.state.callOutAccessibilityData)}
+        >
+          <>
             {this.props.onRenderCalloutPerHorizonalBar ? (
               this.props.onRenderCalloutPerHorizonalBar(this.state.barCalloutProps)
             ) : (
@@ -154,9 +168,9 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 color={this.state.lineColor}
               />
             )}
-          </Callout>
-        </div>
-      </FocusZone>
+          </>
+        </Callout>
+      </div>
     );
   }
 
@@ -179,6 +193,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
         xCalloutValue: point.xAxisCalloutData!,
         yCalloutValue: point.yAxisCalloutData!,
         barCalloutProps: point,
+        callOutAccessibilityData: point.callOutAccessibilityData,
       });
     }
   }
@@ -207,29 +222,44 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   };
 
   private _getChartDataText = (data: IChartProps) => {
-    return this.props.barChartCustomData ? this.props.barChartCustomData(data) : this._getDefaultTextData(data);
+    return this.props.barChartCustomData ? (
+      <div data-is-focusable={true} role="text">
+        {this.props.barChartCustomData(data)}
+      </div>
+    ) : (
+      this._getDefaultTextData(data)
+    );
   };
 
   private _getDefaultTextData = (data: IChartProps): JSX.Element => {
     const chartDataMode = this.props.chartDataMode || 'default';
-    const x = data!.chartData![0].horizontalBarChartdata!.x;
-    const y = data!.chartData![0].horizontalBarChartdata!.y;
+    const chartData: IChartDataPoint = data!.chartData![0];
+    const x = chartData.horizontalBarChartdata!.x;
+    const y = chartData.horizontalBarChartdata!.y;
 
+    const accessibilityData = this._getAccessibleDataObject(chartData.chartDataAccessibilityData);
     switch (chartDataMode) {
       case 'default':
+        const chartDataText: string = x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         return (
-          <div className={this._classNames.chartDataText}>{x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}</div>
+          <div className={this._classNames.chartDataText} {...accessibilityData}>
+            {chartDataText}
+          </div>
         );
       case 'fraction':
         return (
-          <div>
+          <div {...accessibilityData}>
             <span className={this._classNames.chartDataText}>{x}</span>
             <span className={this._classNames.chartDataTextDenominator}>{'/' + y}</span>
           </div>
         );
       case 'percentage':
-        const dataRatio = Math.round((x / y) * 100);
-        return <div className={this._classNames.chartDataText}>{dataRatio + '%'}</div>;
+        const dataRatioPercentage = `${Math.round((x / y) * 100)}%`;
+        return (
+          <div className={this._classNames.chartDataText} {...accessibilityData}>
+            {dataRatioPercentage}
+          </div>
+        );
     }
   };
 
@@ -288,5 +318,16 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _getAccessibleDataObject = (accessibleData?: IAccessibilityProps, role: string = 'text') => {
+    accessibleData = accessibleData ?? {};
+    return {
+      role,
+      'data-is-focusable': true,
+      'aria-label': accessibleData!.ariaLabel,
+      'aria-labelledby': accessibleData!.ariaLabelledBy,
+      'aria-describedby': accessibleData!.ariaDescribedBy,
+    };
   };
 }

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -68,7 +68,7 @@ export interface IHorizontalBarChartProps {
    * Custom text to the chart (right side of the chart)
    * IChartProps will be available as props to the method prop.
    * If this method not given, default values (IHorizontalDataPoint {x,y})
-   * will be used to disaply the data/text based on given chartModeData prop.
+   * will be used to display the data/text based on given chartModeData prop.
    */
   barChartCustomData?: IRenderFunction<IChartProps>;
 }

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -121,6 +121,16 @@ export interface IChartDataPoint {
    * This is an optional prop, If haven't given data will take
    */
   yAxisCalloutData?: string;
+
+  /**
+   * Accessibility data for chart data
+   */
+  chartDataAccessibilityData?: IAccessibilityProps;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IVerticalBarChartDataPoint {
@@ -243,6 +253,11 @@ export interface IChartProps {
   chartTitle?: string;
 
   /**
+   * Accessibility data for chart title
+   */
+  chartTitleAccessibilityData?: IAccessibilityProps;
+
+  /**
    * data for the points in the chart
    */
   chartData?: IChartDataPoint[];
@@ -251,6 +266,23 @@ export interface IChartProps {
    * data for the points in the line chart
    */
   lineChartData?: ILineChartPoints[];
+}
+
+export interface IAccessibilityProps {
+  /**
+   * Accessibility aria-label
+   */
+  ariaLabel?: string;
+
+  /**
+   * Accessibility aria-labelledBy
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * Accessibility aria-describedBy
+   */
+  ariaDescribedBy?: string;
 }
 
 export interface IVSChartDataPoint {

--- a/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { HorizontalBarChart, IChartProps } from '@uifabric/charting';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+
+export const HorizontalBarChartCustomAccessibilityExample: React.FunctionComponent<{}> = () => {
+  const data: IChartProps[] = [
+    {
+      chartTitle: 'one',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about one' },
+      chartData: [
+        {
+          legend: 'one',
+          horizontalBarChartdata: { x: 1543, y: 15000 },
+          color: DefaultPalette.tealDark,
+          xAxisCalloutData: '2021/06/10',
+          yAxisCalloutData: '41%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 1543 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart one 2021/06/10 41%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'two',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about two' },
+      chartData: [
+        {
+          legend: 'two',
+          horizontalBarChartdata: { x: 800, y: 15000 },
+          color: DefaultPalette.purple,
+          xAxisCalloutData: '2021/06/11',
+          yAxisCalloutData: '52%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 800 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart two 2021/06/11 52%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'three',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about three' },
+      chartData: [
+        {
+          legend: 'three',
+          horizontalBarChartdata: { x: 8888, y: 15000 },
+          color: DefaultPalette.redDark,
+          xAxisCalloutData: '2021/06/12',
+          yAxisCalloutData: '63%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 8888 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart three 2021/06/12 63%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'four',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about four' },
+      chartData: [
+        {
+          legend: 'four',
+          horizontalBarChartdata: { x: 15888, y: 15000 },
+          color: DefaultPalette.themeDarkAlt,
+          xAxisCalloutData: '2021/06/13',
+          yAxisCalloutData: '74%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 15888 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart four 2021/06/13 74%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'five',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about five' },
+      chartData: [
+        {
+          legend: 'five',
+          horizontalBarChartdata: { x: 11444, y: 15000 },
+          color: DefaultPalette.themePrimary,
+          xAxisCalloutData: '2021/06/14',
+          yAxisCalloutData: '85%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 11444 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart five 2021/06/14 85%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'six',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about six' },
+      chartData: [
+        {
+          legend: 'six',
+          horizontalBarChartdata: { x: 14000, y: 15000 },
+          color: DefaultPalette.greenDark,
+          xAxisCalloutData: '2021/06/15',
+          yAxisCalloutData: '96%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 14000 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart six 2021/06/15 96%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'seven',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about seven' },
+      chartData: [
+        {
+          legend: 'seven',
+          horizontalBarChartdata: { x: 9855, y: 15000 },
+          color: DefaultPalette.accent,
+          xAxisCalloutData: '2021/06/16',
+          yAxisCalloutData: '98%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 9855 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart seven 2021/06/16 98%' },
+        },
+      ],
+    },
+    {
+      chartTitle: 'eight',
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart showing about eight' },
+      chartData: [
+        {
+          legend: 'eight',
+          horizontalBarChartdata: { x: 4250, y: 15000 },
+          color: DefaultPalette.blueLight,
+          xAxisCalloutData: '2021/06/17',
+          yAxisCalloutData: '99%',
+          chartDataAccessibilityData: { ariaLabel: 'Data 4250 of 15000' },
+          callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart eight 2021/06/17 99%' },
+        },
+      ],
+    },
+  ];
+
+  return <HorizontalBarChart data={data} width={600} />;
+};

--- a/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChartPage.tsx
+++ b/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChartPage.tsx
@@ -5,11 +5,12 @@ import { ComponentPage, ExampleCard, IComponentDemoPageProps, PropertiesTableSet
 import { HorizontalBarChartBasicExample } from './HorizontalBarChart.Basic.Example';
 import { HorizontalBarChartCustomCalloutExample } from './HorizontalBarChart.CustomCallout.Example';
 import { HorizontalBarChartBenchmarkExample } from './HorizontalBarChart.Benchmark.Example';
+import { HorizontalBarChartCustomAccessibilityExample } from './HorizontalBarChart.CustomAccessibility.Example';
 
 const HorizontalBarChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx') as string;
 const HorizontalBarChartCustomCalloutExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx') as string;
 const HorizontalBarChartBenchmarkExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.Benchmark.Example.tsx') as string;
-
+const HorizontalBarChartCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx') as string;
 export class HorizontalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (
@@ -26,6 +27,12 @@ export class HorizontalBarChartPage extends React.Component<IComponentDemoPagePr
             </ExampleCard>
             <ExampleCard title="HorizontalBarChart with benchmark" code={HorizontalBarChartBenchmarkExampleCode}>
               <HorizontalBarChartBenchmarkExample />
+            </ExampleCard>
+            <ExampleCard
+              title="HorizontalBarChart Custom Accessibility"
+              code={HorizontalBarChartCustomAccessibilityExampleCode}
+            >
+              <HorizontalBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
### Original description
**Cherry pick of** [18687](https://github.com/microsoft/fluentui/pull/18687)


#### Description of changes
Changes are related to Horizontal Bar Chart accessibility

1. Changed focus zone direction to horizontal, so same row data can also be read by forward and backward buttons.
2. Accessibility Data prop added for the chart title, chart data, and Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
3. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator. 
4. Custom Accessibility example is added for Horizontal bar chart. 

**Without Custom Accessibility Data:**

![image](https://user-images.githubusercontent.com/29042635/123322307-bfb04680-d551-11eb-890f-6cc134dee7fc.png)


**With Custom Accessibility Data**
![image](https://user-images.githubusercontent.com/29042635/123322979-8f1cdc80-d552-11eb-8454-49c18615c53b.png)


#### Focus areas to test
1. Horizontal Bar chart accessibility
