### PR TITLE
Use colorScheme for chat variables

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
@@ -1,4 +1,3 @@
-export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
 export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
 export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatMessageVariables.ts
@@ -1,10 +1,7 @@
 import { ChatMessageVariables } from '../../../teams/components/Chat/chatMessageVariables';
 
-export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => {
-  return {
-    backgroundColor: siteVars.colorScheme.default.background,
-    backgroundColorMine: siteVars.colorScheme.brand.background1,
-    authorColor: siteVars.colorScheme.default.foreground2,
-    authorFontWeight: siteVars.fontWeightRegular,
-  };
-};
+export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => ({
+  authorColor: siteVars.colorScheme.default.foreground2,
+  authorFontWeight: siteVars.fontWeightRegular,
+  backgroundColor: siteVars.colorScheme.default.background,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Chat/chatVariables.ts
@@ -1,7 +1,0 @@
-import { ChatVariables } from '../../../teams/components/Chat/chatVariables';
-
-export const chatVariables = (siteVars: any): Partial<ChatVariables> => {
-  return {
-    backgroundColor: siteVars.colorScheme.default.background2,
-  };
-};

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/componentVariables.ts
@@ -1,5 +1,4 @@
 export { avatarVariables as Avatar } from './components/Avatar/avatarVariables';
-export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
 export { dialogVariables as Dialog } from './components/Dialog/dialogVariables';
 export { dividerVariables as Divider } from './components/Divider/dividerVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatMessageVariables.ts
@@ -1,15 +1,8 @@
 import { ChatMessageVariables } from '../../../teams/components/Chat/chatMessageVariables';
 
-export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => {
-  return {
-    backgroundColor: siteVars.colors.grey[600],
-    backgroundColorMine: siteVars.colors.brand[900],
-    authorColor: siteVars.colors.grey[250],
-    contentColor: siteVars.colors.white,
-    color: siteVars.colors.white,
-    hasMentionNubbinColor: siteVars.colors.orange[300],
-    isImportantColor: siteVars.colors.red[300],
-    compactHoverBackground: siteVars.colorScheme.default.backgroundHover,
-    compactHoverBorder: `solid 1px ${siteVars.colorScheme.default.backgroundHover}`,
-  };
-};
+export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => ({
+  authorColor: siteVars.colorScheme.default.foreground1,
+  backgroundColor: siteVars.colorScheme.default.background4,
+  compactHoverBackground: siteVars.colorScheme.default.backgroundHover,
+  compactHoverBorder: `solid 1px ${siteVars.colorScheme.default.backgroundHover}`,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Chat/chatVariables.ts
@@ -1,7 +1,0 @@
-import { ChatVariables } from '../../../teams/components/Chat/chatVariables';
-
-export const chatVariables = (siteVars: any): Partial<ChatVariables> => {
-  return {
-    backgroundColor: siteVars.colors.grey[800],
-  };
-};

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Chat/chatMessageVariables.ts
@@ -1,18 +1,9 @@
 import { ChatMessageVariables } from '../../../teams/components/Chat/chatMessageVariables';
 
-export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => {
-  return {
-    backgroundColor: siteVars.colors.black,
-    backgroundColorMine: siteVars.colors.black,
-    authorColor: siteVars.colors.white,
-    contentColor: siteVars.colors.white,
-    color: siteVars.colors.white,
-    border: `1px solid ${siteVars.colors.white}`,
-    compactHoverBorder: `solid 1px ${siteVars.accessibleYellow}`,
-    hasMentionColor: siteVars.accessibleYellow,
-    hasMentionNubbinColor: siteVars.accessibleYellow,
-    isImportantColor: siteVars.accessibleYellow,
-    badgeTextColor: siteVars.colors.black,
-    reactionGroupBorderColor: siteVars.colors.white,
-  };
-};
+export const chatMessageVariables = (siteVars: any): Partial<ChatMessageVariables> => ({
+  border: `solid ${siteVars.borderWidth} ${siteVars.colorScheme.default.border}`,
+  compactHoverBorder: `solid ${siteVars.borderWidth} ${siteVars.accessibleYellow}`,
+  hasMentionColor: siteVars.accessibleYellow,
+  isImportantColor: siteVars.accessibleYellow,
+  reactionGroupBorderColor: siteVars.colorScheme.default.border,
+});

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/componentVariables.ts
@@ -1,4 +1,3 @@
-export { chatVariables as Chat } from './components/Chat/chatVariables';
 export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessageVariables';
 export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
 export { textVariables as Text } from './components/Text/textVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatMessageVariables.ts
@@ -1,8 +1,6 @@
 import { ChatMessageVariables } from '../../../teams/components/Chat/chatMessageVariables';
 
 export const chatMessageVariables = (siteVars): Partial<ChatMessageVariables> => ({
-  backgroundColor: siteVars.colorScheme.default.background,
-  backgroundColorMine: siteVars.colorScheme.brand.background1,
   authorColor: siteVars.colorScheme.default.foreground2,
   authorFontWeight: siteVars.fontWeightRegular,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-v2/components/Chat/chatVariables.ts
@@ -1,5 +1,0 @@
-import { ChatVariables } from '../../../teams/components/Chat/chatVariables';
-
-export const chatVariables = (siteVars): Partial<ChatVariables> => ({
-  backgroundColor: siteVars.colorScheme.default.background2,
-});

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemStyles.ts
@@ -5,7 +5,7 @@ import { pxToRem } from '../../../../utils';
 import { ChatItemVariables } from './chatItemVariables';
 
 export const chatItemStyles: ComponentSlotStylesPrepared<ChatItemStylesProps, ChatItemVariables> = {
-  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+  root: ({ props: p }): ICSSInJSStyle => ({
     position: 'relative',
     ...((!p.attached || p.attached === 'top') && {
       paddingTop: p.density === 'compact' ? pxToRem(8) : pxToRem(16),
@@ -14,7 +14,6 @@ export const chatItemStyles: ComponentSlotStylesPrepared<ChatItemStylesProps, Ch
       paddingTop: p.density === 'compact' ? 0 : pxToRem(2),
     }),
     paddingBottom: 0,
-
     ...(p.density === 'compact' && {
       marginTop: pxToRem(-2),
       marginBottom: pxToRem(-2),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemVariables.ts
@@ -1,18 +1,18 @@
 import { pxToRem } from '../../../../utils';
 
 export interface ChatItemVariables {
-  margin: string;
   gutterMargin: string;
   gutterMarginCompact: string;
+  margin: string;
   messageMargin: string;
   messageMarginCompact: string;
   messageMarginEndCompact: string;
 }
 
 export const chatItemVariables = (): ChatItemVariables => ({
-  margin: pxToRem(8),
   gutterMargin: pxToRem(10),
   gutterMarginCompact: pxToRem(2),
+  margin: pxToRem(8),
   messageMargin: pxToRem(40),
   messageMarginCompact: pxToRem(56),
   messageMarginEndCompact: pxToRem(16),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
@@ -10,8 +10,8 @@ export const chatMessageReadStatusStyles: ComponentSlotStylesPrepared<
 > = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
     position: 'absolute',
-    right: p.density === 'compact' ? v.rightPositionCompact : v.rightPoistion,
-    bottom: p.density === 'compact' ? v.bottomPositionCompact : v.bottomPoistion,
+    right: p.density === 'compact' ? v.rightPositionCompact : v.rightPosition,
+    bottom: p.density === 'compact' ? v.bottomPositionCompact : v.bottomPosition,
     ':after': {
       content: `"${p.title}"`,
       ...(screenReaderContainerStyles as ICSSInJSStyle),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
@@ -1,15 +1,15 @@
 import { pxToRem } from '../../../../utils';
 
 export interface ChatMessageReadStatusVariables {
-  rightPoistion?: string;
-  rightPositionCompact: string;
-  bottomPoistion?: string;
+  bottomPosition?: string;
   bottomPositionCompact: string;
+  rightPosition?: string;
+  rightPositionCompact: string;
 }
 
 export const chatMessageReadStatusVariables = (siteVars): ChatMessageReadStatusVariables => ({
-  rightPoistion: pxToRem(-24),
-  rightPositionCompact: pxToRem(-16),
-  bottomPoistion: pxToRem(0),
+  bottomPosition: pxToRem(0),
   bottomPositionCompact: pxToRem(2),
+  rightPosition: pxToRem(-24),
+  rightPositionCompact: pxToRem(-16),
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -38,7 +38,6 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
     } = componentStyleFunctionParam;
     return {
       borderRadius: v.borderRadius,
-      color: v.color,
       display: 'inline-block',
       outline: 0,
       position: 'relative',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -4,78 +4,76 @@ export interface ChatMessageVariables {
   actionMenuBoxShadow: string;
   actionMenuPositionRight: string;
   actionMenuPositionTop: string;
-  backgroundColor: string;
-  backgroundColorMine: string;
-  borderRadius: string;
-  color: string;
-  offset: string;
-  padding: string;
-  paddingCompact: string;
-  authorMarginRight: string;
-  authorMarginRightCompact: string;
   authorColor: string;
   authorColorMineCompact: string;
   authorFontWeight: number;
   authorFontWeightCompact: number;
-  headerMarginBottom: string;
+  authorMarginRight: string;
+  authorMarginRightCompact: string;
+  backgroundColor: string;
+  backgroundColorMine: string;
+  badgeShadow: string;
+  badgeTextColor: string;
+  border: string;
+  borderRadius: string;
+  compactBorder: string;
   compactHoverBackground: string;
+  compactHoverBorder: string;
   compactSpacing: string;
   contentColor: string;
-  linkColor: string;
-  linkColorMine: string;
-  border: string;
-  compactBorder: string;
-  compactHoverBorder: string;
-  badgeShadow: string;
-  isImportant: boolean;
   hasMention: boolean;
   hasMentionColor: string;
   hasMentionNubbinColor: string;
+  headerMarginBottom: string;
+  isImportant: boolean;
   isImportantColor: string;
-  badgeTextColor: string;
-  reactionGroupMarginLeft: string;
+  linkColor: string;
+  linkColorMine: string;
+  offset: string;
+  overlayZIndex: number;
+  padding: string;
+  paddingCompact: string;
   reactionGroupBorderColor: string;
+  reactionGroupMarginLeft: string;
   showActionMenu?: boolean;
   zIndex: number;
-  overlayZIndex: number;
 }
 
 export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   actionMenuBoxShadow: siteVars.shadowLevel1,
   actionMenuPositionRight: pxToRem(5),
   actionMenuPositionTop: pxToRem(-30),
-  backgroundColor: siteVars.colors.white,
-  backgroundColorMine: siteVars.colors.brand[100],
-  borderRadius: siteVars.borderRadiusMedium,
-  color: 'rgb(64, 64, 64)',
-  offset: pxToRem(100),
-  padding: pxToRem(16),
-  paddingCompact: pxToRem(3),
-  authorMarginRight: pxToRem(12),
-  authorMarginRightCompact: pxToRem(8),
   authorColor: siteVars.colorScheme.default.foreground,
   authorColorMineCompact: siteVars.colorScheme.brand.foreground,
   authorFontWeight: siteVars.fontWeightSemibold,
   authorFontWeightCompact: siteVars.fontWeightSemibold,
-  headerMarginBottom: pxToRem(2),
-  compactHoverBackground: siteVars.colorScheme.default.backgroundHover3,
-  compactSpacing: pxToRem(12),
-  contentColor: siteVars.colors.grey[750],
-  linkColor: siteVars.colorScheme.brand.foreground1,
-  linkColorMine: siteVars.colorScheme.brand.foreground2,
-  border: 'none',
-  compactBorder: `solid 1px transparent`,
-  compactHoverBorder: `solid 1px ${siteVars.colorScheme.default.backgroundHover3}`,
+  authorMarginRight: pxToRem(12),
+  authorMarginRightCompact: pxToRem(8),
+  backgroundColor: siteVars.colorScheme.default.background,
+  backgroundColorMine: siteVars.colorScheme.brand.background1,
   badgeShadow: siteVars.shadowLevel1Dark,
-  isImportant: false,
+  badgeTextColor: siteVars.colorScheme.brand.foreground4,
+  border: 'none',
+  borderRadius: siteVars.borderRadiusMedium,
+  compactBorder: `solid ${siteVars.borderWidth} transparent`,
+  compactHoverBackground: siteVars.colorScheme.default.backgroundHover3,
+  compactHoverBorder: `solid ${siteVars.borderWidth} ${siteVars.colorScheme.default.backgroundHover3}`,
+  compactSpacing: pxToRem(12),
+  contentColor: siteVars.colorScheme.default.foreground,
   hasMention: false,
   hasMentionColor: siteVars.colors.orange[300],
-  hasMentionNubbinColor: siteVars.colors.orange[400],
-  isImportantColor: siteVars.colors.red[400],
-  badgeTextColor: siteVars.colors.white,
-  reactionGroupMarginLeft: pxToRem(12),
+  hasMentionNubbinColor: siteVars.colorScheme.orange.background,
+  headerMarginBottom: pxToRem(2),
+  isImportant: false,
+  isImportantColor: siteVars.colorScheme.red.background,
+  linkColor: siteVars.colorScheme.brand.foreground1,
+  linkColorMine: siteVars.colorScheme.brand.foreground2,
+  offset: pxToRem(100),
+  overlayZIndex: siteVars.zIndexes.overlay,
+  padding: pxToRem(16),
+  paddingCompact: pxToRem(3),
   reactionGroupBorderColor: 'transparent',
+  reactionGroupMarginLeft: pxToRem(12),
   showActionMenu: undefined,
   zIndex: siteVars.zIndexes.foreground,
-  overlayZIndex: siteVars.zIndexes.overlay,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatStyles.ts
@@ -5,14 +5,13 @@ import { pxToRem } from '../../../../utils';
 import { ChatVariables } from './chatVariables';
 
 export const chatStyles: ComponentSlotStylesPrepared<ChatStylesProps, ChatVariables> = {
-  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+  root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
     backgroundColor: v.backgroundColor,
-    border: `1px solid ${v.backgroundColor}`,
+    border: `${siteVariables.borderWidth} solid ${v.backgroundColor}`,
     display: 'flex',
     flexDirection: 'column',
     listStyle: 'none',
-    padding:
-      p.density === 'compact' ? `0 ${pxToRem(4)} ${pxToRem(2)} ${pxToRem(4)}` : `0 ${pxToRem(10)} 0 ${pxToRem(10)}`,
     margin: 0,
+    padding: p.density === 'compact' ? `0 ${pxToRem(4)} ${pxToRem(2)}` : `0 ${pxToRem(10)} 0 ${pxToRem(10)}`,
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatVariables.ts
@@ -3,5 +3,5 @@ export interface ChatVariables {
 }
 
 export const chatVariables = (siteVars): ChatVariables => ({
-  backgroundColor: siteVars.colors.grey[100],
+  backgroundColor: siteVars.colorScheme.default.background2,
 });


### PR DESCRIPTION
Cleans up all Chat-related styles by
* Moving from `siteVars.colors` to `siteVars.colorScheme`
  * Except for `hasMentionColor` as that has some special handling (see https://github.com/microsoft/fluent-ui-react/pull/1232)
    @codepretty Do you remember what the reason is to have different colors for at-mention bar and nubbin?
* Remove not needed theme overrides
* Sort variables alphabetically

There are no changes to any styling results.