### PR TITLE
fix: update bundle-size call in pipeline

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -25,12 +25,8 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn build --no-cache $(sinceArg)
-        displayName: build packages
-
-      - script: |
-          yarn lage bundle-size --no-cache
-        displayName: create reports for packages
+          yarn lage bundle-size --no-cache --verbose $(sinceArg)
+        displayName: build packages & create reports
 
       - script: |
           yarn bundle-size upload-report --branch=$(Build.SourceBranchName) --commit-sha $(Build.SourceVersion)

--- a/lage.config.js
+++ b/lage.config.js
@@ -4,6 +4,7 @@ module.exports = {
     build: ['^build'],
     'build:info': [],
     bundle: ['build'],
+    'bundle-size': ['build'],
     'bundle:storybook': ['build'],
     'screener:build': [],
     screener: ['screener:build'],


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [ ] ~~Include a change request file using `$ yarn change`~~

#### Problem

Currently we are running `bundle` & `bundle-size` (_without `sinceArg`, oops_) commands separately. That causes build failures for N* builds as it builds packages only for affected packages:


<details>
<summary>list of built packages (example)</summary>

```
verb @fluentui/ability-attributes build completed, took 17.00s
verb @fluentui/react-northstar build:info completed, took 2m 14.29s
verb @fluentui/scripts build completed, took 0.24s
verb @fluentui/a11y-testing build completed, took 6.38s
verb @fluentui/react-conformance build completed, took 15.88s
verb @fluentui/accessibility build completed, took 21.55s
verb @fluentui/react-component-event-listener build completed, took 17.00s
verb @fluentui/react-component-nesting-registry build completed, took 16.90s
verb @fluentui/react-component-ref build completed, took 27.65s
verb @fluentui/react-proptypes build completed, took 19.37s
verb @fluentui/state build completed, took 14.47s
verb @fluentui/styles build completed, took 18.26s
verb @fluentui/docs-components build completed, took 19.57s
verb @fluentui/set-version build completed, took 8.39s
verb @fluentui/example-data build completed, took 12.85s
verb @fluentui/test-utilities build completed, took 11.56s
verb @fluentui/webpack-utilities build completed, took 8.93s
verb @fluentui/keyboard-key build completed, took 12.68s
verb @fluentui/dom-utilities build completed, took 12.30s
verb @fluentui/date-time-utilities build completed, took 11.34s
verb @fluentui/merge-styles build completed, took 13.80s
verb @fluentui/react-northstar-styles-renderer build completed, took 17.79s
verb @fluentui/react-window-provider build completed, took 15.28s
verb @fluentui/jest-serializer-merge-styles build completed, took 4.53s
verb @fluentui/react-northstar-emotion-renderer build completed, took 15.61s
verb @fluentui/react-northstar-fela-renderer build completed, took 14.21s
verb @fluentui/utilities build completed, took 12.45s
verb @fluentui/react-hooks build completed, took 14.20s
verb @fluentui/theme build completed, took 13.31s
verb @fluentui/react-bindings build completed, took 42.27s
verb @fluentui/style-utilities build completed, took 10.63s
verb @fluentui/common-styles build completed, took 2.01s
verb @fluentui/font-icons-mdl2 build completed, took 9.42s
verb @fluentui/foundation-legacy build completed, took 16.52s
verb @fluentui/react-focus build completed, took 16.72s
verb @fluentui/react build completed, took 43.33s
verb @fluentui/react-icons-northstar build completed, took 31.85s
```
</details>

But then we will run `bundle-size` without scoping and will not have required artifacts:

```
$ /mnt/work/1/s/node_modules/.bin/lage bundle-size --no-cache
info Lage task runner - let's make it
info @fluentui/react-theme bundle-size ▶️ start 
info @fluentui/react-theme bundle-size ❌ fail 
```

- on `master` it passes because it builds everything
- on original PR it passed because we built everything (a change `*.yml` invalidates `--since`):

https://github.com/microsoft/fluentui/blob/2b6f9b68a6d4ba683ccb10b462b1e2a897b20cc5/lage.config.js#L41-L43 

#### Description of changes

This PR backports a change from #18256.

Another option is to add `sinceArg` to `bundle-size` command:

```diff
      - script: |
-         yarn lage bundle-size --no-cache
+         yarn lage bundle-size --no-cache $(sinceArg)
        displayName: create reports for packages
```

But current solution should give us better concurrency us `lage` will run `bundle-size` once all required `build`s are completed.
