### PR TITLE
(web-components) Fixed ability to set palette base color on DSP

### DIFF
--- a/change/@fluentui-web-components-ecc6dedb-e591-44e9-b8f3-e237d8bdbd24.json
+++ b/change/@fluentui-web-components-ecc6dedb-e591-44e9-b8f3-e237d8bdbd24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed ability to set palette base color on DSP",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/card/fixtures/card.html
+++ b/packages/web-components/src/card/fixtures/card.html
@@ -99,5 +99,18 @@
         <fluent-button appearance="lightweight">Lightweight</fluent-button>
       </div>
     </fluent-card>
+
+    <fluent-design-system-provider accent-base-color="#00a900" neutral-base-color="#A90000">
+      <fluent-card>
+        <div class="contents">
+          Accent and neutral color by DSP
+          <fluent-button appearance="accent">Accent</fluent-button>
+          <fluent-button>Neutral</fluent-button>
+          <fluent-button appearance="stealth">Stealth</fluent-button>
+          <fluent-button appearance="outline">Outline</fluent-button>
+          <fluent-button appearance="lightweight">Lightweight</fluent-button>
+        </div>
+      </fluent-card>
+    </fluent-design-system-provider>
   </div>
 </fluent-design-system-provider>

--- a/packages/web-components/src/design-system-provider/index.ts
+++ b/packages/web-components/src/design-system-provider/index.ts
@@ -192,6 +192,7 @@ export class DesignSystemProvider extends FoundationElement {
   @attr({
     attribute: 'accent-base-color',
     converter: swatchConverter,
+    mode: 'fromView',
   })
   public accentBaseColor: Swatch;
 
@@ -214,6 +215,7 @@ export class DesignSystemProvider extends FoundationElement {
   @attr({
     attribute: 'neutral-base-color',
     converter: swatchConverter,
+    mode: 'fromView',
   })
   public neutralBaseColor: Swatch;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Attribute converter seemed to be getting reset without `fromView` mode.

Added a test scenario on `Card` Storybook.

#### Focus areas to test

(optional)
