### PR TITLE
Add docs about localized strings for Calendar, DatePicker, ColorPicker

### DIFF
--- a/packages/react-examples/src/react/Calendar/Calendar.Button.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Button.Example.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { Calendar, FocusTrapZone, Callout, DirectionalHint } from '@fluentui/react';
-import { DefaultButton } from '@fluentui/react/lib/Button';
+import {
+  Calendar,
+  FocusTrapZone,
+  Callout,
+  DirectionalHint,
+  defaultCalendarStrings,
+  DefaultButton,
+} from '@fluentui/react';
 import { useBoolean } from '@fluentui/react-hooks';
 
 export const CalendarButtonExample: React.FunctionComponent = () => {
@@ -43,6 +49,8 @@ export const CalendarButtonExample: React.FunctionComponent = () => {
               highlightCurrentMonth
               isDayPickerVisible
               showGoToToday
+              // Calendar uses English strings by default. For localized apps, you must override this prop.
+              strings={defaultCalendarStrings}
             />
           </FocusTrapZone>
         </Callout>

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
+import { Calendar, DateRangeType, DayOfWeek, defaultCalendarStrings } from '@fluentui/react';
 
 const workWeekDays = [DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday];
 
@@ -30,6 +30,8 @@ export const CalendarInlineContiguousWorkWeekDaysExample: React.FunctionComponen
         workWeekDays={workWeekDays}
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.CustomDayCellRef.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.CustomDayCellRef.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, ICalendarDayProps } from '@fluentui/react';
+import { Calendar, ICalendarDayProps, defaultCalendarStrings } from '@fluentui/react';
 
 const calendarDayProps: Partial<ICalendarDayProps> = {
   customDayCellRef: (element, date, classNames) => {
@@ -29,6 +29,8 @@ export const CalendarInlineCustomDayCellRefExample: React.FunctionComponent = ()
         calendarDayProps={calendarDayProps}
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.DateBoundaries.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.DateBoundaries.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { addMonths, addYears, addDays } from '@fluentui/date-time-utilities';
-import { Calendar } from '@fluentui/react';
+import { addMonths, addYears, addDays, Calendar, defaultCalendarStrings } from '@fluentui/react';
 import { useConst } from '@fluentui/react-hooks';
 
 export const CalendarInlineDateBoundariesExample: React.FunctionComponent = () => {
@@ -30,6 +29,8 @@ export const CalendarInlineDateBoundariesExample: React.FunctionComponent = () =
         restrictedDates={restrictedDates}
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar } from '@fluentui/react';
+import { Calendar, defaultCalendarStrings } from '@fluentui/react';
 
 export const CalendarInlineExample: React.FunctionComponent = () => {
   const [selectedDate, setSelectedDate] = React.useState<Date>(new Date());
@@ -7,7 +7,13 @@ export const CalendarInlineExample: React.FunctionComponent = () => {
   return (
     <div style={{ height: '360px' }}>
       <div>Selected date: {selectedDate?.toLocaleString() || 'Not set'}</div>
-      <Calendar showGoToToday onSelectDate={setSelectedDate} value={selectedDate} />
+      <Calendar
+        showGoToToday
+        onSelectDate={setSelectedDate}
+        value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.MarkedDays.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.MarkedDays.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Calendar, ICalendarDayProps } from '@fluentui/react';
-import { addDays } from '@fluentui/date-time-utilities';
+import { Calendar, ICalendarDayProps, defaultCalendarStrings, addDays } from '@fluentui/react';
 
 const calendarDayProps: Partial<ICalendarDayProps> = {
   getMarkedDays: (startingDate, endingDate) => [addDays(startingDate, 3), addDays(startingDate, 4)],
@@ -18,6 +17,8 @@ export const CalendarInlineMarkedDaysExample = () => {
         value={selectedDate}
         // Add the marked days
         calendarDayProps={calendarDayProps}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.MonthOnly.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.MonthOnly.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, DateRangeType } from '@fluentui/react';
+import { Calendar, DateRangeType, defaultCalendarStrings } from '@fluentui/react';
 
 export const CalendarInlineMonthOnlyExample: React.FunctionComponent = () => {
   const [selectedDateRange, setSelectedDateRange] = React.useState<Date[]>();
@@ -28,6 +28,8 @@ export const CalendarInlineMonthOnlyExample: React.FunctionComponent = () => {
         isDayPickerVisible={false}
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.MonthSelection.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.MonthSelection.Example.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react/lib/Button';
-import { addDays, getDateRangeArray } from '@fluentui/date-time-utilities';
-import { Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
-import { mergeStyleSets } from '@fluentui/style-utilities';
+import {
+  Calendar,
+  DateRangeType,
+  DayOfWeek,
+  DefaultButton,
+  mergeStyleSets,
+  defaultCalendarStrings,
+  addDays,
+  getDateRangeArray,
+} from '@fluentui/react';
 
 const styles = mergeStyleSets({
   wrapper: { height: 360 },
@@ -59,6 +65,8 @@ export const CalendarInlineMonthSelectionExample: React.FunctionComponent = () =
         onSelectDate={onSelectDate}
         value={selectedDate}
         firstDayOfWeek={firstDayOfWeek}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
       <div>
         <DefaultButton className={styles.button} onClick={goPrevious} text="Previous" />

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.MultidayDayView.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.MultidayDayView.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Calendar, Dropdown, IDropdownOption } from '@fluentui/react';
-import { mergeStyleSets } from '@fluentui/style-utilities';
+import { Calendar, Dropdown, IDropdownOption, mergeStyleSets, defaultCalendarStrings } from '@fluentui/react';
 
 const styles = mergeStyleSets({
   wrapper: { height: 360 },
@@ -55,6 +54,8 @@ export const CalendarInlineMultidayDayViewExample: React.FunctionComponent = () 
         onSelectDate={onSelectDate}
         value={selectedDate}
         calendarDayProps={{ daysToSelectInDayView }}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
       <Dropdown
         className={styles.dropdown}

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
+import { Calendar, DateRangeType, DayOfWeek, defaultCalendarStrings } from '@fluentui/react';
 
 const workWeekDays = [DayOfWeek.Tuesday, DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Friday];
 
@@ -32,6 +32,8 @@ export const CalendarInlineNonContiguousWorkWeekDaysExample: React.FunctionCompo
         showGoToToday
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.OverlaidMonthPicker.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.OverlaidMonthPicker.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar } from '@fluentui/react';
+import { Calendar, defaultCalendarStrings } from '@fluentui/react';
 
 export const CalendarInlineOverlaidMonthExample: React.FunctionComponent = () => {
   const [selectedDate, setSelectedDate] = React.useState<Date>();
@@ -18,6 +18,8 @@ export const CalendarInlineOverlaidMonthExample: React.FunctionComponent = () =>
         showGoToToday={false}
         onSelectDate={onSelectDate}
         value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.SixWeeks.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.SixWeeks.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar } from '@fluentui/react';
+import { Calendar, defaultCalendarStrings } from '@fluentui/react';
 
 export const CalendarInlineSixWeeksExample: React.FunctionComponent = () => {
   const [selectedDate, setSelectedDate] = React.useState<Date>();
@@ -12,7 +12,14 @@ export const CalendarInlineSixWeeksExample: React.FunctionComponent = () => {
     <div style={{ height: '360px' }}>
       <div>Selected date: {selectedDate?.toLocaleString() || 'Not set'}</div>
 
-      <Calendar showSixWeeksByDefault showGoToToday onSelectDate={onSelectDate} value={selectedDate} />
+      <Calendar
+        showSixWeeksByDefault
+        showGoToToday
+        onSelectDate={onSelectDate}
+        value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.WeekNumbers.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.WeekNumbers.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar } from '@fluentui/react';
+import { Calendar, defaultCalendarStrings } from '@fluentui/react';
 
 export const CalendarInlineWeekNumbersExample: React.FunctionComponent = () => {
   const [selectedDate, setSelectedDate] = React.useState<Date>();
@@ -12,7 +12,14 @@ export const CalendarInlineWeekNumbersExample: React.FunctionComponent = () => {
     <div style={{ height: '360px' }}>
       <div>Selected date: {selectedDate?.toLocaleString() || 'Not set'}</div>
 
-      <Calendar showWeekNumbers showGoToToday onSelectDate={onSelectDate} value={selectedDate} />
+      <Calendar
+        showWeekNumbers
+        showGoToToday
+        onSelectDate={onSelectDate}
+        value={selectedDate}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/react/Calendar/Calendar.Inline.WeekSelection.Example.tsx
+++ b/packages/react-examples/src/react/Calendar/Calendar.Inline.WeekSelection.Example.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react/lib/Button';
-import { addDays, getDateRangeArray } from '@fluentui/date-time-utilities';
-import { Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
-import { mergeStyleSets } from '@fluentui/style-utilities';
+import {
+  DefaultButton,
+  addDays,
+  getDateRangeArray,
+  Calendar,
+  DateRangeType,
+  DayOfWeek,
+  mergeStyleSets,
+  defaultCalendarStrings,
+} from '@fluentui/react';
 
 const styles = mergeStyleSets({
   wrapper: { height: 360 },
@@ -59,6 +65,8 @@ export const CalendarInlineWeekSelectionExample: React.FunctionComponent = () =>
         onSelectDate={onSelectDate}
         value={selectedDate}
         firstDayOfWeek={firstDayOfWeek}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
       />
       <div>
         <DefaultButton className={styles.button} onClick={goPrevious} text="Previous" />

--- a/packages/react-examples/src/react/Calendar/docs/CalendarBestPractices.md
+++ b/packages/react-examples/src/react/Calendar/docs/CalendarBestPractices.md
@@ -7,3 +7,4 @@
 
 - Use the following format for dates: month, day, year, as in July 31, 2016. When space is limited, use numbers and slashes for dates if the code supports that format and automatically displays the appropriate date format for different locales. For example, 2/16/19.
 - Don't use ordinal numbers (such as 1st, 12th, or 23rd) to indicate a date.
+- The control provides English strings by default. For localized apps, you must override these using the `strings` prop.

--- a/packages/react-examples/src/react/ColorPicker/docs/ColorPickerBestPractices.md
+++ b/packages/react-examples/src/react/ColorPicker/docs/ColorPickerBestPractices.md
@@ -1,0 +1,3 @@
+### Content
+
+- The control provides English strings by default. For localized apps, you must override these using the `strings` prop.

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Basic.Example.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek, Dropdown, IDropdownOption, mergeStyles } from '@fluentui/react';
+import {
+  DatePicker,
+  DayOfWeek,
+  Dropdown,
+  IDropdownOption,
+  mergeStyles,
+  defaultDatePickerStrings,
+} from '@fluentui/react';
 
 const days: IDropdownOption[] = [
   { text: 'Sunday', key: DayOfWeek.Sunday },
@@ -21,7 +28,13 @@ export const DatePickerBasicExample: React.FunctionComponent = () => {
 
   return (
     <div className={rootClass}>
-      <DatePicker firstDayOfWeek={firstDayOfWeek} placeholder="Select a date..." ariaLabel="Select a date" />
+      <DatePicker
+        firstDayOfWeek={firstDayOfWeek}
+        placeholder="Select a date..."
+        ariaLabel="Select a date"
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
+      />
       <Dropdown
         label="Select the first day of the week"
         options={days}

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Bounded.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Bounded.Example.tsx
@@ -31,6 +31,7 @@ export const DatePickerBoundedExample: React.FunctionComponent = () => {
       </div>
       <DatePicker
         styles={datePickerStyles}
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
         strings={strings}
         placeholder="Select a date..."
         ariaLabel="Select a date"

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Disabled.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Disabled.Example.tsx
@@ -1,14 +1,26 @@
 import * as React from 'react';
-import { DatePicker, mergeStyles } from '@fluentui/react';
+import { DatePicker, mergeStyles, defaultDatePickerStrings } from '@fluentui/react';
 
 const rootClass = mergeStyles({ maxWidth: 300, selectors: { '> *': { marginBottom: 15 } } });
 
 export const DatePickerDisabledExample: React.FunctionComponent = () => {
   return (
     <div className={rootClass}>
-      <DatePicker disabled placeholder="Select a date..." ariaLabel="Select a date" />
+      <DatePicker
+        disabled
+        placeholder="Select a date..."
+        ariaLabel="Select a date"
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
+      />
 
-      <DatePicker disabled label="Disabled (with label)" placeholder="Select a date..." ariaLabel="Select a date" />
+      <DatePicker
+        disabled
+        label="Disabled (with label)"
+        placeholder="Select a date..."
+        ariaLabel="Select a date"
+        strings={defaultDatePickerStrings}
+      />
     </div>
   );
 };

--- a/packages/react-examples/src/react/DatePicker/DatePicker.ExternalControls.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.ExternalControls.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatePicker, addDays, mergeStyleSets } from '@fluentui/react';
+import { DatePicker, addDays, mergeStyleSets, defaultDatePickerStrings } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 
 const styles = mergeStyleSets({
@@ -25,6 +25,8 @@ export const DatePickerExternalControlsExample = () => {
         onSelectDate={setSelectedDate as (date: Date | null | undefined) => void}
         placeholder="Select a date..."
         ariaLabel="Select a date"
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
       />
       <div>
         <DefaultButton className={styles.button} onClick={goPrevious} text="Previous" />

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Format.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Format.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { DatePicker, IDatePicker, mergeStyleSets } from '@fluentui/react';
-import { DefaultButton } from '@fluentui/react/lib/Button';
+import { DatePicker, IDatePicker, mergeStyleSets, defaultDatePickerStrings, DefaultButton } from '@fluentui/react';
 
 const styles = mergeStyleSets({
   root: { selectors: { '> *': { marginBottom: 15 } } },
@@ -56,6 +55,8 @@ export const DatePickerFormatExample: React.FunctionComponent = () => {
         formatDate={onFormatDate}
         parseDateFromString={onParseDateFromString}
         className={styles.control}
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
       />
       <DefaultButton aria-label="Clear the date input" onClick={onClick} text="Clear" />
       <div>Selected date: {(value || '').toString()}</div>

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Input.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Input.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react/lib/Button';
-import { DatePicker, IDatePicker, mergeStyleSets } from '@fluentui/react';
+import { DatePicker, IDatePicker, mergeStyleSets, defaultDatePickerStrings, DefaultButton } from '@fluentui/react';
 
 const styles = mergeStyleSets({
   root: { selectors: { '> *': { marginBottom: 15 } } },
@@ -31,6 +30,8 @@ export const DatePickerInputExample: React.FunctionComponent = () => {
         value={value}
         onSelectDate={setValue as (date: Date | null | undefined) => void}
         className={styles.control}
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
       />
       <DefaultButton aria-label="Clear the date input" onClick={onClick} text="Clear" />
     </div>

--- a/packages/react-examples/src/react/DatePicker/DatePicker.Required.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.Required.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatePicker, mergeStyleSets } from '@fluentui/react';
+import { DatePicker, mergeStyleSets, defaultDatePickerStrings } from '@fluentui/react';
 
 const styles = mergeStyleSets({
   root: { selectors: { '> *': { marginBottom: 15 } } },
@@ -16,12 +16,15 @@ export const DatePickerRequiredExample: React.FunctionComponent = () => {
         placeholder="Select a date..."
         ariaLabel="Select a date"
         className={styles.control}
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
       />
       <DatePicker
         isRequired
         placeholder="Date required with no label..."
         ariaLabel="Select a date"
         className={styles.control}
+        strings={defaultDatePickerStrings}
       />
     </div>
   );

--- a/packages/react-examples/src/react/DatePicker/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/react-examples/src/react/DatePicker/DatePicker.WeekNumbers.Example.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek, Dropdown, IDropdownOption, mergeStyles } from '@fluentui/react';
+import {
+  DatePicker,
+  DayOfWeek,
+  Dropdown,
+  IDropdownOption,
+  mergeStyles,
+  defaultDatePickerStrings,
+} from '@fluentui/react';
 
 const days: IDropdownOption[] = [
   { text: 'Sunday', key: DayOfWeek.Sunday },
@@ -28,6 +35,8 @@ export const DatePickerWeekNumbersExample: React.FunctionComponent = () => {
         showMonthPickerAsOverlay={true}
         placeholder="Select a date..."
         ariaLabel="Select a date"
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
       />
       <Dropdown
         label="Select the first day of the week"

--- a/packages/react-examples/src/react/DatePicker/docs/DatePickerBestPractices.md
+++ b/packages/react-examples/src/react/DatePicker/docs/DatePickerBestPractices.md
@@ -5,3 +5,4 @@
 ### Content
 
 - The control provides the date in a specific format. If the date can be entered in an input field, provide helper text in the appropriate format.
+- The control provides English strings by default. For localized apps, you must override these using the `strings` prop.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18954

#### Description of changes

Update Calendar, DatePicker, and ColorPicker best practices and examples to explicitly call out that localized strings are required and how to override them.