### PR TITLE
fix(dropdownStyles): overflow-x hidden to remove scrollbar

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -56,6 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `compact`-prop to `Chat` (and `ChatMessage`) that displays the Chat in compact density @Hirse ([#18334](https://github.com/microsoft/fluentui/pull/18334))
 - Make disabled Menu items focusable @adamsamec ([#17939](https://github.com/microsoft/fluentui/pull/17939))
 - Fix `MenuButton` to avoid arrow keys to move to cells inside a table @assuncaocharles ([#18663](https://github.com/microsoft/fluentui/pull/18663))
+- Fix dropdown container overflow-x @assuncaocharles ([#18749](https://github.com/microsoft/fluentui/pull/18749))
 
 ### Performance
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -140,6 +140,7 @@ export const dropdownStyles: ComponentSlotStylesPrepared<DropdownStylesProps, Dr
     display: 'flex',
     flexWrap: 'wrap',
     overflowY: 'auto',
+    overflowX: 'hidden',
     maxHeight: v.selectedItemsMaxHeight,
     width: '100%',
     ...(p.hasToggleIndicator && { paddingRight: v.toggleIndicatorSize }),


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix scroll appearing for small dropdown

Before:

<img width="120" alt="Screen Shot 2021-06-28 at 11 45 59 AM" src="https://user-images.githubusercontent.com/8545105/123657157-ed71e580-d806-11eb-9a2f-82eac2d63630.png">

After:

<img width="135" alt="Screen Shot 2021-06-28 at 11 46 08 AM" src="https://user-images.githubusercontent.com/8545105/123657180-f4005d00-d806-11eb-954a-9948f05a1369.png">


#### Focus areas to test

(optional)
