### PR TITLE
chore(a11y-testing): use new keyboard-keys package

### DIFF
--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -19,18 +19,19 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.2",
+    "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/react": "16.9.42",
-    "@fluentui/scripts": "^1.0.0",
     "enzyme": "~3.10.0",
     "react": "16.8.6"
   },
   "dependencies": {
+    "@fluentui/keyboard-keys": "^9.0.0-alpha.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
     "enzyme": "^3.0.0",
-    "react": ">=16.8.0 <18.0.0",
-    "jest": "^24.0.0"
+    "jest": "^24.0.0",
+    "react": ">=16.8.0 <18.0.0"
   }
 }

--- a/packages/a11y-testing/src/facades/ComponentTestFacade.tsx
+++ b/packages/a11y-testing/src/facades/ComponentTestFacade.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Props, PropValue, TestFacade } from '../types';
 import { ReactWrapper, mount } from 'enzyme';
+import { Enter, Space, keyCodes } from '@fluentui/keyboard-keys';
 
 export class ComponentTestFacade implements TestFacade {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -83,18 +84,18 @@ export class ComponentTestFacade implements TestFacade {
 
   public pressSpaceKey(selector: string) {
     if (selector === 'root') {
-      this.renderedComponent.simulate('keydown', { keyCode: 32 });
+      this.renderedComponent.simulate('keydown', { keyCode: keyCodes.Space, key: Space });
       return;
     }
-    this.renderedComponent.find(selector).simulate('keydown', { keyCode: 32 });
+    this.renderedComponent.find(selector).simulate('keydown', { keyCode: keyCodes.Space, key: Space });
   }
 
   public pressEnterKey(selector: string) {
     if (selector === 'root') {
-      this.renderedComponent.simulate('keydown', { keyCode: 13 });
+      this.renderedComponent.simulate('keydown', { keyCode: keyCodes.Enter, key: Enter });
       return;
     }
-    this.renderedComponent.find(selector).simulate('keydown', { keyCode: 13 });
+    this.renderedComponent.find(selector).simulate('keydown', { keyCode: keyCodes.Enter, key: Enter });
   }
 
   public forProps = (props: Props): TestFacade => {

--- a/packages/keyboard-keys/etc/keyboard-keys.api.md
+++ b/packages/keyboard-keys/etc/keyboard-keys.api.md
@@ -700,7 +700,7 @@ declare namespace keyCodes {
         NonConvert_2 as NonConvert,
         Accept_2 as Accept,
         ModeChange_2 as ModeChange,
-        Space,
+        Space_2 as Space,
         PageUp_2 as PageUp,
         PageDown_2 as PageDown,
         End_2 as End,
@@ -1294,7 +1294,10 @@ export const Soft3 = "Soft3";
 export const Soft4 = "Soft4";
 
 // @public (undocumented)
-const Space = 32;
+export const Space = " ";
+
+// @public (undocumented)
+const Space_2 = 32;
 
 // @public (undocumented)
 export const SpeechCorrectionList = "SpeechCorrectionList";

--- a/packages/keyboard-keys/src/keys.ts
+++ b/packages/keyboard-keys/src/keys.ts
@@ -13,6 +13,7 @@ export const SymbolLock = 'SymbolLock';
 export const Hyper = 'Hyper';
 export const Super = 'Super';
 export const Enter = 'Enter';
+export const Space = ' ';
 export const Tab = 'Tab';
 export const ArrowDown = 'ArrowDown';
 export const ArrowLeft = 'ArrowLeft';


### PR DESCRIPTION
First step to full migration per #18587

Adds `keyboard-keys` as a dependency to `a11y-testing` and uses both
keyCodes and keys

#### Pull request checklist

- [x] Addresses an existing issue: Fixes partially #19013
- [x] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
