### PR TITLE
Include website packages in the release build

### DIFF
--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -10,18 +10,28 @@ if (argv.length < 1) {
 
   yarn run:published <script> [<args>]
 
-This command runs <script> for all beachball-published packages (and their dependencies).
+This command runs <script> for all beachball-published packages, as well as packages for the version 8 website.
 `);
 
   process.exit(0);
 }
 
-// Only include the packages that are published daily by beachball.
-// This logic does the same thing as "--scope \"!packages/fluentui/*\"" in the root package.json's
-// publishing-related scripts (and excludes private packages, which beachball does internally).
-// It will need to be updated if the --scope changes.
+const websitePackages = [
+  '@fluentui/public-docsite',
+  '@fluentui/public-docsite-resources',
+  '@fluentui/react-examples',
+  '@fluentui/api-docs',
+];
+
+// Only include the packages that are published daily by beachball, and some website/doc packages
+// (which must be built and uploaded with each release). This is similar to "--scope \"!packages/fluentui/*\""
+// in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
 const beachballPackageScopes = Object.entries(getAllPackageInfo())
-  .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
+  .filter(
+    ([, { packageJson, packagePath }]) =>
+      !/[\\/]fluentui[\\/]/.test(packagePath) &&
+      (packageJson.private !== true || websitePackages.includes(packageJson.name)),
+  )
   .map(([packageName]) => `--to=${packageName}`);
 
 const lageArgs = [


### PR DESCRIPTION
#18912 stopped publishing the website packages, but they still need to be built during the daily release build. Update the `run:published` script to handle this.