### PR TITLE
Set ChatMessage timestamp to inline-block

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Carousel` animation in controlled mode @assuncaocharles ([#18798](https://github.com/microsoft/fluentui/pull/18798))
-
+- Wrap ChatMessage header elements correctly @Hirse ([#18837](https://github.com/microsoft/fluentui/pull/18837))
 
 <!--------------------------------[ v0.57.0 ]------------------------------- -->
 ## [v0.57.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.57.0) (2021-06-29)

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -98,6 +98,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
     const { props: p, variables: v } = componentStyleFunctionParam;
     return {
       color: v.timestampColor,
+      display: 'inline-block',
       ...getChatMessageDensityStyles(p.density).timestamp?.(componentStyleFunctionParam),
     };
   },


### PR DESCRIPTION
Set ChatMessage timestamp to display as `inline-block` so the ChatMessage header can wrap between elements.

*Before*:
Author wraps even though there is space for the full name
![Author wraps](https://user-images.githubusercontent.com/2564094/124679466-4c73d200-de79-11eb-828e-fae12f0600aa.png)

*After*:
Author stays in one line and header elements wrap between elements
![Author stays in one line](https://user-images.githubusercontent.com/2564094/124679534-75946280-de79-11eb-8ed4-2a3615808caa.png)
