### PR TITLE
[DatePicker] Fixed website crash after selecting firstDayOfWeek

### DIFF
--- a/change/@fluentui-react-examples-7ee03592-696d-4f24-9499-a4ec1cd9f0d8.json
+++ b/change/@fluentui-react-examples-7ee03592-696d-4f24-9499-a4ec1cd9f0d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed DatePicker site crash after selecting firstDayOfWeek",
+  "packageName": "@fluentui/react-examples",
+  "email": "hetanthakkar1@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Basic.Example.tsx
@@ -16,7 +16,7 @@ export const DatePickerBasicExample: React.FunctionComponent = () => {
   const [firstDayOfWeek, setFirstDayOfWeek] = React.useState(DayOfWeek.Sunday);
 
   const onDropdownChange = React.useCallback((event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setFirstDayOfWeek((DayOfWeek as any)[option.key]);
+    setFirstDayOfWeek(option.key as number);
   }, []);
 
   return (

--- a/packages/react-examples/src/react/DatePicker/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.WeekNumbers.Example.tsx
@@ -16,7 +16,7 @@ export const DatePickerWeekNumbersExample: React.FunctionComponent = () => {
   const [firstDayOfWeek, setFirstDayOfWeek] = React.useState(DayOfWeek.Sunday);
 
   const onDropdownChange = React.useCallback((event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setFirstDayOfWeek((DayOfWeek as any)[option.key]);
+    setFirstDayOfWeek(option.key as number);
   }, []);
 
   return (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18736
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixed: Whole site crash after selecting the first day of the week in Date Picker. The problem arises because the value of firstDayOfWeek prop was passed as Sunday instead of 0 and same happened with other days

#### Focus areas to test

(optional)
