### PR TITLE
Add ThemeDropdown to Prototypes

### DIFF
--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/Prototypes.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/Prototypes.tsx
@@ -1,7 +1,22 @@
 import * as React from 'react';
 import DocumentTitle from 'react-document-title';
 
-import { Box, Header, ICSSInJSStyle, Segment } from '@fluentui/react-northstar';
+import {
+  Box,
+  Dropdown,
+  Flex,
+  Header,
+  ICSSInJSStyle,
+  Provider,
+  Segment,
+  teamsDarkTheme,
+  teamsDarkV2Theme,
+  teamsHighContrastTheme,
+  teamsTheme,
+  teamsV2Theme,
+  Text,
+  ThemePrepared,
+} from '@fluentui/react-northstar';
 
 interface PrototypeSectionProps {
   title?: React.ReactNode;
@@ -12,27 +27,73 @@ interface ComponentPrototypeProps extends PrototypeSectionProps {
   description?: React.ReactNode;
 }
 
-export const PrototypeSection: React.FunctionComponent<PrototypeSectionProps> = ({ children, styles, title }) => (
-  <Box styles={{ margin: '20px', ...styles }}>
-    <DocumentTitle title={`Fluent UI - ${title || 'Prototype'}`} />
-    <Header as="h1">{title}</Header>
-    {children}
-  </Box>
-);
+type ThemeName = 'Teams' | 'Teams Dark' | 'Teams High Contrast' | 'Teams V2' | 'Teams Dark V2';
+
+const themes: Record<ThemeName, ThemePrepared> = {
+  Teams: teamsTheme,
+  'Teams Dark': teamsDarkTheme,
+  'Teams High Contrast': teamsHighContrastTheme,
+  'Teams V2': teamsV2Theme,
+  'Teams Dark V2': teamsDarkV2Theme,
+};
+
+const ThemeContext = React.createContext<ThemeName>('Teams');
+
+export const PrototypeSection: React.FunctionComponent<PrototypeSectionProps> = ({ children, styles, title }) => {
+  const [theme, setTheme] = React.useState<ThemeName>('Teams');
+  const changeTheme = React.useCallback((_, { value }) => setTheme(value), [setTheme]);
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <DocumentTitle title={`Fluent UI - ${title || 'Prototype'}`} />
+      <Flex
+        gap="gap.medium"
+        space="between"
+        vAlign="center"
+        styles={{
+          backdropFilter: 'blur(10px)',
+          background: '#dddddd88',
+          borderBottom: '1px solid #00000022',
+          padding: '20px',
+          position: 'sticky',
+          top: 0,
+          zIndex: 1000,
+        }}
+      >
+        <Flex.Item shrink={0}>
+          <Header as="h1" content={title} style={{ marginBottom: '0', marginTop: '0' }} />
+        </Flex.Item>
+        <Dropdown
+          items={Object.keys(themes)}
+          onChange={changeTheme}
+          placeholder="Theme"
+          variables={{ width: '14rem' }}
+        />
+      </Flex>
+      <Box styles={{ padding: '20px', ...styles }}>{children}</Box>
+    </ThemeContext.Provider>
+  );
+};
 
 export const ComponentPrototype: React.FunctionComponent<ComponentPrototypeProps> = ({
   children,
   description,
   styles,
   title,
-}) => (
-  <Box styles={{ marginTop: '20px', ...styles }}>
-    {(title || description) && (
+}) => {
+  const theme = React.useContext(ThemeContext);
+
+  return (
+    <Box styles={{ marginBottom: '30px', ...styles }}>
+      {(title || description) && (
+        <Segment style={{ borderBottom: '1px solid #dddddd' }}>
+          {title && <Header as="h3" content={title} style={{ margin: '0' }} />}
+          {description && <Text content={description} />}
+        </Segment>
+      )}
       <Segment>
-        {title && <Header as="h3">{title}</Header>}
-        {description && <p>{description}</p>}
+        <Provider theme={themes[theme]}>{children}</Provider>
       </Segment>
-    )}
-    <Segment>{children}</Segment>
-  </Box>
-);
+    </Box>
+  );
+};


### PR DESCRIPTION
- Aligns header of Prototypes with header for components, guides
- Add ThemeDropdown to Prototypes

![image](https://user-images.githubusercontent.com/2564094/126213184-855ed30e-1d59-4257-9d34-5af44f17c84c.png)
