### PR TITLE
Azure themes stories

### DIFF
--- a/change/@fluentui-azure-themes-6418b13a-0982-48b5-abf9-96b70c17f49c.json
+++ b/change/@fluentui-azure-themes-6418b13a-0982-48b5-abf9-96b70c17f49c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed azure theme disabled primary button hover style",
+  "packageName": "@fluentui/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -19,7 +19,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   ButtonBorderDisabled: DarkSemanticColors.disabledButton.background,
   ButtonBorderFocus: DarkSemanticColors.secondaryButton.focus.border,
   buttonText: DarkSemanticColors.secondaryButton.rest.text,
-  buttonTextChecked: DarkSemanticColors.secondaryButton.pressed.border,
+  buttonTextChecked: DarkSemanticColors.secondaryButton.pressed.text,
   buttonTextCheckedHovered: DarkSemanticColors.secondaryButton.hover.border,
   buttonTextDisabled: DarkSemanticColors.disabledButton.text,
   buttonTextHovered: DarkSemanticColors.secondaryButton.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -19,7 +19,7 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   ButtonBorderDisabled: HighContrastDarkSemanticColors.disabledButton.background,
   ButtonBorderFocus: HighContrastDarkSemanticColors.secondaryButton.focus.border,
   buttonText: HighContrastDarkSemanticColors.secondaryButton.rest.text,
-  buttonTextChecked: HighContrastDarkSemanticColors.secondaryButton.pressed.border,
+  buttonTextChecked: HighContrastDarkSemanticColors.secondaryButton.pressed.text,
   buttonTextCheckedHovered: HighContrastDarkSemanticColors.secondaryButton.hover.border,
   buttonTextDisabled: HighContrastDarkSemanticColors.disabledButton.text,
   buttonTextHovered: HighContrastDarkSemanticColors.secondaryButton.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -19,7 +19,7 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   ButtonBorderDisabled: HighContrastLightSemanticColors.disabledButton.text,
   ButtonBorderFocus: HighContrastLightSemanticColors.secondaryButton.focus.border,
   buttonText: HighContrastLightSemanticColors.secondaryButton.rest.text,
-  buttonTextChecked: HighContrastLightSemanticColors.secondaryButton.pressed.border,
+  buttonTextChecked: HighContrastLightSemanticColors.secondaryButton.pressed.text,
   buttonTextCheckedHovered: HighContrastLightSemanticColors.secondaryButton.hover.border,
   buttonTextDisabled: HighContrastLightSemanticColors.disabledButton.text,
   buttonTextHovered: HighContrastLightSemanticColors.secondaryButton.hover.color,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -19,7 +19,7 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   ButtonBorderDisabled: LightSemanticColors.disabledButton.background,
   ButtonBorderFocus: LightSemanticColors.secondaryButton.focus.border,
   buttonText: LightSemanticColors.secondaryButton.rest.text,
-  buttonTextChecked: LightSemanticColors.secondaryButton.pressed.border,
+  buttonTextChecked: LightSemanticColors.secondaryButton.pressed.text,
   buttonTextCheckedHovered: LightSemanticColors.secondaryButton.hover.border,
   buttonTextDisabled: LightSemanticColors.disabledButton.text,
   buttonTextHovered: LightSemanticColors.secondaryButton.hover.color,

--- a/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
@@ -13,34 +13,21 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       height: StyleConstants.inputControlHeight,
       padding: '0px 16px',
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
-      color: semanticColors.buttonText,
       selectors: {
         // standard button
         '&.is-expanded': {
           color: semanticColors.buttonTextHovered,
           borderColor: semanticColors.inputBorderHovered,
         },
-        '&.ms-Button--primary.is-disabled': {
-          backgroundColor: semanticColors.primaryButtonBackgroundDisabled,
-          color: semanticColors.primaryButtonTextDisabled,
-          border: `${StyleConstants.borderWidth} solid
-          ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
-        },
         '&.ms-Button--primary': {
-          backgroundColor: semanticColors.primaryButtonBackground,
           height: StyleConstants.inputControlHeight,
           padding: '0px 16px',
-          color: semanticColors.primaryButtonText,
           border: `${StyleConstants.borderWidth} solid ${semanticColors.primaryButtonBorder}`,
           selectors: {
             ':hover': {
-              backgroundColor: semanticColors.primaryButtonBackgroundHovered,
-              color: semanticColors.primaryButtonTextHovered,
               borderColor: semanticColors.primaryButtonBackgroundHovered,
             },
             ':active': {
-              backgroundColor: semanticColors.primaryButtonBackgroundPressed,
-              color: semanticColors.primaryButtonTextPressed,
               borderColor: semanticColors.primaryButtonBackgroundPressed,
             },
             ':focus': {
@@ -50,12 +37,11 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
             },
           },
         },
+        '&.ms-Button--primary.is-disabled': {
+          border: `${StyleConstants.borderWidth} solid
+          ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
+        },
       },
-    },
-    rootDisabled: {
-      backgroundColor: semanticColors.primaryButtonBackgroundDisabled,
-      color: semanticColors.primaryButtonTextDisabled,
-      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
     rootFocused: {
       selectors: {
@@ -68,28 +54,21 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       fill: semanticColors.buttonTextHovered,
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
     },
-    rootHovered: {
-      backgroundColor: semanticColors.buttonBackgroundHovered,
-      color: semanticColors.buttonTextHovered,
-    },
-    rootPressed: {
-      backgroundColor: semanticColors.buttonBackgroundPressed,
-      color: semanticColors.buttonTextHovered,
-    },
     rootChecked: {
-      backgroundColor: semanticColors.buttonBackgroundPressed,
       border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.inputBorderPressed}`,
-      color: semanticColors.buttonTextHovered,
     },
     rootCheckedHovered: {
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorderHovered}`,
-      backgroundColor: semanticColors.buttonBackgroundHovered,
-      color: semanticColors.buttonTextHovered,
     },
     rootCheckedPressed: {
       backgroundColor: semanticColors.buttonBackgroundPressed,
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
       color: semanticColors.buttonTextHovered,
+    },
+    rootDisabled: {
+      backgroundColor: semanticColors.primaryButtonBackgroundDisabled,
+      color: semanticColors.primaryButtonTextDisabled,
+      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
     splitButtonContainer: {
       selectors: {

--- a/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
@@ -9,16 +9,9 @@ export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
 
   return {
     root: {
-      backgroundColor: semanticColors.primaryButtonBackground,
       height: StyleConstants.inputControlHeight,
       padding: '0px 16px',
-      color: semanticColors.primaryButtonText,
       border: `${StyleConstants.borderWidth} solid ${semanticColors.primaryButtonBorder}`,
-    },
-    rootDisabled: {
-      backgroundColor: semanticColors.primaryButtonBackgroundDisabled,
-      color: semanticColors.primaryButtonTextDisabled,
-      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
     rootFocused: {
       selectors: {
@@ -30,19 +23,7 @@ export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       color: semanticColors.primaryButtonText,
       borderColor: extendedSemanticColors.primaryCompoundButtonBorder,
     },
-    rootHovered: {
-      backgroundColor: semanticColors.primaryButtonBackgroundHovered,
-      color: semanticColors.primaryButtonTextHovered,
-      borderColor: semanticColors.primaryButtonBackgroundHovered,
-    },
-    rootPressed: {
-      backgroundColor: semanticColors.primaryButtonBackgroundPressed,
-      color: semanticColors.primaryButtonTextPressed,
-      borderColor: semanticColors.primaryButtonBackgroundPressed,
-    },
     rootChecked: {
-      backgroundColor: semanticColors.primaryButtonBackgroundPressed,
-      color: semanticColors.primaryButtonTextPressed,
       border: 'none',
     },
     rootCheckedHovered: {
@@ -52,6 +33,9 @@ export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
     rootCheckedPressed: {
       backgroundColor: semanticColors.primaryButtonBackgroundPressed,
       color: semanticColors.primaryButtonTextPressed,
+    },
+    rootDisabled: {
+      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.primaryButtonBorderDisabled} !important`,
     },
   };
 };

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  Customizer as DeprecatedCustomizer,
-  TextField,
-  Stack,
   Checkbox,
-  SearchBox,
-  Link,
+  ICustomizerProps,
   Label,
+  Link,
+  SearchBox,
+  Stack,
   Text,
+  TextField,
   ThemeProvider,
 } from '@fluentui/react';
 import { DefaultButton, CompoundButton, PrimaryButton } from '@fluentui/react/lib/Button';
@@ -41,9 +41,17 @@ import { TeachingBubbleBasicExample } from '../components/TeachingBubble.stories
 import { MessageBarBasicExample } from '../components/messageBar.stories';
 import { TooltipBasicExample } from '../components/tooltip.stories';
 
-// Workaround to prevent errors on usage of Customizer, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
-const Customizer = DeprecatedCustomizer;
+const ThemeProviderAdapter: React.FunctionComponent<ICustomizerProps> = props => (
+  <ThemeProvider
+    applyTo="body"
+    theme={{
+      ...(props?.settings as any).theme,
+      components: props.scopedSettings,
+    }}
+  >
+    {props.children}
+  </ThemeProvider>
+);
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -150,33 +158,25 @@ const Example = () => (
 );
 
 export const Light = () => (
-  <Customizer {...AzureCustomizationsLight}>
-    <ThemeProvider applyTo="body">
-      <Example />
-    </ThemeProvider>
-  </Customizer>
+  <ThemeProviderAdapter {...AzureCustomizationsLight}>
+    <Example />
+  </ThemeProviderAdapter>
 );
 
 export const Dark = () => (
-  <Customizer {...AzureCustomizationsDark}>
-    <ThemeProvider applyTo="body">
-      <Example />
-    </ThemeProvider>
-  </Customizer>
+  <ThemeProviderAdapter {...AzureCustomizationsDark}>
+    <Example />
+  </ThemeProviderAdapter>
 );
 
 export const HighContrastLight = () => (
-  <Customizer {...AzureCustomizationsHighContrastLight}>
-    <ThemeProvider applyTo="body">
-      <Example />
-    </ThemeProvider>
-  </Customizer>
+  <ThemeProviderAdapter {...AzureCustomizationsHighContrastLight}>
+    <Example />
+  </ThemeProviderAdapter>
 );
 
 export const HighContrastDark = () => (
-  <Customizer {...AzureCustomizationsHighContrastDark}>
-    <ThemeProvider applyTo="body">
-      <Example />
-    </ThemeProvider>
-  </Customizer>
+  <ThemeProviderAdapter {...AzureCustomizationsHighContrastDark}>
+    <Example />
+  </ThemeProviderAdapter>
 );

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  Checkbox,
-  ICustomizerProps,
-  Label,
-  Link,
-  SearchBox,
-  Stack,
-  Text,
+  Customizer as DeprecatedCustomizer,
   TextField,
+  Stack,
+  Checkbox,
+  SearchBox,
+  Link,
+  Label,
+  Text,
   ThemeProvider,
 } from '@fluentui/react';
 import { DefaultButton, CompoundButton, PrimaryButton } from '@fluentui/react/lib/Button';
@@ -41,17 +41,9 @@ import { TeachingBubbleBasicExample } from '../components/TeachingBubble.stories
 import { MessageBarBasicExample } from '../components/messageBar.stories';
 import { TooltipBasicExample } from '../components/tooltip.stories';
 
-const ThemeProviderAdapter: React.FunctionComponent<ICustomizerProps> = props => (
-  <ThemeProvider
-    applyTo="body"
-    theme={{
-      ...(props?.settings as any).theme,
-      components: props.scopedSettings,
-    }}
-  >
-    {props.children}
-  </ThemeProvider>
-);
+// Workaround to prevent errors on usage of Customizer, without disabling all deprecation checks
+// eslint-disable-next-line deprecation/deprecation
+const Customizer = DeprecatedCustomizer;
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -158,25 +150,33 @@ const Example = () => (
 );
 
 export const Light = () => (
-  <ThemeProviderAdapter {...AzureCustomizationsLight}>
-    <Example />
-  </ThemeProviderAdapter>
+  <Customizer {...AzureCustomizationsLight}>
+    <ThemeProvider applyTo="body">
+      <Example />
+    </ThemeProvider>
+  </Customizer>
 );
 
 export const Dark = () => (
-  <ThemeProviderAdapter {...AzureCustomizationsDark}>
-    <Example />
-  </ThemeProviderAdapter>
+  <Customizer {...AzureCustomizationsDark}>
+    <ThemeProvider applyTo="body">
+      <Example />
+    </ThemeProvider>
+  </Customizer>
 );
 
 export const HighContrastLight = () => (
-  <ThemeProviderAdapter {...AzureCustomizationsHighContrastLight}>
-    <Example />
-  </ThemeProviderAdapter>
+  <Customizer {...AzureCustomizationsHighContrastLight}>
+    <ThemeProvider applyTo="body">
+      <Example />
+    </ThemeProvider>
+  </Customizer>
 );
 
 export const HighContrastDark = () => (
-  <ThemeProviderAdapter {...AzureCustomizationsHighContrastDark}>
-    <Example />
-  </ThemeProviderAdapter>
+  <Customizer {...AzureCustomizationsHighContrastDark}>
+    <ThemeProvider applyTo="body">
+      <Example />
+    </ThemeProvider>
+  </Customizer>
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
- Disabled PrimaryButton is shown as enabled when hovered under azure-themes. https://fabricweb.z5.web.core.windows.net/oufr/8.23.5/#/examples/button
![image](https://user-images.githubusercontent.com/67673432/126295023-d785b317-6926-430e-87bd-c1bb3e4af00a.png)
Fix
  - Moved disabled styles as the last styles, after hover styles;
  - As azure-themes has already defined semantic colors, removed duplicated button styles using the same semantic colors.
- Azure themes storybook doesn't work. PrimaryButton below should have height of 24px under azure-themes.
![image](https://user-images.githubusercontent.com/67673432/126295280-4e4acfbe-c5b4-47b5-957f-f6bc424445d0.png)
ThemeProvider doesn't merge styles automatically, so inner ThemeProvider reset outer customizer styles.
https://github.com/microsoft/fluentui/blob/cf8d7a43d6de92501cef58200aff21fb3d1590a5/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx#L152-L158

After fix
![image](https://user-images.githubusercontent.com/67673432/126306983-f949523a-995e-422f-b3f6-024759a6961e.png)

