### PR TITLE
Align ChatMessageDetails color with header

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Fix `Carousel` animation in controlled mode @assuncaocharles ([#18798](https://github.com/microsoft/fluentui/pull/18798))
 - Wrap ChatMessage header elements correctly @Hirse ([#18837](https://github.com/microsoft/fluentui/pull/18837))
+- Align ChatMessageDetails color with ChatMessage header @Hirse ([#18840](https://github.com/microsoft/fluentui/pull/18840))
 - Fix compact hover background in dark themes @Hirse ([#18842](https://github.com/microsoft/fluentui/pull/18842))
 
 

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
@@ -1,3 +1,4 @@
 export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
+export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
 export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageDetailsVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageDetailsVariables.ts
@@ -1,0 +1,5 @@
+import { ChatMessageDetailsVariables } from '../../../teams/components/Chat/chatMessageDetailsVariables';
+
+export const chatMessageDetailsVariables = (siteVars): Partial<ChatMessageDetailsVariables> => ({
+  detailsColor: siteVars.colorScheme.default.foreground2,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
@@ -1,2 +1,3 @@
 export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
+export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageDetailsVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageDetailsVariables.ts
@@ -1,0 +1,5 @@
+import { ChatMessageDetailsVariables } from '../../../teams/components/Chat/chatMessageDetailsVariables';
+
+export const chatMessageDetailsVariables = (siteVars): Partial<ChatMessageDetailsVariables> => ({
+  detailsColor: siteVars.colorScheme.default.foreground2,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageDetailsStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageDetailsStyles.ts
@@ -8,25 +8,15 @@ export const chatMessageDetailsStyles: ComponentSlotStylesPrepared<
   ChatMessageDetailsVariables
 > = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    fontSize: v.detailsFontSize,
+    color: v.detailsColor,
     display: 'inline-block',
+    fontSize: v.detailsFontSize,
     ...(p.density === 'comfy' && {
-      color: v.detailsColor,
-      ':hover': {
-        color: v.detailsHoverColor,
-      },
-      ...(p.mine && {
-        color: v.detailsColorMine,
-        ':hover': {
-          color: v.detailsHoverColorMine,
-        },
-      }),
       ...((p.attached === 'top' || !p.attached) && {
         marginLeft: v.detailsMargin,
       }),
     }),
     ...(p.density === 'compact' && {
-      color: v.detailsColorCompact,
       alignSelf: 'flex-start',
       flexShrink: 0,
       marginLeft: v.detailsMargin,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageDetailsVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageDetailsVariables.ts
@@ -2,20 +2,12 @@ import { pxToRem } from '../../../../utils';
 
 export interface ChatMessageDetailsVariables {
   detailsColor: string;
-  detailsHoverColor: string;
-  detailsColorCompact: string;
-  detailsColorMine: string;
-  detailsHoverColorMine: string;
   detailsFontSize: string;
   detailsMargin: string;
 }
 
 export const chatMessageDetailsVariables = (siteVars): ChatMessageDetailsVariables => ({
-  detailsColor: siteVars.colors.grey[350],
-  detailsHoverColor: siteVars.colors.grey[500],
-  detailsColorCompact: siteVars.colorScheme.default.foreground2,
-  detailsColorMine: siteVars.colors.grey[500],
-  detailsHoverColorMine: siteVars.colors.grey[500],
+  detailsColor: siteVars.colorScheme.default.foreground1,
   detailsFontSize: siteVars.fontSizes.small,
   detailsMargin: pxToRem(12),
 });


### PR DESCRIPTION
Fixes the mismatch of colors between the details and other header elements thereby also resolving contrast issues for dark theme.

Note, timestamp colors for dark theme is adjusted in #18841.

*Before:*
![ChatMessageDetails Default](https://user-images.githubusercontent.com/2564094/124805076-df5f4b80-df0f-11eb-828a-98430a768792.png)
![ChatMessageDetails Dark](https://user-images.githubusercontent.com/2564094/124805078-dff7e200-df0f-11eb-8267-2048d59677f1.png)
![ChatMessageDetails Contrast](https://user-images.githubusercontent.com/2564094/124805080-dff7e200-df0f-11eb-99ee-58aa2d78b40c.png)
![ChatMessageDetails DefaultV2](https://user-images.githubusercontent.com/2564094/124805082-e0907880-df0f-11eb-9198-7712081d5919.png)
![ChatMessageDetails DarkV2](https://user-images.githubusercontent.com/2564094/124805083-e0907880-df0f-11eb-9708-fabe56b8db30.png)


*After:*
![After ChatMessageDetails Default](https://user-images.githubusercontent.com/2564094/124805629-a1165c00-df10-11eb-9842-fe52fb833caf.png)
![After ChatMessageDetails Dark](https://user-images.githubusercontent.com/2564094/124805632-a1165c00-df10-11eb-8b98-23b34211120d.png)
![After ChatMessageDetails Contrast](https://user-images.githubusercontent.com/2564094/124805636-a1aef280-df10-11eb-9c0a-860093ba772c.png)
![After ChatMessageDetails DefaultV2](https://user-images.githubusercontent.com/2564094/124805638-a1aef280-df10-11eb-8638-4e71ff6a1e68.png)
![After ChatMessageDetails DarkV2](https://user-images.githubusercontent.com/2564094/124805642-a2478900-df10-11eb-94f7-c409f4e1ff2b.png)



Also removes the hover effect to keep it simple since that doesn't seem to be used in Teams anyway.
@assuncaocharles Do you have more information on why that hover was added originally?