### PR TITLE
Pass Icon 'title' as alt text for File Type Icons

### DIFF
--- a/change/@fluentui-react-7eb8bada-74c0-4dff-ae1d-95b5e4e1154d.json
+++ b/change/@fluentui-react-7eb8bada-74c0-4dff-ae1d-95b5e4e1154d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Pass Icon 'title' as alt text for File Type Icons",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-7461cda2-bfdb-439b-9e4b-d8cc535dc905.json
+++ b/change/@fluentui-react-file-type-icons-7461cda2-bfdb-439b-9e4b-d8cc535dc905.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Pass Icon 'title' as alt text for File Type Icons",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-0f42c617-f8f9-462c-9031-bffc959065e0.json
+++ b/change/@fluentui-style-utilities-0f42c617-f8f9-462c-9031-bffc959065e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Pass Icon 'title' as alt text for File Type Icons",
+  "packageName": "@fluentui/style-utilities",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -53,7 +53,7 @@ export interface IFileTypeIconOptions {
  * will return `{ iconName: 'docx16_2x_png' }` if the `devicePixelRatio` is 2.
  * @param options
  */
-export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string } {
+export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string; title?: string } {
   // First, obtain the base name of the icon using the extension or type.
   let iconBaseName: string;
   const { extension, type, size, imageFileType } = options;
@@ -64,7 +64,7 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
   let _size: FileTypeIconSize = size || DEFAULT_ICON_SIZE;
   let suffix: string = getFileTypeIconSuffix(_size, imageFileType);
 
-  return { iconName: iconBaseName + suffix };
+  return { iconName: iconBaseName + suffix, title: extension };
 }
 
 export function getFileTypeIconNameFromExtensionOrType(

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -53,7 +53,7 @@ export interface IFileTypeIconOptions {
  * will return `{ iconName: 'docx16_2x_png' }` if the `devicePixelRatio` is 2.
  * @param options
  */
-export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string; title?: string } {
+export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string; 'aria-label'?: string } {
   // First, obtain the base name of the icon using the extension or type.
   let iconBaseName: string;
   const { extension, type, size, imageFileType } = options;
@@ -64,7 +64,7 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
   let _size: FileTypeIconSize = size || DEFAULT_ICON_SIZE;
   let suffix: string = getFileTypeIconSuffix(_size, imageFileType);
 
-  return { iconName: iconBaseName + suffix, title: extension };
+  return { iconName: iconBaseName + suffix, 'aria-label': extension };
 }
 
 export function getFileTypeIconNameFromExtensionOrType(

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -30,20 +30,20 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
     // 1.5x is a special case where both SVGs and PNGs need a different image.
 
     fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_1.5x/' + type + '.png'} height="100%" width="100%" />
+      <img src={baseUrl + size + '_1.5x/' + type + '.png'} height="100%" width="100%" alt="" />
     );
     fileTypeIcons[type + size + '_1.5x' + SVG_SUFFIX] = (
-      <img src={baseUrl + size + '_1.5x/' + type + '.svg'} height="100%" width="100%" />
+      <img src={baseUrl + size + '_1.5x/' + type + '.svg'} height="100%" width="100%" alt="" />
     );
 
     fileTypeIcons[type + size + '_2x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_2x/' + type + '.png'} height="100%" width="100%" />
+      <img src={baseUrl + size + '_2x/' + type + '.png'} height="100%" width="100%" alt="" />
     );
     fileTypeIcons[type + size + '_3x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_3x/' + type + '.png'} height="100%" width="100%" />
+      <img src={baseUrl + size + '_3x/' + type + '.png'} height="100%" width="100%" alt="" />
     );
     fileTypeIcons[type + size + '_4x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_4x/' + type + '.png'} height="100%" width="100%" />
+      <img src={baseUrl + size + '_4x/' + type + '.png'} height="100%" width="100%" alt="" />
     );
   });
 
@@ -56,6 +56,7 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
         overflow: 'hidden',
       },
       icons: fileTypeIcons,
+      mergeImageProps: true,
     },
     options,
   );

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5345,11 +5345,13 @@ export interface IHSV {
 // @public (undocumented)
 export interface IIconContent {
     // (undocumented)
-    children?: string;
+    children?: string | JSX.Element;
     // (undocumented)
     fontFamily?: string;
     // (undocumented)
     iconClassName?: string;
+    // (undocumented)
+    mergeImageProps?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/Icon/FontIcon.tsx
+++ b/packages/react/src/components/Icon/FontIcon.tsx
@@ -45,6 +45,7 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
   const { iconClassName, children, fontFamily, mergeImageProps } = iconContent;
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLElement>>(props, htmlElementProperties);
+  const accessibleName = props['aria-label'] || props.title;
   const containerProps =
     props['aria-label'] || props['aria-labelledby'] || props.title
       ? {
@@ -57,8 +58,8 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
   let finalChildren = children;
 
   if (mergeImageProps) {
-    if (typeof children === 'object' && typeof children.props === 'object' && props.title) {
-      finalChildren = React.cloneElement(children, { alt: props.title });
+    if (typeof children === 'object' && typeof children.props === 'object' && accessibleName) {
+      finalChildren = React.cloneElement(children, { alt: accessibleName });
     }
   }
 
@@ -70,6 +71,7 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
       {...(mergeImageProps
         ? {
             title: undefined,
+            'aria-label': undefined,
           }
         : {})}
       className={css(MS_ICON, classNames.root, iconClassName, !iconName && classNames.placeholder, className)}

--- a/packages/react/src/components/Icon/FontIcon.tsx
+++ b/packages/react/src/components/Icon/FontIcon.tsx
@@ -57,7 +57,7 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
   let finalChildren = children;
 
   if (mergeImageProps) {
-    if (typeof children === 'object' && typeof children.props === 'object') {
+    if (typeof children === 'object' && typeof children.props === 'object' && props.title) {
       finalChildren = React.cloneElement(children, { alt: props.title });
     }
   }

--- a/packages/react/src/components/Icon/FontIcon.tsx
+++ b/packages/react/src/components/Icon/FontIcon.tsx
@@ -6,9 +6,10 @@ import { css, getNativeProps, htmlElementProperties, memoizeFunction } from '../
 import { getIcon, IIconRecord, IIconSubsetRecord } from '../../Styling';
 
 export interface IIconContent {
-  children?: string;
+  children?: string | JSX.Element;
   iconClassName?: string;
   fontFamily?: string;
+  mergeImageProps?: boolean;
 }
 
 export const getIconContent = memoizeFunction(
@@ -26,6 +27,7 @@ export const getIconContent = memoizeFunction(
       children: code,
       iconClassName: subset.className,
       fontFamily: subset.fontFace && subset.fontFace.fontFamily,
+      mergeImageProps: subset.mergeImageProps,
     };
   },
   undefined,
@@ -40,29 +42,42 @@ export const getIconContent = memoizeFunction(
 export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
   const { iconName, className, style = {} } = props;
   const iconContent = getIconContent(iconName) || {};
-  const { iconClassName, children, fontFamily } = iconContent;
+  const { iconClassName, children, fontFamily, mergeImageProps } = iconContent;
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLElement>>(props, htmlElementProperties);
   const containerProps =
     props['aria-label'] || props['aria-labelledby'] || props.title
       ? {
-          role: 'img',
+          role: mergeImageProps ? undefined : 'img',
         }
       : {
           'aria-hidden': true,
         };
+
+  let finalChildren = children;
+
+  if (mergeImageProps) {
+    if (typeof children === 'object' && typeof children.props === 'object') {
+      finalChildren = React.cloneElement(children, { alt: props.title });
+    }
+  }
 
   return (
     <i
       data-icon-name={iconName}
       {...containerProps}
       {...nativeProps}
+      {...(mergeImageProps
+        ? {
+            title: undefined,
+          }
+        : {})}
       className={css(MS_ICON, classNames.root, iconClassName, !iconName && classNames.placeholder, className)}
       // Apply the font family this way to ensure it doesn't get overridden by Fabric Core ms-Icon styles
       // https://github.com/microsoft/fluentui/issues/10449
       style={{ fontFamily, ...style }}
     >
-      {children}
+      {finalChildren}
     </i>
   );
 };

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -32,7 +32,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
       // eslint-disable-next-line deprecation/deprecation
       !!this.props.imageProps || this.props.iconType === IconType.image || this.props.iconType === IconType.Image;
     const iconContent = getIconContent(iconName) || {};
-    const { iconClassName, children: iconContentChildren } = iconContent;
+    const { iconClassName, children: iconContentChildren, mergeImageProps } = iconContent;
 
     const classNames = getClassNames(styles, {
       theme: theme!,
@@ -55,7 +55,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
 
     // eslint-disable-next-line deprecation/deprecation
     const ariaLabel = this.props['aria-label'] || this.props.ariaLabel;
-    const accessibleName = imageProps.alt || ariaLabel;
+    const accessibleName = imageProps.alt || ariaLabel || this.props.title;
     const hasName = !!(
       accessibleName ||
       this.props['aria-labelledby'] ||
@@ -64,16 +64,34 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
     );
     const containerProps = hasName
       ? {
-          role: isImage ? undefined : 'img',
-          'aria-label': isImage ? undefined : accessibleName,
+          role: isImage || mergeImageProps ? undefined : 'img',
+          'aria-label': isImage || mergeImageProps ? undefined : accessibleName,
         }
       : {
           'aria-hidden': true,
         };
 
+    let finalIconContentChildren = iconContentChildren;
+
+    if (mergeImageProps && finalIconContentChildren && typeof finalIconContentChildren === 'object') {
+      finalIconContentChildren = React.cloneElement(iconContentChildren, {
+        alt: this.props.title,
+      });
+    }
+
     return (
-      <RootType data-icon-name={iconName} {...containerProps} {...nativeProps} className={classNames.root}>
-        {isImage ? <ImageType {...imageProps} /> : children || iconContentChildren}
+      <RootType
+        data-icon-name={iconName}
+        {...containerProps}
+        {...nativeProps}
+        {...(mergeImageProps
+          ? {
+              title: undefined,
+            }
+          : {})}
+        className={classNames.root}
+      >
+        {isImage ? <ImageType {...imageProps} /> : children || finalIconContentChildren}
       </RootType>
     );
   }

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -73,7 +73,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
 
     let finalIconContentChildren = iconContentChildren;
 
-    if (mergeImageProps && iconContentChildren && typeof iconContentChildren === 'object') {
+    if (mergeImageProps && iconContentChildren && typeof iconContentChildren === 'object' && this.props.title) {
       finalIconContentChildren = React.cloneElement(iconContentChildren, {
         alt: this.props.title,
       });

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -73,9 +73,9 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
 
     let finalIconContentChildren = iconContentChildren;
 
-    if (mergeImageProps && iconContentChildren && typeof iconContentChildren === 'object' && this.props.title) {
+    if (mergeImageProps && iconContentChildren && typeof iconContentChildren === 'object' && accessibleName) {
       finalIconContentChildren = React.cloneElement(iconContentChildren, {
-        alt: this.props.title,
+        alt: accessibleName,
       });
     }
 
@@ -87,6 +87,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
         {...(mergeImageProps
           ? {
               title: undefined,
+              'aria-label': undefined,
             }
           : {})}
         className={classNames.root}

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -73,7 +73,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
 
     let finalIconContentChildren = iconContentChildren;
 
-    if (mergeImageProps && finalIconContentChildren && typeof finalIconContentChildren === 'object') {
+    if (mergeImageProps && iconContentChildren && typeof iconContentChildren === 'object') {
       finalIconContentChildren = React.cloneElement(iconContentChildren, {
         alt: this.props.title,
       });

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -206,6 +206,7 @@ export interface IIconSubset {
     icons: {
         [key: string]: string | JSX.Element;
     };
+    mergeImageProps?: boolean;
     // (undocumented)
     style?: IRawStyle;
 }

--- a/packages/style-utilities/src/utilities/icons.ts
+++ b/packages/style-utilities/src/utilities/icons.ts
@@ -9,8 +9,8 @@ export interface IIconSubset {
 
   style?: IRawStyle;
   /**
-   * Whether or not to merge any props required for images into the child elements for
-   * accessibiity comlpliance.
+   * Indicates to the icon renderer that it is safe to merge any props on the original `Icon` element
+   * onto the child content element registered for the icon which are valid for HTML images.
    */
   mergeImageProps?: boolean;
 }

--- a/packages/style-utilities/src/utilities/icons.ts
+++ b/packages/style-utilities/src/utilities/icons.ts
@@ -8,6 +8,11 @@ export interface IIconSubset {
   };
 
   style?: IRawStyle;
+  /**
+   * Whether or not to merge any props required for images into the child elements for
+   * accessibiity comlpliance.
+   */
+  mergeImageProps?: boolean;
 }
 
 export interface IIconSubsetRecord extends IIconSubset {


### PR DESCRIPTION
#### Description of changes

Fixed an accessibility issue in which the `alt` text on the `img` elements emitted for File Type Icons are not properly set, and in which a provided `title` applied to the icon is set as the `aria-label` on the `i` wrapper element instead of propagated onto the `img`. Now, setting a `title` on the `Icon` propagates the value as `alt` on the `img`, if the registered icon allows it for the content.

Updated `IIconSubset` to support `JSX.Element` officially in the type of the content (this is being used, just not declared as such), and added a `mergeImageProps` option which the `initializeFileTypeIcon` flow uses to signal that it is safe to push some props from the 'container' onto the `img` element itself.

Since the `initializeFileTypeIcons` function emits `JSX.Element` values directly, it is proper to use `React.clontElement` to graft custom props onto the result.

Updated `initializeFileTypeIcons` to emit the input value of `extension` as `title` since extensions are locale-invariant and it's a good way to ensure `alt` text is populated for existing apps making use of this feature which don't supply `aria-label` themselves.

#### Focus areas to test

Validate no regression in the File Type Icons demo and that only `alt` is assigned when there is a default `title`.
Validate that usage of `Icon` and `FontIcon` do not regress their accessible status.
