### PR TITLE
Change visuals for tooltip: subtle and noArrow are now the defaults

### DIFF
--- a/change/@fluentui-react-tooltip-43a091f2-09f9-4be8-b5e7-2f4877ae6311.json
+++ b/change/@fluentui-react-tooltip-43a091f2-09f9-4be8-b5e7-2f4877ae6311.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change visual defaults for tooltip, and update API Replace `subtle` prop with `inverted`, and `noArrow` with `pointing`",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-43a091f2-09f9-4be8-b5e7-2f4877ae6311.json
+++ b/change/@fluentui-react-tooltip-43a091f2-09f9-4be8-b5e7-2f4877ae6311.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Change visual defaults for tooltip, and update API Replace `subtle` prop with `inverted`, and `noArrow` with `pointing`",
+  "comment": "Change visual defaults for tooltip. Replace `subtle` prop with `inverted`, and `noArrow` with `pointing`",
   "packageName": "@fluentui/react-tooltip",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -35,12 +35,12 @@ export interface TooltipProps extends ComponentPropsCompat, React_2.HTMLAttribut
     }) | ((props: TooltipTriggerProps) => React_2.ReactNode) | null;
     content: ShorthandPropsCompat<ComponentPropsCompat>;
     hideDelay?: number;
-    noArrow?: boolean;
+    inverted?: boolean;
     offset?: number;
     onVisibleChange?: (event: React_2.PointerEvent<HTMLElement> | React_2.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => void;
+    pointing?: boolean;
     position?: Position;
     showDelay?: number;
-    subtle?: boolean;
     target?: HTMLElement | PopperVirtualElement | null;
     triggerAriaAttribute?: 'label' | 'labelledby' | 'describedby' | null;
     visible?: boolean;

--- a/packages/react-tooltip/src/Tooltip.stories.tsx
+++ b/packages/react-tooltip/src/Tooltip.stories.tsx
@@ -29,30 +29,25 @@ export const Basic = () => {
     <>
       Hover or focus the buttons to show their tooltips:
       <div className={styles.exampleList}>
-        <Tooltip content="This is a default tooltip" triggerAriaAttribute="describedby">
+        <Tooltip content="Default tooltip">
           <button>Default</button>
         </Tooltip>
-        <Tooltip content="This is a subtle tooltip" subtle triggerAriaAttribute="describedby">
-          <button>Subtle</button>
+        <Tooltip content="Inverted tooltip" inverted>
+          <button>Inverted</button>
         </Tooltip>
-        <Tooltip content="This tooltip has no arrow" noArrow triggerAriaAttribute="describedby">
-          <button>No arrow</button>
+        <Tooltip content="Tooltip pointing to its target" pointing>
+          <button>Pointing</button>
         </Tooltip>
         <Tooltip
-          triggerAriaAttribute="describedby"
           content={
             <>
-              This <i>tooltip</i> has <u>formatted</u> content
+              <u>Formatted</u> <i>content</i>
             </>
           }
         >
           <button>Formatted content</button>
         </Tooltip>
-        <Tooltip
-          content="This tooltip targets the red square"
-          target={exampleTarget}
-          triggerAriaAttribute="describedby"
-        >
+        <Tooltip content="Tooltip pointing to a custom target" target={exampleTarget} pointing>
           <button>
             Custom target:{' '}
             <div
@@ -61,7 +56,7 @@ export const Basic = () => {
             />
           </button>
         </Tooltip>
-        <Tooltip content="The trigger button was rendered by a render function" triggerAriaAttribute="describedby">
+        <Tooltip content="Trigger button using a render function">
           {triggerProps => (
             <div>
               <button {...triggerProps}>Custom trigger</button>
@@ -166,6 +161,7 @@ export const OnlyIfTruncated = () => {
       <Tooltip
         content={text}
         visible={tooltipVisible}
+        position="below"
         onVisibleChange={(_ev, { visible }) => {
           if (
             visible &&

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -46,14 +46,18 @@ export interface TooltipProps extends ComponentPropsCompat, React.HTMLAttributes
   target?: HTMLElement | PopperVirtualElement | null;
 
   /**
-   * Color variant with a subtle look
+   * Color variant with inverted colors
+   *
+   * @defaultvalue false
    */
-  subtle?: boolean;
+  inverted?: boolean;
 
   /**
-   * Do not render an arrow pointing to the target element
+   * Render an arrow pointing to the target element
+   *
+   * @defaultvalue false
    */
-  noArrow?: boolean;
+  pointing?: boolean;
 
   /**
    * Distance between the tooltip and the target element, in pixels

--- a/packages/react-tooltip/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-tooltip/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -21,9 +21,6 @@ exports[`Tooltip renders a description tooltip content always 1`] = `
       id="tooltip-4"
       role="tooltip"
     >
-      <div
-        class=""
-      />
       Description tooltip
     </div>
   </div>
@@ -62,9 +59,6 @@ exports[`Tooltip renders the content of a nontrivial tooltip 1`] = `
       id="the-tooltip-id"
       role="tooltip"
     >
-      <div
-        class=""
-      />
       <span>
         This is a 
         <strong>

--- a/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
@@ -17,7 +17,7 @@ export const renderTooltip = (state: TooltipState) => {
       {state.shouldRenderTooltip && (
         <Portal>
           <slots.root {...slotProps.root}>
-            {!state.noArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
+            {state.pointing && <div ref={state.arrowRef} className={state.arrowClassName} />}
             <slots.content {...slotProps.content} />
           </slots.root>
         </Portal>

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -99,7 +99,7 @@ export const useTooltip = (
     position: state.position,
     align: state.align,
     target: state.target,
-    offset: [0, state.offset + (state.noArrow ? 0 : arrowHeight)],
+    offset: [0, state.offset + (state.pointing ? arrowHeight : 0)],
     arrowPadding: 2 * tooltipBorderRadius,
   });
 

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -15,8 +15,8 @@ const useStyles = makeStyles({
     lineHeight: theme.global.type.lineHeights.base[200],
     borderRadius: theme.global.borderRadius.medium, // Update tooltipBorderRadius in useTooltip.tsx if this changes
 
-    background: theme.alias.color.neutral.neutralForeground2, // TODO should be neutralBackgroundInverted
-    color: theme.alias.color.neutral.neutralForegroundInverted,
+    background: theme.alias.color.neutral.neutralBackground1,
+    color: theme.alias.color.neutral.neutralForeground1,
 
     // TODO need to add versions of theme.alias.shadow.shadow8, etc. that work with filter
     filter:
@@ -28,9 +28,9 @@ const useStyles = makeStyles({
     display: 'block',
   },
 
-  subtle: theme => ({
-    background: theme.alias.color.neutral.neutralBackground1,
-    color: theme.alias.color.neutral.neutralForeground1,
+  inverted: theme => ({
+    background: theme.alias.color.neutral.neutralForeground2, // TODO should be neutralBackgroundInverted
+    color: theme.alias.color.neutral.neutralForegroundInverted,
   }),
 
   arrow: theme => ({
@@ -69,7 +69,7 @@ export const useTooltipStyles = (state: TooltipState): TooltipState => {
 
   state.className = mergeClasses(
     styles.root,
-    state.subtle && styles.subtle,
+    state.inverted && styles.inverted,
     state.visible && styles.visible,
     state.className,
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19045
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Change visual defaults for tooltip: subtle and noArrow are now the defaults.

Replace `subtle` prop with `inverted`, and `noArrow` with `pointing`
