### PR TITLE
Porting ComboBox aria-labelledby fix to (V7)

### DIFF
--- a/change/office-ui-fabric-react-662b1ad2-53b0-4e9a-a325-0e76c0f18677.json
+++ b/change/office-ui-fabric-react-662b1ad2-53b0-4e9a-a325-0e76c0f18677.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing a bug within the V7 ComboBox which caused aria-labeledby to be added to list even when label was absent.",
+  "packageName": "office-ui-fabric-react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 import * as renderer from 'react-test-renderer';
-import { KeyCodes } from '../../Utilities';
+import { KeyCodes, resetIds } from '../../Utilities';
 
 import { ComboBox, IComboBoxState } from './ComboBox';
 import { IComboBox, IComboBoxOption, IComboBoxProps } from './ComboBox.types';
@@ -63,6 +63,10 @@ describe('ComboBox', () => {
       }
       domNode = undefined;
     }
+  });
+
+  beforeEach(() => {
+    resetIds();
   });
 
   it('Renders correctly', () => {
@@ -812,7 +816,7 @@ describe('ComboBox', () => {
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={'customAriaLabel'} />);
     const inputElement = wrapper.find('input').getDOMNode();
 
-    expect(inputElement.getAttribute('aria-labelledby')).toBe('ComboBox358-label');
+    expect(inputElement.getAttribute('aria-labelledby')).toBe('ComboBox0-label');
   });
 
   it('does not add aria-required to the DOM when the required prop is not set', () => {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -801,6 +801,20 @@ describe('ComboBox', () => {
     expect(ariaRequiredAttribute).toEqual('true');
   });
 
+  it('correctly handles (aria-labelledby) when no label prop is provided', () => {
+    wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} aria-labelledby={'customAriaLabel'} />);
+    const inputElement = wrapper.find('input').getDOMNode();
+
+    expect(inputElement.getAttribute('aria-labelledby')).toBeNull();
+  });
+
+  it('correctly handles (aria-labelledby) when label prop is provided', () => {
+    wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={'customAriaLabel'} />);
+    const inputElement = wrapper.find('input').getDOMNode();
+
+    expect(inputElement.getAttribute('aria-labelledby')).toBe('ComboBox358-label');
+  });
+
   it('does not add aria-required to the DOM when the required prop is not set', () => {
     const comboBoxRef = React.createRef<any>();
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} componentRef={comboBoxRef} />);

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1322,14 +1322,14 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
 
   // Render List of items
   private _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem, options } = props;
+    const { onRenderItem, options, label } = props;
 
     const id = this._id;
     return (
       <div
         id={id + '-list'}
         className={this._classNames.optionsContainer}
-        aria-labelledby={id + '-label'}
+        aria-labelledby={label && id + '-label'}
         role="listbox"
       >
         {options.map(item => (onRenderItem as any)(item, this._onRenderItem))}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -512,7 +512,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           top: 0px;
         }
     data-ktp-target="ktp-a"
-    id="ComboBox4wrapper"
+    id="ComboBox0wrapper"
   >
     <input
       aria-autocomplete="both"
@@ -567,7 +567,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
       data-is-interactable={true}
       data-ktp-execute-target="ktp-a"
       data-lpignore={true}
-      id="ComboBox4-input"
+      id="ComboBox0-input"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -741,7 +741,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
     aria-atomic="true"
     aria-live="polite"
     className=""
-    id="ComboBox4-error"
+    id="ComboBox0-error"
     role="region"
   >
     


### PR DESCRIPTION
#### Pull request checklist
- [X] Addresses an existing issue: Fixes https://github.com/microsoft/fluentui/issues/13525
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Porting (https://github.com/microsoft/fluentui/pull/18734) fix to V7 **ComboBox**. This PR resolves a bug within the ComboBox component. When creating a ComboBox, aria-labelledby was added to the list container even when label was not present. This fix:

1. Ports the application of the aria-labelledby prop from (the Autofill within ComboBox's render ) to _onRenderList.
2. Adds two tests to check if aria-labelledby is being applied correctly.
