### PR TITLE
Very basic Input implementation

### DIFF
--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -4,28 +4,36 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
-import { ComponentStateCompat } from '@fluentui/react-utilities';
+import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentState } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public
 export const Input: React_2.ForwardRefExoticComponent<InputProps & React_2.RefAttributes<HTMLElement>>;
 
-// @public
-export type InputDefaultedProps = never;
-
-// @public
-export interface InputProps extends ComponentPropsCompat, React_2.HTMLAttributes<HTMLElement> {
+// @public (undocumented)
+export interface InputCommons extends Omit<React_2.HTMLAttributes<HTMLElement>, 'children'> {
 }
 
 // @public
-export type InputShorthandProps = never;
+export interface InputProps extends ComponentProps<Partial<InputSlots>>, Partial<InputCommons> {
+}
 
 // @public
-export const inputShorthandProps: InputShorthandProps[];
+export const inputShorthandProps: (keyof InputSlots)[];
+
+// @public (undocumented)
+export type InputSlots = {
+    input: React_2.InputHTMLAttributes<HTMLInputElement>;
+    inputWrapper: React_2.HTMLAttributes<HTMLElement>;
+    bookendBefore: React_2.HTMLAttributes<HTMLElement>;
+    bookendAfter: React_2.HTMLAttributes<HTMLElement>;
+    insideStart: React_2.HTMLAttributes<HTMLElement>;
+    insideEnd: React_2.HTMLAttributes<HTMLElement>;
+};
 
 // @public
-export interface InputState extends ComponentStateCompat<InputProps, InputShorthandProps, InputDefaultedProps> {
+export interface InputState extends ComponentState<InputSlots>, InputCommons {
     ref: React_2.Ref<HTMLElement>;
 }
 
@@ -33,11 +41,10 @@ export interface InputState extends ComponentStateCompat<InputProps, InputShorth
 export const renderInput: (state: InputState) => JSX.Element;
 
 // @public
-export const useInput: (props: InputProps, ref: React_2.Ref<HTMLElement>, defaultProps?: InputProps | undefined) => InputState;
+export const useInput: (props: InputProps, ref: React_2.Ref<HTMLElement>) => InputState;
 
 // @public
 export const useInputStyles: (state: InputState) => InputState;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-input/src/components/Input/Input.stories.tsx
+++ b/packages/react-input/src/components/Input/Input.stories.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { makeStyles } from '@fluentui/react-make-styles';
+import { Input } from './Input';
+import { useId } from '@fluentui/react-utilities';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px',
+    width: '300px',
+  },
+});
+
+export const InputExamples = () => {
+  const styles = useStyles();
+  const inputId1 = useId();
+  return (
+    <div className={styles.container}>
+      <Input />
+      <div>
+        <label htmlFor={inputId1}>with a label</label>
+        <Input id={inputId1} />
+      </div>
+    </div>
+  );
+};
+
+export default {
+  title: 'Components/Input',
+  component: Input,
+};

--- a/packages/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-input/src/components/Input/Input.test.tsx
@@ -12,7 +12,7 @@ describe('Input', () => {
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
 
   it('renders a default state', () => {
-    const result = render(<Input>Default Input</Input>);
+    const result = render(<Input />);
     expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -1,31 +1,35 @@
 import * as React from 'react';
-import { ComponentPropsCompat, ComponentStateCompat } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+
+export type InputSlots = {
+  /** The actual `<input>` element */
+  input: React.InputHTMLAttributes<HTMLInputElement>;
+  /**
+   * Wrapper element containing `insideStart`, `input`, and `insideEnd`. This is the element that
+   * visually appears to be the input and is used for borders, focus styling, etc.
+   */
+  inputWrapper: React.HTMLAttributes<HTMLElement>;
+  /** Element before the input field, visually separated from it */
+  bookendBefore: React.HTMLAttributes<HTMLElement>;
+  /** Element after the input field, visually separated from it */
+  bookendAfter: React.HTMLAttributes<HTMLElement>;
+  /** Element at the start of the input field, visually appearing to be inside of it */
+  insideStart: React.HTMLAttributes<HTMLElement>;
+  /** Element at the end of the input field, visually appearing to be inside of it */
+  insideEnd: React.HTMLAttributes<HTMLElement>;
+};
+
+export interface InputCommons extends Omit<React.HTMLAttributes<HTMLElement>, 'children'> {}
 
 /**
  * Input Props
  */
-export interface InputProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
-  /*
-   * TODO Add props and slots here
-   * Any slot property should be listed in the inputShorthandProps array below
-   * Any property that has a default value should be listed in InputDefaultedProps as e.g. 'size' | 'icon'
-   */
-}
-
-/**
- * Names of the shorthand properties in InputProps
- */
-export type InputShorthandProps = never; // TODO add shorthand property names
-
-/**
- * Names of InputProps that have a default value in useInput
- */
-export type InputDefaultedProps = never; // TODO add names of properties with default values
+export interface InputProps extends ComponentProps<Partial<InputSlots>>, Partial<InputCommons> {}
 
 /**
  * State used in rendering Input
  */
-export interface InputState extends ComponentStateCompat<InputProps, InputShorthandProps, InputDefaultedProps> {
+export interface InputState extends ComponentState<InputSlots>, InputCommons {
   /**
    * Ref to the root element
    */

--- a/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`Input renders a default state 1`] = `
   <div
     class=""
   >
-    Default Input
+    <div>
+      <input />
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-input/src/components/Input/renderInput.tsx
+++ b/packages/react-input/src/components/Input/renderInput.tsx
@@ -1,18 +1,25 @@
 import * as React from 'react';
-import { getSlotsCompat } from '@fluentui/react-utilities';
-import { InputState } from './Input.types';
+import { getSlots } from '@fluentui/react-utilities';
+import { InputSlots, InputState } from './Input.types';
 import { inputShorthandProps } from './useInput';
 
 /**
  * Render the final JSX of Input
  */
 export const renderInput = (state: InputState) => {
-  const { slots, slotProps } = getSlotsCompat(state, inputShorthandProps);
-
+  const { slots, slotProps } = getSlots<InputSlots>(state, inputShorthandProps);
+  delete slotProps.input.children;
+  delete slotProps.inputWrapper.children;
   return (
     <slots.root {...slotProps.root}>
-      {/* TODO Add additional slots in the appropriate place */}
-      {state.children}
+      <slots.bookendBefore {...slotProps.bookendBefore} />
+      {/* TODO is wrapper needed? (for borders, focus styling, etc) */}
+      <slots.inputWrapper {...slotProps.inputWrapper}>
+        <slots.insideStart {...slotProps.insideStart} />
+        <slots.input {...slotProps.input} />
+        <slots.insideEnd {...slotProps.insideEnd} />
+      </slots.inputWrapper>
+      <slots.bookendAfter {...slotProps.bookendAfter} />
     </slots.root>
   );
 };

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -1,15 +1,18 @@
 import * as React from 'react';
-import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { InputProps, InputShorthandProps, InputState } from './Input.types';
+import { resolveShorthand } from '@fluentui/react-utilities';
+import { InputProps, InputSlots, InputState } from './Input.types';
 
 /**
- * Array of all shorthand properties listed in InputShorthandProps
+ * Array of all shorthand properties listed in InputShorthandPropsCompat
  */
-export const inputShorthandProps: InputShorthandProps[] = [
-  /* TODO add shorthand property names */
+export const inputShorthandProps: (keyof InputSlots)[] = [
+  'input',
+  'inputWrapper',
+  'bookendBefore',
+  'bookendAfter',
+  'insideStart',
+  'insideEnd',
 ];
-
-const mergeProps = makeMergeProps<InputState>({ deepMerge: inputShorthandProps });
 
 /**
  * Create the state required to render Input.
@@ -18,17 +21,21 @@ const mergeProps = makeMergeProps<InputState>({ deepMerge: inputShorthandProps }
  * before being passed to renderInput.
  *
  * @param props - props from this instance of Input
- * @param ref - reference to root HTMLElement of Input
- * @param defaultProps - (optional) default prop values provided by the implementing type
+ * @param ref - reference to root HTMLInputElement of Input
  */
-export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>, defaultProps?: InputProps): InputState => {
-  const state = mergeProps(
-    {
-      ref,
+export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>): InputState => {
+  return {
+    ...props,
+    components: {
+      input: 'input',
     },
-    defaultProps && resolveShorthandProps(defaultProps, inputShorthandProps),
-    resolveShorthandProps(props, inputShorthandProps),
-  );
-
-  return state;
+    // temporarily must add fake children to prevent getSlots from substituting nullRender
+    input: resolveShorthand(props.input, { children: '😭' }),
+    inputWrapper: resolveShorthand(props.inputWrapper, { children: '😭' }),
+    bookendAfter: resolveShorthand(props.bookendAfter),
+    bookendBefore: resolveShorthand(props.bookendBefore),
+    insideEnd: resolveShorthand(props.insideEnd),
+    insideStart: resolveShorthand(props.insideStart),
+    ref,
+  };
 };

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -3,7 +3,7 @@ import { resolveShorthand } from '@fluentui/react-utilities';
 import { InputProps, InputSlots, InputState } from './Input.types';
 
 /**
- * Array of all shorthand properties listed in InputShorthandPropsCompat
+ * Array of all shorthand properties listed as the keys of InputSlots
  */
 export const inputShorthandProps: (keyof InputSlots)[] = [
   'input',

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -1,15 +1,17 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { InputState } from './Input.types';
+import { InputSlots, InputState } from './Input.types';
 
 /**
  * Styles for the root slot
  */
-const useStyles = makeStyles({
-  root: theme => ({
-    // TODO Add default styles for the root element
-  }),
-
-  // TODO add additional classes for different states and/or slots
+const useStyles = makeStyles<keyof InputSlots | 'root'>({
+  root: theme => ({}),
+  input: theme => ({}),
+  inputWrapper: theme => ({}),
+  bookendBefore: theme => ({}),
+  bookendAfter: theme => ({}),
+  insideStart: theme => ({}),
+  insideEnd: theme => ({}),
 });
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #18131

#### Description of changes

Very basic implementation of Input. It has all the slots (with tentative names) but no styling or behavior, and none of the planned additional props.

(Note that this does NOT incorporate any of the alternative approaches for handling native props proposed in #18804 or #18983.)