### PR TITLE
Pivot: Removing circular imports

### DIFF
--- a/change/@fluentui-react-323b483a-1796-4a76-8e73-cd5a41cb7600.json
+++ b/change/@fluentui-react-323b483a-1796-4a76-8e73-cd5a41cb7600.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pivot: removed cyclic imports that were causing ordering issues with esbuild output.",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -6,7 +6,9 @@ import { useOverflow } from '../../utilities/useOverflow';
 import { FocusZone, IFocusZone, FocusZoneDirection } from '../../FocusZone';
 import { DirectionalHint, IContextualMenuProps } from '../ContextualMenu/ContextualMenu.types';
 import { Icon } from '../Icon/Icon';
-import { IPivot, IPivotItemProps, IPivotProps, IPivotStyleProps, IPivotStyles, PivotItem } from './index';
+import { IPivot, IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
+import { PivotItem } from './PivotItem';
+import { IPivotItemProps } from './PivotItem.types';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Pivot/index.ts exports PivotBase.ts
PivotBase imports index.ts

This cyclic dependency causes esbuild to output the modules in the wrong order.

Adjusting the imports in PivotBase to import directly from sibling files rather than the index.
