### PR TITLE
Remove tooltip from close button on TeachingBubble

### DIFF
--- a/change/@fluentui-react-0d58d8e0-bfd5-4792-ae7c-ed484c764279.json
+++ b/change/@fluentui-react-0d58d8e0-bfd5-4792-ae7c-ed484c764279.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove title tooltip from TeachingBubble close button",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-dba766e8-3fa8-46e3-b932-0f2160dc3539.json
+++ b/change/@fluentui-react-examples-dba766e8-3fa8-46e3-b932-0f2160dc3539.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot updates for removing close button tooltip",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -1075,7 +1075,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                             onKeyUp={[Function]}
                                             onMouseDown={[Function]}
                                             onMouseUp={[Function]}
-                                            title="Close"
                                             type="button"
                                           >
                                             <span

--- a/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -136,7 +136,6 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
       <IconButton
         className={classNames.closeButton}
         iconProps={{ iconName: 'Cancel' }}
-        title={closeButtonAriaLabel}
         ariaLabel={closeButtonAriaLabel}
         onClick={onDismiss}
       />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12383](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12383)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The close button doesn't require a tooltip, and having one causes a11y issues, particularly since it'll always be within another non-modal widget. This just removes the internally applied `title` attribute.

ETA: the other issue here was the title attribute always duplicated the accessible name/aria-label, which isn't great :P