### PR TITLE
Add more logging to debug northstar dts error

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,7 +54,7 @@
       "console": "integratedTerminal"
     },
     {
-      "name": "Run server",
+      "name": "Run server-rendered-app",
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/apps/server-rendered-app/server/index.js",
@@ -62,14 +62,14 @@
       "stopOnEntry": false,
       "args": ["-i"],
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },
       "sourceMaps": true
     },
     {
-      "name": "Build fabric",
+      "name": "Build @fluentui/react",
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/scripts/just-scripts.js",
@@ -77,42 +77,15 @@
       "stopOnEntry": false,
       "args": ["ts"],
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
+      "console": "integratedTerminal",
       "env": {
         "NODE_ENV": "development"
       },
       "sourceMaps": true
     },
     {
-      "name": "Debug build",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/scripts/just-scripts.js",
-      "stopOnEntry": false,
-      "args": ["build"],
-      "cwd": "${workspaceRoot}/packages/style-utilities",
-      "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
-      "env": {
-        "NODE_ENV": "development"
-      }
-    },
-    {
-      "name": "Debug build Dogfood",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/scripts/just-scripts.js",
-      "stopOnEntry": false,
-      "args": ["webpack", "--", "--production", "--dogfood"],
-      "cwd": "${workspaceRoot}/apps/public-docsite",
-      "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
-      "env": {
-        "NODE_ENV": "development"
-      }
-    },
-    {
-      "name": "Debug npm start (public-docsite)",
+      "name": "Start public-docsite",
       "type": "node",
       "request": "launch",
       // scripts/start.js generates this script path and launches a subprocess (which is harder
@@ -124,7 +97,7 @@
       // Use the config file for public-docsite, plus command line options used in start.js
       "args": [
         "--nolazy",
-        "--debug",
+        "--inspect",
         "--config",
         "${workspaceRoot}/apps/public-docsite/webpack.serve.config.js",
         "--open"
@@ -139,10 +112,10 @@
       "request": "launch",
       "program": "${workspaceRoot}/apps/ssr-tests/node_modules/mocha/bin/_mocha",
       "stopOnEntry": false,
-      "args": ["--debug", "dist/ssr-tests.js"],
+      "args": ["--inspect", "dist/ssr-tests.js"],
       "cwd": "${workspaceRoot}/apps/ssr-tests",
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },
@@ -157,7 +130,7 @@
       "stopOnEntry": false,
       "args": ["--name", "TestComponentName"],
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },
@@ -179,7 +152,7 @@
         "--age",
         "10"
       ],
-      "runtimeArgs": ["--nolazy", "--debug", "-r", "${workspaceRoot}/scripts/ts-node-register"],
+      "runtimeArgs": ["--nolazy", "--inspect", "-r", "${workspaceRoot}/scripts/ts-node-register"],
       "env": {
         "NODE_ENV": "development"
       },
@@ -195,7 +168,7 @@
       "stopOnEntry": false,
       "runtimeExecutable": null,
       "args": ["--ext", ".ts,.tsx,.js,.jsx", "src"],
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },
@@ -210,7 +183,7 @@
       "cwd": "${workspaceRoot}/packages/api-docs",
       "stopOnEntry": false,
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },
@@ -223,7 +196,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
       "stopOnEntry": false,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       // You can change the task name and cwd locally as needed
       "args": ["build"],
       "cwd": "${workspaceRoot}/packages/fluentui/react-northstar",

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -1,13 +1,10 @@
 const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
-const fs = require('fs');
 const path = require('path');
 const findGitRoot = require('../monorepo/findGitRoot');
 const getResolveAlias = require('../webpack/getResolveAlias');
 const webpack = require('webpack');
 
 module.exports = (/** @type {webpack.Configuration} */ config) => {
-  const gitRoot = findGitRoot();
-
   config.resolveLoader = {
     ...config.resolveLoader,
     modules: [
@@ -77,7 +74,7 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
   config.resolve.alias = {
     // Use the aliases for react-examples since the examples and demo may depend on some things
     // that the package itself doesn't (and it will include the aliases for all the package's deps)
-    ...getResolveAlias(false, path.join(gitRoot, 'packages/react-examples')),
+    ...getResolveAlias(false, path.join(findGitRoot(), 'packages/react-examples')),
   };
 
   config.plugins.push(new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }));
@@ -95,21 +92,6 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
       // Plugins have circular references, and they're probably not the issue here
       JSON.stringify(config, (key, value) => (key === 'plugins' ? undefined : value), 2),
     );
-    const northstarPath = path.join(gitRoot, 'packages/fluentui/react-northstar');
-    const filesToWatch = [
-      path.join(gitRoot, 'tsconfig.json'),
-      path.join(northstarPath, 'tsconfig.json'),
-      path.join(northstarPath, 'package.json'),
-    ];
-    for (const file of filesToWatch) {
-      fs.watchFile(file, (curr, prev) => {
-        // Get the stack but remove the first line about it being an error
-        const stack = new Error().stack.split(/\r?\n/g).slice(1).join('\n');
-        const isAccess = curr.mtime.getTime() === prev.mtime.getTime();
-        console.log(`${isAccess ? 'Accessed' : 'Modified'} ${file}:`);
-        console.log(stack);
-      });
-    }
   }
 
   return config;

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -103,13 +103,8 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
     ];
     for (const file of filesToWatch) {
       fs.watchFile(file, (curr, prev) => {
-        let stack;
-        try {
-          throw new Error();
-        } catch (err) {
-          // Get the stack but remove the first line about it being an error
-          stack = err.stack.split(/\r?\n/g).slice(1).join('\n');
-        }
+        // Get the stack but remove the first line about it being an error
+        const stack = new Error().stack.split(/\r?\n/g).slice(1).join('\n');
         const isAccess = curr.mtime.getTime() === prev.mtime.getTime();
         console.log(`${isAccess ? 'Accessed' : 'Modified'} ${file}:`);
         console.log(stack);

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -1,10 +1,13 @@
 const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
+const fs = require('fs');
 const path = require('path');
 const findGitRoot = require('../monorepo/findGitRoot');
 const getResolveAlias = require('../webpack/getResolveAlias');
 const webpack = require('webpack');
 
 module.exports = (/** @type {webpack.Configuration} */ config) => {
+  const gitRoot = findGitRoot();
+
   config.resolveLoader = {
     ...config.resolveLoader,
     modules: [
@@ -74,7 +77,7 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
   config.resolve.alias = {
     // Use the aliases for react-examples since the examples and demo may depend on some things
     // that the package itself doesn't (and it will include the aliases for all the package's deps)
-    ...getResolveAlias(false, path.join(findGitRoot(), 'packages/react-examples')),
+    ...getResolveAlias(false, path.join(gitRoot, 'packages/react-examples')),
   };
 
   config.plugins.push(new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }));
@@ -85,6 +88,34 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
   }
 
   config.optimization.minimize = false;
+
+  if (process.env.TF_BUILD) {
+    console.log(
+      'Storybook webpack config:',
+      // Plugins have circular references, and they're probably not the issue here
+      JSON.stringify(config, (key, value) => (key === 'plugins' ? undefined : value), 2),
+    );
+    const northstarPath = path.join(gitRoot, 'packages/fluentui/react-northstar');
+    const filesToWatch = [
+      path.join(gitRoot, 'tsconfig.json'),
+      path.join(northstarPath, 'tsconfig.json'),
+      path.join(northstarPath, 'package.json'),
+    ];
+    for (const file of filesToWatch) {
+      fs.watchFile(file, (curr, prev) => {
+        let stack;
+        try {
+          throw new Error();
+        } catch (err) {
+          // Get the stack but remove the first line about it being an error
+          stack = err.stack.split(/\r?\n/g).slice(1).join('\n');
+        }
+        const isAccess = curr.mtime.getTime() === prev.mtime.getTime();
+        console.log(`${isAccess ? 'Accessed' : 'Modified'} ${file}:`);
+        console.log(stack);
+      });
+    }
+  }
 
   return config;
 };

--- a/scripts/tasks/storybook.ts
+++ b/scripts/tasks/storybook.ts
@@ -83,7 +83,9 @@ export function buildStorybookTask() {
       mode: 'static',
       outputDir: path.join(process.cwd(), 'dist/storybook'),
     };
-    console.log('Storybook options:', JSON.stringify(options, null, 2));
+    if (process.env.TF_BUILD) {
+      console.log('Storybook options:', JSON.stringify(options, null, 2));
+    }
     await storybook(options);
   };
 }

--- a/scripts/tasks/storybook.ts
+++ b/scripts/tasks/storybook.ts
@@ -83,6 +83,7 @@ export function buildStorybookTask() {
       mode: 'static',
       outputDir: path.join(process.cwd(), 'dist/storybook'),
     };
+    console.log('Storybook options:', JSON.stringify(options, null, 2));
     await storybook(options);
   };
 }


### PR DESCRIPTION
@ling1726 and I tried to debug the recurring error from #18769 where `bundle:storybook` for `@fluentui/react` fails because it can't find the northstar dts folder (which it shouldn't ever be looking at). So far neither of us can repro the issue, and we're not sure based on the config how this could possibly be happening, so try adding more logging.