### PR TITLE
Fix MessageBar link styling

### DIFF
--- a/change/office-ui-fabric-react-2021-07-19-00-42-30-users-tahsia-fixMessageBarStyling.json
+++ b/change/office-ui-fabric-react-2021-07-19-00-42-30-users-tahsia-fixMessageBarStyling.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Removed styling and updated examples",
+  "packageName": "office-ui-fabric-react",
+  "email": "tahsia@microsoft.com",
+  "commit": "0c71d8f636cff9ec1fb728c591b9ce476f714a59",
+  "dependentChangeType": "patch",
+  "date": "2021-07-19T07:42:30.421Z"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -230,11 +230,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
       classNames.innerText,
       {
         lineHeight: 16,
-        selectors: {
-          '& span a': {
-            paddingLeft: 4,
-          },
-        },
       },
       truncated && {
         overflow: 'visible',

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -31,7 +31,7 @@ const choiceGroupStyles = {
 
 const DefaultExample = () => (
   <MessageBar>
-    Info/Default MessageBar.
+    Info/Default MessageBar.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>
@@ -45,7 +45,7 @@ const ErrorExample = (p: IExampleProps) => (
     onDismiss={p.resetChoice}
     dismissButtonAriaLabel="Close"
   >
-    Error MessageBar with single line, with dismiss button.
+    Error MessageBar with single line, with dismiss button.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>
@@ -82,7 +82,7 @@ const SevereExample = (p: IExampleProps) => (
       </div>
     }
   >
-    SevereWarning MessageBar with action buttons which defaults to multiline.
+    SevereWarning MessageBar with action buttons which defaults to multiline.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>
@@ -100,7 +100,7 @@ const SuccessExample = () => (
     messageBarType={MessageBarType.success}
     isMultiline={false}
   >
-    Success MessageBar with single line and action buttons.
+    Success MessageBar with single line and action buttons.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>
@@ -119,7 +119,7 @@ const WarningExample = (p: IExampleProps) => (
       </div>
     }
   >
-    Warning MessageBar content.
+    Warning MessageBar content.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>
@@ -143,7 +143,7 @@ const WarningExample2 = (p: IExampleProps) => (
     scelerisque. Curabitur vitae orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras
     faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse
     platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu
-    mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris.
+    mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris.{' '}
     <Link href="www.bing.com" target="_blank">
       Visit our website.
     </Link>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removed paddingLeft; 4 for MessageBar component's links. 

#### Focus areas to test

Verify that MessageBar component no longer has a strange gap between normal text and link.
