### PR TITLE
text-field: start/end display flex

### DIFF
--- a/change/@fluentui-web-components-20a4b8e4-bb09-49e6-bf6e-a580388a0f26.json
+++ b/change/@fluentui-web-components-20a4b8e4-bb09-49e6-bf6e-a580388a0f26.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fluent-text-field: start/end display flex",
+  "packageName": "@fluentui/web-components",
+  "email": "fredrik.rasch@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -135,6 +135,7 @@ export const textFieldStyles = (context, definition) =>
 
     .start,
     .end {
+      display: flex;
       margin: auto;
       fill: currentcolor;
     }


### PR DESCRIPTION
This PR brings fluentui web-components to parity with the bugfix accepted in https://github.com/microsoft/fast/pull/4938

#### Pull request checklist

- [x] Addresses an existing issue: https://github.com/microsoft/fast/pull/4938
- [x] Include a change request file using `$ yarn change`

#### Description of changes

* `start` and `end` slot in `fluent-text-field` get the `display: flex` rule.
* ~Add Fabric Core CSS to storybook for testing components with non-svg icons.~

#### Focus areas to test

`fluent-text-field`
