### PR TITLE
Fix initialization of Responsive Mode on small screens

### DIFF
--- a/change/@fluentui-react-00695482-2fe3-44e4-bf1d-48d5d8a52851.json
+++ b/change/@fluentui-react-00695482-2fe3-44e4-bf1d-48d5d8a52851.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix initial ResponsiveMode value",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.tsx
@@ -63,8 +63,8 @@ export function initializeResponsiveMode(element?: HTMLElement): void {
   }
 }
 
-export function getInitialResponsiveMode() {
-  return _defaultMode || _lastMode || ResponsiveMode.large;
+export function getInitialResponsiveMode(): ResponsiveMode {
+  return _defaultMode ?? _lastMode ?? ResponsiveMode.large;
 }
 
 /**


### PR DESCRIPTION
#### Description of changes

Fixed an issue where, if the window was the smallest size, a call to `initializeResponsiveMode()` would actually set the responsive mode to `ResponsiveMode.large` due to a bad cascade of checks.

#### Focus areas to test

Validate behavior of `withResponsiveMode()`.
