### PR TITLE
fix(babel-make-styles): update regex for rules

### DIFF
--- a/change/@fluentui-babel-make-styles-7135d933-ff17-4a52-82b3-c445affe6aff.json
+++ b/change/@fluentui-babel-make-styles-7135d933-ff17-4a52-82b3-c445affe6aff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update regex for rules",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -16,9 +16,11 @@ function evaluate(code: string, filename: string, babelOptions: TransformOptions
     evaluate: true,
 
     rules: [
+      /* TODO: rules should be configurable */
+
       { action: shakerEvaluator },
       {
-        test: /\/node_modules\//,
+        test: /[/\\]node_modules[/\\]/,
         action: 'ignore',
       },
     ],


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18801
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In #18801 we noticed inconsistent behavior of `@linaria/shaker`: after debugging the issue I realized that it is executed for different files based on OS.

`matchedRules` in `module.ts` were different:
https://github.com/callstack/linaria/blob/e92bcd93ed51b847cab0c9e3fa7c578328c1ddaf/packages/babel/src/module.ts#L296-L317

##### Ubuntu

```
office-ui-fabric-react/node_modules/inline-style-expand-shorthand/lib/expandProperty.js
matchedRules [
  { test: /node_modules/, action: 'ignore' },
  { action: [Function: shaker] }
]
office-ui-fabric-react/node_modules/inline-style-expand-shorthand/lib/expandWithMerge.js
matchedRules [
  { test: /node_modules/, action: 'ignore' },
  { action: [Function: shaker] }
]
```

##### Windows

```
office-ui-fabric-react\node_modules\inline-style-expand-shorthand\lib\expandProperty.js
matchedRules [
  { action: [Function: shaker] }
]
office-ui-fabric-react\node_modules\inline-style-expand-shorthand\lib\expandWithMerge.js
matchedRules [
  { action: [Function: shaker] }
]
```

This happened because regex that we were using did not take into account slashes difference:

https://github.com/microsoft/fluentui/blob/6c37a1cb5c312d4be8b239bfd9f6c9f28e9f0d24/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts#L20-L23

In Linaria's code a proper regex is used: https://github.com/callstack/linaria/blob/e92bcd93ed51b847cab0c9e3fa7c578328c1ddaf/packages/babel/src/utils/loadOptions.ts#L31