### PR TITLE
Fixing bug in start script of converged packages

### DIFF
--- a/change/@fluentui-react-accordion-f82dd2e6-9197-4e4e-adef-39b0a508f4b7.json
+++ b/change/@fluentui-react-accordion-f82dd2e6-9197-4e4e-adef-39b0a508f4b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-e0fb776f-33d8-4175-8a8a-768b64aa678c.json
+++ b/change/@fluentui-react-aria-e0fb776f-33d8-4175-8a8a-768b64aa678c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-aria",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-142541c4-a20c-43dc-9507-f8d4ea3d785a.json
+++ b/change/@fluentui-react-image-142541c4-a20c-43dc-9507-f8d4ea3d785a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-image",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-33750d23-44f1-4382-8ec6-80912176cb45.json
+++ b/change/@fluentui-react-label-33750d23-44f1-4382-8ec6-80912176cb45.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-label",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-0c6c75fb-88af-4ab4-85cd-ce245ddfd9a9.json
+++ b/change/@fluentui-react-menu-0c6c75fb-88af-4ab4-85cd-ce245ddfd9a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-menu",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-b57e2631-ef24-4e3d-b0df-bc684a256183.json
+++ b/change/@fluentui-react-popover-b57e2631-ef24-4e3d-b0df-bc684a256183.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-popover",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-cf56d7e5-9b2e-4741-93e1-4a4bba333ca9.json
+++ b/change/@fluentui-react-portal-cf56d7e5-9b2e-4741-93e1-4a4bba333ca9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-portal",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-04fd5907-6b0c-4624-ad62-5b39727b7164.json
+++ b/change/@fluentui-react-positioning-04fd5907-6b0c-4624-ad62-5b39727b7164.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-546f4ed5-b575-4e23-80d2-ad3d14bf87c2.json
+++ b/change/@fluentui-react-provider-546f4ed5-b575-4e23-80d2-ad3d14bf87c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-867fa3f7-f376-4e05-8acc-f7f81814830d.json
+++ b/change/@fluentui-react-tabster-867fa3f7-f376-4e05-8acc-f7f81814830d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing bug in start script of converged packages.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -17,7 +17,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-accordion/src && yarn docs",

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -17,7 +17,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-aria/src && yarn docs",

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -18,7 +18,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-image/src && yarn docs",

--- a/packages/react-label/package.json
+++ b/packages/react-label/package.json
@@ -17,7 +17,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/packages/react-label/src && yarn docs",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -21,7 +21,7 @@
     "e2e": "e2e",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "storybook": "start-storybook",
     "test": "jest"
   },

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -18,7 +18,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "storybook": "start-storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -17,7 +17,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-portal/src && yarn docs",

--- a/packages/react-positioning/package.json
+++ b/packages/react-positioning/package.json
@@ -21,7 +21,7 @@
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-positioning/src && yarn docs",
     "storybook": "start-storybook",
-    "start": "storybook"
+    "start": "yarn storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.1",

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -21,7 +21,7 @@
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-provider/src && yarn docs",
     "storybook": "start-storybook",
-    "start": "storybook"
+    "start": "yarn storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.1",

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -21,7 +21,7 @@
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-tabster/src && yarn docs",
-    "start": "storybook"
+    "start": "yarn storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.1",

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -18,7 +18,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-text/src && yarn docs",

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -534,7 +534,7 @@ describe('migrate-converged-pkg generator', () => {
         'code-style': 'just-scripts code-style',
         just: 'just-scripts',
         lint: 'just-scripts lint',
-        start: 'storybook',
+        start: 'yarn storybook',
         storybook: 'start-storybook',
         test: 'jest',
       });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -282,7 +282,7 @@ function updateNpmScripts(tree: Tree, options: NormalizedSchema) {
       // eslint-disable-next-line @fluentui/max-len
     ] = `tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/${options.normalizedPkgName}/src && yarn docs`;
     json.scripts.storybook = 'start-storybook';
-    json.scripts.start = 'storybook';
+    json.scripts.start = 'yarn storybook';
     json.scripts.test = 'jest';
 
     return json;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes a bug on the script that migrates converged packages where the `start` script was not working because it was set as `storybook` instead of `yarn storybook`.