### PR TITLE
chore(react-shared-contexts): migrate to new DX

### DIFF
--- a/change/@fluentui-react-shared-contexts-83896c52-ee1a-455c-a947-bc4422289130.json
+++ b/change/@fluentui-react-shared-contexts-83896c52-ee1a-455c-a947-bc4422289130.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "migrate to new DX",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,5 +29,6 @@ module.exports = {
     '<rootDir>/packages/react-slider',
     '<rootDir>/packages/make-styles-webpack-loader',
     '<rootDir>/packages/react-avatar',
+    '<rootDir>/packages/react-shared-contexts',
   ],
 };

--- a/nx.json
+++ b/nx.json
@@ -106,7 +106,7 @@
     "@fluentui/react-portal": { "tags": ["vNext"], "implicitDependencies": [] },
     "@fluentui/react-positioning": { "tags": ["vNext"], "implicitDependencies": [] },
     "@fluentui/react-provider": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
-    "@fluentui/react-shared-contexts": { "implicitDependencies": [] },
+    "@fluentui/react-shared-contexts": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },
     "@fluentui/react-storybook": { "implicitDependencies": [] },
     "@fluentui/react-tabs": { "implicitDependencies": [] },
     "@fluentui/react-tabster": { "tags": ["vNext", "platform:web"], "implicitDependencies": [] },

--- a/packages/react-shared-contexts/config/api-extractor.json
+++ b/packages/react-shared-contexts/config/api-extractor.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.json"
 }

--- a/packages/react-shared-contexts/config/api-extractor.local.json
+++ b/packages/react-shared-contexts/config/api-extractor.local.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "./api-extractor.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/<unscopedPackageName>/src/index.d.ts"
+}

--- a/packages/react-shared-contexts/jest.config.js
+++ b/packages/react-shared-contexts/jest.config.js
@@ -1,5 +1,20 @@
-let path = require('path');
-let { createConfig } = require('@fluentui/scripts/jest/jest-resources');
-module.exports = createConfig({
-  setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
-});
+// @ts-check
+
+/**
+ * @type {jest.InitialOptions}
+ */
+module.exports = {
+  displayName: 'react-shared-contexts',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.json',
+      diagnostics: false,
+    },
+  },
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  coverageDirectory: './coverage',
+  setupFilesAfterEnv: ['./config/tests.js'],
+};

--- a/packages/react-shared-contexts/package.json
+++ b/packages/react-shared-contexts/package.json
@@ -17,8 +17,9 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start-test": "just-scripts jest-watch",
-    "update-snapshots": "just-scripts jest -u"
+    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
+    "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-shared-contexts/src && yarn docs",
+    "test": "jest --passWithNoTests"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.2",

--- a/packages/react-shared-contexts/tsconfig.json
+++ b/packages/react-shared-contexts/tsconfig.json
@@ -1,23 +1,17 @@
 {
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
   "compilerOptions": {
-    "target": "es5",
-    "outDir": "lib",
-    "module": "commonjs",
+    "target": "ES5",
+    "module": "CommonJS",
     "lib": ["es5", "dom"],
+    "outDir": "dist",
     "jsx": "react",
     "declaration": true,
-    "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "noImplicitAny": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
     "preserveConstEnums": true,
-    "skipLibCheck": true,
-    "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
-  },
-  "include": ["src"]
+  }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -183,7 +183,11 @@
       "projectType": "library",
       "sourceRoot": "packages/react-provider/src"
     },
-    "@fluentui/react-shared-contexts": { "root": "packages/react-shared-contexts", "projectType": "library" },
+    "@fluentui/react-shared-contexts": {
+      "root": "packages/react-shared-contexts",
+      "projectType": "library",
+      "sourceRoot": "packages/react-shared-contexts/src"
+    },
     "@fluentui/react-storybook": { "root": "packages/react-storybook", "projectType": "library" },
     "@fluentui/react-tabs": { "root": "packages/react-tabs", "projectType": "library" },
     "@fluentui/react-tabster": {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #18579
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR migrates `@fluentui/react-shared-contexts` to new DX.

Applied changes:
- `./jest.config.js` remove `snapshotSerializers` (this package doesn't use makeStyles)
- removed `./.storybook` and scripts from `./package.json` (there are no stories for this package and should not be)
- cleaned up `./tsconfig.json#compilerOptions.types` (remove `inline-style-expand` & `storybook-addons`)


