### PR TITLE
chore: fix "variables.isPR" usages in pipeline files

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -35,7 +35,7 @@ jobs:
       - script: |
           yarn bundle-size upload-report --branch=$(Build.SourceBranchName) --commit-sha $(Build.SourceVersion)
         displayName: upload a report (base only)
-        condition: not(variables.isPR)
+        condition: eq(variables.isPR, false)
         env:
           # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables
           BUNDLESIZE_ACCOUNT_KEY: $(bundlesize-account-key)

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -30,14 +30,14 @@ steps:
   # @fluentui/perf-test Baseline
   - script: |
       yarn perf:test:base
-    condition: not(variables.isPR)
+    condition: eq(variables.isPR, false)
     workingDirectory: packages/fluentui/perf-test
     displayName: Perf Test Base (Fluent)
 
   # @fluentui/perf-test PR
   - script: |
       yarn perf:test
-    condition: variables.isPR
+    condition: eq(variables.isPR, true)
     workingDirectory: packages/fluentui/perf-test
     displayName: Perf Test (Fluent)
 
@@ -76,18 +76,18 @@ steps:
 
   - script: |
       yarn stats:build
-    condition: not(variables.isPR)
+    condition: eq(variables.isPR, false)
     displayName: Bundle Statistics (master only)
 
   - script: |
       yarn perf
-    condition: not(variables.isPR)
+    condition: eq(variables.isPR, false)
     displayName: Performance Tests (master only)
 
   # HEADS UP: also see tag-version-prefix in fluentui-publish.js
   - script: |
       yarn stats:save --tag=`git tag --points-at HEAD | grep ^@fluentui/react-northstar_v | grep -o 'northstar_v.*'`
-    condition: not(variables.isPR)
+    condition: eq(variables.isPR, false)
     displayName: Save Statistics to DB (master only)
     env:
       STATS_URI: $(STATS_URI)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       - script: |
           yarn danger ci
         displayName: danger
-        condition: variables.isPR
+        condition: eq(variables.isPR, true)
         env:
           DANGER_GITHUB_API_TOKEN: $(DANGER_GITHUB_API_TOKEN)
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [ ] ~~Include a change request file using `$ yarn change`~~

#### Description of changes

In #18322 I added an additional CI step to run only for `master` builds:

https://github.com/microsoft/fluentui/blob/f945172f2b3904cf993a6a7f65a13bbe44f31fbe/azure-pipelines.bundlesize.yml#L35-L38

But surprisingly it does not work:

![image](https://user-images.githubusercontent.com/14183168/124770534-b2745e00-df3a-11eb-90fa-bcac0790401a.png)

This happened because `variables.*` in Azure Pipelines are strings (only `parameters.*` can be typed) (the problem is described in [Developer Community](https://developercommunity.visualstudio.com/t/azure-pipeline-issues-when-using-booleans-with-yam/582977)):

> Variables are different from runtime parameters, which are typed and available during template parsing.

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables

---

It also means that all current checks are broken, the easiest way to ensure is to check any `master` build: we should skip Danger.js check there, but it runs:

![image](https://user-images.githubusercontent.com/14183168/124771205-3c242b80-df3b-11eb-80b4-29be380be63b.png)

