### PR TITLE
(Testing) - Enabling component-handles-ref conformance test in Callout

### DIFF
--- a/change/@fluentui-react-78d23b5a-6702-4aa7-82a1-f37fc17cb17d.json
+++ b/change/@fluentui-react-78d23b5a-6702-4aa7-82a1-f37fc17cb17d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enabling component-handles-ref conformance test within Callout.",
+  "packageName": "@fluentui/react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -32,7 +32,8 @@ describe('Callout', () => {
     Component: Callout,
     displayName: 'Callout',
     targetComponent: CalloutContent,
-    disabledTests: ['component-handles-ref', 'component-handles-classname'],
+    requiredProps: { doNotLayer: true },
+    disabledTests: ['component-handles-classname'],
   });
 
   it('target id strings does not throw exception', () => {


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Enabling `doNotLayer` within requiredProps allowing for the `component-handles-ref` test to run. Callout doesn't apply the className to the root element so `component-handles-classname` still is unable to run successfully.
