### PR TITLE
chore: update codeowners with convergence team owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,8 @@ perf-test/ @microsoft/fluentui-react-build
 # todo-app/
 
 #### Packages
+packages/storybook/ @cxe-prg @teams-prg
+packages/react-focus/ @microsoft/cxe-red
 packages/react-charting/ @Raghurk
 packages/react-date-time @lorejoh12 @evlevy
 packages/date-time-utilities @lorejoh12 @evlevy
@@ -89,16 +91,11 @@ packages/style-utilities/ @dzearing
 packages/style-utilities/src/interfaces/ @phkuo @dzearing
 packages/style-utilities/src/styles/ @phkuo @dzearing
 packages/theme/ @dzearing
-packages/react-provider/ @teams-prg
 packages/react-monaco-editor/ @ecraig12345
 # packages/utilities/
 packages/utilities/positioning/ @microsoft/cxe-red
 packages/azure-themes/ @hyoshis @Jacqueline-ms @wsmd
-packages/make-styles/ @teams-prg
-packages/react-make-styles/ @teams-prg
-packages/react-aria/ @bsunderhus
-packages/babel-make-styles/ @teams-prg
-packages/jest-serializer-make-styles/ @teams-prg
+
 
 ### Fabric
 # common/
@@ -107,27 +104,43 @@ common/_semanticSlots.scss @microsoft/cxe-red @phkuo
 common/_themeOverrides.scss @microsoft/cxe-red @phkuo
 common/_common.scss @microsoft/cxe-red @phkuo
 
-## Component packages
-packages/react-avatar/ @microsoft/cxe-red @behowell
+## Convergence packages
+packages/babel-make-styles/ @teams-prg
+packages/bundle-size/ @teams-prg @microsoft/fluentui-react-build
+packages/jest-serializer-make-styles/ @teams-prg
+packages/keyboard-keys/ @teams-prg
+packages/make-styles/ @teams-prg
+packages/make-styles-webpack-loader/ @teams-prg
+packages/react-avatar/ @microsoft/cxe-red
 packages/react-menu/ @teams-prg
-packages/react-badge/ @ling1726 @layershifter @assuncaocharles @behowell
-packages/react-button/ @microsoft/cxe-red @dzearing @khmakoto
-packages/react-card/ @microsoft/cxe-red @khmakoto
-packages/react-checkbox/ @microsoft/cxe-red @khmakoto
-packages/react-components/ @layershifter @miroslavstastny
-packages/react-focus/ @microsoft/cxe-red @khmakoto
+packages/react-badge/ @teams-prg @microsoft/cxe-red
+packages/react-button/ @microsoft/cxe-red
+packages/react-card/ @microsoft/cxe-red
+packages/react-checkbox/ @microsoft/cxe-red
+packages/react-components/ @teams-prg @cxe-prg @microsoft/cxe-red
 packages/react-image/ @cxe-prg
-packages/react-input/ @microsoft/cxe-red @ecraig12345
-packages/react-storybook/ @cxe-prg @ling1726 @layershifter
-packages/storybook/ @cxe-prg @ling1726 @layershifter
-packages/react-link/ @microsoft/cxe-red @khmakoto
+packages/react-text/ @cxe-prg
+packages/react-input/ @microsoft/cxe-red
+packages/react-storybook/ @cxe-prg @teams-prg
+packages/react-link/ @microsoft/cxe-red
+packages/react-tabs/ @microsoft/cxe-red
+packages/react-toggle/ @microsoft/cxe-red
+packages/react-tooltip/ @microsoft/cxe-red
+packages/react-label/ @microsoft/cxe-red
+packages/react-make-styles/ @teams-prg
+packages/react-aria/ @teams-prg
+packages/react-context-selector/ @teams-prg
+packages/react-popover/ @teams-prg
+packages/react-utilities/ @teams-prg
+packages/react-tabster/ @teams-prg
+packages/react-provider/ @teams-prg
+packages/react-positioning/ @teams-prg
+packages/react-portal/ @teams-prg
+packages/react-divider/ @microsoft/cxe-red
+packages/react-accordion/ @teams-prg
 packages/react-slider/ @microsoft/cxe-red
-packages/react-tabs/ @microsoft/cxe-red @behowell
-packages/react-toggle/ @microsoft/cxe-red @behowell
-packages/react-tooltip/ @microsoft/cxe-red @behowell
-packages/react-label/ @microsoft/cxe-red @sopranopillow
 
-## Components
+## Components / v8
 packages/react @microsoft/cxe-red
 packages/react/src/components/ActivityItem/ @microsoft/cxe-red @khmakoto
 packages/react/src/components/Announced/ @microsoft/cxe-red @khmakoto


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue: ~
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

As previously agreed we wanna use team ownership policy (for all converged and new packages added by our teams)

This PR
- removes single owners (to mitigate BUS factor)
- adds all missing packages and its owners

#### Focus areas to test

(optional)
