### PR TITLE
feat(react-tabster): create :focus-within focus indicator

### DIFF
--- a/change/@fluentui-react-tabster-621efb27-0dcb-437c-acf4-61e34dde919d.json
+++ b/change/@fluentui-react-tabster-621efb27-0dcb-437c-acf4-61e34dde919d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Create :focus-within indicator style rule",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -12,6 +12,9 @@ import { Types } from 'tabster';
 // @public (undocumented)
 export const createFocusIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>) => MakeStylesStyleRule<Theme>;
 
+// @public (undocumented)
+export const createFocusWithinIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>) => MakeStylesStyleRule<Theme>;
+
 // @public
 export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions | undefined) => Types.TabsterDOMAttribute;
 

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -10,10 +10,13 @@ import type { Theme } from '@fluentui/react-theme';
 import { Types } from 'tabster';
 
 // @public (undocumented)
-export const createFocusIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>) => MakeStylesStyleRule<Theme>;
+export const createFocusIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>, options?: CreateFocusIndicatorStyleRuleOptions) => MakeStylesStyleRule<Theme>;
 
 // @public (undocumented)
-export const createFocusWithinIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>) => MakeStylesStyleRule<Theme>;
+export interface CreateFocusIndicatorStyleRuleOptions {
+    // (undocumented)
+    selector?: 'focus' | 'focus-within';
+}
 
 // @public
 export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions | undefined) => Types.TabsterDOMAttribute;

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -12,5 +12,14 @@ export const createFocusIndicatorStyleRule = (
   ':focus-visible': {
     outline: 'none',
   },
-  [KEYBOARD_NAV_SELECTOR]: typeof rule === 'function' ? rule(theme) : rule,
+  [`${KEYBOARD_NAV_SELECTOR} :focus`]: typeof rule === 'function' ? rule(theme) : rule,
+});
+
+export const createFocusWithinIndicatorStyleRule = (
+  rule: MakeStylesStyleRule<Theme> = defaultStyleRule,
+): MakeStylesStyleRule<Theme> => theme => ({
+  ':focus-visible': {
+    outline: 'none',
+  },
+  [`${KEYBOARD_NAV_SELECTOR} :focus-within`]: typeof rule === 'function' ? rule(theme) : rule,
 });

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -6,20 +6,21 @@ const defaultStyleRule = (theme: Theme) => ({
   outline: `solid 1px ${theme.alias.color.neutral.neutralForeground1}`,
 });
 
+export interface CreateFocusIndicatorStyleRuleOptions {
+  selector?: 'focus' | 'focus-within';
+}
+
+const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
+  selector: 'focus',
+};
+
 export const createFocusIndicatorStyleRule = (
   rule: MakeStylesStyleRule<Theme> = defaultStyleRule,
+  options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
 ): MakeStylesStyleRule<Theme> => theme => ({
   ':focus-visible': {
     outline: 'none',
   },
-  [`${KEYBOARD_NAV_SELECTOR} :focus`]: typeof rule === 'function' ? rule(theme) : rule,
-});
-
-export const createFocusWithinIndicatorStyleRule = (
-  rule: MakeStylesStyleRule<Theme> = defaultStyleRule,
-): MakeStylesStyleRule<Theme> => theme => ({
-  ':focus-visible': {
-    outline: 'none',
-  },
-  [`${KEYBOARD_NAV_SELECTOR} :focus-within`]: typeof rule === 'function' ? rule(theme) : rule,
+  [`${KEYBOARD_NAV_SELECTOR} :${options.selector || defaultOptions.selector}`]:
+    typeof rule === 'function' ? rule(theme) : rule,
 });

--- a/packages/react-tabster/src/symbols.ts
+++ b/packages/react-tabster/src/symbols.ts
@@ -1,2 +1,2 @@
 export const KEYBOARD_NAV_ATTRIBUTE = 'data-keyboard-nav' as const;
-export const KEYBOARD_NAV_SELECTOR = `:global([${KEYBOARD_NAV_ATTRIBUTE}]) :focus` as const;
+export const KEYBOARD_NAV_SELECTOR = `:global([${KEYBOARD_NAV_ATTRIBUTE}])` as const;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`


### Description

Adds case for `:focus-within` as an alternative for `createFocusIndicatorStyleRule`