### PR TITLE
Adding focus styles to TextField's `canRevealPassword` eye button

### DIFF
--- a/change/@fluentui-react-36ed44d2-3e28-4a9d-9d17-77281dad9ce5.json
+++ b/change/@fluentui-react-36ed44d2-3e28-4a9d-9d17-77281dad9ce5.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react",
+  "email": "ilrosen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-36ed44d2-3e28-4a9d-9d17-77281dad9ce5.json
+++ b/change/@fluentui-react-36ed44d2-3e28-4a9d-9d17-77281dad9ce5.json
@@ -1,6 +1,0 @@
-{
-  "type": "patch",
-  "packageName": "@fluentui/react",
-  "email": "ilrosen@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-b34c7428-3beb-4310-8047-6b2c188cd404.json
+++ b/change/@fluentui-react-b34c7428-3beb-4310-8047-6b2c188cd404.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Apply getFocusStyle to TextField's `canRevealPassword` icon button",
+  "packageName": "@fluentui/react",
+  "email": "ilrosen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -2109,11 +2109,27 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   border: none;
                   color: #0078d4;
                   height: 30px;
+                  outline: transparent;
                   padding-bottom: 0px;
                   padding-left: 4px;
                   padding-right: 4px;
                   padding-top: 0px;
+                  position: relative;
                   width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
                 }
                 &:hover {
                   background-color: #f3f2f1;

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -2122,13 +2122,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid #ffffff;
-                  bottom: 1px;
+                  bottom: 2px;
                   content: "";
-                  left: 1px;
+                  left: 2px;
                   outline: 1px solid #605e5c;
                   position: absolute;
-                  right: 1px;
-                  top: 1px;
+                  right: 2px;
+                  top: 2px;
                   z-index: 1;
                 }
                 &:hover {

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -421,7 +421,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       classNames.revealButton,
       'ms-Button',
       'ms-Button--icon',
-      getFocusStyle(theme),
+      getFocusStyle(theme, { inset: 1 }),
       {
         height: 30,
         width: 32,

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -1,11 +1,11 @@
 import {
   AnimationClassNames,
+  getFocusStyle,
   getGlobalClassNames,
   getInputFocusStyle,
   HighContrastSelector,
   IStyle,
   normalize,
-  getFocusStyle,
   getPlaceholderStyles,
   IconFontSizes,
   getHighContrastNoAdjustStyle,

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -5,6 +5,7 @@ import {
   HighContrastSelector,
   IStyle,
   normalize,
+  getFocusStyle,
   getPlaceholderStyles,
   IconFontSizes,
   getHighContrastNoAdjustStyle,
@@ -420,6 +421,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       classNames.revealButton,
       'ms-Button',
       'ms-Button--icon',
+      getFocusStyle(theme),
       {
         height: 30,
         width: 32,

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1464,11 +1464,27 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
               border: none;
               color: #0078d4;
               height: 30px;
+              outline: transparent;
               padding-bottom: 0px;
               padding-left: 4px;
               padding-right: 4px;
               padding-top: 0px;
+              position: relative;
               width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
             }
             &:hover {
               background-color: #f3f2f1;

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1477,13 +1477,13 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
             }
             .ms-Fabric--isFocusVisible &:focus:after {
               border: 1px solid #ffffff;
-              bottom: 1px;
+              bottom: 2px;
               content: "";
-              left: 1px;
+              left: 2px;
               outline: 1px solid #605e5c;
               position: absolute;
-              right: 1px;
-              top: 1px;
+              right: 2px;
+              top: 2px;
               z-index: 1;
             }
             &:hover {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18908 Fixes #18900
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Use a Fluent IconButton, instead of a primitive HTML Button

#### Focus areas to test

Textfield w/ the `canRevealPassword` prop set to true.
