### PR TITLE
Added Focus Props as optional prop to Pivot component

### DIFF
--- a/change/office-ui-fabric-react-0e75c7a7-9e98-4737-9dff-63fdb728f8c9.json
+++ b/change/office-ui-fabric-react-0e75c7a7-9e98-4737-9dff-63fdb728f8c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added focusZoneProps to the Pivot component to have ability be more customized",
+  "packageName": "office-ui-fabric-react",
+  "email": "nikolenkoanton92@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6676,6 +6676,7 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
     // @deprecated
     defaultSelectedIndex?: number;
     defaultSelectedKey?: string;
+    focusZoneProps?: IFocusZoneProps;
     getTabId?: (itemKey: string, index: number) => string;
     headersOnly?: boolean;
     // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -13,12 +13,11 @@ import {
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
-import { FocusZone, IFocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
 import { PivotItem } from './PivotItem';
 import { PivotLinkFormat } from './Pivot.types';
 import { PivotLinkSize } from './Pivot.types';
 import { Icon } from '../../Icon';
-import { IFocusZoneProps } from '@fluentui/react-focus';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
 const PivotName = 'Pivot';

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -8,15 +8,17 @@ import {
   classNamesFunction,
   warn,
   initializeComponentRef,
+  css,
 } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
-import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusZone, IFocusZone, FocusZoneDirection } from '../../FocusZone';
 import { PivotItem } from './PivotItem';
 import { PivotLinkFormat } from './Pivot.types';
 import { PivotLinkSize } from './Pivot.types';
 import { Icon } from '../../Icon';
+import { IFocusZoneProps } from '@fluentui/react-focus';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
 const PivotName = 'Pivot';
@@ -94,6 +96,7 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   }
 
   public render(): JSX.Element {
+    const { focusZoneProps } = this.props;
     const linkCollection = this._getPivotLinks(this.props);
     const selectedKey = this._getSelectedKey(linkCollection);
 
@@ -103,10 +106,10 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
 
     return (
       <div role="toolbar" {...divProps}>
-        {this._renderPivotLinks(linkCollection, selectedKey)}
+        {this._renderPivotLinks(linkCollection, selectedKey, focusZoneProps)}
         {selectedKey &&
           linkCollection.links.map(
-            link =>
+            (link) =>
               (link.alwaysRender === true || selectedKey === link.itemKey) &&
               this._renderPivotItem(linkCollection, link.itemKey, selectedKey === link.itemKey),
           )}
@@ -136,15 +139,20 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   /**
    * Renders the set of links to route between pivots
    */
-  private _renderPivotLinks(linkCollection: PivotLinkCollection, selectedKey: string | null | undefined): JSX.Element {
-    const items = linkCollection.links.map(l => this._renderPivotLink(linkCollection, l, selectedKey));
+  private _renderPivotLinks(
+    linkCollection: PivotLinkCollection,
+    selectedKey: string | null | undefined,
+    focusZoneProps: IFocusZoneProps | undefined,
+  ): JSX.Element {
+    const items = linkCollection.links.map((l) => this._renderPivotLink(linkCollection, l, selectedKey));
 
     return (
       <FocusZone
-        className={this._classNames.root}
         role="tablist"
         componentRef={this._focusZone}
         direction={FocusZoneDirection.horizontal}
+        {...focusZoneProps}
+        className={css(this._classNames.root, focusZoneProps?.className)}
       >
         {items}
       </FocusZone>

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -3,6 +3,7 @@ import { PivotBase } from './Pivot.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { PivotItem } from './PivotItem';
+import { IFocusZoneProps } from '../../FocusZone';
 
 /**
  * {@docCategory Pivot}
@@ -108,6 +109,11 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
+
+  /**
+   * Props passed to the `FocusZone` component used as the root of `Pivot`.
+   */
+  focusZoneProps?: IFocusZoneProps;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Similar [PR#18430](https://github.com/microsoft/fluentui/pull/18430) was already merged to the latest fluentui, this PR should go to v7 version

As part of our internal component we are using vertical tabs. This additional prop should help us customize the direction of the focus to address some of the accessibility issue.
It also can be good starting point to address this(https://github.com/microsoft/fluentui/issues/3593) request in the future.

#### Focus areas to test

(optional)
