### PR TITLE
Custom Accessibility Change for Grouped Vertical Bar Chart

### DIFF
--- a/change/@fluentui-react-charting-1951da9b-ced2-41a4-94f8-91e690c1b727.json
+++ b/change/@fluentui-react-charting-1951da9b-ced2-41a4-94f8-91e690c1b727.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GroupedVertical Chart accessibility change",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-examples-9806a281-e8d3-422d-bc63-9b1e1b13828f.json
+++ b/change/@fluentui-react-examples-9806a281-e8d3-422d-bc63-9b1e1b13828f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GroupedVertical Chart accessibility change",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -7,8 +7,15 @@ import { classNamesFunction, getId, getRTL, memoizeFunction, warnDeprecations } 
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartTypes, tooltipOfXAxislabels, XAxisTypes, getTypeOfAxis } from '../../utilities/index';
 import {
+  ChartTypes,
+  getAccessibleDataObject,
+  tooltipOfXAxislabels,
+  XAxisTypes,
+  getTypeOfAxis,
+} from '../../utilities/index';
+import {
+  IAccessibilityProps,
   CartesianChart,
   ILegend,
   IGroupedVerticalBarChartData,
@@ -40,6 +47,7 @@ interface IGVSingleDataPoint {
 export interface IGroupedVerticalBarChartState extends IBasestate {
   titleForHoverCard: string;
   dataPointCalloutProps?: IGVBarChartSeriesPoint;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class GroupedVerticalBarChartBase extends React.Component<
@@ -121,6 +129,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
       onDismiss: this._closeCallout,
       ...this.props.calloutProps,
+      preventDismissOnLostFocus: true,
+      ...getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false),
     };
     const tickParams = {
       tickValues: this.props.tickValues!,
@@ -215,6 +225,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
         xCalloutValue: pointData.xAxisCalloutData,
         yCalloutValue: pointData.yAxisCalloutData,
         dataPointCalloutProps: pointData,
+        callOutAccessibilityData: pointData.callOutAccessibilityData,
       });
     }
   };
@@ -237,6 +248,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             xCalloutValue: pointData.xAxisCalloutData,
             yCalloutValue: pointData.yAxisCalloutData,
             dataPointCalloutProps: pointData,
+            callOutAccessibilityData: pointData.callOutAccessibilityData,
           });
         }
       });
@@ -300,6 +312,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             onBlur={this._onBarLeave}
             onClick={this.props.href ? this._redirectToUrl.bind(this, this.props.href!) : pointData.onClick}
             aria-labelledby={`toolTip${this._calloutId}`}
+            role="text"
           />,
         );
     });

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -136,6 +137,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -156,6 +158,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -180,6 +183,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -200,6 +204,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -220,6 +225,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -670,6 +676,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -690,6 +697,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -710,6 +718,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -734,6 +743,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -754,6 +764,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -774,6 +785,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1204,6 +1216,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -1224,6 +1237,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -1244,6 +1258,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1268,6 +1283,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -1288,6 +1304,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -1308,6 +1325,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1435,6 +1453,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -1455,6 +1474,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -1475,6 +1495,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1499,6 +1520,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -1519,6 +1541,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -1539,6 +1562,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1989,6 +2013,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -2009,6 +2034,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -2029,6 +2055,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2053,6 +2080,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -2073,6 +2101,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -2093,6 +2122,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2543,6 +2573,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -2563,6 +2594,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -2583,6 +2615,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2607,6 +2640,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -2627,6 +2661,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -2647,6 +2682,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -3097,6 +3133,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -3117,6 +3154,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -3137,6 +3175,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -3161,6 +3200,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -3181,6 +3221,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -3201,6 +3242,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -460,6 +460,11 @@ export interface IGVBarChartSeriesPoint {
    * onClick action for each datapoint in the chart
    */
   onClick?: VoidFunction;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IGroupedVerticalBarChartData {

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -5,6 +5,7 @@ import { select as d3Select, event as d3Event } from 'd3-selection';
 import { format as d3Format } from 'd3-format';
 import * as d3TimeFormat from 'd3-time-format';
 import {
+  IAccessibilityProps,
   IEventsAnnotationProps,
   ILineChartPoints,
   ILineChartDataPoint,
@@ -897,4 +898,25 @@ export const pointTypes: PointTypes = {
   [Points.octagon]: {
     widthRatio: 2.414,
   },
+};
+
+/**
+ * @param accessibleData accessible data
+ * @param role string to define role of tag
+ * @param isDataFocusable boolean
+ * function returns the accessibility data object
+ */
+export const getAccessibleDataObject = (
+  accessibleData?: IAccessibilityProps,
+  role: string = 'text',
+  isDataFocusable: boolean = true,
+) => {
+  accessibleData = accessibleData ?? {};
+  return {
+    role,
+    'data-is-focusable': isDataFocusable,
+    'aria-label': accessibleData!.ariaLabel,
+    'aria-labelledby': accessibleData!.ariaLabelledBy,
+    'aria-describedby': accessibleData!.ariaDescribedBy,
+  };
 };

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+import {
+  GroupedVerticalBarChart,
+  IGroupedVerticalBarChartProps,
+  IGroupedVerticalBarChartData,
+} from '@fluentui/react-charting';
+interface IGroupedBarChartState {
+  width: number;
+  height: number;
+}
+
+export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Component<{}, IGroupedBarChartState> {
+  constructor(props: IGroupedVerticalBarChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 400,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _basicExample(): JSX.Element {
+    const data: IGroupedVerticalBarChartData[] = [
+      {
+        name: 'Metadata info multi lines text Completed',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 1 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 44000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '44%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 44%',
+            },
+          },
+        ],
+      },
+      {
+        name: 'Meta Data2',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 2 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 3000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '3%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+            },
+          },
+        ],
+      },
+
+      {
+        name: 'Single line text ',
+        series: [
+          {
+            key: 'series1',
+            data: 14000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '14%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 3 of 4, Bar series 1 of 2 2020/04/30 14%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 50000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '50%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 50%',
+            },
+          },
+        ],
+      },
+      {
+        name: 'Hello World!!!',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 4 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 3000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '3%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+            },
+          },
+        ],
+      },
+    ];
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div style={rootStyle}>
+          <GroupedVerticalBarChart
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            showYAxisGridLines
+            wrapXAxisLables
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChartPage.tsx
@@ -10,10 +10,12 @@ import {
 import { GroupedVerticalBarChartBasicExample } from './GroupedVerticalBarChart.Basic.Example';
 import { GroupedVerticalBarChartTruncatedExample } from './GroupedVerticalBarChart.Truncated.Example';
 import { GroupedVerticalBarChartStyledExample } from './GroupedVerticalBarChart.Styled.Example';
+import { GroupedVerticalBarChartCustomAccessibilityExample } from './GroupedVerticalBarChart.CustomAccessibility.Example';
 
 const GroupedVerticalBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx') as string;
 const GroupedVerticalStyledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx') as string;
 const GroupedVerticalTruncatedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Truncated.Example.tsx') as string;
+const GroupedVerticalCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx') as string;
 
 export class GroupedVerticalBarChart extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -31,6 +33,12 @@ export class GroupedVerticalBarChart extends React.Component<IComponentDemoPageP
             </ExampleCard>
             <ExampleCard title="Grouped Vertical Bar Chart Styled" code={GroupedVerticalStyledExampleCode}>
               <GroupedVerticalBarChartStyledExample />
+            </ExampleCard>
+            <ExampleCard
+              title="Grouped Vertical Bar Chart Custom Accessibility"
+              code={GroupedVerticalCustomAccessibilityExampleCode}
+            >
+              <GroupedVerticalBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changes are related to Grouped Vertical Bar Chart accessibility

1. Accessibility Data prop added for the Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
Custom Accessibility example is added for Grouped Vertical Bar Chart.

**Before Change:**

![image](https://user-images.githubusercontent.com/29042635/125088656-45ec9100-e0eb-11eb-8288-a9492c014ef0.png)

**After Change:**

![image](https://user-images.githubusercontent.com/29042635/125088918-821ff180-e0eb-11eb-9f70-c385c5233ec0.png)

#### Focus areas to test

(optional)
