### PR TITLE
fix(Carousel): fix navigation item click

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix style debugging throw error in dev environment @yuanboxue-amber ([#18955](https://github.com/microsoft/fluentui/pull/18955))
 - Fix `ChatMessage` to pass `popperRef` from user to `usePopper` @yuanboxue-amber ([#18950](https://github.com/microsoft/fluentui/pull/18950))
 - Fix hover styles for Splitbutton Toggle button part @TanelVari ([#18976](https://github.com/microsoft/fluentui/pull/18976))
+- Fix `Carousel` navigation item click @chassunc ([#19019](https://github.com/microsoft/fluentui/pull/19019))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
+++ b/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { Carousel, Button } from '@fluentui/react-northstar';
+import { Carousel, Button, carouselNavigationItemClassName } from '@fluentui/react-northstar';
 
 export const selectors = {
   CarouselClass: 'carousel',
   ItemButton: 'item-button',
   HiddenContent: 'hidden-content',
+  Navigation: carouselNavigationItemClassName,
+  second: 'second',
 };
 
 const CarouselClickableContentExample = () => {
@@ -19,6 +21,11 @@ const CarouselClickableContentExample = () => {
           <Button className={selectors.ItemButton} onClick={() => setClicked(true)} content="Test" />
         </div>
       ),
+    },
+    {
+      key: 'second',
+      id: 'second',
+      content: <div className={selectors.second}>second</div>,
     },
   ];
 

--- a/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
+++ b/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
@@ -32,7 +32,18 @@ const CarouselClickableContentExample = () => {
   return (
     <>
       {clicked && <div className={selectors.HiddenContent}>First Hidden</div>}
-      <Carousel className={selectors.CarouselClass} ariaRoleDescription="carousel" items={carouselItems} />
+      <Carousel
+        navigation={{
+          'aria-label': 'people portraits',
+          items: carouselItems.map((item, index) => ({
+            key: item.id,
+            'aria-controls': item.id,
+          })),
+        }}
+        className={selectors.CarouselClass}
+        ariaRoleDescription="carousel"
+        items={carouselItems}
+      />
     </>
   );
 };

--- a/packages/fluentui/e2e/tests/carouselClickableContent.spec.ts
+++ b/packages/fluentui/e2e/tests/carouselClickableContent.spec.ts
@@ -4,6 +4,8 @@ describe('Carousel with clickable content', () => {
   const carousel = `.${selectors.CarouselClass}`;
   const button = `.${selectors.ItemButton}`;
   const hiddenContent = `.${selectors.HiddenContent}`;
+  const navigationItem = `.${selectors.Navigation}`;
+  const secondContent = `.${selectors.second}`;
 
   beforeEach(() => {
     cy.gotoTestCase(__filename, carousel);
@@ -13,5 +15,10 @@ describe('Carousel with clickable content', () => {
     cy.get(hiddenContent).should('not.exist');
     cy.clickOn(button);
     cy.get(hiddenContent).should('be.visible');
+  });
+
+  it('Click the dots should navigate', () => {
+    cy.get(navigationItem).eq(1).click();
+    cy.get(secondContent).should('be.visible');
   });
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselNavigationStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselNavigationStyles.ts
@@ -22,6 +22,8 @@ export const carouselNavigationStyles: ComponentSlotStylesPrepared<
       backgroundColor: v.backgroundColor || 'inherit',
       listStyleType: 'none',
       justifyContent: 'center',
+      position: 'relative',
+      zIndex: 2,
       ...(!vertical &&
         thumbnails && {
           justifyContent: 'start',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This allow user to click in the navigation item in the `Carousel` since it broke when we introduced `PaddleContainer` in 0.53

#### Focus areas to test

(optional)
