### PR TITLE
[web-components] add attr for changing accent base color on design system provider

### DIFF
--- a/change/@fluentui-web-components-876829c2-6a54-4777-9c1f-a007225a458a.json
+++ b/change/@fluentui-web-components-876829c2-6a54-4777-9c1f-a007225a458a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add attribute to recreate the accent palette using design system provider",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -299,6 +299,7 @@ export const density: import("@microsoft/fast-foundation").CSSDesignToken<number
 // @public
 export class DesignSystemProvider extends FoundationElement {
     constructor();
+    accentBaseColor: Swatch;
     accentFillActiveDelta: number;
     accentFillFocusDelta: number;
     accentFillHoverDelta: number;

--- a/packages/web-components/src/design-system-provider/index.ts
+++ b/packages/web-components/src/design-system-provider/index.ts
@@ -185,6 +185,28 @@ export class DesignSystemProvider extends FoundationElement {
   public fillColor: Swatch;
 
   /**
+   * A convenience to recreate the accentPalette
+   * @remarks
+   * HTML attribute: accent-base-color
+   */
+  @attr({
+    attribute: 'accent-base-color',
+    converter: swatchConverter,
+  })
+  public accentBaseColor: Swatch;
+
+  /**
+   * @internal
+   */
+  private accentBaseColorChanged(prev: Swatch, next: Swatch): void {
+    if (next !== undefined && next !== null) {
+      accentPalette.setValueFor(this, PaletteRGB.create(next as SwatchRGB));
+    } else {
+      accentPalette.deleteValueFor(this);
+    }
+  }
+
+  /**
    * A convenience to recreate the neutralPalette
    * @remarks
    * HTML attribute: neutral-base-color


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adds a new attribute enabling the easy updating of the accent-base color token from the Fluent DSP.

#### Focus areas to test

(optional)
