### PR TITLE
fix(buttonStyles): Fix tinted high contrast color

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -49,6 +49,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set `ChatMessageDetails` margin based on `attached` prop @Hirse ([#18681](https://github.com/microsoft/fluentui/pull/18681))
 - Fix `ChatMessage` timestamp color for v2 themes @Hirse ([#18711](https://github.com/microsoft/fluentui/pull/18711))
 - Prevent focusable elements to be selectable @assuncaocharles ([#18738](https://github.com/microsoft/fluentui/pull/18738))
+- Fix tinted `Button` color in HC theme @assuncaocharles ([#18755](https://github.com/microsoft/fluentui/pull/18755))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
@@ -9,7 +9,7 @@ export const buttonVariables = (siteVars: any): Partial<ButtonVariables> => {
     borderColorFocus: 'transparent',
     backgroundColorDisabled: siteVars.accessibleGreen,
     colorFocus: siteVars.colorScheme.default.foregroundHover,
-
+    tintedColorHover: siteVars.colorScheme.brand.foregroundHover,
     primaryBackgroundColorActive: siteVars.colors.white,
     primaryBackgroundColorFocus: siteVars.accessibleCyan,
 

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
@@ -9,7 +9,6 @@ export const buttonVariables = (siteVars: any): Partial<ButtonVariables> => {
     borderColorFocus: 'transparent',
     backgroundColorDisabled: siteVars.accessibleGreen,
     colorFocus: siteVars.colorScheme.default.foregroundHover,
-    tintedColorHover: siteVars.colorScheme.brand.foregroundHover,
     primaryBackgroundColorActive: siteVars.colors.white,
     primaryBackgroundColorFocus: siteVars.accessibleCyan,
 

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Button/buttonVariables.ts
@@ -9,6 +9,7 @@ export const buttonVariables = (siteVars: any): Partial<ButtonVariables> => {
     borderColorFocus: 'transparent',
     backgroundColorDisabled: siteVars.accessibleGreen,
     colorFocus: siteVars.colorScheme.default.foregroundHover,
+
     primaryBackgroundColorActive: siteVars.colors.white,
     primaryBackgroundColorFocus: siteVars.accessibleCyan,
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -198,6 +198,7 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
 
         ':hover': {
           backgroundColor: v.tintedBackgroundColorHover,
+          color: v.tintedColorHover,
         },
 
         ':focus': {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonVariables.ts
@@ -118,7 +118,7 @@ export const buttonVariables = (siteVars: any): ButtonVariables => ({
   primaryBorderColor: 'transparent',
 
   tintedColor: siteVars.colorScheme.brand.foreground,
-  tintedColorHover: siteVars.colorScheme.brand.foreground,
+  tintedColorHover: siteVars.colorScheme.brand.foregroundHover,
   tintedBackgroundColor: siteVars.colorScheme.default.background,
   tintedBackgroundColorActive: siteVars.colorScheme.brand.backgroundHover1,
   tintedBackgroundColorHover: siteVars.colorScheme.brand.backgroundHover1,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix color for Tinted button in High Contrast.

Before: 

![before](https://user-images.githubusercontent.com/8545105/123715560-eff82d80-d84e-11eb-9735-8a76104072b6.png)

After:

<img width="455" alt="Screen Shot 2021-06-28 at 8 22 42 PM" src="https://user-images.githubusercontent.com/8545105/123715574-f4bce180-d84e-11eb-91d9-691ddcd053a7.png">


#### Focus areas to test

(optional)
