### PR TITLE
Stop publishing doc site-related packages

### DIFF
--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluentui/public-docsite-resources",
   "version": "8.1.40",
+  "private": true,
   "description": "Fluent UI React local demo app",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluentui/public-docsite",
   "version": "8.2.40",
+  "private": true,
   "description": "The official website for the Fluent UI project.",
   "sideEffects": true,
   "main": "lib-commonjs/root.js",

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluentui/api-docs",
   "version": "8.1.34",
+  "private": true,
   "description": "A package that transforms api-extractor .api.json files into page.json files",
   "repository": {
     "type": "git",

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluentui/react-examples",
   "version": "8.34.3",
+  "private": true,
   "description": "Example code and docs for Fluent UI packages.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We started publishing the doc site-related packages a couple months ago for testing purposes related to module federation. This appears to no longer be needed and causes a lot of headaches, so stop publishing the packages.