### PR TITLE
Make tests work if repo is under a parent folder called src

### DIFF
--- a/change/@fluentui-react-conformance-8bc87a4a-e3fd-4c34-8385-dd89b6458570.json
+++ b/change/@fluentui-react-conformance-8bc87a4a-e3fd-4c34-8385-dd89b6458570.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make tests work if repo is under a parent folder called src",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -243,8 +243,7 @@ export const defaultTests: TestObject = {
     it(`is exported at top-level (exported-top-level)`, () => {
       try {
         const { displayName, componentPath, Component } = testInfo;
-        const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-        const indexFile = require(path.join(rootPath, 'src', 'index'));
+        const indexFile = require(path.join(getPackagePath(componentPath), 'src', 'index'));
 
         expect(indexFile[displayName]).toBe(Component);
       } catch (e) {
@@ -262,8 +261,7 @@ export const defaultTests: TestObject = {
     it(`has corresponding top-level file 'package/src/Component' (has-top-level-file)`, () => {
       try {
         const { displayName, componentPath, Component } = testInfo;
-        const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
-        const topLevelFile = require(path.join(rootPath, 'src', displayName));
+        const topLevelFile = require(path.join(getPackagePath(componentPath), 'src', displayName));
 
         expect(topLevelFile[displayName]).toBe(Component);
       } catch (e) {
@@ -461,3 +459,9 @@ export const defaultTests: TestObject = {
     });
   },
 };
+
+function getPackagePath(componentPath: string) {
+  // Use lastIndexOf in case anyone has all their repos under a folder called "src" (it happens)
+  const srcIndex = componentPath.replace(/\\/g, '/').lastIndexOf('/src/');
+  return componentPath.slice(0, srcIndex);
+}

--- a/packages/react-examples/src/ComponentExamples.test.tsx
+++ b/packages/react-examples/src/ComponentExamples.test.tsx
@@ -119,7 +119,14 @@ function setCacheFullWarning(enabled: boolean) {
 }
 
 function getPackageAndExampleName(examplePath: string): [string, string] {
-  return [examplePath.replace(/\\/g, '/').match(/\/src\/([^/]+)/)![1], path.basename(examplePath)];
+  // Examples should be under paths like:
+  // /<repoRoot>/packages/react-examples/src/some-pkg/SomeComponent/SomeComponent.Whatever.Example.tsx
+  const pathSegments = examplePath.split(/[\\/]/g);
+  // Use lastIndexOf in case anyone has all their repos under a folder called "src" (it happens)
+  const srcIndex = pathSegments.lastIndexOf('src');
+  const packageName = pathSegments[srcIndex + 1];
+  const exampleName = pathSegments.slice(-1)[0];
+  return [packageName, exampleName];
 }
 
 /** Run tests on these packages' examples */


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The conformance tests and component example tests assumed that there would only be one folder called `src` in file paths within the repo. This breaks the tests for people who put all their repos under a parent folder called `src`. Fix the tests to use more specific checks.