### PR TITLE
 fix(babel-make-styles): handle member expressions

### DIFF
--- a/change/@fluentui-babel-make-styles-068419f3-6b78-4423-af67-3838915e422e.json
+++ b/change/@fluentui-babel-make-styles-068419f3-6b78-4423-af67-3838915e422e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "handle MemberExpression as a mixin",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/object-mixins/code.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/code.ts
@@ -1,8 +1,9 @@
 import { makeStyles } from '@fluentui/react-make-styles';
-import { flexStyles, gridStyles } from './mixins';
+import { flexStyles, gridStyles, typography } from './mixins';
 
 export const useStyles = makeStyles({
   root: flexStyles,
+  header: typography.header,
 
   icon: { ...flexStyles, color: 'red' },
   image: { ...gridStyles('10px'), color: 'green' },

--- a/packages/babel-make-styles/__fixtures__/object-mixins/mixins.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/mixins.ts
@@ -9,3 +9,8 @@ export const gridStyles = (gridGap: string): MakeStyles => ({
   display: 'grid',
   gridGap,
 });
+
+export const typography: Record<'text' | 'header', MakeStyles> = {
+  text: { fontWeight: 'normal' },
+  header: { fontWeight: 'bold' },
+};

--- a/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
@@ -1,10 +1,13 @@
 import { __styles } from '@fluentui/react-make-styles';
-import { flexStyles, gridStyles } from './mixins';
+import { flexStyles, gridStyles, typography } from './mixins';
 export const useStyles = __styles(
   {
     root: {
       mc9l5x: 'f22iagw',
       Beiy3e4: 'f1vx9l62',
+    },
+    header: {
+      Bhrd7zp: 'f16wzh4i',
     },
     icon: {
       mc9l5x: 'f22iagw',
@@ -21,6 +24,7 @@ export const useStyles = __styles(
     d: [
       '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
+      '.f16wzh4i{font-weight:bold;}',
       '.fe3e8s9{color:red;}',
       '.f13qh94s{display:grid;}',
       '.fz44487{grid-gap:10px;}',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: unblocks #18968
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds handling of `MemberExpression` in `@fluentui/babel-make-styles` and covers it with tests. This fix is a blocker for #18968 where it causes a build failure:

```
ERR! [9:16:53 AM] x SyntaxError: /mnt/work/2/s/packages/react-text/lib-commonjs/components/Display/Display.js: We met an unhandled case, this is a bug, please include a stacktrace and report it at https://github.com/microsoft/fluentui
ERR!   10 |  */
ERR!   11 | var useStyles = react_make_styles_1.makeStyles({
ERR! > 12 |     root: index_2.typographyStyles.display,
ERR!      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERR!   13 | });
ERR!   14 | /**
ERR!   15 |  * Text wrapper component for the Display typography variant
```