### PR TITLE
Charting: CherryPick #18811: Fixed when chart data is empty for Stacked Bar and Multi Stacked Bar chart. #18811

### DIFF
--- a/change/@uifabric-charting-a94d58fd-16ca-4a59-b797-a732006b7835.json
+++ b/change/@uifabric-charting-a94d58fd-16ca-4a59-b797-a732006b7835.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cherry pick-Stacked Bar and Multi Stacked Bar chart: fixed when chart data is empty",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -205,7 +205,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     const hideNumber = hideRatio === undefined ? false : hideRatio;
     const showRatio = !hideNumber && data!.chartData!.length === 2;
     const showNumber = !hideNumber && data!.chartData!.length === 1;
-    const chartDataVal: number = data!.chartData![0].data ? data!.chartData![0].data : 0;
 
     return (
       <div className={this._classNames.singleChartRoot}>
@@ -218,7 +217,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             )}
             {showRatio && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <strong>{chartDataVal}</strong>
+                <strong>{data!.chartData![0].data ? data!.chartData![0].data : 0}</strong>
                 {!hideDenominator && <span>/{total}</span>}
               </div>
             )}

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -99,7 +99,6 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       targetRatio,
     });
 
-    const chartDataVal: number = data!.chartData![0].data ? data!.chartData![0].data : 0;
     return (
       <div className={this._classNames.root}>
         <FocusZone direction={FocusZoneDirection.horizontal}>
@@ -111,7 +110,9 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
             )}
             {showRatio && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <span className={this._classNames.ratioNumerator}>{chartDataVal}</span>
+                <span className={this._classNames.ratioNumerator}>
+                  {data!.chartData![0].data ? data!.chartData![0].data : 0}
+                </span>
                 {!this.props.hideDenominator && (
                   <span>
                     /<span className={this._classNames.ratioDenominator}>{total}</span>


### PR DESCRIPTION
### Original description
**Cherry-pick of** [#18811](https://github.com/microsoft/fluentui/pull/18811)

#### Description of changes
When chart data is passed as an empty array, then code was breaking.
Now handled the breaking code. 
When chart data is not passed, then a disabled bar will be shown.  

#### Focus areas to test
Stacked bar chart and multi-stacked bar chart, with empty chart data. 

**Before Fix:**

![image](https://user-images.githubusercontent.com/29042635/124261894-fcca9900-db4e-11eb-9b53-fe63b77c7ad1.png)


**After Fix:**

![image](https://user-images.githubusercontent.com/29042635/124261962-0fdd6900-db4f-11eb-8632-76d675024aef.png)

