### PR TITLE
fix(Dropdown): fix openOnFocus dropdowns' close/re-open cycle, remove auto-added title attribute

### DIFF
--- a/change/@fluentui-react-3af54bdf-3a82-4afc-9fe2-175a6705db0c.json
+++ b/change/@fluentui-react-3af54bdf-3a82-4afc-9fe2-175a6705db0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix openOnFocus bug with closing the dropdown, remove default tooltip text",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -955,7 +955,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       return;
     }
 
-    // hasFocus tracks whether the root element has focus so always update the state.
+    // hasFocus tracks whether the root element or dropdown has focus so always update the state.
     this.setState({ hasFocus: false });
 
     if (this.props.onBlur) {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -62,7 +62,7 @@ interface IDropdownInternalProps extends Omit<IDropdownProps, 'ref'>, IWithRespo
 
 interface IDropdownState {
   isOpen: boolean;
-  /** Whether the root dropdown element has focus. */
+  /** Used to track whether focus is already within the Dropdown, for openOnFocus handling. */
   hasFocus: boolean;
   calloutRenderEdge?: RectangleEdge;
 }
@@ -955,7 +955,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       return;
     }
 
-    // hasFocus tracks whether the root element or dropdown has focus so always update the state.
     this.setState({ hasFocus: false });
 
     if (this.props.onBlur) {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -760,7 +760,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       ? this._classNames.dropdownItemDisabled
       : this._classNames.dropdownItem;
 
-    const { title = item.text } = item;
+    const { title } = item;
 
     const multiSelectItemStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.multiSelectItem as IStyleFunctionOrObject<
@@ -950,13 +950,14 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       return;
     }
 
+    if (this.state.isOpen) {
+      // Do not call onBlur or update focus state when the callout is opened
+      return;
+    }
+
     // hasFocus tracks whether the root element has focus so always update the state.
     this.setState({ hasFocus: false });
 
-    if (this.state.isOpen) {
-      // Do not onBlur when the callout is opened
-      return;
-    }
     if (this.props.onBlur) {
       this.props.onBlur(ev);
     }

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -413,19 +413,19 @@ describe('Dropdown', () => {
       expect(titleElement.text()).toEqual('4');
     });
 
-    it('Shows correct tooltip with and without title prop specified', () => {
+    it('Shows correct tooltip only if title prop is specified', () => {
       wrapper = mount(<Dropdown label="testgroup" options={DEFAULT_OPTIONS} />);
 
       wrapper.find('.ms-Dropdown').simulate('click');
 
       const firstItemElement = document.querySelector('.ms-Dropdown-item[data-index="1"]') as HTMLElement;
-      expect(firstItemElement.getAttribute('title')).toEqual('1');
+      expect(firstItemElement.getAttribute('title')).toBeFalsy();
 
       const secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
       expect(secondItemElement.getAttribute('title')).toEqual('test');
 
       const thirdItemElement = document.querySelector('.ms-Dropdown-item[data-index="3"]') as HTMLElement;
-      expect(thirdItemElement.getAttribute('title')).toEqual('3');
+      expect(thirdItemElement.getAttribute('title')).toBeFalsy();
     });
 
     it('opens on focus if openOnKeyboardFocus is true', () => {
@@ -447,15 +447,22 @@ describe('Dropdown', () => {
       expect(secondItemElement).toBeTruthy();
     });
 
-    // Debatable whether this is desirable, but in the meantime, the test documents the behavior
-    it('uses item text as title attribute if no title provided', () => {
-      const options: IDropdownOption[] = [{ key: 'a', text: 'a' }];
-      wrapper = mount(<Dropdown options={options} />);
+    it('closes on blur when openOnKeyboardFocus is true', () => {
+      wrapper = mount(<Dropdown openOnKeyboardFocus label="testgroup" options={DEFAULT_OPTIONS} />);
 
-      wrapper.find('.ms-Dropdown').simulate('click');
+      wrapper.find('.ms-Dropdown').simulate('focus');
 
-      const item = wrapper.find('.ms-Dropdown-item');
-      expect(item.getElements()[0].props.title).toBe('a');
+      let dropdownElement = document.querySelector('.ms-Dropdown-items') as HTMLElement;
+      expect(dropdownElement).toBeTruthy();
+
+      // blur, force the dropdown to close, then focus again
+      // the second focus is simulating the behavior of the Callout when closed
+      wrapper.find('.ms-Dropdown').simulate('blur');
+      wrapper.find('.ms-Dropdown').simulate('keydown', { which: KeyCodes.escape });
+      wrapper.find('.ms-Dropdown').simulate('focus');
+
+      dropdownElement = document.querySelector('.ms-Dropdown-items') as HTMLElement;
+      expect(dropdownElement).toBeFalsy();
     });
 
     it('uses item title attribute if provided', () => {

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -622,7 +622,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
-                    title="1"
                   >
                     <input
                       aria-checked="true"
@@ -650,7 +649,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                       id="Dropdown0-list1"
                       role="option"
                       tabindex="0"
-                      title="1"
                       type="checkbox"
                     />
                     <label
@@ -1653,7 +1651,6 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                     id="Dropdown0-list1"
                     role="option"
                     tabindex="0"
-                    title="1"
                     type="button"
                   >
                     <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18951
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates Dropdown to not set `hasFocus: false` when the dropdown's Callout is closing, which allows a Dropdown with `openOnFocus: true` to close without re-opening.

Also updates the `title` attribute to only be applied if the `title` prop is passed. I can split this out to another PR if needed; Another team logged a bug for this, and I updated it while working on Dropdown.
