### PR TITLE
chore: add bundle size fixtures for converged components

### DIFF
--- a/change/@fluentui-react-accordion-d53c34c3-050f-48bb-b846-55b67f20461e.json
+++ b/change/@fluentui-react-accordion-d53c34c3-050f-48bb-b846-55b67f20461e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-619c1c28-65b3-40c2-a6ff-da67ad6e5c65.json
+++ b/change/@fluentui-react-avatar-619c1c28-65b3-40c2-a6ff-da67ad6e5c65.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-76207d1a-f8b1-4a54-a8cc-0c0e4ce494dd.json
+++ b/change/@fluentui-react-badge-76207d1a-f8b1-4a54-a8cc-0c0e4ce494dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-a13dfcdb-c462-4810-acd7-8def41be06a2.json
+++ b/change/@fluentui-react-button-a13dfcdb-c462-4810-acd7-8def41be06a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-7ccf19c6-365a-4925-82d8-ffcf86b1397d.json
+++ b/change/@fluentui-react-components-7ccf19c6-365a-4925-82d8-ffcf86b1397d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-b89f09a3-f4df-4ec4-8f52-bbf7b70b5229.json
+++ b/change/@fluentui-react-label-b89f09a3-f4df-4ec4-8f52-bbf7b70b5229.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-label",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-fa384405-297e-4c66-9538-cc63d7d93f9e.json
+++ b/change/@fluentui-react-link-fa384405-297e-4c66-9538-cc63d7d93f9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-7425fea9-3512-4bd5-9bc1-fa5c3a220d6d.json
+++ b/change/@fluentui-react-menu-7425fea9-3512-4bd5-9bc1-fa5c3a220d6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-d75aa864-6d31-449d-b513-b7bb5733fb94.json
+++ b/change/@fluentui-react-portal-d75aa864-6d31-449d-b513-b7bb5733fb94.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-ffbe8c35-45a6-40e1-95de-f8c0c5482b4b.json
+++ b/change/@fluentui-react-positioning-ffbe8c35-45a6-40e1-95de-f8c0c5482b4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-7975b6b8-3f8a-48b4-8155-255d6085d06e.json
+++ b/change/@fluentui-react-provider-7975b6b8-3f8a-48b4-8155-255d6085d06e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-f4da5bb7-703a-4e09-aa91-16748adc9bde.json
+++ b/change/@fluentui-react-tooltip-f4da5bb7-703a-4e09-aa91-16748adc9bde.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-728d555e-d087-4b7e-9f68-ae57ca7370a9.json
+++ b/change/@fluentui-react-utilities-728d555e-d087-4b7e-9f68-ae57ca7370a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-accordion/bundle-size/Accordion.fixture.js
+++ b/packages/react-accordion/bundle-size/Accordion.fixture.js
@@ -1,0 +1,7 @@
+import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from '@fluentui/react-accordion';
+
+console.log(Accordion, AccordionItem, AccordionHeader, AccordionPanel);
+
+export default {
+  name: 'Accordion (including children components)',
+};

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-avatar/bundle-size/Avatar.fixture.js
+++ b/packages/react-avatar/bundle-size/Avatar.fixture.js
@@ -1,0 +1,7 @@
+import { Avatar } from '@fluentui/react-avatar';
+
+console.log(Avatar);
+
+export default {
+  name: 'Avatar',
+};

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-badge/bundle-size/Badge.fixture.js
+++ b/packages/react-badge/bundle-size/Badge.fixture.js
@@ -1,0 +1,7 @@
+import { Badge } from '@fluentui/react-badge';
+
+console.log(Badge);
+
+export default {
+  name: 'Badge',
+};

--- a/packages/react-badge/bundle-size/CounterBadge.fixture.js
+++ b/packages/react-badge/bundle-size/CounterBadge.fixture.js
@@ -1,0 +1,7 @@
+import { CounterBadge } from '@fluentui/react-badge';
+
+console.log(CounterBadge);
+
+export default {
+  name: 'CounterBadge',
+};

--- a/packages/react-badge/bundle-size/PresenseBadge.fixture.js
+++ b/packages/react-badge/bundle-size/PresenseBadge.fixture.js
@@ -1,0 +1,7 @@
+import { PresenseBadge } from '@fluentui/react-badge';
+
+console.log(PresenseBadge);
+
+export default {
+  name: 'PresenseBadge',
+};

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-button/bundle-size/Button.fixture.js
+++ b/packages/react-button/bundle-size/Button.fixture.js
@@ -3,5 +3,5 @@ import { Button } from '@fluentui/react-button';
 console.log(Button);
 
 export default {
-  name: 'Button - Default',
+  name: 'Button',
 };

--- a/packages/react-button/bundle-size/CompoundButton.fixture.js
+++ b/packages/react-button/bundle-size/CompoundButton.fixture.js
@@ -1,0 +1,7 @@
+import { CompoundButton } from '@fluentui/react-button';
+
+console.log(CompoundButton);
+
+export default {
+  name: 'CompoundButton',
+};

--- a/packages/react-button/bundle-size/MenuButton.fixture.js
+++ b/packages/react-button/bundle-size/MenuButton.fixture.js
@@ -1,0 +1,7 @@
+import { MenuButton } from '@fluentui/react-button';
+
+console.log(MenuButton);
+
+export default {
+  name: 'MenuButton',
+};

--- a/packages/react-button/bundle-size/ToggleButton.fixture.js
+++ b/packages/react-button/bundle-size/ToggleButton.fixture.js
@@ -1,0 +1,7 @@
+import { ToggleButton } from '@fluentui/react-button';
+
+console.log(ToggleButton);
+
+export default {
+  name: 'ToggleButton',
+};

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-components/bundle-size/MultipleComponents.fixture.js
+++ b/packages/react-components/bundle-size/MultipleComponents.fixture.js
@@ -1,0 +1,39 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionPanel,
+  Button,
+  FluentProvider,
+  Image,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItem,
+  MenuPopover,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+} from '@fluentui/react-components';
+
+console.log(
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionPanel,
+  Button,
+  FluentProvider,
+  Image,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItem,
+  MenuPopover,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+);
+
+export default {
+  name: 'react-components: Accordion, Button, FluentProvider, Image, Menu, Popover',
+};

--- a/packages/react-components/bundle-size/ProviderAndTheme.fixture.js
+++ b/packages/react-components/bundle-size/ProviderAndTheme.fixture.js
@@ -1,0 +1,7 @@
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+
+console.log(FluentProvider, webLightTheme);
+
+export default {
+  name: 'react-components: FluentProvider & webLightTheme',
+};

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -15,6 +15,7 @@
     "build": "just-scripts build",
     "bundle": "just-scripts bundle",
     "bundle:storybook": "just-scripts storybook:build",
+    "bundle-size": "bundle-size measure",
     "chromatic": "npx chromatic@5.6.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name bundle:storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",

--- a/packages/react-label/bundle-size/Label.fixture.js
+++ b/packages/react-label/bundle-size/Label.fixture.js
@@ -1,0 +1,7 @@
+import { Label } from '@fluentui/react-label';
+
+console.log(Label);
+
+export default {
+  name: 'Label',
+};

--- a/packages/react-label/package.json
+++ b/packages/react-label/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-link/bundle-size/Label.fixture.js
+++ b/packages/react-link/bundle-size/Label.fixture.js
@@ -1,0 +1,7 @@
+import { Link } from '@fluentui/react-link';
+
+console.log(Link);
+
+export default {
+  name: 'Link',
+};

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-menu/bundle-size/Menu.Selectable.fixture.js
+++ b/packages/react-menu/bundle-size/Menu.Selectable.fixture.js
@@ -11,5 +11,5 @@ import {
 console.log(Menu, MenuTrigger, MenuList, MenuItem, MenuItemCheckbox, MenuItemRadio, MenuPopover);
 
 export default {
-  name: 'Menu - Selectable',
+  name: 'Menu  (including selectable components)',
 };

--- a/packages/react-menu/bundle-size/Menu.fixture.js
+++ b/packages/react-menu/bundle-size/Menu.fixture.js
@@ -3,5 +3,5 @@ import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/re
 console.log(Menu, MenuTrigger, MenuList, MenuItem, MenuPopover);
 
 export default {
-  name: 'Menu - Default',
+  name: 'Menu (including children components)',
 };

--- a/packages/react-portal/bundle-size/Portal.fixture.js
+++ b/packages/react-portal/bundle-size/Portal.fixture.js
@@ -1,0 +1,7 @@
+import { Portal } from '@fluentui/react-portal';
+
+console.log(Portal);
+
+export default {
+  name: 'Popover',
+};

--- a/packages/react-portal/bundle-size/Portal.fixture.js
+++ b/packages/react-portal/bundle-size/Portal.fixture.js
@@ -3,5 +3,5 @@ import { Portal } from '@fluentui/react-portal';
 console.log(Portal);
 
 export default {
-  name: 'Popover',
+  name: 'Portal',
 };

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-positioning/bundle-size/usePopper.fixture.js
+++ b/packages/react-positioning/bundle-size/usePopper.fixture.js
@@ -1,0 +1,7 @@
+import { usePopper } from '@fluentui/react-positioning';
+
+console.log(usePopper);
+
+export default {
+  name: 'usePopper',
+};

--- a/packages/react-positioning/package.json
+++ b/packages/react-positioning/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-provider/bundle-size/FluentProvider.fixture.js
+++ b/packages/react-provider/bundle-size/FluentProvider.fixture.js
@@ -1,0 +1,7 @@
+import { FluentProvider } from '@fluentui/react-provider';
+
+console.log(FluentProvider);
+
+export default {
+  name: 'FluentProvider',
+};

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "test": "jest",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",

--- a/packages/react-tooltip/bundle-size/Tooltip.fixture.js
+++ b/packages/react-tooltip/bundle-size/Tooltip.fixture.js
@@ -1,0 +1,7 @@
+import { Tooltip } from '@fluentui/react-tooltip';
+
+console.log(Tooltip);
+
+export default {
+  name: 'Tooltip',
+};

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-utilities/bundle-size/SSRProvider.fixture.js
+++ b/packages/react-utilities/bundle-size/SSRProvider.fixture.js
@@ -1,0 +1,7 @@
+import { SSRProvider } from '@fluentui/react-utilities';
+
+console.log(SSRProvider);
+
+export default {
+  name: 'SSRProvider',
+};

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #17697
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR recreates all existing fixtures in SizeAuditor for `@fluentui/react-components` to replace it with new bundle size tool.
Pipelines are cleaned up in #18971.