### PR TITLE
Fix ComboBox ariaLabel to propagate to the listbox element [v8]

### DIFF
--- a/change/@fluentui-react-101dd3b5-b031-4d5c-8c53-09fe8259aaab.json
+++ b/change/@fluentui-react-101dd3b5-b031-4d5c-8c53-09fe8259aaab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Propagate ariaLabel to the dropdown list element",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -832,6 +832,18 @@ describe('ComboBox', () => {
     );
   });
 
+  it('sets ariaLabel on both the input and the dropdown list', () => {
+    safeMount(<ComboBox options={RENDER_OPTIONS} ariaLabel="customAriaLabel" persistMenu />, wrapper => {
+      const inputElement = wrapper.find('input').getDOMNode();
+      expect(inputElement.getAttribute('aria-label')).toBe('customAriaLabel');
+      expect(inputElement.getAttribute('aria-labelledby')).toBeNull();
+
+      const listElement = wrapper.find('.ms-ComboBox-optionsContainer').getDOMNode();
+      expect(listElement.getAttribute('aria-label')).toBe('customAriaLabel');
+      expect(listElement.getAttribute('aria-labelledby')).toBeNull();
+    });
+  });
+
   it('adds aria-required to the DOM when the required prop is set to true', () => {
     safeMount(<ComboBox options={DEFAULT_OPTIONS} required />, wrapper => {
       const inputElement = wrapper.find('input').getDOMNode();

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -269,6 +269,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       text: 'defaultSelectedKey',
       selectedKey: 'value',
       dropdownWidth: 'useComboBoxAsMenuWidth',
+      ariaLabel: 'label',
     });
 
     this._id = props.id || getId('ComboBox');
@@ -1289,7 +1290,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
   // Render List of items
   private _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem, options, label } = props;
+    const { onRenderItem, options, label, ariaLabel } = props;
 
     const id = this._id;
     return (
@@ -1297,6 +1298,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         id={id + '-list'}
         className={this._classNames.optionsContainer}
         aria-labelledby={label && id + '-label'}
+        aria-label={ariaLabel && !label ? ariaLabel : undefined}
         role="listbox"
       >
         {options.map(item => onRenderItem?.(item, this._onRenderItem))}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13705
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix the ComboBox ariaLabel prop to set the aria-label of the dropdown listbox element in addition to the input element.

[This is also being fixed in the 7.0 branch via #18891]