### PR TITLE
Set Id correctly when contextualMenuSection's title is an IContextualMenuItem

### DIFF
--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -13,6 +13,12 @@ import {
 } from 'office-ui-fabric-react';
 
 const baseProps: IButtonProps = {
+  styles: {
+    label: {
+      marginLeft: '30px',
+      marginRight: '5px',
+    },
+  },
   iconProps: {
     iconName: 'AddFriend',
   },

--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -13,12 +13,6 @@ import {
 } from 'office-ui-fabric-react';
 
 const baseProps: IButtonProps = {
-  styles: {
-    label: {
-      marginLeft: '30px',
-      marginRight: '5px',
-    },
-  },
   iconProps: {
     iconName: 'AddFriend',
   },

--- a/change/office-ui-fabric-react-6cb0fb86-3b85-434a-b698-8d193a7375dd.json
+++ b/change/office-ui-fabric-react-6cb0fb86-3b85-434a-b698-8d193a7375dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set id correctly on header item when title is an IContextualMenuItem",
+  "packageName": "office-ui-fabric-react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -647,7 +647,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
         };
         ariaLabellledby = id;
       } else {
-        const id = this._id + sectionProps.title.key.replace(/\s/g, '');
+        const id = sectionProps.title.id || this._id + sectionProps.title.key.replace(/\s/g, '');
         headerContextualMenuItem = { ...sectionProps.title, id };
         ariaLabellledby = id;
       }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -647,8 +647,9 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
         };
         ariaLabellledby = id;
       } else {
-        headerContextualMenuItem = sectionProps.title;
-        ariaLabellledby = this._id + sectionProps.title.text?.replace(/\s/g, '');
+        const id = sectionProps.title.text ? this._id + sectionProps.title.text.replace(/\s/g, '') : this._id;
+        headerContextualMenuItem = { ...sectionProps.title, id };
+        ariaLabellledby = id;
       }
 
       if (headerContextualMenuItem) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -647,6 +647,9 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
         };
         ariaLabellledby = id;
       } else {
+        // Since title is an IContextualMenuItem and text property is optional
+        // there is the possibility if text is undefined that the id would appear
+        // in the DOM with 'undefined' appended to the end of the id, breaking the aria-labelledby scenario.
         const id = sectionProps.title.text ? this._id + sectionProps.title.text.replace(/\s/g, '') : this._id;
         headerContextualMenuItem = { ...sectionProps.title, id };
         ariaLabellledby = id;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -647,10 +647,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
         };
         ariaLabellledby = id;
       } else {
-        // Since title is an IContextualMenuItem and text property is optional
-        // there is the possibility if text is undefined that the id would appear
-        // in the DOM with 'undefined' appended to the end of the id, breaking the aria-labelledby scenario.
-        const id = sectionProps.title.text ? this._id + sectionProps.title.text.replace(/\s/g, '') : this._id;
+        const id = this._id + sectionProps.title.key.replace(/\s/g, '');
         headerContextualMenuItem = { ...sectionProps.title, id };
         ariaLabellledby = id;
       }


### PR DESCRIPTION
#### Description of changes

When a menu section's title is an IContextualMenuItem we were not setting the id on the created 'headerContextualMenuItem'.

This meant that the group had an 'aria-labelledby' set on it, but the div around the title's span element did not.  So screen readers could not accurately read out when a user entered a menu section

PR for master: https://github.com/microsoft/fluentui/pull/18853