### PR TITLE
update foundation version to fix token typings

### DIFF
--- a/change/@fluentui-web-components-1cd186c6-5c38-4758-accc-eadbd613d930.json
+++ b/change/@fluentui-web-components-1cd186c6-5c38-4758-accc-eadbd613d930.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update fast-foundation version to fix design token typings",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.1.0",
     "@microsoft/fast-element": "^1.4.0",
-    "@microsoft/fast-foundation": "^2.0.0",
+    "@microsoft/fast-foundation": "^2.5.0",
     "lodash-es": "^4.17.20",
     "tslib": "^1.13.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,10 +2699,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.4.0.tgz#761b5ebdde1a271c5f96f7c15fab9f5a2a10657f"
   integrity sha512-7BC/juFc7S4HMGt/tNCP9bjwtUslheGiPM2jtIibe1bj+PO34woUfH5TxaklOT6sRStig/0fODX4R5oqY4DYLA==
 
-"@microsoft/fast-foundation@^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.1.0.tgz#ae053866a87327f18edd3ad34483a324da680d4e"
-  integrity sha512-U0KDIZPLAmJkZEveFaNA4rXZsj7Cjyji0L/rg5LX+LdC1I6Kf+T+Z09jyV+7sqohthr1cr6vWQd9Jp2cK8uKCw==
+"@microsoft/fast-foundation@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.5.0.tgz#f205befe050735c5a55bdc76f60c70087c67cd78"
+  integrity sha512-+WUuXrNa1k6SffAuDEAXrDhQb9PVMY7oEAoOjDHqgZkM5F3aYB/uTJ1vPe3tqf3OX54LdHQtT1HGtfVM3RrAGw==
   dependencies:
     "@microsoft/fast-element" "^1.4.0"
     "@microsoft/fast-web-utilities" "^4.8.0"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
A type error in the typing for CSSDesignToken did not like to work with Swatch. We've extended the typing in v2.5.0

#### Focus areas to test

(optional)
