### PR TITLE
Fix callout position bug when target element has changed

### DIFF
--- a/change/office-ui-fabric-react-47a3684d-ab59-433a-91c8-7646906dac7c.json
+++ b/change/office-ui-fabric-react-47a3684d-ab59-433a-91c8-7646906dac7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reset position of CalloutContent control if the target prop has changed.",
+  "packageName": "office-ui-fabric-react",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -600,7 +600,9 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   // Whether or not the current positions should be reset
   private _didPositionPropsChange(newProps: ICalloutProps, oldProps: ICalloutProps): boolean {
     return (
-      (!newProps.hidden && newProps.hidden !== oldProps.hidden) || newProps.directionalHint !== oldProps.directionalHint
+      (!newProps.hidden && newProps.hidden !== oldProps.hidden) ||
+      newProps.directionalHint !== oldProps.directionalHint ||
+      newProps.target !== oldProps.target
     );
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In the OOUI repository, they write their own `AppTooltip` control. One `AppTooltip` instance can be reused on multiple target elements. 

There's a bug whereby if 2 target elements share the same `AppTooltip` instance, `CalloutContent`, which is the underlying component for Tooltip, tries to reuse the edge alignment value from the previous target, and thus ignoring the `directionalHint` value of the current target.

The fix is to reset the `position` value if the `target` element has changed.

#### Focus areas to test

Tooltips