### PR TITLE
Sync versions after failed publish

### DIFF
--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -15,7 +15,7 @@
     "start": "start-storybook --port 5555"
   },
   "dependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/example-data": "^8.2.4",
     "@fluentui/font-icons-mdl2": "^8.1.6",

--- a/change/@fluentui-babel-make-styles-45e4f8dc-1057-442c-8089-8aa9f2480886.json
+++ b/change/@fluentui-babel-make-styles-45e4f8dc-1057-442c-8089-8aa9f2480886.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-webpack-loader-20a0191a-631e-41fd-bbaf-6808f96cf14d.json
+++ b/change/@fluentui-make-styles-webpack-loader-20a0191a-631e-41fd-bbaf-6808f96cf14d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-2fd3b086-008b-43f2-8c47-369607af6344.json
+++ b/change/@fluentui-react-accordion-2fd3b086-008b-43f2-8c47-369607af6344.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-accordion",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-5fb5dcf4-b173-4c70-8103-fd24d0e16e3c.json
+++ b/change/@fluentui-react-avatar-5fb5dcf4-b173-4c70-8103-fd24d0e16e3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-8081259c-eeb7-4fad-ac43-a49797548411.json
+++ b/change/@fluentui-react-badge-8081259c-eeb7-4fad-ac43-a49797548411.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-e566294d-6ffa-47e0-a94c-a80d6c84c999.json
+++ b/change/@fluentui-react-button-e566294d-6ffa-47e0-a94c-a80d6c84c999.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-20d6303c-cc2e-4574-b713-1fc449157116.json
+++ b/change/@fluentui-react-divider-20d6303c-cc2e-4574-b713-1fc449157116.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-divider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-be96c05b-d11c-4b24-94ca-ef21e63b12ca.json
+++ b/change/@fluentui-react-image-be96c05b-d11c-4b24-94ca-ef21e63b12ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-f5a23a65-bea6-4f86-9af4-f8a27575912e.json
+++ b/change/@fluentui-react-link-f5a23a65-bea6-4f86-9af4-f8a27575912e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-29dc7d5c-8862-45c7-80c0-3134c9a8f1b2.json
+++ b/change/@fluentui-react-menu-29dc7d5c-8862-45c7-80c0-3134c9a8f1b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-4fd79dd9-6bd4-4673-93c5-ad9482b9addc.json
+++ b/change/@fluentui-react-tooltip-4fd79dd9-6bd4-4673-93c5-ad9482b9addc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync babel-make-styles with published version",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-make-styles/package.json
+++ b/packages/babel-make-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/babel-make-styles",
-  "version": "9.0.0-alpha.26",
+  "version": "9.0.0-alpha.27",
   "description": "A Babel plugin that performs build time transforms for @fluentui/make-styles",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",

--- a/packages/make-styles-webpack-loader/package.json
+++ b/packages/make-styles-webpack-loader/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.10.4",
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@linaria/babel-preset": "^3.0.0-beta.7",
     "enhanced-resolve": "^5.8.2",
     "tslib": "^2.1.0"

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-divider/package.json
+++ b/packages/react-divider/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -24,7 +24,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "^9.0.0-alpha.26",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.27",
     "@fluentui/eslint-plugin": "^1.3.2",
     "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.25",
     "@fluentui/react-conformance": "^0.4.3",


### PR DESCRIPTION
Update `@fluentui/babel-make-styles` to the latest published version `9.0.0-alpha.27` after a release build failed partway through.