### PR TITLE
fix(Popover): apply styles correctly

### DIFF
--- a/change/@fluentui-react-popover-5b139582-44d1-4d84-ae38-e5fd590f9286.json
+++ b/change/@fluentui-react-popover-5b139582-44d1-4d84-ae38-e5fd590f9286.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Popover): apply styles correctly",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -86,17 +86,18 @@ export const usePopoverSurfaceStyles = (state: PopoverSurfaceState): PopoverSurf
   const styles = useStyles();
   state.className = mergeClasses(
     styles.root,
-    state.className,
     state.size === 'small' && styles.smallPadding,
     state.size === 'medium' && styles.mediumPadding,
     state.size === 'large' && styles.largePadding,
     state.inverted && styles.inverted,
     state.brand && styles.brand,
+    state.className,
   );
 
   state.arrowClassName = mergeClasses(
     styles.arrow,
     state.size === 'small' ? styles.smallArrow : styles.mediumLargeArrow,
+    state.arrowClassName,
   );
 
   return state;

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -97,7 +97,6 @@ export const usePopoverSurfaceStyles = (state: PopoverSurfaceState): PopoverSurf
   state.arrowClassName = mergeClasses(
     styles.arrow,
     state.size === 'small' ? styles.smallArrow : styles.mediumLargeArrow,
-    state.arrowClassName,
   );
 
   return state;


### PR DESCRIPTION
It is not possible to override certain `PopoverSurface` styles using makeStyles
because the `className` prop is passed in the beginning of the
`mergeClasses` call

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18760
- [x] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
