### PR TITLE
fix(ChatMessage): pass popperRef from actionMenu to usePopper

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` trigger order of props being spread @chassunc ([#18875](https://github.com/microsoft/fluentui/pull/18875))
 - Ensure wide content fits in compact ChatMessage @Hirse ([#18871](https://github.com/microsoft/fluentui/pull/18871))
 - Adding back data-is-focusable attribute for `menuitem` @kolaps33 ([#18934](https://github.com/microsoft/fluentui/pull/18934))
+- Fix `ChatMessage` to pass `popperRef` from user to `usePopper` @yuanboxue-amber ([#18950](https://github.com/microsoft/fluentui/pull/18950))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -289,7 +289,7 @@ export const ChatMessage: ComponentWithAs<'div', ChatMessageProps> &
     modifiers,
 
     ...positioningProps,
-    popperRef: useMergedRefs(positioningProps.popperRef, popperRef),
+    popperRef: useMergedRefs(positioningProps?.popperRef, popperRef),
   });
 
   // `focused` state is used for show/hide actionMenu

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -16,6 +16,7 @@ import {
   useStyles,
   useTelemetry,
   useUnhandledProps,
+  useMergedRefs,
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
@@ -286,9 +287,9 @@ export const ChatMessage: ComponentWithAs<'div', ChatMessageProps> &
 
     enabled: hasActionMenu && positionActionMenu,
     modifiers,
-    popperRef,
 
     ...positioningProps,
+    popperRef: useMergedRefs(positioningProps.popperRef, popperRef),
   });
 
   // `focused` state is used for show/hide actionMenu


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

ChatMessage component takes `actionMenu` prop, which takes positioning props to be passed to `usePopper` hook.
But the `popperRef` from consumer is override by `popperRef` defined internally in the component.
This PR merged the `popperRef` from consumer and internal `popperRef`:
```ts
const popperRef = React.useRef<PopperRefHandle>();
...
usePopper({
  ...
  popperRef: useMergedRefs(positioningProps.popperRef, popperRef),
})
```

#### Focus areas to test

(optional)
