### PR TITLE
Docs only: add Combobox example and a11y docs for using doNotLayer on callout

### DIFF
--- a/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
@@ -1,20 +1,11 @@
 import * as React from 'react';
-import { ComboBox, IComboBoxOption, IComboBoxStyles, SelectableOptionMenuItemType } from '@fluentui/react';
+import { ComboBox, IComboBoxOption, IComboBoxStyles } from '@fluentui/react';
 
 const options: IComboBoxOption[] = [
-  { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
   { key: 'B', text: 'Option B' },
   { key: 'C', text: 'Option C' },
   { key: 'D', text: 'Option D' },
-  { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
-  { key: 'Header2', text: 'Second heading', itemType: SelectableOptionMenuItemType.Header },
-  { key: 'E', text: 'Option E' },
-  { key: 'F', text: 'Option F', disabled: true },
-  { key: 'G', text: 'Option G' },
-  { key: 'H', text: 'Option H' },
-  { key: 'I', text: 'Option I' },
-  { key: 'J', text: 'Option J' },
 ];
 // Optional styling to make the example look nicer
 const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
@@ -28,6 +19,11 @@ export const ComboBoxInlineExample: React.FunctionComponent = () => {
         options={options}
         styles={comboBoxStyles}
         calloutProps={{ doNotLayer: true }}
+      />
+      <div
+        // since this example is an inline picker, it needs some forced space below
+        // so when embedded in an iframe in the website, the dropdown shows up
+        style={{ height: '10em' }}
       />
     </div>
   );

--- a/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
@@ -22,7 +22,7 @@ export const ComboBoxInlineExample: React.FunctionComponent = () => {
       />
       <div
         // since this example is an inline picker, it needs some forced space below
-        // so when embedded in an iframe in the website, the dropdown shows up
+        // so when wrapped in an overflow: hidden container in the website, the dropdown shows up
         style={{ height: '10em' }}
       />
     </div>

--- a/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { ComboBox, IComboBoxOption, IComboBoxStyles, SelectableOptionMenuItemType } from '@fluentui/react';
+
+const options: IComboBoxOption[] = [
+  { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C' },
+  { key: 'D', text: 'Option D' },
+  { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
+  { key: 'Header2', text: 'Second heading', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'E', text: 'Option E' },
+  { key: 'F', text: 'Option F', disabled: true },
+  { key: 'G', text: 'Option G' },
+  { key: 'H', text: 'Option H' },
+  { key: 'I', text: 'Option I' },
+  { key: 'J', text: 'Option J' },
+];
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+
+export const ComboBoxInlineExample: React.FunctionComponent = () => {
+  return (
+    <div>
+      <ComboBox
+        defaultSelectedKey="C"
+        label="Combobox with inline options list"
+        options={options}
+        styles={comboBoxStyles}
+        calloutProps={{ doNotLayer: true }}
+      />
+    </div>
+  );
+};

--- a/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ComboBoxBasicExample } from './ComboBox.Basic.Example';
+import { ComboBoxInlineExample } from './ComboBox.Inline.Example';
 import { ComboBoxTogglesExample } from './ComboBox.Toggles.Example';
 import { ComboBoxControlledExample } from './ComboBox.Controlled.Example';
 import { ComboBoxControlledMultiExample } from './ComboBox.ControlledMulti.Example';
@@ -10,6 +11,7 @@ import { ComboBoxCustomStyledExample } from './ComboBox.CustomStyled.Example';
 import { IDocPageProps } from '@fluentui/react/lib/common/DocPage.types';
 
 const ComboBoxBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Basic.Example.tsx') as string;
+const ComboBoxInlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx') as string;
 const ComboBoxTogglesExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Toggles.Example.tsx') as string;
 const ComboBoxControlledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Controlled.Example.tsx') as string;
 const ComboBoxControlledMultiExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.ControlledMulti.Example.tsx') as string;
@@ -26,6 +28,11 @@ export const ComboBoxPageProps: IDocPageProps = {
       title: 'Basic uncontrolled ComboBox',
       code: ComboBoxBasicExampleCode,
       view: <ComboBoxBasicExample />,
+    },
+    {
+      title: 'ComboBox with inline dropdown',
+      code: ComboBoxInlineExampleCode,
+      view: <ComboBoxInlineExample />,
     },
     {
       title: 'ComboBox with toggleable autoComplete and allowFreeform',

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -12,5 +12,5 @@
 Combobox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Combobox options dropdown inline unless they are in overflow containers. To do so, set the following property on the Combobox, as demonstrated in the ComboBox with inline dropdown example:
 
 ```js
-pickerCalloutProps={{ doNotLayer: true }}
+calloutProps={{ doNotLayer: true }}
 ```

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -6,3 +6,11 @@
 
 - Use single words or shortened statements as options.
 - Don't use punctuation at the end of options.
+
+### Accessibility
+
+Combobox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Combobox options dropdown inline unless they are in overflow containers. To do so, set the following property on the Combobox, as demonstrated in the ComboBox with inline dropdown example:
+
+```js
+pickerCalloutProps={{ doNotLayer: true }}
+```

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Inline.Example.tsx.shot
@@ -1,0 +1,412 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders ComboBox.Inline.Example.tsx correctly 1`] = `
+<div>
+  <div
+    className="ms-ComboBox-container "
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      id="ComboBox0-label"
+    >
+      Combobox with inline options list
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            max-width: 300px;
+            outline: 0;
+            padding-left: 9px;
+            padding-right: 32px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
+            border-color: #323130;
+          }
+          &:hover .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+            color: GrayText;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: GrayText;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover:after {
+            border-color: Highlight;
+          }
+          &:active {
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active:after {
+            border-color: Highlight;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          &:focus .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-ComboBox-Input {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: WindowText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            color: HighlightText;
+            forced-color-adjust: none;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+            border-color: Highlight;
+          }
+          &:focus:after {
+            border-radius: 2px;
+            border: 2px solid #0078d4;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      data-ktp-target={true}
+      id="ComboBox0wrapper"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-expanded={false}
+        aria-labelledby="ComboBox0-label"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #323130;
+              font: inherit;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-is-interactable={true}
+        data-ktp-execute-target={true}
+        data-lpignore={true}
+        id="ComboBox0-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        role="combobox"
+        spellCheck={false}
+        style={
+          Object {
+            "fontFamily": "inherit",
+          }
+        }
+        type="text"
+        value="Option C"
+      />
+      <button
+        aria-hidden={true}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 100%;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              text-align: center;
+              text-decoration: none;
+              top: 0px;
+              user-select: none;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+              forced-color-adjust: none;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
+              -ms-high-contrast-adjust: none;
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+              forced-color-adjust: none;
+            }
+        data-is-focusable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 12px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                }
+            data-icon-name="ChevronDown"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-hidden={true}
+      aria-live="polite"
+      id="ComboBox0-error"
+      role="region"
+    >
+      
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Inline.Example.tsx.shot
@@ -408,5 +408,12 @@ exports[`Component Examples renders ComboBox.Inline.Example.tsx correctly 1`] = 
       
     </div>
   </div>
+  <div
+    style={
+      Object {
+        "height": "10em",
+      }
+    }
+  />
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12280](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12280)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is essentially the same as #18495, but for Combobox. That PR already made the necessary changes to Callout, so this PR only adds an example and docs wording to `react-examples/Combobox`.
