### PR TITLE
Fix scroll to view handling for picker suggestions

### DIFF
--- a/change/@fluentui-react-0a0866a7-027c-4bcc-9bf0-c250338f2592.json
+++ b/change/@fluentui-react-0a0866a7-027c-4bcc-9bf0-c250338f2592.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update picker suggestions scroll into view so it works with inline suggestions",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-f266c949-1ec9-4b12-aee8-d437ba6330f8.json
+++ b/change/@fluentui-react-examples-f266c949-1ec9-4b12-aee8-d437ba6330f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adds new example of a TagPicker with an inline suggestions dropdown",
+  "packageName": "@fluentui/react-examples",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Pickers/TagPicker.Inline.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Inline.Example.tsx
@@ -71,7 +71,7 @@ export const TagPickerInlineExample: React.FunctionComponent = () => {
         // since this example is an inline picker, it needs some forced space below
         // so when embedded in the docssite, the dropdown shows up
         style={{ height: '10em' }}
-      ></div>
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Pickers/TagPicker.Inline.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Inline.Example.tsx
@@ -67,6 +67,11 @@ export const TagPickerInlineExample: React.FunctionComponent = () => {
           id: pickerId,
         }}
       />
+      <div
+        // since this example is an inline picker, it needs some forced space below
+        // so when embedded in the docssite, the dropdown shows up
+        style={{ height: '10em' }}
+      ></div>
     </div>
   );
 };

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
@@ -109,5 +109,12 @@ exports[`Component Examples renders TagPicker.Inline.Example.tsx correctly 1`] =
       </div>
     </div>
   </div>
+  <div
+    style={
+      Object {
+        "height": "10em",
+      }
+    }
+  />
 </div>
 `;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9608,6 +9608,8 @@ export class Suggestions<T> extends React_2.Component<ISuggestionsProps<T>, ISug
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
+    protected _scrollContainer: React_2.RefObject<HTMLDivElement>;
+    // (undocumented)
     scrollSelected(): void;
     // (undocumented)
     protected _searchForMoreButton: React_2.RefObject<IButton>;

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -45,6 +45,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
   protected _forceResolveButton = React.createRef<IButton>();
   protected _searchForMoreButton = React.createRef<IButton>();
   protected _selectedElement = React.createRef<HTMLDivElement>();
+  protected _scrollContainer = React.createRef<HTMLDivElement>();
   private activeSelectedElement: HTMLDivElement | null;
   private _classNames: Partial<IProcessedStyleSet<ISuggestionsStyles>>;
 
@@ -324,10 +325,23 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     }
   }
 
-  // TODO get the element to scroll into view properly regardless of direction.
   public scrollSelected(): void {
-    if (this._selectedElement.current && this._selectedElement.current.scrollIntoView !== undefined) {
-      this._selectedElement.current.scrollIntoView(false);
+    if (
+      this._selectedElement.current &&
+      this._scrollContainer.current &&
+      this._scrollContainer.current.scrollTo !== undefined
+    ) {
+      const { offsetHeight, offsetTop } = this._selectedElement.current;
+      const { offsetHeight: parentOffsetHeight, scrollTop } = this._scrollContainer.current;
+
+      const isAbove = offsetTop < scrollTop;
+      const isBelow = offsetTop + offsetHeight > scrollTop + parentOffsetHeight;
+
+      if (isAbove) {
+        this._scrollContainer.current.scrollTo(0, offsetTop);
+      } else if (isBelow) {
+        this._scrollContainer.current.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight);
+      }
     }
   }
 
@@ -392,6 +406,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       <div
         className={this._classNames.suggestionsContainer}
         id={suggestionsListId}
+        ref={this._scrollContainer}
         role="listbox"
         aria-label={suggestionsContainerAriaLabel || headerText}
       >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously pickers' Suggestions.tsx component had scroll into view that would call `element.scrollIntoView()` when the active item changed. This only worked in the past because the suggestions were in a callout with a fixed position, and it wouldn't scroll. When the callout is inline, that behavior combined with the callout's own dismiss-on-scroll functionality means that it was impossible to navigate the suggestions without auto-selecting the first one.

The new scroll-into-view functionality explicitly checks whether the suggestion item is out of the parent's scroll area, and scrolls the parent listbox if it is. The page as a whole should now never be scrolled, so arrowing through items should never auto-select 😅.