### PR TITLE
User/v scharde/donut chart accessibility

### DIFF
--- a/change/@fluentui-react-charting-e1b3a885-91c6-4663-8613-2adb57fd8483.json
+++ b/change/@fluentui-react-charting-e1b3a885-91c6-4663-8613-2adb57fd8483.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Donut chart custom accessibility change",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-292153ef-66f4-43d3-b6e7-8817fdcf814c.json
+++ b/change/@fluentui-react-examples-292153ef-66f4-43d3-b6e7-8817fdcf814c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Donut chart custom accessibility change",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
@@ -56,6 +56,7 @@ export class Arc extends React.Component<IArcProps, IArcState> {
           opacity={opacity}
           onClick={href ? this._redirectToUrl.bind(this, href) : this.props.data?.data.onClick}
           aria-labelledby={this.props.calloutId}
+          role="text"
         />
         <text textAnchor={'middle'} className={classNames.insideDonutString} y={5}>
           {this.props.valueInsideDonut!}

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -4,7 +4,7 @@ import * as scale from 'd3-scale';
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard, ILegend, Legends } from '../../index';
+import { IAccessibilityProps, ChartHoverCard, ILegend, Legends } from '../../index';
 import { Pie } from './Pie/index';
 import { IChartDataPoint, IChartProps, IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles } from './index';
 
@@ -24,6 +24,7 @@ export interface IDonutChartState {
   focusedArcId?: string;
   selectedLegend: string;
   dataPointCalloutProps?: IChartDataPoint;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChartState> {
@@ -134,6 +135,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
           onDismiss={this._closeCallout}
           preventDismissOnLostFocus={true}
           {...this.props.calloutProps!}
+          {...this._getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false)}
         >
           {this.props.onRenderCalloutPerDataPoint ? (
             this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps!)
@@ -234,6 +236,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       yCalloutValue: data.yAxisCalloutData!,
       focusedArcId: id,
       dataPointCalloutProps: data,
+      callOutAccessibilityData: data.callOutAccessibilityData!,
     });
   };
 
@@ -249,6 +252,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       yCalloutValue: data.yAxisCalloutData!,
       activeLegend: data.legend,
       dataPointCalloutProps: data,
+      callOutAccessibilityData: data.callOutAccessibilityData!,
     });
   };
   private _onBlur = (): void => {
@@ -273,4 +277,19 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       return valueInsideDonut;
     }
   }
+
+  private _getAccessibleDataObject = (
+    accessibleData?: IAccessibilityProps,
+    role: string = 'text',
+    isDataFocusable: boolean = true,
+  ) => {
+    accessibleData = accessibleData ?? {};
+    return {
+      role,
+      'data-is-focusable': isDataFocusable,
+      'aria-label': accessibleData!.ariaLabel,
+      'aria-labelledby': accessibleData!.ariaLabelledBy,
+      'aria-describedby': accessibleData!.ariaDescribedBy,
+    };
+  };
 }

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -98,6 +99,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -417,6 +419,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -451,6 +454,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -770,6 +774,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -804,6 +809,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -889,6 +895,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -923,6 +930,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -1242,6 +1250,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -1278,6 +1287,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { DonutChart, IDonutChartProps, IChartProps, IChartDataPoint } from '@fluentui/react-charting';
+
+export class DonutChartCustomAccessibilityExample extends React.Component<IDonutChartProps, {}> {
+  constructor(props: IDonutChartProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const points: IChartDataPoint[] = [
+      {
+        legend: 'first',
+        data: 20000,
+        color: '#E5E5E5',
+        xAxisCalloutData: '2020/04/30',
+        callOutAccessibilityData: { ariaLabel: 'Pia chart 1 of 2 2020/04/30' },
+      },
+      {
+        legend: 'second',
+        data: 39000,
+        color: '#0078D4',
+        xAxisCalloutData: '2020/04/20',
+        callOutAccessibilityData: { ariaLabel: 'Pia chart 2 of 2 2020/04/20' },
+      },
+    ];
+
+    const chartTitle = 'Stacked Bar chart example';
+
+    const data: IChartProps = {
+      chartTitle: chartTitle,
+      chartData: points,
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Donut chart' },
+    };
+    return (
+      <DonutChart
+        data={data}
+        innerRadius={55}
+        href={'https://developer.microsoft.com/en-us/'}
+        legendsOverflowText={'overflow Items'}
+        hideLegend={true}
+        height={220}
+        width={176}
+        valueInsideDonut={39000}
+      />
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChartPage.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChartPage.tsx
@@ -10,10 +10,12 @@ import {
 import { DonutChartBasicExample } from './DonutChart.Basic.Example';
 import { DonutChartDynamicExample } from './DonutChart.Dynamic.Example';
 import { DonutChartCustomCalloutExample } from './DonutChart.CustomCallout.Example';
+import { DonutChartCustomAccessibilityExample } from './DonutChart.CustomAccessibility.Example';
 
 const DonutChartBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.Basic.Example.tsx') as string;
 const DonutChartDynamicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx') as string;
 const DonutChartCustomCalloutExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.CustomCallout.Example.tsx') as string;
+const DonutChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx') as string;
 
 export class DonutChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -31,6 +33,9 @@ export class DonutChartPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard title="DonutChart Custom Callout" code={DonutChartCustomCalloutExampleCode}>
               <DonutChartCustomCalloutExample />
+            </ExampleCard>
+            <ExampleCard title="DonutChart Custom Accessibility" code={DonutChartCustomAccessibilityExampleCode}>
+              <DonutChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Changes are related to Donut Chart accessibility

1. Accessibility Data prop added for the chart title and Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
Custom Accessibility example is added for Donut chart.

**Without Custom Accessibility Data:**

![image](https://user-images.githubusercontent.com/29042635/124931109-87176f00-e01f-11eb-8a0e-17cc2bf1994c.png)

**With Custom Accessibility Data:**

![image](https://user-images.githubusercontent.com/29042635/124931376-c80f8380-e01f-11eb-9bd2-98dfaa0867e6.png)

