### PR TITLE
Migrate react-input to new DX and create Input from template

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '<rootDir>/packages/react-portal',
     '<rootDir>/packages/react-aria',
     '<rootDir>/packages/react-image',
+    '<rootDir>/packages/react-input',
     '<rootDir>/packages/react-positioning',
     '<rootDir>/packages/react-popover',
     '<rootDir>/packages/react-link',

--- a/nx.json
+++ b/nx.json
@@ -99,7 +99,7 @@
     "@fluentui/react-icons-mdl2": { "implicitDependencies": [] },
     "@fluentui/react-icons-mdl2-branded": { "implicitDependencies": [] },
     "@fluentui/react-image": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
-    "@fluentui/react-input": { "implicitDependencies": [] },
+    "@fluentui/react-input": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
     "@fluentui/react-link": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
     "@fluentui/react-make-styles": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
     "@fluentui/react-menu": { "tags": ["vNext"], "implicitDependencies": [] },

--- a/packages/react-input/.storybook/main.js
+++ b/packages/react-input/.storybook/main.js
@@ -1,0 +1,11 @@
+const rootMain = require('../../../.storybook/main');
+
+module.exports = /** @type {Pick<import('../../../.storybook/main').StorybookConfig,'addons'|'stories'|'webpackFinal'>} */ ({
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  addons: [...rootMain.addons],
+  webpackFinal: (config, options) => {
+    const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+    return localConfig;
+  },
+});

--- a/packages/react-input/.storybook/preview.js
+++ b/packages/react-input/.storybook/preview.js
@@ -1,0 +1,3 @@
+import * as rootPreview from '../../../.storybook/preview';
+
+export const decorators = [...rootPreview.decorators];

--- a/packages/react-input/.storybook/tsconfig.json
+++ b/packages/react-input/.storybook/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  },
+  "exclude": ["../**/*.test.ts", "../**/*.test.js", "../**/*.test.tsx", "../**/*.test.jsx"],
+  "include": ["../src/**/*", "*.js"]
+}

--- a/packages/react-input/config/api-extractor.json
+++ b/packages/react-input/config/api-extractor.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.json"
 }

--- a/packages/react-input/config/api-extractor.local.json
+++ b/packages/react-input/config/api-extractor.local.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "./api-extractor.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/<unscopedPackageName>/src/index.d.ts"
+}

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -4,6 +4,40 @@
 
 ```ts
 
+import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentState } from '@fluentui/react-utilities';
+import * as React_2 from 'react';
+
+// @public
+export const Input: React_2.ForwardRefExoticComponent<InputProps & React_2.RefAttributes<HTMLElement>>;
+
+// @public
+export type InputDefaultedProps = never;
+
+// @public
+export interface InputProps extends ComponentProps, React_2.HTMLAttributes<HTMLElement> {
+}
+
+// @public
+export type InputShorthandProps = never;
+
+// @public
+export const inputShorthandProps: InputShorthandProps[];
+
+// @public
+export interface InputState extends ComponentState<InputProps, InputShorthandProps, InputDefaultedProps> {
+    ref: React_2.Ref<HTMLElement>;
+}
+
+// @public
+export const renderInput: (state: InputState) => JSX.Element;
+
+// @public
+export const useInput: (props: InputProps, ref: React_2.Ref<HTMLElement>, defaultProps?: InputProps | undefined) => InputState;
+
+// @public
+export const useInputStyles: (state: InputState) => InputState;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-input/jest.config.js
+++ b/packages/react-input/jest.config.js
@@ -1,9 +1,21 @@
-const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-const path = require('path');
+// @ts-check
 
-const config = createConfig({
-  setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
+/**
+ * @type {jest.InitialOptions}
+ */
+module.exports = {
+  displayName: 'react-input',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.json',
+      diagnostics: false,
+    },
+  },
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  coverageDirectory: './coverage',
+  setupFilesAfterEnv: ['./config/tests.js'],
   snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
-});
-
-module.exports = config;
+};

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -18,10 +18,11 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "start-test": "just-scripts jest-watch",
-    "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "start": "storybook",
+    "test": "jest",
+    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
+    "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-input/src && yarn docs",
+    "storybook": "start-storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.1",

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -18,7 +18,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "storybook",
+    "start": "yarn storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-input/src && yarn docs",

--- a/packages/react-input/src/Input.ts
+++ b/packages/react-input/src/Input.ts
@@ -1,0 +1,1 @@
+export * from './components/Input/index';

--- a/packages/react-input/src/common/isConformant.ts
+++ b/packages/react-input/src/common/isConformant.ts
@@ -1,0 +1,12 @@
+import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    asPropHandlesRef: true,
+    componentPath: module!.parent!.filename.replace('.test', ''),
+  };
+
+  baseIsConformant(defaultOptions, testInfo);
+}

--- a/packages/react-input/src/common/isConformant.ts
+++ b/packages/react-input/src/common/isConformant.ts
@@ -6,6 +6,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
+    disabledTests: ['has-docblock'],
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-input/src/components/Input/Input.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Input } from './Input';
+import { isConformant } from '../../common/isConformant';
+
+describe('Input', () => {
+  isConformant({
+    Component: Input,
+    displayName: 'Input',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<Input>Default Input</Input>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-input/src/components/Input/Input.tsx
+++ b/packages/react-input/src/components/Input/Input.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useInput } from './useInput';
+import { InputProps } from './Input.types';
+import { renderInput } from './renderInput';
+import { useInputStyles } from './useInputStyles';
+
+/**
+ * Input component
+ */
+export const Input = React.forwardRef<HTMLElement, InputProps>((props, ref) => {
+  const state = useInput(props, ref);
+
+  useInputStyles(state);
+  return renderInput(state);
+});
+
+Input.displayName = 'Input';

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+
+/**
+ * Input Props
+ */
+export interface InputProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+  /*
+   * TODO Add props and slots here
+   * Any slot property should be listed in the inputShorthandProps array below
+   * Any property that has a default value should be listed in InputDefaultedProps as e.g. 'size' | 'icon'
+   */
+}
+
+/**
+ * Names of the shorthand properties in InputProps
+ */
+export type InputShorthandProps = never; // TODO add shorthand property names
+
+/**
+ * Names of InputProps that have a default value in useInput
+ */
+export type InputDefaultedProps = never; // TODO add names of properties with default values
+
+/**
+ * State used in rendering Input
+ */
+export interface InputState extends ComponentState<InputProps, InputShorthandProps, InputDefaultedProps> {
+  /**
+   * Ref to the root element
+   */
+  ref: React.Ref<HTMLElement>;
+}

--- a/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input renders a default state 1`] = `
+<div>
+  <div
+    class=""
+  >
+    Default Input
+  </div>
+</div>
+`;

--- a/packages/react-input/src/components/Input/index.ts
+++ b/packages/react-input/src/components/Input/index.ts
@@ -1,0 +1,5 @@
+export * from './Input';
+export * from './Input.types';
+export * from './renderInput';
+export * from './useInput';
+export * from './useInputStyles';

--- a/packages/react-input/src/components/Input/renderInput.tsx
+++ b/packages/react-input/src/components/Input/renderInput.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import { InputState } from './Input.types';
+import { inputShorthandProps } from './useInput';
+
+/**
+ * Render the final JSX of Input
+ */
+export const renderInput = (state: InputState) => {
+  const { slots, slotProps } = getSlots(state, inputShorthandProps);
+
+  return (
+    <slots.root {...slotProps.root}>
+      {/* TODO Add additional slots in the appropriate place */}
+      {state.children}
+    </slots.root>
+  );
+};

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
+import { InputProps, InputShorthandProps, InputState } from './Input.types';
+
+/**
+ * Array of all shorthand properties listed in InputShorthandProps
+ */
+export const inputShorthandProps: InputShorthandProps[] = [
+  /* TODO add shorthand property names */
+];
+
+const mergeProps = makeMergeProps<InputState>({ deepMerge: inputShorthandProps });
+
+/**
+ * Create the state required to render Input.
+ *
+ * The returned state can be modified with hooks such as useInputStyles,
+ * before being passed to renderInput.
+ *
+ * @param props - props from this instance of Input
+ * @param ref - reference to root HTMLElement of Input
+ * @param defaultProps - (optional) default prop values provided by the implementing type
+ */
+export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>, defaultProps?: InputProps): InputState => {
+  const state = mergeProps(
+    {
+      ref,
+    },
+    defaultProps && resolveShorthandProps(defaultProps, inputShorthandProps),
+    resolveShorthandProps(props, inputShorthandProps),
+  );
+
+  return state;
+};

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -1,0 +1,26 @@
+import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { InputState } from './Input.types';
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: theme => ({
+    // TODO Add default styles for the root element
+  }),
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the Input slots based on the state
+ */
+export const useInputStyles = (state: InputState): InputState => {
+  const styles = useStyles();
+  state.className = mergeClasses(styles.root, state.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-input/src/index.ts
+++ b/packages/react-input/src/index.ts
@@ -1,2 +1,1 @@
-// TODO: replace with real exports
-export {};
+export * from './Input';

--- a/packages/react-input/tsconfig.json
+++ b/packages/react-input/tsconfig.json
@@ -1,22 +1,17 @@
 {
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
   "compilerOptions": {
-    "baseUrl": ".",
+    "target": "ES5",
+    "module": "CommonJS",
+    "lib": ["es5", "dom"],
     "outDir": "dist",
-    "target": "es5",
-    "module": "commonjs",
     "jsx": "react",
     "declaration": true,
-    "sourceMap": true,
+    "experimentalDecorators": true,
     "importHelpers": true,
     "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
-    "skipLibCheck": true,
-    "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
-  },
-  "include": ["src"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -33,6 +33,7 @@
       "@fluentui/react-aria": ["packages/react-aria/src/index.ts"],
       "@fluentui/react-link": ["packages/react-link/src/index.ts"],
       "@fluentui/react-image": ["packages/react-image/src/index.ts"],
+      "@fluentui/react-input": ["packages/react-input/src/index.ts"],
       "@fluentui/react-divider": ["packages/react-divider/src/index.ts"],
       "@fluentui/react-label": ["packages/react-label/src/index.ts"],
       "@fluentui/jest-serializer-make-styles": ["packages/jest-serializer-make-styles/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -139,7 +139,11 @@
       "projectType": "library",
       "sourceRoot": "packages/react-image/src"
     },
-    "@fluentui/react-input": { "root": "packages/react-input", "projectType": "library" },
+    "@fluentui/react-input": {
+      "root": "packages/react-input",
+      "projectType": "library",
+      "sourceRoot": "packages/react-input/src"
+    },
     "@fluentui/react-link": {
       "root": "packages/react-link",
       "projectType": "library",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #18579 and #18131

#### Description of changes

Migrate react-input build.

Create Input component from template (no modifications).

(Doing these things together for expediency because they're both templates/boilerplate, and I'm leaving on vacation next week and would like to get as much done on this as possible before then.)