### PR TITLE
Charting: CherryPick #18880: Custom Accessibility Change for Grouped Vertical Bar Chart #18880

### DIFF
--- a/change/@fluentui-react-examples-87a33e23-5baf-4ca4-ace4-2b008c036677.json
+++ b/change/@fluentui-react-examples-87a33e23-5baf-4ca4-ace4-2b008c036677.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GroupedVertical Chart accessibility change",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-94b0a709-a662-46f0-ba71-11fdbf7ee03c.json
+++ b/change/@uifabric-charting-94b0a709-a662-46f0-ba71-11fdbf7ee03c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GroupedVertical Chart accessibility change",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -13,8 +13,15 @@ import {
   memoizeFunction,
   warnDeprecations,
 } from 'office-ui-fabric-react/lib/Utilities';
-import { ChartTypes, tooltipOfXAxislabels, XAxisTypes, getTypeOfAxis } from '../../utilities/index';
 import {
+  ChartTypes,
+  getAccessibleDataObject,
+  tooltipOfXAxislabels,
+  XAxisTypes,
+  getTypeOfAxis,
+} from '../../utilities/index';
+import {
+  IAccessibilityProps,
   CartesianChart,
   ILegend,
   IGroupedVerticalBarChartData,
@@ -46,6 +53,7 @@ interface IGVSingleDataPoint {
 export interface IGroupedVerticalBarChartState extends IBasestate {
   titleForHoverCard: string;
   dataPointCalloutProps?: IGVBarChartSeriesPoint;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class GroupedVerticalBarChartBase extends React.Component<
@@ -127,6 +135,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
       onDismiss: this._closeCallout,
       ...this.props.calloutProps,
+      preventDismissOnLostFocus: true,
+      ...getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false),
     };
     const tickParams = {
       tickValues: this.props.tickValues!,
@@ -221,6 +231,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
         xCalloutValue: pointData.xAxisCalloutData,
         yCalloutValue: pointData.yAxisCalloutData,
         dataPointCalloutProps: pointData,
+        callOutAccessibilityData: pointData.callOutAccessibilityData,
       });
     }
   };
@@ -243,6 +254,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             xCalloutValue: pointData.xAxisCalloutData,
             yCalloutValue: pointData.yAxisCalloutData,
             dataPointCalloutProps: pointData,
+            callOutAccessibilityData: pointData.callOutAccessibilityData,
           });
         }
       });
@@ -306,6 +318,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             onBlur={this._onBarLeave}
             onClick={this.props.href ? this._redirectToUrl.bind(this, this.props.href!) : pointData.onClick}
             aria-labelledby={`toolTip${this._calloutId}`}
+            role="text"
           />,
         );
     });

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -136,6 +137,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -156,6 +158,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -180,6 +183,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -200,6 +204,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -220,6 +225,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -678,6 +684,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -698,6 +705,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -718,6 +726,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -742,6 +751,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -762,6 +772,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -782,6 +793,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1220,6 +1232,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -1240,6 +1253,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -1260,6 +1274,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1284,6 +1299,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -1304,6 +1320,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -1324,6 +1341,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1451,6 +1469,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -1471,6 +1490,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -1491,6 +1511,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -1515,6 +1536,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -1535,6 +1557,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -1555,6 +1578,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2013,6 +2037,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -2033,6 +2058,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -2053,6 +2079,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2077,6 +2104,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -2097,6 +2125,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -2117,6 +2146,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2575,6 +2605,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -2595,6 +2626,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -2615,6 +2647,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -2639,6 +2672,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -2659,6 +2693,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -2679,6 +2714,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -3137,6 +3173,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={5.333333333333329}
@@ -3157,6 +3194,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={0}
@@ -3177,6 +3215,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}
@@ -3201,6 +3240,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
             y={0}
@@ -3221,6 +3261,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={8.0327868852459}
             y={20}
@@ -3241,6 +3282,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
+            role="text"
             width={7.267759562841528}
             x={15.683060109289613}
             y={0}

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -461,6 +461,11 @@ export interface IGVBarChartSeriesPoint {
    * onClick action for each datapoint in the chart
    */
   onClick?: VoidFunction;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IGroupedVerticalBarChartData {

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -5,6 +5,7 @@ import { select as d3Select, event as d3Event } from 'd3-selection';
 import { format as d3Format } from 'd3-format';
 import * as d3TimeFormat from 'd3-time-format';
 import {
+  IAccessibilityProps,
   IEventsAnnotationProps,
   ILineChartPoints,
   ILineChartDataPoint,
@@ -928,4 +929,25 @@ export const pointTypes: PointTypes = {
   [Points.octagon]: {
     widthRatio: 2.414,
   },
+};
+
+/**
+ * @param accessibleData accessible data
+ * @param role string to define role of tag
+ * @param isDataFocusable boolean
+ * function returns the accessibility data object
+ */
+export const getAccessibleDataObject = (
+  accessibleData?: IAccessibilityProps,
+  role: string = 'text',
+  isDataFocusable: boolean = true,
+) => {
+  accessibleData = accessibleData ?? {};
+  return {
+    role,
+    'data-is-focusable': isDataFocusable,
+    'aria-label': accessibleData!.ariaLabel,
+    'aria-labelledby': accessibleData!.ariaLabelledBy,
+    'aria-describedby': accessibleData!.ariaDescribedBy,
+  };
 };

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import {
+  GroupedVerticalBarChart,
+  IGroupedVerticalBarChartData,
+  IGroupedVerticalBarChartProps,
+} from '@uifabric/charting';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+
+interface IGroupedBarChartState {
+  width: number;
+  height: number;
+}
+
+export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Component<{}, IGroupedBarChartState> {
+  constructor(props: IGroupedVerticalBarChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 400,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _basicExample(): JSX.Element {
+    const data: IGroupedVerticalBarChartData[] = [
+      {
+        name: 'Metadata info multi lines text Completed',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 1 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 44000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '44%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 44%',
+            },
+          },
+        ],
+      },
+      {
+        name: 'Meta Data2',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 2 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 3000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '3%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+            },
+          },
+        ],
+      },
+
+      {
+        name: 'Single line text ',
+        series: [
+          {
+            key: 'series1',
+            data: 14000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '14%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 3 of 4, Bar series 1 of 2 2020/04/30 14%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 50000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '50%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 50%',
+            },
+          },
+        ],
+      },
+      {
+        name: 'Hello World!!!',
+        series: [
+          {
+            key: 'series1',
+            data: 33000,
+            color: DefaultPalette.blueLight,
+            legend: 'MetaData1',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '33%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Group series 4 of 4, Bar series 1 of 2 2020/04/30 33%',
+            },
+          },
+          {
+            key: 'series2',
+            data: 3000,
+            color: DefaultPalette.blue,
+            legend: 'MetaData4',
+            xAxisCalloutData: '2020/04/30',
+            yAxisCalloutData: '3%',
+            callOutAccessibilityData: {
+              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+            },
+          },
+        ],
+      },
+    ];
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div style={rootStyle}>
+          <GroupedVerticalBarChart
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            showYAxisGridLines
+            wrapXAxisLables
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChartPage.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChartPage.tsx
@@ -5,10 +5,12 @@ import { ComponentPage, ExampleCard, IComponentDemoPageProps, PropertiesTableSet
 import { GroupedVerticalBarChartBasicExample } from './GroupedVerticalBarChart.Basic.Example';
 import { GroupedVerticalBarChartBasic2Example } from './GroupedVerticalBarChart.Basic2.Example';
 import { GroupedVerticalBarChartStyledExample } from './GroupedVerticalBarChart.Styled.Example';
+import { GroupedVerticalBarChartCustomAccessibilityExample } from './GroupedVerticalBarChart.CustomAccessibility.Example';
 
 const GroupedVerticalBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx') as string;
 const GroupedVerticalStyledExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx') as string;
 const GroupedVerticalBasic2ExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic2.Example.tsx') as string;
+const GroupedVerticalCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx') as string;
 
 export class GroupedVerticalBarChart extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -26,6 +28,12 @@ export class GroupedVerticalBarChart extends React.Component<IComponentDemoPageP
             </ExampleCard>
             <ExampleCard title="Grouped Vertical Bar Chart Styled" code={GroupedVerticalStyledExampleCode}>
               <GroupedVerticalBarChartStyledExample />
+            </ExampleCard>
+            <ExampleCard
+              title="Grouped Vertical Bar Chart Custom Accessibility"
+              code={GroupedVerticalCustomAccessibilityExampleCode}
+            >
+              <GroupedVerticalBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
**Original description**

Cherry pick of [#18880](https://github.com/microsoft/fluentui/pull/18880)

#### Description of changes

Changes are related to Grouped Vertical Bar Chart accessibility

1. Accessibility Data prop added for the Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
Custom Accessibility example is added for Grouped Vertical Bar Chart.

**Before Change:**

![image](https://user-images.githubusercontent.com/29042635/125088656-45ec9100-e0eb-11eb-8288-a9492c014ef0.png)

**After Change:**

![image](https://user-images.githubusercontent.com/29042635/125088918-821ff180-e0eb-11eb-9f70-c385c5233ec0.png)

#### Focus areas to test

(optional)
