### PR TITLE
Adding a new property which allow user to make navagation unclickable

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -112,6 +112,9 @@ export interface CarouselProps extends UIComponentProps, ChildrenComponentProps 
 
   /** Shorthand for the paddle that navigates to the previous item. */
   paddlePrevious?: ShorthandValue<CarouselPaddleProps>;
+
+  /** A navigation may be clickable */
+  disableClickableNav?: boolean;
 }
 
 export type CarouselStylesProps = { isFromKeyboard: boolean; shouldFocusContainer: boolean };
@@ -160,6 +163,7 @@ export const Carousel: ComponentWithAs<'div', CarouselProps> &
     design,
     styles,
     variables,
+    disableClickableNav,
   } = props;
 
   const ElementType = getElementType(props);
@@ -443,6 +447,8 @@ export const Carousel: ComponentWithAs<'div', CarouselProps> &
         }),
         overrideProps: (predefinedProps: CarouselNavigationItemProps) => ({
           onItemClick: (e: React.SyntheticEvent, itemProps: CarouselNavigationItemProps) => {
+            if (disableClickableNav) return;
+
             const { index } = itemProps;
 
             setActiveIndex(e, index, true);

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -59,9 +59,6 @@ export interface CarouselNavigationProps extends UIComponentProps, ChildrenCompo
 
   /** A vertical carousel navigation displays elements vertically. */
   vertical?: boolean;
-
-  /** A navigation may be clickable */
-  disableClickableNav?: boolean;
 }
 
 export type CarouselNavigationStylesProps = Required<
@@ -92,7 +89,6 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
     vertical,
     thumbnails,
     styles,
-    disableClickableNav,
   } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CarouselNavigation.handledProps, props);
@@ -120,16 +116,13 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
     rtl: context.rtl,
   });
 
-  const handleItemOverrides = (variables: any, disableClickableNav: boolean) => predefinedProps =>
-    disableClickableNav
-      ? undefined
-      : {
-          onClick: (e, itemProps) => {
-            _.invoke(props, 'onItemClick', e, itemProps);
-            _.invoke(predefinedProps, 'onClick', e, itemProps);
-          },
-          variables: mergeVariablesOverrides(variables, predefinedProps.variables),
-        };
+  const handleItemOverrides = (variables: any) => predefinedProps => ({
+    onClick: (e, itemProps) => {
+      _.invoke(props, 'onItemClick', e, itemProps);
+      _.invoke(predefinedProps, 'onClick', e, itemProps);
+    },
+    variables: mergeVariablesOverrides(variables, predefinedProps.variables),
+  });
 
   const renderItems = () => {
     return _.map(items, (item, index) =>
@@ -144,7 +137,7 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
             vertical,
             thumbnails,
           }),
-        overrideProps: handleItemOverrides(variables, disableClickableNav),
+        overrideProps: handleItemOverrides(variables),
       }),
     );
   };

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -116,7 +116,7 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
     rtl: context.rtl,
   });
 
-  const handleItemOverrides = (variables: any) => predefinedProps => ({
+  const handleItemOverrides = variables => predefinedProps => ({
     onClick: (e, itemProps) => {
       _.invoke(props, 'onItemClick', e, itemProps);
       _.invoke(predefinedProps, 'onClick', e, itemProps);

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -120,13 +120,16 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
     rtl: context.rtl,
   });
 
-  const handleItemOverrides = variables => predefinedProps => ({
-    onClick: (e, itemProps) => {
-      _.invoke(props, 'onItemClick', e, itemProps);
-      _.invoke(predefinedProps, 'onClick', e, itemProps);
-    },
-    variables: mergeVariablesOverrides(variables, predefinedProps.variables),
-  });
+  const handleItemOverrides = (variables: any, disableClickableNav: boolean) => predefinedProps =>
+    disableClickableNav
+      ? undefined
+      : {
+          onClick: (e, itemProps) => {
+            _.invoke(props, 'onItemClick', e, itemProps);
+            _.invoke(predefinedProps, 'onClick', e, itemProps);
+          },
+          variables: mergeVariablesOverrides(variables, predefinedProps.variables),
+        };
 
   const renderItems = () => {
     return _.map(items, (item, index) =>
@@ -141,7 +144,7 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
             vertical,
             thumbnails,
           }),
-        overrideProps: disableClickableNav ? undefined : handleItemOverrides(variables),
+        overrideProps: handleItemOverrides(variables, disableClickableNav),
       }),
     );
   };

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -59,6 +59,9 @@ export interface CarouselNavigationProps extends UIComponentProps, ChildrenCompo
 
   /** A vertical carousel navigation displays elements vertically. */
   vertical?: boolean;
+
+  /** A navigation may be clickable */
+  disableClickableNav?: boolean;
 }
 
 export type CarouselNavigationStylesProps = Required<
@@ -89,6 +92,7 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
     vertical,
     thumbnails,
     styles,
+    disableClickableNav,
   } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CarouselNavigation.handledProps, props);
@@ -137,7 +141,7 @@ export const CarouselNavigation: ComponentWithAs<'ul', CarouselNavigationProps> 
             vertical,
             thumbnails,
           }),
-        overrideProps: handleItemOverrides(variables),
+        overrideProps: disableClickableNav ? undefined : handleItemOverrides(variables),
       }),
     );
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
 Requirement 1850100: Make store carousel banner navigator dots not clickable
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Giving user an option that can making carousel navigator dots not clickable
(give an overview)

#### Focus areas to test

(optional)
