### PR TITLE
Add TSconfigPaths plugin to vr-tests storybook

### DIFF
--- a/apps/vr-tests/.storybook/main.js
+++ b/apps/vr-tests/.storybook/main.js
@@ -1,4 +1,6 @@
 // your app's webpack.config.js
+const path = require('path');
+const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 const custom = require('@fluentui/scripts/storybook/webpack.config');
 
 module.exports = {
@@ -8,6 +10,18 @@ module.exports = {
     // disable react-docgen-typescript (totally not needed here, slows things down a lot)
     reactDocgen: false,
   },
-  webpackFinal: config => custom(config),
+  webpackFinal: config => {
+    const tsPaths = new TsconfigPathsPlugin({
+      configFile: path.resolve(__dirname, '../../../tsconfig.base.json'),
+    });
+
+    if (config.resolve) {
+      config.resolve.plugins
+        ? config.resolve.plugins.push(tsPaths)
+        : (config.resolve.plugins = [tsPaths]);
+    }
+
+    return custom(config);
+  },
   addons: ['@storybook/addon-actions'],
 };


### PR DESCRIPTION
#### Pull request checklist

~- Addresses an existing issue: Fixes #0000~
~- Include a change request file using `$ yarn change`~

#### Description of changes

We currently have a custom script ([getResolveAlias](https://github.com/microsoft/fluentui/blob/master/scripts/webpack/getResolveAlias.js)) to parse through the `react-examples` dependencies and generate the path aliases for our `vr-tests` in our [webpack config](https://github.com/microsoft/fluentui/blob/master/scripts/storybook/webpack.config.js#L77). Given that we're dropping `react-examples` and opting for colocated stories, this will not generate the path aliases for converged packages.
As such, I applied the same plugin we use for our main .storybook config file (thanks for the help @Hotell!), while keeping the same custom implementation for v8 packages.

I was not able to check for duplicate entries that may be caused due to converged packages not being migrated to the new DX as the plugin changes the aliases after the config is applied but it doesn't seem to cause any conflicts.
Also, this shouldn't be a problem as soon as all vNext packages are migrated.

#### Focus areas to test

`yarn lage screener:build --to vr-tests --debug --verbose --no-cache` should run without alias problems (tested with #19022).
