### PR TITLE
Fix styles debugging throw error under dev environment

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` trigger order of props being spread @chassunc ([#18875](https://github.com/microsoft/fluentui/pull/18875))
 - Ensure wide content fits in compact ChatMessage @Hirse ([#18871](https://github.com/microsoft/fluentui/pull/18871))
 - Adding back data-is-focusable attribute for `menuitem` @kolaps33 ([#18934](https://github.com/microsoft/fluentui/pull/18934))
+- Fix style debugging throw error in dev environment @yuanboxue-amber ([#18955](https://github.com/microsoft/fluentui/pull/18955))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
@@ -210,8 +210,8 @@ export const resolveStyles = (
           }
 
           if (process.env.NODE_ENV !== 'production' && isDebugEnabled) {
-            resolvedStylesDebug[slotName] = (resolvedStyles[slotName] as any)['_debug'];
-            delete (resolvedStyles[slotName] as any)['_debug'];
+            resolvedStylesDebug[slotName] = (resolvedStyles[slotName] as any)?.['_debug'];
+            delete (resolvedStyles[slotName] as any)?.['_debug'];
           }
 
           if (telemetry?.enabled && telemetry.performance[primaryDisplayName]) {
@@ -335,8 +335,8 @@ export const resolveStyles = (
         }
 
         if (process.env.NODE_ENV !== 'production' && isDebugEnabled) {
-          resolvedStylesDebug[slotName] = (target[slotName] as any)['_debug'];
-          delete (target[slotName] as any)['_debug'];
+          resolvedStylesDebug[slotName] = (target[slotName] as any)?.['_debug'];
+          delete (target[slotName] as any)?.['_debug'];
         }
 
         if (telemetry?.enabled && telemetry.performance[primaryDisplayName]) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Under dev environment, style debugging tool throw the following errors:
<img width="454" alt="Screenshot 2021-07-15 at 16 11 01" src="https://user-images.githubusercontent.com/28751745/125802398-d348414b-0cbb-4aed-a93c-948e63e9efc4.png">

To reproduce:
1. start fluent UI docsite in dev mode
2. navigate to Avatar component
3. the screen went blank and this error appears in console



Reason: 
This happens for components that has some slots without a default style.

#### Focus areas to test

(optional)
