### PR TITLE
removes duplicate styles for expand-collapse-glyph on tree item causing specificity and ordering issues

### DIFF
--- a/change/@fluentui-web-components-6f977179-43de-4a13-82d5-d68f7fee4453.json
+++ b/change/@fluentui-web-components-6f977179-43de-4a13-82d5-d68f7fee4453.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "removes duplicate styles for expand-collapse-glyph on tree item causing specificity/ordering issues",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/src/tree-item/tree-item.styles.ts
@@ -174,10 +174,10 @@ export const treeItemStyles: (context: ElementDefinitionContext, definition: Tre
       width: 16px;
       height: 16px;
       transition: transform 0.1s linear;
-      transform: rotate(-45deg);
       pointer-events: none;
       fill: ${neutralForegroundRest};
     }
+
     .start,
     .end {
       display: flex;
@@ -200,10 +200,6 @@ export const treeItemStyles: (context: ElementDefinitionContext, definition: Tre
       ${
         /* need to swap out once we understand how horizontalSpacing will work */ ''
       } margin-inline-start: calc(${designUnit} * 2px + 2px);
-    }
-
-    :host(.expanded) > .positioning-region .expand-collapse-glyph {
-      ${/* transform needs to be localized */ ''} transform: rotate(0deg);
     }
 
     :host(.expanded) > .items {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Duplicative styles were causing specificity and ordering issues likely creating differences in how styles were being added to the browser in Safari and Firefox. This resulted in the tree item glyph being incorrectly rotated. This was likely the issue causing #18370.

Closes #18370

![image](https://user-images.githubusercontent.com/13071055/124341944-023ada00-db75-11eb-9bb2-3fcf87484244.png)

#### Focus areas to test

(optional)
