### PR TITLE
fix(E2E): Revert popover e2e

### DIFF
--- a/change/@fluentui-react-popover-365da331-2682-4cbe-b411-5156b6b14e79.json
+++ b/change/@fluentui-react-popover-365da331-2682-4cbe-b411-5156b6b14e79.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(E2E): Revert popover e2e",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -16,7 +16,6 @@
     "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "e2e": "e2e",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",


### PR DESCRIPTION
Reverts turning on popover e2e in CI because cypress does support
parallelism. Need to make modifications to run E2E from the root of the repo so that cypress is only opened once

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
