### PR TITLE
chore: bump @linaria/babel-preset & @linaria/shaker

### DIFF
--- a/change/@fluentui-babel-make-styles-31db43f1-c89d-4d23-a682-33f8006d4b62.json
+++ b/change/@fluentui-babel-make-styles-31db43f1-c89d-4d23-a682-33f8006d4b62.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bump @linaria/babel-preset & @linaria/shaker",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-make-styles-webpack-loader-24c43fb8-8c0d-4302-8082-04ab02e79c5e.json
+++ b/change/@fluentui-make-styles-webpack-loader-24c43fb8-8c0d-4302-8082-04ab02e79c5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bump @linaria/babel-preset & @linaria/shaker",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-make-styles/package.json
+++ b/packages/babel-make-styles/package.json
@@ -33,8 +33,8 @@
     "@babel/template": "^7.12.13",
     "@babel/traverse": "^7.12.13",
     "@fluentui/make-styles": "^9.0.0-alpha.28",
-    "@linaria/babel": "^3.0.0-beta.0",
-    "@linaria/shaker": "^3.0.0-beta.5",
+    "@linaria/babel-preset": "^3.0.0-beta.7",
+    "@linaria/shaker": "^3.0.0-beta.8",
     "tslib": "^2.1.0"
   },
   "beachball": {

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -1,6 +1,6 @@
 import { NodePath, PluginObj, PluginPass, TransformOptions, types as t } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
-import { Module } from '@linaria/babel';
+import { Module } from '@linaria/babel-preset';
 import { resolveStyleRulesForSlots, CSSRulesByBucket, StyleBucketName, MakeStyles } from '@fluentui/make-styles';
 
 import { UNHANDLED_CASE_ERROR } from './constants';

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -3,7 +3,7 @@ import { Scope } from '@babel/traverse';
 import * as template from '@babel/template';
 import generator from '@babel/generator';
 import { resolveProxyValues } from '@fluentui/make-styles';
-import { Module, StrictOptions } from '@linaria/babel';
+import { Module, StrictOptions } from '@linaria/babel-preset';
 import shakerEvaluator from '@linaria/shaker';
 
 import { astify } from './astify';

--- a/packages/make-styles-webpack-loader/package.json
+++ b/packages/make-styles-webpack-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/make-styles-webpack-loader",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "A Webpack for makeStyles",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
@@ -26,8 +26,16 @@
   "dependencies": {
     "@babel/core": "^7.10.4",
     "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.7",
     "enhanced-resolve": "^5.8.2",
     "tslib": "^2.1.0"
+  },
+  "beachball": {
+    "tag": "alpha",
+    "disallowedChangeTypes": [
+      "major",
+      "minor",
+      "patch"
+    ]
   }
 }

--- a/packages/make-styles-webpack-loader/src/webpackLoader.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.ts
@@ -1,4 +1,4 @@
-import { EvalCache, Module } from '@linaria/babel';
+import { EvalCache, Module } from '@linaria/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
 import * as path from 'path';
 import * as webpack from 'webpack';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2558,10 +2558,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@linaria/babel-preset@^3.0.0-beta.5":
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@linaria/babel-preset/-/babel-preset-3.0.0-beta.5.tgz#34088faf49eb5408839c2975b1445ed99b87dd69"
-  integrity sha512-mPhf5voj4GkFyDYmllkh50McCW8GucJc+o/YvhP4+9N1lmDg0pp9WRERmV92do9WJ9kJvVAe5joVy9TNZJLnTQ==
+"@linaria/babel-preset@^3.0.0-beta.7":
+  version "3.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@linaria/babel-preset/-/babel-preset-3.0.0-beta.7.tgz#015f4406ce11d6c78bc6dec58801dc5a500e1c0e"
+  integrity sha512-NE5f//T9ywXZA+W+Pw1YjWKdzskUpaV7GVkxXhkxLM2la1+S4xOoZR1rzW77bR1C9GFFwzZTeb8XP85whb2ZqQ==
   dependencies:
     "@babel/generator" ">=7"
     "@babel/plugin-syntax-dynamic-import" ">=7"
@@ -2569,54 +2569,40 @@
     "@linaria/core" "^3.0.0-beta.4"
     "@linaria/logger" "^3.0.0-beta.3"
     cosmiconfig "^5.1.0"
-    source-map "^0.6.1"
+    source-map "^0.7.3"
     stylis "^3.5.4"
 
-"@linaria/babel@^3.0.0-beta.0":
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@linaria/babel/-/babel-3.0.0-beta.0.tgz#60ee6eb011017f918c4ebfe3ec66a44b20b1e40e"
-  integrity sha512-IA2P9Es8iIfc/p12riN+hHVxrjIzkQ2xcdb2s8Ltszz21WN2I39WubDjk+DOUQAgLNoKH2HsgX0wWnW9zT4Bgw==
-  dependencies:
-    "@babel/generator" ">=7"
-    "@babel/plugin-syntax-dynamic-import" ">=7"
-    "@babel/template" ">=7"
-    "@linaria/core" "^3.0.0-beta.0"
-    "@linaria/logger" "^3.0.0-beta.0"
-    cosmiconfig "^5.1.0"
-    source-map "^0.6.1"
-    stylis "^3.5.4"
-
-"@linaria/core@^3.0.0-beta.0", "@linaria/core@^3.0.0-beta.4":
+"@linaria/core@^3.0.0-beta.4":
   version "3.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@linaria/core/-/core-3.0.0-beta.4.tgz#ae878874773c15b189792e277771f68fef18019a"
   integrity sha512-NzxeMDxRt57nR6tLFZ8xIstp5ld9JQPIyp9+TKtQZhoX3oJuUru+S4vXPr1Gach6VaqKKKT5T6fmJgJl9MMprw==
 
-"@linaria/logger@^3.0.0-beta.0", "@linaria/logger@^3.0.0-beta.3":
+"@linaria/logger@^3.0.0-beta.3":
   version "3.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@linaria/logger/-/logger-3.0.0-beta.3.tgz#4bb8f0f36567cea7cac16a60fb3474fbfec491a7"
   integrity sha512-Z2k0RJuA4PffcZcwBN1By8FmcCvcFUe9GHc846B6hNP09zDVhHSFLKJN9NfXJCzJ/9PifOxSUKyOjLtpv3EhGA==
   dependencies:
     debug "^4.1.1"
 
-"@linaria/preeval@^3.0.0-beta.5":
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@linaria/preeval/-/preeval-3.0.0-beta.5.tgz#1774f741fa310c00a6b15eede30aa4fd7579e06e"
-  integrity sha512-T4jaqBTL9vhL/AVE0RQj8H6JAqIfilpbh6JCnjiNqfnlVV4bBlvDMThzBrHGMgXGomlKw/qox4TuV+tN9W/1Ag==
+"@linaria/preeval@^3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@linaria/preeval/-/preeval-3.0.0-beta.8.tgz#b7c7fc7540e6deef731a94df4b65dc6bdf4197ae"
+  integrity sha512-zZcs9sMtpBh9KXvBmKCyocbcjUe5sZQbTHNe2VayfWTzPwNuMnvZ+qcs4nFrli4XKVOoIKIz7T1wmN4CC/X88Q==
   dependencies:
-    "@linaria/babel-preset" "^3.0.0-beta.5"
+    "@linaria/babel-preset" "^3.0.0-beta.7"
 
-"@linaria/shaker@^3.0.0-beta.5":
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@linaria/shaker/-/shaker-3.0.0-beta.5.tgz#9b85cb6323634a4f623f04e2e5bf4baec3e4aff8"
-  integrity sha512-5E2qLrEa2Aaj5dN9eyjg0kZdvZdQ1NAHPEBR1j/osXKRjPk9oMk97NLiislAXWHs2LlKdH0UZz1w1KcrwfBM8A==
+"@linaria/shaker@^3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@linaria/shaker/-/shaker-3.0.0-beta.8.tgz#3114de281284638b4926638c4636b412104db9b8"
+  integrity sha512-8vMoJvndJODH7XAufluSDnrEtvP5EhL/HwiVD1icRF4YgMSHVCkzEI7qhmxoC7jD/jQPbJFdt3T/OGkZzKSjNQ==
   dependencies:
     "@babel/generator" ">=7"
     "@babel/plugin-transform-runtime" ">=7"
     "@babel/plugin-transform-template-literals" ">=7"
     "@babel/preset-env" ">=7"
-    "@linaria/babel-preset" "^3.0.0-beta.5"
+    "@linaria/babel-preset" "^3.0.0-beta.7"
     "@linaria/logger" "^3.0.0-beta.3"
-    "@linaria/preeval" "^3.0.0-beta.5"
+    "@linaria/preeval" "^3.0.0-beta.8"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
 
 "@mdx-js/loader@^1.5.1", "@mdx-js/loader@^1.5.5":


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #18936
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR bumps `@linaria/packages`:
- `@linaria/babel` => `@linaria/babel-preset` as the package was renamed in https://github.com/callstack/linaria/pull/720
- `@linaria/shaker` to adopt a fix for https://github.com/callstack/linaria/issues/800 that is a blocker for #18936

Modifies `./package.json` to include proper settings for `beachball`.