### PR TITLE
fix(E2E): Do not run e2e tests in parallel

### DIFF
--- a/change/@fluentui-react-popover-b10e3379-f5a5-4aef-b1e2-feab91432803.json
+++ b/change/@fluentui-react-popover-b10e3379-f5a5-4aef-b1e2-feab91432803.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable e2e tests in CI",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "copy-notices": "node scripts/copy-notices.js",
     "create-component": "plop --plopfile ./scripts/create-component/create-component.ts --dest . --require ./scripts/ts-node-register",
     "create-package": "plop --plopfile ./scripts/create-package/plopfile.ts --dest . --require ./scripts/ts-node-register",
-    "e2e": "lage e2e --verbose --mode run",
+    "e2e": "lage e2e --verbose --concurrency=1 --mode run",
     "format": "node scripts/format.js",
     "generate-version-files": "yarn workspace @fluentui/scripts just generate-version-files",
     "graph": "node ./scripts/dependency-graph-generator/index.js",

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -19,6 +19,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",
+    "e2e": "yarn e2e",
     "storybook": "start-storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -19,7 +19,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",
-    "e2e": "yarn e2e",
+    "e2e": "e2e",
     "storybook": "start-storybook",
     "test": "jest",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",


### PR DESCRIPTION
Cypress can only have one instance running at a time, do not run
multiple packages e2e tests in parallel.

Another possible solution is to run the command from the root, but this
is too slow with the current test per packag setup since cypress will scan the whole repo for e2e tests.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
