### PR TITLE
fix: prevent components selections

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix missing `vertical` prop from parent context in `MenuItemContent` @assuncaocharles ([#18570](https://github.com/microsoft/fluentui/pull/18570))
 - Add `AvatarStatusIcon` to theme types @assuncaocharles ([#18583](https://github.com/microsoft/fluentui/pull/18583))
 - Fix `Text` error low luminosity in dark themes @assuncaocharles ([#18694](https://github.com/microsoft/fluentui/pull/18694))
+- Prevent focusable elements to be selectable @assuncaocharles ([#18738](https://github.com/microsoft/fluentui/pull/18738))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionTitleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionTitleStyles.ts
@@ -15,7 +15,7 @@ export const accordionTitleStyles: ComponentSlotStylesPrepared<AccordionTitleSty
     display: 'grid',
     gridTemplateColumns: 'auto',
     msGridColumns: 'auto',
-
+    userSelect: 'none',
     ...(p.content && {
       gridTemplateColumns: 'auto 1fr',
       msGridColumns: 'auto 1fr',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Breadcrumb/breadcrumbLinkStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Breadcrumb/breadcrumbLinkStyles.ts
@@ -42,6 +42,7 @@ export const breadcrumbLinkStyles: ComponentSlotStylesPrepared<BreadcrumbLinkSty
     });
 
     return {
+      userSelect: 'none',
       display: 'flex',
       alignItems: 'center',
       position: 'relative',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -36,6 +36,7 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
       verticalAlign: 'middle',
       cursor: 'pointer',
       transition: faster,
+      userSelect: 'none',
 
       ...(p.size === 'small' && {
         padding: v.sizeSmallPadding,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
@@ -209,7 +209,7 @@ export const checkboxStyles: ComponentSlotStylesPrepared<CheckboxStylesProps, Ch
 
   label: ({ props: p }): ICSSInJSStyle => ({
     display: 'block', // IE11: should be forced to be block, as inline-block is not supported
-
+    userSelect: 'none',
     gridColumn: 3,
     msGridColumn: 3,
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
@@ -47,7 +47,7 @@ export const listItemStyles: ComponentSlotStylesPrepared<ListItemStylesProps, Li
       padding: v.rootPadding,
       ...((p.selectable || p.navigable) && {
         position: 'relative',
-
+        userSelect: 'none',
         // hide the end media by default
         [`& .${listItemEndMediaClassName}`]: { display: 'none' },
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemContentStyles.ts
@@ -12,6 +12,7 @@ export const menuItemContentStyles: ComponentSlotStylesPrepared<MenuItemContentS
       marginTop: pxToRem(-4),
       marginBottom: pxToRem(-4),
       display: 'inline-block',
+      userSelect: 'none',
       ...((p.inSubmenu || p.vertical) && {
         width: 'max-content',
         minWidth: pxToRem(46 - widthAdjust),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -84,5 +84,6 @@ export const radioGroupItemStyles: ComponentSlotStylesPrepared<RadioGroupItemSty
 
   label: (): ICSSInJSStyle => ({
     margin: `0 0 0 ${pxToRem(12)}`,
+    userSelect: 'none',
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
@@ -23,6 +23,7 @@ export const toolbarCustomItemStyles: ComponentSlotStylesPrepared<ToolbarCustomI
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      userSelect: 'none',
       ...(p.fitted !== true &&
         p.fitted !== 'horizontally' && {
           paddingLeft: v.customItemHorizontalPadding,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
@@ -25,6 +25,7 @@ export const toolbarItemStyles: ComponentSlotStylesPrepared<ToolbarItemStylesPro
       padding: v.itemPadding,
       color: v.foreground || colors.foreground1,
       cursor: 'pointer',
+      userSelect: 'none',
 
       ':focus': borderFocusStyles[':focus'],
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemStyles.ts
@@ -30,6 +30,7 @@ export const toolbarMenuItemStyles: ComponentSlotStylesPrepared<ToolbarMenuItemS
       cursor: 'pointer',
       minHeight: v.itemHeight,
       lineHeight: v.lineHeightBase,
+      userSelect: 'none',
 
       ':focus': {
         outline: 0,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeTitleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tree/treeTitleStyles.ts
@@ -19,6 +19,7 @@ export const treeTitleStyles: ComponentSlotStylesPrepared<TreeTitleStylesProps, 
       marginLeft: pxToRem(1 + (p.level - 1) * 10),
       paddingRight: v.paddingRight,
       paddingLeft: v.paddingLeft,
+      userSelect: 'none',
       ...(p.selectable && {
         display: 'flex',
         justifyContent: 'space-between',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Prevent focusable elements to be selectable since we don't want that all components have the content select on user interactions with it. 

#### Focus areas to test

(optional)
