### PR TITLE
Accessibility fixes for react-docsite-components

### DIFF
--- a/change/@fluentui-react-docsite-components-29e0e38f-097a-4cbf-bf10-85b2eb331511.json
+++ b/change/@fluentui-react-docsite-components-29e0e38f-097a-4cbf-bf10-85b2eb331511.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Accessibility fixes for nav, feedback list, header",
+  "comment": "Accessibility fixes for nav, feedback list, header, properties table",
   "packageName": "@fluentui/react-docsite-components",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-docsite-components-29e0e38f-097a-4cbf-bf10-85b2eb331511.json
+++ b/change/@fluentui-react-docsite-components-29e0e38f-097a-4cbf-bf10-85b2eb331511.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility fixes for nav, feedback list, header",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -3,11 +3,12 @@ import { mergeStyles, getTheme } from '@fluentui/react/lib/Styling';
 import {
   DetailsList,
   DetailsRow,
-  IDetailsRowProps,
   IDetailsRowStyles,
   DetailsListLayoutMode,
   IColumn,
   ColumnActionsMode,
+  IDetailsListProps,
+  DetailsHeader,
 } from '@fluentui/react/lib/DetailsList';
 import { Link } from '@fluentui/react/lib/Link';
 import { SelectionMode } from '@fluentui/react/lib/Selection';
@@ -228,6 +229,7 @@ const ApiDetailsList: React.FunctionComponent<IApiDetailsListProps> = React.memo
       selectionMode={SelectionMode.none}
       layoutMode={DetailsListLayoutMode.justified}
       onRenderRow={_onRenderRow}
+      onRenderDetailsHeader={_onRenderHeader}
       onShouldVirtualize={_returnFalse}
     />
   );
@@ -247,9 +249,18 @@ const rowStyles: Partial<IDetailsRowStyles> = {
   },
   isMultiline: { wordBreak: 'break-word' },
 };
-function _onRenderRow(props: IDetailsRowProps) {
-  return <DetailsRow {...props} styles={rowStyles} />;
-}
+const _onRenderRow: IDetailsListProps['onRenderRow'] = props => {
+  return <DetailsRow {...props!} styles={rowStyles} />;
+};
+
+const _onRenderHeader: IDetailsListProps['onRenderDetailsHeader'] = props => {
+  return (
+    <DetailsHeader
+      {...props!}
+      ariaLabelForToggleAllGroupsButton={props!.isAllCollapsed ? 'Expand all groups' : 'Collapse all groups'}
+    />
+  );
+};
 
 /** Field names used in the API list (used in generating columns and renderers) */
 type ApiListFieldName = 'name' | 'value' | 'type' | 'defaultValue' | 'description' | 'signature';

--- a/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/react-docsite-components/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -3,12 +3,11 @@ import { mergeStyles, getTheme } from '@fluentui/react/lib/Styling';
 import {
   DetailsList,
   DetailsRow,
+  IDetailsRowProps,
   IDetailsRowStyles,
   DetailsListLayoutMode,
   IColumn,
   ColumnActionsMode,
-  IDetailsListProps,
-  DetailsHeader,
 } from '@fluentui/react/lib/DetailsList';
 import { Link } from '@fluentui/react/lib/Link';
 import { SelectionMode } from '@fluentui/react/lib/Selection';
@@ -229,7 +228,6 @@ const ApiDetailsList: React.FunctionComponent<IApiDetailsListProps> = React.memo
       selectionMode={SelectionMode.none}
       layoutMode={DetailsListLayoutMode.justified}
       onRenderRow={_onRenderRow}
-      onRenderDetailsHeader={_onRenderHeader}
       onShouldVirtualize={_returnFalse}
     />
   );
@@ -249,18 +247,9 @@ const rowStyles: Partial<IDetailsRowStyles> = {
   },
   isMultiline: { wordBreak: 'break-word' },
 };
-const _onRenderRow: IDetailsListProps['onRenderRow'] = props => {
-  return <DetailsRow {...props!} styles={rowStyles} />;
-};
-
-const _onRenderHeader: IDetailsListProps['onRenderDetailsHeader'] = props => {
-  return (
-    <DetailsHeader
-      {...props!}
-      ariaLabelForToggleAllGroupsButton={props!.isAllCollapsed ? 'Expand all groups' : 'Collapse all groups'}
-    />
-  );
-};
+function _onRenderRow(props: IDetailsRowProps) {
+  return <DetailsRow {...props} styles={rowStyles} />;
+}
 
 /** Field names used in the API list (used in generating columns and renderers) */
 type ApiListFieldName = 'name' | 'value' | 'type' | 'defaultValue' | 'description' | 'signature';

--- a/packages/react-docsite-components/src/components/FeedbackList/FeedbackList.styles.ts
+++ b/packages/react-docsite-components/src/components/FeedbackList/FeedbackList.styles.ts
@@ -49,14 +49,7 @@ export const getStyles: IStyleFunction<IFeedbackListStyleProps, IFeedbackListSty
         },
       },
     ],
-    itemName: [
-      theme.fonts.mediumPlus,
-      {
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      },
-    ],
+    itemName: theme.fonts.mediumPlus,
     itemLabel: [
       {
         fontSize: theme.fonts.small.fontSize,

--- a/packages/react-docsite-components/src/components/Header/Header.tsx
+++ b/packages/react-docsite-components/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export class HeaderBase extends React.Component<IHeaderProps, IHeaderState> {
     // For screen sizes large down, hide the side links.
     const sideLinks = isLargeDown ? [] : this.props.sideLinks;
 
-    const classNames = getClassNames(styles, { theme });
+    const classNames = getClassNames(styles, { theme, isLargeDown });
     const { subComponentStyles } = classNames;
 
     return (
@@ -62,6 +62,7 @@ export class HeaderBase extends React.Component<IHeaderProps, IHeaderState> {
                     className={classNames.button}
                     onClick={this._onGearClick}
                     aria-label="Settings"
+                    aria-expanded={!!contextMenu}
                   >
                     <Icon iconName="Settings" styles={subComponentStyles.icons} />
                   </button>,

--- a/packages/react-docsite-components/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/react-docsite-components/src/components/PropertiesTable/PropertiesTable.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { DetailsList, DetailsListLayoutMode, IColumn, IGroup } from '@fluentui/react/lib/DetailsList';
+import {
+  DetailsHeader,
+  DetailsList,
+  DetailsListLayoutMode,
+  IColumn,
+  IDetailsListProps,
+  IGroup,
+} from '@fluentui/react/lib/DetailsList';
 import { SelectionMode } from '@fluentui/react/lib/Selection';
 import { ITheme } from '@fluentui/react/lib/Styling';
 import { styled, classNamesFunction, IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
@@ -92,6 +99,17 @@ const ENUM_COLUMNS: IColumn[] = getColumns([
   { key: 'description', name: 'Description', minWidth: 300, maxWidth: 400 },
 ]);
 
+const onShouldVirtualize = () => false;
+
+const onRenderHeader: IDetailsListProps['onRenderDetailsHeader'] = props => {
+  return (
+    <DetailsHeader
+      {...props!}
+      ariaLabelForToggleAllGroupsButton={props!.isAllCollapsed ? 'Expand all groups' : 'Collapse all groups'}
+    />
+  );
+};
+
 class PropertiesTableBase extends React.PureComponent<IPropertiesTableProps> {
   public static defaultProps: Partial<IPropertiesTableProps> = {
     title: 'Properties',
@@ -139,15 +157,12 @@ class PropertiesTableBase extends React.PureComponent<IPropertiesTableProps> {
           groups={this._groups}
           columns={renderAsEnum ? ENUM_COLUMNS : DEFAULT_COLUMNS}
           styles={classNames.subComponentStyles.list}
-          onShouldVirtualize={this._onShouldVirtualize}
+          onShouldVirtualize={onShouldVirtualize}
+          onRenderDetailsHeader={onRenderHeader}
         />
       </div>
     );
   }
-
-  private _onShouldVirtualize = (): boolean => {
-    return false;
-  };
 
   private _getGroups(): IGroup[] {
     const groups: IGroup[] = [];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16552, fixes #16550, fixes #16612
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix some accessibility issues with the legacy demo app components (which are also used by a handful of other teams):
- Allow closing nav with escape key (small screens only)
- Add aria-expanded to settings button
- Add label for expand/collapse all button in properties tables
- Allow long issue names in feedback list to wrap

[Try out the changes here](https://fluentuipr.z22.web.core.windows.net/pull/18928/public-docsite-resources/demo/index.html)