### PR TITLE
chore: fix "variables.isPR" condition in azure-pipelines.bundlesize.yml

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -31,7 +31,7 @@ jobs:
       - script: |
           yarn bundle-size compare-reports --branch=$(System.PullRequest.TargetBranch) --output=markdown --verbose
         displayName: compare bundle size with base (PR only)
-        condition: variables.isPR
+        condition: eq(variables.isPR, true)
 
       - task: GithubPRComment@0
         displayName: Post results to PR (PR only)


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] ~~Include a change request file using `$ yarn change`~~

#### Description of changes

The same as #18847, I overlooked it in #18256 when was merging conflicts. Currently it causes build failures for `master` as runs a task that should be evaluated only for PR:

![image](https://user-images.githubusercontent.com/14183168/125623142-0794bbcd-ea86-479a-8844-5da5b205f09c.png)
