### PR TITLE
chore: remove SizeAuditor task for @fluentui/react-components

### DIFF
--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -3,7 +3,6 @@ const {
   buildEntries,
   buildEntry,
   createWebpackConfig,
-  createFluentConvergedFixtures,
   createFluentNorthstarFixtures,
   createFluentReactFixtures,
   createEntry,
@@ -15,9 +14,6 @@ let entries;
 if (package === '@fluentui/react-northstar') {
   createFluentNorthstarFixtures();
   entries = buildEntries('@fluentui/react-northstar');
-} else if (package === '@fluentui/react-components') {
-  createFluentConvergedFixtures();
-  entries = buildEntries('@fluentui/react-components');
 } else if (package === '@fluentui/react') {
   createFluentReactFixtures();
   createEntry('@fluentui/keyboard-key');

--- a/apps/test-bundles/webpackUtils.js
+++ b/apps/test-bundles/webpackUtils.js
@@ -98,64 +98,6 @@ function createFluentNorthstarFixtures() {
   });
 }
 
-/**
- * Webpack will remove any unused import as a dead code (tree shaking).
- * Thus we are creating temporary JS files with top-level component imports
- * and console logging them. This will ensure that the code is active
- * and that webpack bundles it correctly.
- */
-function createFluentConvergedFixtures() {
-  const packageName = '@fluentui/react-components';
-
-  // Imports definition is temporary manual, we should find a better way and automate it
-  const imports = [
-    // components
-    'Accordion',
-    'Avatar',
-    'Badge',
-    'Button',
-    'CompoundButton',
-    'Divider',
-    'Image',
-    'Label',
-    'Link',
-    'Menu',
-    'MenuButton',
-    'Portal',
-    'ToggleButton',
-    'Tooltip',
-
-    // Provider-related
-    'FluentProvider',
-    'useFluent',
-
-    // themes
-    'teamsLightTheme',
-    'webLightTheme',
-
-    // makeStyles
-    'mergeClasses',
-    'makeStyles',
-    'makeStaticStyles',
-    '__styles',
-
-    // utils
-    // 'usePopper',
-  ];
-
-  imports.forEach(importName => {
-    const importStatement = `import { ${importName} } from '${packageName}'; console.log(${importName})`;
-    try {
-      const folderName = getFolderName(packageName);
-      const entryPath = path.join(FIXTURE_PATH, folderName, `${importName}.js`);
-
-      fs.outputFileSync(entryPath, importStatement, 'utf-8');
-    } catch (err) {
-      console.log(err);
-    }
-  });
-}
-
 // Files which should not be considered top-level entries.
 const TopLevelEntryFileExclusions = ['index.js', 'version.js', 'index.bundle.js'];
 
@@ -238,7 +180,6 @@ function getFolderName(packageName) {
 module.exports = {
   buildEntries,
   buildEntry,
-  createFluentConvergedFixtures,
   createFluentNorthstarFixtures,
   createFluentReactFixtures,
   createEntry,

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -91,44 +91,6 @@ jobs:
 
       - template: .devops/templates/cleanup.yml
 
-  - job: build_converged
-    workspace:
-      clean: all
-    timeoutInMinutes: 75
-    pool: 'Self Host Ubuntu'
-    steps:
-      - template: .devops/templates/tools.yml
-
-      - task: Bash@3
-        inputs:
-          filePath: yarn-ci.sh
-        displayName: yarn
-
-      - script: yarn build --to @fluentui/react-components --no-cache
-        displayName: yarn build to @fluentui/react-components
-
-      - script: yarn workspace test-bundles bundle:size
-        displayName: yarn bundle test-bundles
-        env:
-          PACKAGE: '@fluentui/react-components'
-
-      - script: yarn bundlesizecollect
-        displayName: 'Collate Bundle Size Information'
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Bundle Size information to Azure Dev Ops Artifacts'
-        inputs:
-          PathtoPublish: 'apps/test-bundles/dist/bundlesize.json'
-          ArtifactName: bundlesize-converged
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact dist folder upon build for debug'
-        inputs:
-          PathtoPublish: 'apps/test-bundles/dist'
-          ArtifactName: distdrop-converged
-
-      - template: .devops/templates/cleanup.yml
-
   - job: build_northstar
     workspace:
       clean: all
@@ -172,7 +134,6 @@ jobs:
       vmImage: 'windows-2019'
     dependsOn:
       - build_northstar
-      - build_converged
       - build_react
     steps:
       - checkout: none
@@ -184,12 +145,6 @@ jobs:
           targetPath: '$(Build.ArtifactStagingDirectory)/react'
 
       - task: DownloadPipelineArtifact@2
-        displayName: 'Download Pipeline Artifact: @fluentui/react-components'
-        inputs:
-          artifactName: 'bundlesize-converged'
-          targetPath: '$(Build.ArtifactStagingDirectory)/react-converged'
-
-      - task: DownloadPipelineArtifact@2
         displayName: 'Download Pipeline Artifact: @fluentui/react-northstar'
         inputs:
           artifactName: 'bundlesize-northstar'
@@ -198,7 +153,7 @@ jobs:
       - script: 'chocolatey install jq'
         displayName: 'Install jq'
 
-      - script: jq -c -s "reduce .[] as $item ({}; . * $item)" $(Build.ArtifactStagingDirectory)/react-converged/bundlesize.json $(Build.ArtifactStagingDirectory)/react-northstar/bundlesize.json $(Build.ArtifactStagingDirectory)/react/bundlesize.json > $(Build.ArtifactStagingDirectory)/bundlesizes.json
+      - script: jq -c -s "reduce .[] as $item ({}; . * $item)" $(Build.ArtifactStagingDirectory)/react-northstar/bundlesize.json $(Build.ArtifactStagingDirectory)/react/bundlesize.json > $(Build.ArtifactStagingDirectory)/bundlesizes.json
         displayName: 'Merge @fluentui/react, @fluentui/react-components & @fluentui/react-northstar to bundlesizes.json'
 
       - task: PublishBuildArtifacts@1


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #17697
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes SizeAuditor task for converged components as it's not needed anymore.
Fixtures for new bundle size tool are recreated in #18970.