### PR TITLE
Align author name in compact chat with design spec

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -34,6 +34,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))
 
+### Documentation
+- Align author name in compact chat with design spec @Hirse ([#18988](https://github.com/microsoft/fluentui/pull/18988))
+
 
 <!--------------------------------[ v0.57.0 ]------------------------------- -->
 ## [v0.57.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.57.0) (2021-06-29)

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.shorthand.tsx
@@ -23,12 +23,12 @@ const [robinAvatar, robertAvatar] = [
 const items: ShorthandCollection<ChatItemProps> = [
   {
     gutter: <Avatar {...robertAvatar} />,
-    message: <Chat.Message content="Hello" author="Robert" timestamp="10:15 PM" mine />,
+    message: <Chat.Message content="Hello" author="Robert Tolbert" timestamp="10:15 PM" mine />,
     attached: 'top',
     key: 'message-id-1',
   },
   {
-    message: <Chat.Message content="I'm back!" author="Robert" timestamp="10:15 PM" mine />,
+    message: <Chat.Message content="I'm back!" author="Robert Tolbert" timestamp="10:15 PM" mine />,
     attached: true,
     key: 'message-id-2',
   },
@@ -36,7 +36,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="What do you think about goodFood.com?"
-        author="Robert"
+        author="Robert Tolbert"
         details={<EditIcon outline />}
         timestamp="10:16 PM"
         mine
@@ -56,7 +56,7 @@ const items: ShorthandCollection<ChatItemProps> = [
             {'!'}
           </>
         }
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:20 PM"
         badge={{
           icon: <MentionIcon />,
@@ -70,23 +70,25 @@ const items: ShorthandCollection<ChatItemProps> = [
     key: 'message-id-4',
   },
   {
-    message: <Chat.Message content="Looks good!" author="Robin" timestamp="10:21 PM" />,
+    message: <Chat.Message content="Looks good!" author="Robin Counts" timestamp="10:21 PM" />,
     attached: true,
     key: 'message-id-5',
   },
   {
-    message: <Chat.Message content="I also like great-food.com." author="Robin" timestamp="10:25 PM" />,
+    message: <Chat.Message content="I also like great-food.com." author="Robin Counts" timestamp="10:25 PM" />,
     attached: 'bottom',
     key: 'message-id-6',
   },
   {
     gutter: <Avatar {...robertAvatar} />,
-    message: <Chat.Message content="Would you like to grab lunch there?" author="Robert" timestamp="10:30 PM" mine />,
+    message: (
+      <Chat.Message content="Would you like to grab lunch there?" author="Robert Tolbert" timestamp="10:30 PM" mine />
+    ),
     key: 'message-id-7',
   },
   {
     gutter: <Avatar {...robinAvatar} />,
-    message: <Chat.Message content="Sure! Let's try it." author="Robin" timestamp="10:32 PM" />,
+    message: <Chat.Message content="Sure! Let's try it." author="Robin Counts" timestamp="10:32 PM" />,
     key: 'message-id-8',
   },
   {
@@ -98,7 +100,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Ok, let's go."
-        author="Robert"
+        author="Robert Tolbert"
         timestamp="11:15 PM"
         mine
         readStatus={{

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.tsx
@@ -16,12 +16,12 @@ const ChatExampleCompact = () => (
   <Chat density="compact">
     <Chat.Item
       gutter={<Avatar {...robertAvatar} />}
-      message={<Chat.Message content="Hello" author="Robert" timestamp="10:15 PM" mine />}
+      message={<Chat.Message content="Hello" author="Robert Tolbert" timestamp="10:15 PM" mine />}
       attached="top"
       key="message-id-1"
     />
     <Chat.Item
-      message={<Chat.Message content="I'm back!" author="Robert" timestamp="10:15 PM" mine />}
+      message={<Chat.Message content="I'm back!" author="Robert Tolbert" timestamp="10:15 PM" mine />}
       attached={true}
       key="message-id-2"
     />
@@ -29,7 +29,7 @@ const ChatExampleCompact = () => (
       message={
         <Chat.Message
           content="What do you think about goodFood.com?"
-          author="Robert"
+          author="Robert Tolbert"
           details={<EditIcon outline />}
           timestamp="10:16 PM"
           mine
@@ -49,7 +49,7 @@ const ChatExampleCompact = () => (
               {'!'}
             </>
           }
-          author="Robin"
+          author="Robin Counts"
           timestamp="10:20 PM"
           badge={{
             icon: <MentionIcon />,
@@ -63,23 +63,25 @@ const ChatExampleCompact = () => (
       key="message-id-4"
     />
     <Chat.Item
-      message={<Chat.Message content="Looks good!" author="Robin" timestamp="10:21 PM" />}
+      message={<Chat.Message content="Looks good!" author="Robin Counts" timestamp="10:21 PM" />}
       attached={true}
       key="message-id-5"
     />
     <Chat.Item
-      message={<Chat.Message content="I also like great-food.com." author="Robin" timestamp="10:25 PM" />}
+      message={<Chat.Message content="I also like great-food.com." author="Robin Counts" timestamp="10:25 PM" />}
       attached="bottom"
       key="message-id-6"
     />
     <Chat.Item
       gutter={<Avatar {...robertAvatar} />}
-      message={<Chat.Message content="Would you like to grab lunch there?" author="Robert" timestamp="10:30 PM" mine />}
+      message={
+        <Chat.Message content="Would you like to grab lunch there?" author="Robert Tolbert" timestamp="10:30 PM" mine />
+      }
       key="message-id-7"
     />
     <Chat.Item
       gutter={<Avatar {...robinAvatar} />}
-      message={<Chat.Message content="Sure! Let's try it." author="Robin" timestamp="10:32 PM" />}
+      message={<Chat.Message content="Sure! Let's try it." author="Robin Counts" timestamp="10:32 PM" />}
       key="message-id-8"
     />
     <Chat.Item key="message-id-9">
@@ -90,7 +92,7 @@ const ChatExampleCompact = () => (
       message={
         <Chat.Message
           content="Ok, let's go."
-          author="Robert"
+          author="Robert Tolbert"
           timestamp="11:15 PM"
           mine
           readStatus={{

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatErrorState.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatErrorState.tsx
@@ -30,7 +30,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Failed Message"
-        author="Robin"
+        author="Robin Counts"
         mine
         timestamp="11:21"
         header={error}
@@ -52,6 +52,7 @@ export const CompactChatErrorState = () => (
               borderColor: siteVariables.colorScheme.red.border,
               '&:hover': {
                 backgroundColor: siteVariables.colorScheme.red.background1,
+                borderColor: siteVariables.colorScheme.red.border,
               },
             }),
           }),

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatSlots.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatSlots.tsx
@@ -90,7 +90,7 @@ export const CompactChatSlots = () => (
           gutter: <Avatar image={robinAvatar.image} status={{ color: robinAvatar.status.color }} />,
           message: (
             <Chat.Message
-              author="Robin"
+              author="Robin Counts"
               badge={{ icon: <RedbangIcon /> }}
               content="The quick brown fox jumps over the lazy dog. Portez ce vieux whisky au juge blond qui fume. Franz jagt im komplett verwahrlosten Taxi quer durch Bayern. Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu."
               details="Edited"
@@ -115,7 +115,7 @@ export const CompactChatSlots = () => (
           gutter: <Avatar {...robinAvatar} />,
           message: (
             <Chat.Message
-              author="Robin"
+              author="Robin Counts"
               badge={{ icon: <RedbangIcon /> }}
               content="The quick brown fox jumps over the lazy dog. Portez ce vieux whisky au juge blond qui fume. Franz jagt im komplett verwahrlosten Taxi quer durch Bayern. Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu."
               details={<EditIcon outline />}

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithAuthor.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithAuthor.tsx
@@ -7,19 +7,19 @@ import { robinAvatar, timAvatar } from './compactAvatars';
 const items: ShorthandCollection<ChatItemProps> = [
   {
     gutter: <Avatar {...timAvatar} />,
-    message: <Chat.Message content="Message with author inline" author="Tim" timestamp="11:21" />,
+    message: <Chat.Message content="Message with author inline" author="Tim Deboer" timestamp="11:21" />,
     key: 'message-id-1',
     attached: 'top',
   },
   {
     gutter: <Avatar {...timAvatar} />,
-    message: <Chat.Message content="Attached message" author="Tim" timestamp="11:21" />,
+    message: <Chat.Message content="Attached message" author="Tim Deboer" timestamp="11:21" />,
     key: 'message-id-2',
     attached: 'bottom',
   },
   {
     gutter: <Avatar {...robinAvatar} />,
-    message: <Chat.Message content="My message with author inline" author="Robin" timestamp="12:22" mine />,
+    message: <Chat.Message content="My message with author inline" author="Robin Counts" timestamp="12:22" mine />,
     key: 'message-id-3',
   },
   {
@@ -27,7 +27,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Long message wrapping around the author. The quick brown fox jumps over the lazy dog. Portez ce vieux whisky au juge blond qui fume. Franz jagt im komplett verwahrlosten Taxi quer durch Bayern. Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu."
-        author="Tim"
+        author="Tim Deboer"
         timestamp="11:21"
       />
     ),
@@ -50,7 +50,7 @@ const items: ShorthandCollection<ChatItemProps> = [
             Message with non-text content has box elements on the line below author
           </>
         }
-        author="Robin"
+        author="Robin Counts"
         timestamp="12:22"
         mine
       />

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithBadges.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithBadges.tsx
@@ -17,7 +17,7 @@ const items: ShorthandCollection<ChatItemProps> = [
             {'!'}
           </>
         }
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:20"
         mine
         badge={{
@@ -32,7 +32,7 @@ const items: ShorthandCollection<ChatItemProps> = [
   },
   {
     gutter: <Avatar {...timAvatar} />,
-    message: <Chat.Message content="Hey" author="Tim" timestamp="10:21" />,
+    message: <Chat.Message content="Hey" author="Tim Deboer" timestamp="10:21" />,
     key: 'message-id-2',
   },
   {
@@ -40,7 +40,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Please look into this as soon as possible"
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:22"
         mine
         badge={{

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithDetails.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithDetails.tsx
@@ -11,7 +11,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Edited message"
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:20"
         mine
         details={<Tooltip trigger={<EditIcon outline />} content="Edited" />}
@@ -24,7 +24,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Edited and translated message"
-        author="Tim"
+        author="Tim Deboer"
         timestamp="10:22"
         details={
           <>

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithReactions.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithReactions.tsx
@@ -54,7 +54,7 @@ const ChatMessage = ({
   return (
     <Chat.Message
       content={content}
-      author="Tim"
+      author="Tim Deboer"
       timestamp="11:21"
       reactionGroup={reactionGroup}
       actionMenu={!hideActionMenu && actionMenu}

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithReadReceipts.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/compactChat/CompactChatWithReadReceipts.tsx
@@ -8,12 +8,12 @@ import { robinAvatar, timAvatar } from './compactAvatars';
 const items: ShorthandCollection<ChatItemProps> = [
   {
     gutter: <Avatar {...robinAvatar} />,
-    message: <Chat.Message content="Old read message" author="Robin" timestamp="10:15" mine />,
+    message: <Chat.Message content="Old read message" author="Robin Counts" timestamp="10:15" mine />,
     key: 'message-id-1',
   },
   {
     gutter: <Avatar {...timAvatar} />,
-    message: <Chat.Message content="Old reply" author="Tim" timestamp="10:16" />,
+    message: <Chat.Message content="Old reply" author="Tim Deboer" timestamp="10:16" />,
     key: 'message-id-2',
   },
   {
@@ -21,7 +21,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Most recent read message spanning multiple lines. The quick brown fox jumps over the lazy dog. Portez ce vieux whisky au juge blond qui fume. Franz jagt im komplett verwahrlosten Taxi quer durch Bayern. Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu."
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:17"
         mine
         readStatus={{
@@ -37,7 +37,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         content="Sent message"
-        author="Robin"
+        author="Robin Counts"
         timestamp="10:21"
         mine
         readStatus={{


### PR DESCRIPTION
Initially compact chat was supposed to only display given names of message authors, but due to potential problems with splitting names/detecting given name part, the current design spec displays full names in all chat densities.

This PR updates the examples and prototypes of compact chat to reflect that decision and avoid confusion.