### PR TITLE
Fix ComboBox ariaLabel to propagate to the listbox element [v7]

### DIFF
--- a/change/office-ui-fabric-react-fafaf7ee-bd23-4373-a5fb-7f636d983286.json
+++ b/change/office-ui-fabric-react-fafaf7ee-bd23-4373-a5fb-7f636d983286.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Propagate ariaLabel to the dropdown list element",
+  "packageName": "office-ui-fabric-react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -819,6 +819,18 @@ describe('ComboBox', () => {
     expect(inputElement.getAttribute('aria-labelledby')).toBe('ComboBox0-label');
   });
 
+  it('sets ariaLabel on both the input and the dropdown list', () => {
+    wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} ariaLabel="customAriaLabel" persistMenu />);
+
+    const inputElement = wrapper.find('input').getDOMNode();
+    expect(inputElement.getAttribute('aria-label')).toBe('customAriaLabel');
+    expect(inputElement.getAttribute('aria-labelledby')).toBeNull();
+
+    const listElement = wrapper.find('.ms-ComboBox-optionsContainer').getDOMNode();
+    expect(listElement.getAttribute('aria-label')).toBe('customAriaLabel');
+    expect(listElement.getAttribute('aria-labelledby')).toBeNull();
+  });
+
   it('does not add aria-required to the DOM when the required prop is not set', () => {
     const comboBoxRef = React.createRef<any>();
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} componentRef={comboBoxRef} />);

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -198,6 +198,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
       text: 'defaultSelectedKey',
       selectedKey: 'value',
       dropdownWidth: 'useComboBoxAsMenuWidth',
+      ariaLabel: 'label',
     });
 
     this._id = props.id || getId('ComboBox');
@@ -1322,7 +1323,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
 
   // Render List of items
   private _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem, options, label } = props;
+    const { onRenderItem, options, label, ariaLabel } = props;
 
     const id = this._id;
     return (
@@ -1330,6 +1331,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
         id={id + '-list'}
         className={this._classNames.optionsContainer}
         aria-labelledby={label && id + '-label'}
+        aria-label={ariaLabel && !label ? ariaLabel : undefined}
         role="listbox"
       >
         {options.map(item => (onRenderItem as any)(item, this._onRenderItem))}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13705
- [x] Include a change request file using `$ yarn change`

#### Description of changes

[This is a port of #18890 to the v7 branch.]

Fix the ComboBox ariaLabel prop to set the aria-label of the dropdown listbox element in addition to the input element.