### PR TITLE
RFC(storybook): Structural proposals to organize stories for E2E

### DIFF
--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -261,7 +261,7 @@ export const parameters = { controls: { expanded: true } };
 
 ### 5. how to author e2e suites for those stories
 
-> This section assumes that the storybook stories forms the core documentation of Fluent converged.
+> - This section assumes that the storybook stories forms the core documentation of Fluent converged.
 > This may change in the future so the measures proposed in this section might no longer be relevant
 > if this assumption is no longer true.
 

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -363,7 +363,7 @@ We can simply use a css wildcard query selector:
 This means that `Internal` will be a reserved keyword in our stories which will determine visibility. This does not cause
 any conflicts with current stories, since this word is never used in any story name.
 
-This solution will only need to be applied `react-components` storybook since that is the storybook currently targeted for
+This solution will only need to be applied within `react-components` storybook configuration since that is the storybook currently targeted for
 public use. Individual component storybooks are only used for local development, so there is no need to hide internal stories from their nav trees.
 
 ### 8. how to properly annotate stories with TS metadata to get the best DX possible

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -265,7 +265,7 @@ export const parameters = { controls: { expanded: true } };
 > This may change in the future so the measures proposed in this section might no longer be relevant
 > if this assumption is no longer true.
 
-`react-menu` already has entire test suites dedicated to testing against storybook. Since each PR build will
+`react-menu` already has entire test suites dedicated to testing against storybook. Since each PR will build and
 deploy a storybook (storybook build for `react-components` package), the e2e suite (implemented with cypress) for converged components will execute against current PR deployed storybook instance. This
 includes the constraint that until a component is added to `react-components` it cannot be tested in CI.
 

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -266,7 +266,7 @@ export const parameters = { controls: { expanded: true } };
 > if this assumption is no longer true.
 
 `react-menu` already has entire test suites dedicated to testing against storybook. Since each PR build will
-deploy a storybook, the cypress testing solution for converged components will test against the PR storybook. This
+deploy a storybook (storybook build for `react-components` package), the e2e suite (implemented with cypress) for converged components will execute against current PR deployed storybook instance. This
 includes the constraint that until a component is added to `react-components` it cannot be tested in CI.
 
 The e2e testing solution for `react-menu` can be used for any converged component using storybook, and is also used by

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -270,7 +270,7 @@ deploy a storybook, the cypress testing solution for converged components will t
 includes the constraint that until a component is added to `react-components` it cannot be tested in CI.
 
 The e2e testing solution for `react-menu` can be used for any converged component using storybook, and is also used by
-`react-accordion` and `react-popover`. The purposes of E2E tests currently is to run internaction tests against the browser.
+`react-accordion` and `react-popover`. The purposes of E2E tests currently is to run interaction tests against the browser.
 Visual regression tests are handled by screener in `app-vrtests` and is out of the scope of this RFC.
 
 We propose to write an NX workspace generator to setup the e2e testing folder structure and dependencies for each package. The process is quite simple currently but still needs to be done manually.


### PR DESCRIPTION
This PR builds on a previous RFC and proposes an organizational
structure for colocated storybooks and an internal story system for E2E
testing of edge cases whose stories should not be publicly avaialble.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
