### PR TITLE
Button pointer events

### DIFF
--- a/change/@fluentui-react-examples-0568762a-a50b-4fea-98c7-b94aa8d7858e.json
+++ b/change/@fluentui-react-examples-0568762a-a50b-4fea-98c7-b94aa8d7858e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Button: Remove pointer-events: 'none' from disabled styles.",
+  "packageName": "@fluentui/react-examples",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-experiments-8af4b78d-42fd-4144-b2e7-41e7f07a0c4b.json
+++ b/change/@uifabric-experiments-8af4b78d-42fd-4144-b2e7-41e7f07a0c4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-c701200e-2e82-42d3-92af-e2d5ab6e9b34.json
+++ b/change/office-ui-fabric-react-c701200e-2e82-42d3-92af-e2d5ab6e9b34.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Button: Remove pointer-events: 'none' from disabled styles.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             padding-left: 4px;
             padding-right: 4px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;
@@ -170,7 +169,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             padding-left: 4px;
             padding-right: 4px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;
@@ -1120,7 +1118,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           padding-left: 4px;
           padding-right: 4px;
           padding-top: 0;
-          pointer-events: none;
           position: relative;
           text-align: center;
           text-decoration: none;
@@ -1251,7 +1248,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           padding-left: 4px;
           padding-right: 4px;
           padding-top: 0;
-          pointer-events: none;
           position: relative;
           text-align: center;
           text-decoration: none;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
@@ -70,7 +70,6 @@ export const getStyles = memoizeFunction(
           borderColor: disabledBackground,
           color: disabledText,
           cursor: 'default',
-          pointerEvents: 'none',
           selectors: {
             ':hover': noOutline,
             ':focus': noOutline,

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Button.Split.Example.tsx.shot
@@ -865,7 +865,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 padding-left: 16px;
                 padding-right: 16px;
                 padding-top: 0;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -1228,7 +1227,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 padding-left: 16px;
                 padding-right: 16px;
                 padding-top: 0;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -603,7 +603,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           padding-left: 4px;
                           padding-right: 4px;
                           padding-top: 0;
-                          pointer-events: none;
                           position: relative;
                           text-align: center;
                           text-decoration: none;
@@ -955,7 +954,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       padding-left: 4px;
                       padding-right: 4px;
                       padding-top: 0;
-                      pointer-events: none;
                       position: relative;
                       text-align: center;
                       text-decoration: none;
@@ -1151,7 +1149,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         padding-left: 4px;
                         padding-right: 4px;
                         padding-top: 0;
-                        pointer-events: none;
                         position: relative;
                         text-align: center;
                         text-decoration: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Icon.SvgFactory.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Icon.SvgFactory.Example.tsx correctly 1`] = 
             padding-left: 16px;
             padding-right: 16px;
             padding-top: 0;
-            pointer-events: none;
             position: relative;
             text-align: center;
             text-decoration: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -513,7 +513,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           padding-left: 41px;
                           padding-right: 20px;
                           padding-top: 0;
-                          pointer-events: none;
                           position: relative;
                           text-align: center;
                           text-decoration: none;
@@ -972,7 +971,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       padding-left: 27px;
                       padding-right: 20px;
                       padding-top: 0;
-                      pointer-events: none;
                       position: relative;
                       text-align: center;
                       text-decoration: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -205,7 +205,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -350,7 +349,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -228,7 +228,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;
@@ -373,7 +372,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                 padding-left: 0px;
                 padding-right: 0px;
                 padding-top: 0px;
-                pointer-events: none;
                 position: relative;
                 text-align: center;
                 text-decoration: none;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18280
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherry-pick of #17737_

Removes the `pointer-events: 'none'` styling that is applied to disabled buttons. This allows disabled buttons to have native `title` tooltips available (which is how native html buttons work in their disabled state).

This PR additionally circumvents a bug in Safari that does not change some of the `Button` styling when toggling between `enabled` and `disabled` states.
