### PR TITLE
fix(menu item): Adding back data-is-focusable attribute

### DIFF
--- a/packages/fluentui/accessibility/src/behaviors/Menu/menuItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Menu/menuItemBehavior.ts
@@ -1,5 +1,6 @@
 import { keyboardKey, SpacebarKey } from '../../keyboard-key';
 
+import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { Accessibility, AccessibilityAttributes } from '../../types';
 
 /**
@@ -16,6 +17,7 @@ import { Accessibility, AccessibilityAttributes } from '../../types';
  * Adds attribute 'aria-expanded=true' based on the property 'menuOpen' if the component has 'hasMenu' property to 'root' slot.
  * Adds attribute 'aria-haspopup=true' to 'root' slot if 'hasMenu' property is set.
  * Adds attribute 'aria-disabled=true' based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
+ * Adds attribute 'data-is-focusable=true' to 'root' slot.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  * Triggers 'closeMenuAndFocusTrigger' action with 'Escape' on 'wrapper'.
  * Triggers 'closeAllMenusAndFocusNextParentItem' action with 'ArrowRight' on 'wrapper'.
@@ -37,6 +39,7 @@ export const menuItemBehavior: Accessibility<MenuItemBehaviorProps> = props => (
       'aria-labelledby': props['aria-labelledby'],
       'aria-describedby': props['aria-describedby'],
       'aria-disabled': props.disabled,
+      [IS_FOCUSABLE_ATTRIBUTE]: true,
     },
   },
 

--- a/packages/fluentui/accessibility/src/behaviors/Tab/tabBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tab/tabBehavior.ts
@@ -1,5 +1,6 @@
 import { keyboardKey, SpacebarKey } from '../../keyboard-key';
 
+import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { Accessibility, AccessibilityAttributes } from '../../types';
 
 /**
@@ -14,6 +15,7 @@ import { Accessibility, AccessibilityAttributes } from '../../types';
  * Adds attribute 'aria-controls' based on the property 'aria-controls' to 'root' slot.
  * Adds attribute 'aria-disabled=true' based on the property 'disabled'. This can be overriden by providing 'aria-disabled' property directly to the component.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
+ * Adds attribute 'data-is-focusable=true' to 'root' slot.
  */
 export const tabBehavior: Accessibility<TabBehaviorProps> = props => ({
   attributes: {
@@ -29,6 +31,7 @@ export const tabBehavior: Accessibility<TabBehaviorProps> = props => ({
       'aria-describedby': props['aria-describedby'],
       'aria-controls': props['aria-controls'],
       'aria-disabled': props['disabled'],
+      [IS_FOCUSABLE_ATTRIBUTE]: true,
     },
   },
 

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/menuItemAsToolbarButtonBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/menuItemAsToolbarButtonBehavior.ts
@@ -1,5 +1,6 @@
 import { keyboardKey, SpacebarKey } from '../../keyboard-key';
 
+import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { Accessibility } from '../../types';
 import { MenuItemBehaviorProps } from '../Menu/menuItemBehavior';
 
@@ -20,6 +21,7 @@ import { MenuItemBehaviorProps } from '../Menu/menuItemBehavior';
  * Triggers 'closeMenuAndFocusTrigger' action with 'Escape' on 'wrapper'.
  * Triggers 'openMenu' action with 'ArrowDown' on 'wrapper', when orientation is horizontal.
  * Triggers 'doNotNavigateNextParentItem' action with 'ArrowLeft' or 'ArrowRight' on 'wrapper', when toolbar button has submenu and it is opened.
+ * Adds attribute 'data-is-focusable=true' to 'root' slot.
  */
 export const menuItemAsToolbarButtonBehavior: Accessibility<MenuItemBehaviorProps> = props => ({
   attributes: {
@@ -34,6 +36,7 @@ export const menuItemAsToolbarButtonBehavior: Accessibility<MenuItemBehaviorProp
       'aria-label': props['aria-label'],
       'aria-labelledby': props['aria-labelledby'],
       'aria-describedby': props['aria-describedby'],
+      [IS_FOCUSABLE_ATTRIBUTE]: true,
     },
   },
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
In the following PR 
https://github.com/microsoft/fluentui/pull/17939/files

we removed data-is-focusable attribute from couple of behavior. 

This change is working fine on Fluent UI doc page. Unfortunately while integrating components we recognized it could cause issue and items are not navigable anymore. For this reason returning back  data-is-focusable attribute.


#### Focus areas to test
Menu navigation still works.
Disabled menuItem is still navigable. 
