### PR TITLE
fix(Datepicker): aria-popup on the wrong element

### DIFF
--- a/change/@fluentui-react-8bd054ef-8fac-4642-a332-1a58f592952a.json
+++ b/change/@fluentui-react-8bd054ef-8fac-4642-a332-1a58f592952a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Datepicker: move aria-haspopup to the correct element",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -431,17 +431,13 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
 
   return (
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>
-      <div
-        ref={datePickerDiv}
-        aria-haspopup="true"
-        aria-owns={isCalendarShown ? calloutId : undefined}
-        className={classNames.wrapper}
-      >
+      <div ref={datePickerDiv} aria-owns={isCalendarShown ? calloutId : undefined} className={classNames.wrapper}>
         <TextField
           role="combobox"
           label={label}
           aria-expanded={isCalendarShown}
           ariaLabel={ariaLabel}
+          aria-haspopup="dialog"
           aria-controls={isCalendarShown ? calloutId : undefined}
           required={isRequired}
           disabled={disabled}

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -22,9 +22,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
         padding-top: 0px;
       }
 >
-  <div
-    aria-haspopup="true"
-  >
+  <div>
     <div
       className=
           ms-TextField
@@ -92,6 +90,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           <input
             aria-describedby="TextFieldDescription3"
             aria-expanded={false}
+            aria-haspopup="dialog"
             aria-invalid={false}
             className=
                 ms-TextField-field


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

For some reason, `aria-haspopup` was added to a random `<div>` instead of the element with `role="combobox"`. This PR updates only that attribute location + using the specific token value for datepicker instead of `true`.
