### PR TITLE
Accessibility change for VerticalStackedBar chart

### DIFF
--- a/change/@fluentui-react-charting-2d5099d6-d406-4731-b507-6d6f86418d0a.json
+++ b/change/@fluentui-react-charting-2d5099d6-d406-4731-b507-6d6f86418d0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Vertical stacked bar chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -752,6 +752,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             fill={color}
             ref={e => (ref.refElement = e)}
             {...rectFocusProps}
+            role="text"
           />
         );
       });
@@ -765,6 +766,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         onFocus: this._onStackFocus.bind(this, singleChartData, groupRef),
         onBlur: this._handleMouseOut,
         onClick: this._onClick.bind(this, singleChartData),
+        role: 'text',
       };
       return (
         <g

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -8,6 +8,7 @@ import { IPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { ILegend, Legends } from '../Legends/index';
 import {
+  IAccessibilityProps,
   CartesianChart,
   ChartHoverCard,
   IBasestate,
@@ -23,7 +24,13 @@ import {
   IModifiedCartesianChartProps,
 } from '../../index';
 import { FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartTypes, XAxisTypes, getTypeOfAxis, tooltipOfXAxislabels } from '../../utilities/index';
+import {
+  ChartTypes,
+  getAccessibleDataObject,
+  XAxisTypes,
+  getTypeOfAxis,
+  tooltipOfXAxislabels,
+} from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IVerticalStackedBarChartStyleProps, IVerticalStackedBarChartStyles>();
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -56,6 +63,7 @@ export interface IVerticalStackedBarChartState extends IBasestate {
   dataPointCalloutProps?: IVSChartDataPoint;
   stackCalloutProps?: IVerticalStackedChartProps;
   activeXAxisDataPoint: number | string;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 export class VerticalStackedBarChartBase extends React.Component<
   IVerticalStackedBarChartProps,
@@ -144,6 +152,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       hoverXValue: this.state.hoverXValue,
       onDismiss: this._closeCallout,
       ...this.props.calloutProps,
+      ...getAccessibleDataObject(this.state.callOutAccessibilityData),
     };
     const tickParams = {
       tickValues: this.props.tickValues,
@@ -186,7 +195,7 @@ export class VerticalStackedBarChartBase extends React.Component<
   }
 
   /**
-   * This function tells us what to foucs either the whole stack as focusable item.
+   * This function tells us what to focus either the whole stack as focusable item.
    * or each individual item in the stack as focusable item. basically it depends
    * on the prop `isCalloutForStack` if it's false user can focus each individual bar
    * within the bar if it's true then user can focus whole bar as item.
@@ -535,6 +544,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         xCalloutValue: point.xAxisCalloutData ? point.xAxisCalloutData : xAxisPoint,
         yCalloutValue: point.yAxisCalloutData,
         dataPointCalloutProps: point,
+        callOutAccessibilityData: point.callOutAccessibilityData,
       });
     }
   }
@@ -588,6 +598,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       hoverXValue: stack.xAxisPoint,
       stackCalloutProps: stack,
       activeXAxisDataPoint: stack.xAxisPoint,
+      callOutAccessibilityData: stack.stackCallOutAccessibilityData,
     });
   }
 

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -388,6 +388,11 @@ export interface IVSChartDataPoint {
    * This is an optional prop, If haven't given data will take
    */
   yAxisCalloutData?: string;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IVerticalStackedChartProps {
@@ -410,6 +415,10 @@ export interface IVerticalStackedChartProps {
    * line data to render lines on stacked bar chart
    */
   lineData?: ILineDataInVerticalStackedBarChart[];
+  /**
+   * Accessibility data for Whole stack callout
+   */
+  stackCallOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface ILineDataInVerticalStackedBarChart {

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,219 @@
+import * as React from 'react';
+import { IVSChartDataPoint, IVerticalStackedChartProps, VerticalStackedBarChart } from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
+
+interface IVerticalStackedBarState {
+  width: number;
+  height: number;
+  barGapMax: number;
+  showLine: boolean;
+}
+
+export class VerticalStackedBarChartCustomAccessibilityExample extends React.Component<{}, IVerticalStackedBarState> {
+  constructor(props: IVerticalStackedChartProps) {
+    super(props);
+    this.state = {
+      width: 650,
+      height: 350,
+      showLine: true,
+      barGapMax: 2,
+    };
+  }
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _onShowLineChange = (ev: React.FormEvent<HTMLElement>, checked: boolean): void => {
+    this.setState({ showLine: checked });
+  };
+
+  private _basicExample(): JSX.Element {
+    const { showLine } = this.state;
+    const firstChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 40,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '40%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-1 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 5,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '5%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-2 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 20,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '20%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-3 of 4, 2020/04/30 40%' },
+      },
+    ];
+
+    const secondChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 30,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-1 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 20,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '20%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-2 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 40,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '40%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-3 of 4, 2020/04/30 40%' },
+      },
+    ];
+
+    const thirdChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 44,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '44%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-1 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 28,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '28%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-2 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-3 of 4, 2020/04/30 40%' },
+      },
+    ];
+
+    const fourthChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 88,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '88%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 4-1 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 22,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '22%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 4-2 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 4-3 of 4, 2020/04/30 40%' },
+      },
+    ];
+
+    const data: IVerticalStackedChartProps[] = [
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 0,
+
+        ...(showLine && {
+          lineData: [
+            { y: 42, legend: 'Supported Builds', color: DefaultPalette.magenta },
+            { y: 10, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 1 0f 6' },
+      },
+      {
+        chartData: secondChartPoints,
+        xAxisPoint: 20,
+        ...(showLine && {
+          lineData: [{ y: 33, legend: 'Supported Builds', color: DefaultPalette.magenta }],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 2 0f 6' },
+      },
+      {
+        chartData: thirdChartPoints,
+        xAxisPoint: 40,
+        ...(showLine && {
+          lineData: [
+            { y: 60, legend: 'Supported Builds', color: DefaultPalette.magenta },
+            { y: 20, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 3 0f 6' },
+      },
+    ];
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <label>BarGapMax:</label>
+        <input
+          type="range"
+          value={this.state.barGapMax}
+          min={0}
+          max={10}
+          onChange={e => this.setState({ barGapMax: +e.target.value })}
+        />
+        <Checkbox
+          label="show the lines (hide or show the lines)"
+          checked={this.state.showLine}
+          onChange={this._onShowLineChange}
+          styles={{ root: { marginTop: '20px' } }}
+        />
+        <div style={rootStyle}>
+          <VerticalStackedBarChart
+            barGapMax={this.state.barGapMax}
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            chartLabel="Card title"
+            legendProps={{
+              allowFocusOnLegends: true,
+            }}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -118,33 +118,6 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
       },
     ];
 
-    const fourthChartPoints: IVSChartDataPoint[] = [
-      {
-        legend: 'Metadata1',
-        data: 88,
-        color: DefaultPalette.accent,
-        xAxisCalloutData: '2020/04/30',
-        yAxisCalloutData: '88%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 4-1 of 4, 2020/04/30 40%' },
-      },
-      {
-        legend: 'Metadata2',
-        data: 22,
-        color: DefaultPalette.blueMid,
-        xAxisCalloutData: '2020/04/30',
-        yAxisCalloutData: '22%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 4-2 of 4, 2020/04/30 40%' },
-      },
-      {
-        legend: 'Metadata3',
-        data: 30,
-        color: DefaultPalette.blueLight,
-        xAxisCalloutData: '2020/04/30',
-        yAxisCalloutData: '30%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 4-3 of 4, 2020/04/30 40%' },
-      },
-    ];
-
     const data: IVerticalStackedChartProps[] = [
       {
         chartData: firstChartPoints,

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -52,7 +52,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '5%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 1-2 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-2 of 4, 2020/04/30 5%' },
       },
       {
         legend: 'Metadata3',
@@ -60,7 +60,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '20%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 1-3 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-3 of 4, 2020/04/30 20%' },
       },
     ];
 
@@ -71,7 +71,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 2-1 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-1 of 4, 2020/04/30 30%' },
       },
       {
         legend: 'Metadata2',
@@ -79,7 +79,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '20%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 2-2 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-2 of 4, 2020/04/30 20%' },
       },
       {
         legend: 'Metadata3',
@@ -98,7 +98,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '44%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 3-1 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-1 of 4, 2020/04/30 44%' },
       },
       {
         legend: 'Metadata2',
@@ -106,7 +106,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '28%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 3-2 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-2 of 4, 2020/04/30 28%' },
       },
       {
         legend: 'Metadata3',
@@ -114,7 +114,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',
-        callOutAccessibilityData: { ariaLabel: 'Bar series 3-3 of 4, 2020/04/30 40%' },
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-3 of 4, 2020/04/30 30%' },
       },
     ];
 
@@ -129,7 +129,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
             { y: 10, legend: 'Recommended Builds', color: DefaultPalette.redDark },
           ],
         }),
-        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 1 0f 6' },
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 1 of 6' },
       },
       {
         chartData: secondChartPoints,
@@ -137,7 +137,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         ...(showLine && {
           lineData: [{ y: 33, legend: 'Supported Builds', color: DefaultPalette.magenta }],
         }),
-        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 2 0f 6' },
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 2 of 6' },
       },
       {
         chartData: thirdChartPoints,
@@ -148,7 +148,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
             { y: 20, legend: 'Recommended Builds', color: DefaultPalette.redDark },
           ],
         }),
-        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 3 0f 6' },
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 3 of 6' },
       },
     ];
 

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
@@ -11,11 +11,13 @@ import { VerticalStackedBarChartBasicExample } from './VerticalStackedBarChart.B
 import { VerticalStackedBarChartStyledExample } from './VerticalStackedBarChart.Styled.Example';
 import { VerticalStackedBarChartCalloutExample } from './VerticalStackedBarChart.Callout.Example';
 import { VerticalStackedBarChartTooltipExample } from './VerticalStackedBarChart.AxisTooltip.Example';
+import { VerticalStackedBarChartCustomAccessibilityExample } from './VerticalStackedBarChart.CustomAccessibility.Example';
 
 const VerticalBarChartBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx') as string;
 const VerticalBarChartStyledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx') as string;
 const VerticalBarChartCalloutExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx') as string;
 const VerticalBarChartTooltipExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example') as string;
+const VerticalBarChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example') as string;
 
 export class VerticalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -36,6 +38,12 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
             </ExampleCard>
             <ExampleCard title="VerticalStackedBarChart Callout" code={VerticalBarChartTooltipExampleCode}>
               <VerticalStackedBarChartTooltipExample />
+            </ExampleCard>
+            <ExampleCard
+              title="VerticalStackedBarChart Custom Accessibility"
+              code={VerticalBarChartCustomAccessibilityExampleCode}
+            >
+              <VerticalStackedBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Changes are related to Vertical Stacked Bar Chart accessibility

1. Accessibility Data prop added for the Chart Data Callout content and whole stack callout content. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
3. Custom Accessibility example is added.

**Before Change**

1. For Rectangle 
 
![image](https://user-images.githubusercontent.com/29042635/126650126-15bde3b5-cc0f-446d-bd51-8f63dd9aee44.png)

2. For Stack

![image](https://user-images.githubusercontent.com/29042635/126650374-fdc8534b-6de7-461b-b21a-f43ef4511cec.png)


**After Change**

1. For Rectangle

![image](https://user-images.githubusercontent.com/29042635/126651323-93d89383-08f9-4725-ae84-6b57be304d18.png)

2. For Stack

![image](https://user-images.githubusercontent.com/29042635/126651576-9ae8158f-fafd-45d1-bf9c-dff47646c575.png)


(give an overview)

#### Focus areas to test

(optional)
