### PR TITLE
Fix Timestamp colors for dark and both v2 themes

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Carousel` animation in controlled mode @assuncaocharles ([#18798](https://github.com/microsoft/fluentui/pull/18798))
 - Wrap ChatMessage header elements correctly @Hirse ([#18837](https://github.com/microsoft/fluentui/pull/18837))
 - Align ChatMessageDetails color with ChatMessage header @Hirse ([#18840](https://github.com/microsoft/fluentui/pull/18840))
+- Fix Timestamp colors for dark and both v2 themes @Hirse ([#18841](https://github.com/microsoft/fluentui/pull/18841))
 - Fix compact hover background in dark themes @Hirse ([#18842](https://github.com/microsoft/fluentui/pull/18842))
 
 ### Features

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
@@ -2,3 +2,4 @@ export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
 export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
 export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';
+export { textVariables as Text } from './components/Text/textVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageVariables.ts
@@ -6,7 +6,5 @@ export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariable
     backgroundColorMine: siteVars.colorScheme.brand.background1,
     authorColor: siteVars.colorScheme.default.foreground2,
     authorFontWeight: siteVars.fontWeightRegular,
-    timestampColor: siteVars.colorScheme.default.foreground2,
-    timestampColorMine: siteVars.colorScheme.default.foreground2,
   };
 };

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Text/textVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Text/textVariables.ts
@@ -1,0 +1,5 @@
+import { TextVariables } from '../../../teams/components/Text/textVariables';
+
+export const textVariables = (siteVars): Partial<TextVariables> => ({
+  timestampColor: siteVars.colorScheme.default.foreground2,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -7,7 +7,6 @@ export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariable
     authorColor: siteVars.colors.grey[250],
     contentColor: siteVars.colors.white,
     color: siteVars.colors.white,
-    timestampColorMine: siteVars.colors.grey[250],
     hasMentionNubbinColor: siteVars.colors.orange[300],
     isImportantColor: siteVars.colors.red[300],
     compactHoverBackground: siteVars.colorScheme.default.backgroundHover,

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Text/textVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Text/textVariables.ts
@@ -7,5 +7,4 @@ export const textVariables = (siteVariables): Partial<TextVariables> => ({
   errorColor: siteVariables.colors.red[300],
   importantColor: siteVariables.colors.red[300],
   successColor: siteVariables.colors.green[200],
-  timestampColor: siteVariables.colors.grey[400],
 });

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -13,7 +13,6 @@ export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariable
     hasMentionNubbinColor: siteVars.accessibleYellow,
     isImportantColor: siteVars.accessibleYellow,
     badgeTextColor: siteVars.colors.black,
-    timestampColorMine: siteVars.colors.white,
     reactionGroupBorderColor: siteVars.colors.white,
   };
 };

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
@@ -1,3 +1,4 @@
 export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
 export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
+export { textVariables as Text } from './components/Text/textVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageVariables.ts
@@ -5,6 +5,4 @@ export const chatMessageVariables = (siteVars): Partial<ChatMessageVariables> =>
   backgroundColorMine: siteVars.colorScheme.brand.background1,
   authorColor: siteVars.colorScheme.default.foreground2,
   authorFontWeight: siteVars.fontWeightRegular,
-  timestampColor: siteVars.colorScheme.default.foreground2,
-  timestampColorMine: siteVars.colorScheme.default.foreground2,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/components/Text/textVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/components/Text/textVariables.ts
@@ -1,0 +1,5 @@
+import { TextVariables } from '../../../teams/components/Text/textVariables';
+
+export const textVariables = (siteVars): Partial<TextVariables> => ({
+  timestampColor: siteVars.colorScheme.default.foreground2,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -95,9 +95,8 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
   },
 
   timestamp: (componentStyleFunctionParam): ICSSInJSStyle => {
-    const { props: p, variables: v } = componentStyleFunctionParam;
+    const { props: p } = componentStyleFunctionParam;
     return {
-      color: v.timestampColor,
       display: 'inline-block',
       ...getChatMessageDensityStyles(p.density).timestamp?.(componentStyleFunctionParam),
     };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfy.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfy.ts
@@ -78,7 +78,6 @@ export const chatMessageStylesComfy: ComponentSlotStylesPrepared<ChatMessageStyl
 
   timestamp: ({ props: p, variables: v }) => ({
     marginBottom: v.headerMarginBottom,
-    ...(p.mine && { color: v.timestampColorMine }),
     ...((p.attached === 'bottom' || p.attached === true) &&
       !p.hasReactionGroup &&
       (screenReaderContainerStyles as ICSSInJSStyle)),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -36,8 +36,6 @@ export interface ChatMessageVariables {
   reactionGroupMarginLeft: string;
   reactionGroupBorderColor: string;
   showActionMenu?: boolean;
-  timestampColor: string;
-  timestampColorMine: string;
   zIndex: number;
   overlayZIndex: number;
 }
@@ -78,8 +76,6 @@ export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   reactionGroupMarginLeft: pxToRem(12),
   reactionGroupBorderColor: 'transparent',
   showActionMenu: undefined,
-  timestampColor: undefined,
-  timestampColorMine: siteVars.colorScheme.default.foreground1,
   zIndex: siteVars.zIndexes.foreground,
   overlayZIndex: siteVars.zIndexes.overlay,
 });


### PR DESCRIPTION
Modifies the color of the `timestamp` variant of `Text` to fix several issues:
* Fix missing contrast for `dark` and `darkV2` themes
  ![Text timestamp contrast](https://user-images.githubusercontent.com/2564094/124699359-83f57500-de9f-11eb-893d-7e4167c9d7f3.png) ![ChatMessage timestamp contrast](https://user-images.githubusercontent.com/2564094/124699687-1dbd2200-dea0-11eb-852c-dd0ea63c3111.png)
* Align timestamp color with other elements of ChatMessage header
  ![ChatMessage header](https://user-images.githubusercontent.com/2564094/124699803-5fe66380-dea0-11eb-8ac6-332044b8affd.png)
* Remove the need for a specific ChatMessage `timestampColor` 
