### PR TITLE
Add aria-owns to wrapper of pickers and comboboxes

### DIFF
--- a/change/@fluentui-react-5be1fe98-2dc6-4510-8e92-05874bd5f323.json
+++ b/change/@fluentui-react-5be1fe98-2dc6-4510-8e92-05874bd5f323.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add aria-owns to wrapping element of comboboxes and pickers for better virtual cursor screen reader support",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -64,6 +64,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -27,6 +27,7 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         role="presentation"
       >
         <div
+          aria-owns=""
           className=
               ms-BasePicker-text
               {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -27,6 +27,7 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -27,6 +27,7 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -27,6 +27,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -27,6 +27,7 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -170,6 +170,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {
@@ -273,6 +274,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
@@ -38,6 +38,7 @@ exports[`Component Examples renders TagPicker.Inline.Example.tsx correctly 1`] =
       role="presentation"
     >
       <div
+        aria-owns=""
         className=
             ms-BasePicker-text
             {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -568,6 +568,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         ref={this._comboBoxWrapper}
         id={this._id + 'wrapper'}
         className={this._classNames.root}
+        aria-owns={isOpen ? this._id + '-list' : undefined}
       >
         <Autofill
           data-ktp-execute-target={true}
@@ -595,7 +596,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           aria-activedescendant={this._getAriaActiveDescendantValue()}
           aria-required={required}
           aria-disabled={disabled}
-          aria-owns={isOpen ? this._id + '-list' : undefined}
+          aria-controls={isOpen ? this._id + '-list' : undefined}
           spellCheck={false}
           defaultVisibleValue={this._currentVisibleValue}
           suggestedDisplayValue={suggestedDisplayValue}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -384,6 +384,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
   class="ms-ComboBox-container "
 >
   <div
+    aria-owns="ComboBox0-list"
     class=
         ms-ComboBox
         is-open
@@ -505,8 +506,8 @@ exports[`ComboBox Renders correctly when open 1`] = `
     <input
       aria-activedescendant="ComboBox0-list3"
       aria-autocomplete="both"
+      aria-controls="ComboBox0-list"
       aria-expanded="true"
-      aria-owns="ComboBox0-list"
       autocapitalize="off"
       autocomplete="off"
       class=
@@ -1150,6 +1151,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
   class="ms-ComboBox-container "
 >
   <div
+    aria-owns="ComboBox0-list"
     class=
         ms-ComboBox
         is-open
@@ -1271,8 +1273,8 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
     <input
       aria-activedescendant="ComboBox0-list3"
       aria-autocomplete="both"
+      aria-controls="ComboBox0-list"
       aria-expanded="true"
-      aria-owns="ComboBox0-list"
       autocapitalize="off"
       autocomplete="off"
       class=

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -345,7 +345,11 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const hasErrorMessage: boolean = !!errorMessage && errorMessage.length > 0;
 
     return (
-      <div className={this._classNames.root} ref={this.props.hoisted.rootRef}>
+      <div
+        className={this._classNames.root}
+        ref={this.props.hoisted.rootRef}
+        aria-owns={isOpen ? this._listId : undefined}
+      >
         {onRenderLabel(this.props, this._onRenderLabel)}
         <div
           data-is-focusable={!disabled}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`Dropdown multi-select Renders correctly 1`] = `
 
 exports[`Dropdown multi-select Renders correctly when open 1`] = `
 <div
+  aria-owns="Dropdown0-list"
   class="ms-Dropdown-container"
 >
   <div
@@ -1199,6 +1200,7 @@ exports[`Dropdown single-select Renders correctly 1`] = `
 
 exports[`Dropdown single-select Renders correctly when open 1`] = `
 <div
+  aria-owns="Dropdown0-list"
   class="ms-Dropdown-container"
 >
   <div

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -292,7 +292,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
           {selectionAriaLabel || comboLabel}
         </span>
         <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-          <div className={classNames.text}>
+          <div className={classNames.text} aria-owns={suggestionsAvailable}>
             {items.length > 0 && (
               <span
                 id={this._ariaMap.selectedItems}
@@ -1049,7 +1049,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       <div ref={this.root} onBlur={this.onBlur} onFocus={this.onFocus}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
           {this.getSuggestionsAlert(classNames.screenReaderText)}
-          <div className={classNames.text}>
+          <div className={classNames.text} aria-owns={suggestionsAvailable || undefined}>
             <Autofill
               {...(inputProps as any)}
               className={classNames.input}

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`PeoplePicker renders correctly 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -121,6 +122,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className=
           ms-BasePicker-text
           {

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`TagPicker renders correctly 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -331,6 +332,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className=
           ms-BasePicker-text
           {

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`BasePicker renders correctly 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className="ms-BasePicker-text"
     >
       <input
@@ -83,6 +84,7 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
     role="presentation"
   >
     <div
+      aria-owns=""
       className="ms-BasePicker-text"
     >
       <input


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding `aria-owns` to the parent of a combobox (including Dropdown, Pickers, etc.) gives some limited support for a better accessibility tree order that puts the owned element (the dropdown) inline after the triggering combobox.

It doesn't have across-the-board support, but is better than nothing.

The change in this PR is minimal, I only added the `aria-owns` attribute to Dropdown, Combobox, and BasePicker and it uses the same logic as `aria-controls` on the combobox element in each component. Datepicker already does this, which is why it's left out.
