### PR TITLE
fix(babel-make-styles): handle cases when MemberExpression is a function

### DIFF
--- a/change/@fluentui-babel-make-styles-f0d2c1aa-81bc-4c9c-9dfa-1652c666667c.json
+++ b/change/@fluentui-babel-make-styles-f0d2c1aa-81bc-4c9c-9dfa-1652c666667c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix handling of cases when MemberExpression is a function",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/object-mixins/code.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/code.ts
@@ -3,6 +3,7 @@ import { flexStyles, gridStyles, typography } from './mixins';
 
 export const useStyles = makeStyles({
   root: flexStyles,
+  label: typography.text,
   header: typography.header,
 
   icon: { ...flexStyles, color: 'red' },

--- a/packages/babel-make-styles/__fixtures__/object-mixins/mixins.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/mixins.ts
@@ -1,4 +1,5 @@
-import { MakeStyles } from '@fluentui/make-styles';
+import { MakeStyles, MakeStylesStyleRule } from '@fluentui/make-styles';
+import { Theme } from '@fluentui/react-theme';
 
 export const flexStyles: MakeStyles = {
   display: 'flex',
@@ -10,7 +11,7 @@ export const gridStyles = (gridGap: string): MakeStyles => ({
   gridGap,
 });
 
-export const typography: Record<'text' | 'header', MakeStyles> = {
-  text: { fontWeight: 'normal' },
+export const typography: Record<'text' | 'header', MakeStylesStyleRule<Theme>> = {
+  text: theme => ({ fontWeight: theme.global.type.fontWeights.regular }),
   header: { fontWeight: 'bold' },
 };

--- a/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-mixins/output.ts
@@ -6,6 +6,9 @@ export const useStyles = __styles(
       mc9l5x: 'f22iagw',
       Beiy3e4: 'f1vx9l62',
     },
+    label: {
+      Bhrd7zp: 'f1du0uop',
+    },
     header: {
       Bhrd7zp: 'f16wzh4i',
     },
@@ -24,6 +27,7 @@ export const useStyles = __styles(
     d: [
       '.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}',
       '.f1vx9l62{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}',
+      '.f1du0uop{font-weight:var(--global-type-fontWeights-regular);}',
       '.f16wzh4i{font-weight:bold;}',
       '.fe3e8s9{color:red;}',
       '.f13qh94s{display:grid;}',

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.test.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.test.ts
@@ -1,0 +1,16 @@
+import * as Babel from '@babel/core';
+import generator from '@babel/generator';
+
+import { expressionTpl } from './evaluatePathsInVM';
+
+describe('expressionTpl', () => {
+  it('returns an expression based on a template', () => {
+    const expression = Babel.types.identifier('foo');
+
+    const result = expressionTpl({ expression, wrapName: 'wrap', themeVariableName: 'theme' });
+    const resultCode = generator(result).code;
+
+    expect(Babel.types.isCallExpression(result)).toBe(true);
+    expect(resultCode).toMatchInlineSnapshot(`"wrap(() => typeof foo === 'function' ? foo(theme) : foo)"`);
+  });
+});

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -63,7 +63,19 @@ const expressionWrapperTpl = template.statement(`
   };
 `);
 
-const expressionTpl = template.expression(`%%wrapName%%(() => %%expression%%)`);
+/**
+ * Functions, call & member expressions should be wrapped with IIFE to ensure that "theme" object will be passed
+ * without collisions.
+ *
+ * @example
+ * {
+ *   label: foo(), // call expression
+ *   header: typography.header, // could be an object or a function
+ * }
+ */
+const expressionTpl = template.expression(
+  `%%wrapName%%(() => typeof %%expression%% === 'function' ? %%expression%%(%%themeVariableName%%) : %%expression%%)`,
+);
 const exportsPrevalTpl = template.statement(`exports.${EVAL_EXPORT_NAME} = %%expressions%%`);
 
 /**
@@ -96,7 +108,9 @@ function addPreval(
 
       expressionWrapperTpl({ wrapName }),
       exportsPrevalTpl({
-        expressions: t.arrayExpression(lazyDeps.map(expression => expressionTpl({ expression, wrapName }))),
+        expressions: t.arrayExpression(
+          lazyDeps.map(expression => expressionTpl({ expression, wrapName, themeVariableName })),
+        ),
       }),
     ],
     programNode.directives,
@@ -120,17 +134,6 @@ export function evaluatePathsInVM(
     // spreads ("...fooBar") can't be executed directly, so they are wrapped with an object ("{...fooBar}")
     if (nodePath.isSpreadElement()) {
       return t.objectExpression([nodePath.node as t.SpreadElement]);
-    }
-
-    // functions should be wrapped with IIFE to ensure that "theme" object will be passed without collisions
-    if (nodePath.isArrowFunctionExpression() || nodePath.isFunctionExpression()) {
-      return t.callExpression(nodePath.node as t.ArrowFunctionExpression, [t.identifier(themeVariableName)]);
-    }
-
-    // call expressions should be wrapped with IIFE to ensure that "theme" object will be passed without collisions
-    // TODO: right now this only for call expression that returns a function that takes "theme" object as argument
-    if (nodePath.isCallExpression()) {
-      return t.callExpression(nodePath.node as t.CallExpression, [t.identifier(themeVariableName)]);
     }
 
     return nodePath.node;

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -72,8 +72,12 @@ const expressionWrapperTpl = template.statement(`
  *   label: foo(), // call expression
  *   header: typography.header, // could be an object or a function
  * }
+ *
+ * Outputs following template:
+ * @example
+ * wrap(() => typeof foo === 'function' ? foo(theme) : foo)
  */
-const expressionTpl = template.expression(
+export const expressionTpl = template.expression(
   `%%wrapName%%(() => typeof %%expression%% === 'function' ? %%expression%%(%%themeVariableName%%) : %%expression%%)`,
 );
 const exportsPrevalTpl = template.statement(`exports.${EVAL_EXPORT_NAME} = %%expressions%%`);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: unblocks #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue that was discovered in #18968:

```
ERR! [1:02:11 PM] x Error: /mnt/work/2/s/packages/react-text/lib/components/Display/Display.js: We intentionally do not support serialization of functions, this branch should be never executed
ERR!     at Object.astify (/mnt/work/2/s/packages/babel-make-styles/lib/src/utils/astify.js:14:19)
ERR!     at Object.evaluatePathsInVM (/mnt/work/2/s/packages/babel-make-styles/lib/src/utils/evaluatePathsInVM.js:102:39)
ERR!     at Object.evaluatePaths (/mnt/work/2/s/packages/babel-make-styles/lib/src/utils/evaluatePaths.js:22:29)
ERR!     at PluginPass.exit (/mnt/work/2/s/packages/babel-make-styles/lib/src/plugin.js:385:41)
ERR!     at newFn (/mnt/work/2/s/node_modules/@babel/traverse/lib/visitors.js:171:21)
```

In #18973 I added handling for `MemberExpression`s, but it was not enough as they can be represented by objects (original PR added handling for them) or functions:

```tsx
export const useStyles = makeStyles({
  // 👇 it's a MemberExpression, can be a function or an object 😮
  label: typography.text,
})
```

We also don't know in advance what kind of an expression we will get, that's why check is moved to runtime code 😅 This PR adds handling for a function case and removes redundant static checks.