### PR TITLE
fix(react-examples): remove using v8 deps when bundling vNext ReactCo…

### DIFF
--- a/packages/react-examples/.storybook/preview.js
+++ b/packages/react-examples/.storybook/preview.js
@@ -23,7 +23,6 @@ const storyOrder = [
 
 addDecorator(withInfo);
 addDecorator(withPerformance);
-addDecorator(withKeytipLayer);
 addCustomDecorators();
 
 addParameters({
@@ -67,6 +66,13 @@ function addCustomDecorators() {
 
   if (['react-button', 'react-components', 'react-tooltip'].includes(packageNamePlaceholder)) {
     customDecorators.add(withFluentProvider).add(withStrictMode);
+  }
+
+  // add decorators to all stories except vNext react-components suite
+  // - this is needed so we don't creep v8 dependencies to vNext deps
+  // - `withKeytipLayer` is v8 dependency - including it to vNext suite was causing CI errors - `Cannot read property 'disableGlobalClassNames' of undefined `
+  if (packageNamePlaceholder !== 'react-components') {
+    customDecorators.add(withKeytipLayer);
   }
 
   customDecorators.forEach(decorator => addDecorator(decorator));


### PR DESCRIPTION
…mponents storybook

#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes~
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- in following PR (https://github.com/microsoft/fluentui/pull/18977) pipeline started to fail on error `> Cannot read property 'disableGlobalClassNames' of undefined
`
  - https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=211099&view=logs&j=be0e6c0b-16d6-5408-4b39-461952619dc9&t=316e104f-78cd-5457-e6c4-3969b2d4ab79
- after further investigation (thanks @ling1726) we found out that v8 deps were leaking into vNext `react-components` storybook


#### Focus areas to test

(optional)
