### PR TITLE
Prevent tooltip from showing on tab switch for the focused element [v8]

### DIFF
--- a/change/@fluentui-react-e175b02f-9a97-4775-81a2-30f594f3ae69.json
+++ b/change/@fluentui-react-e175b02f-9a97-4775-81a2-30f594f3ae69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent tooltip from showing on tab switch for the focused element",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13541
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The focused element gets a blur event when the document loses focus (e.g. switching tabs in the browser), but we don't want to show the tooltip again when the document gets focus back. Handle this case by checking if the blurred element is still the document's activeElement, and ignoring when it next gets focus back.
