### PR TITLE
fix(pickers): add live region for selected item removal, fix tagpicker focused tag styling

### DIFF
--- a/change/@fluentui-react-77edb3b8-d438-427c-8034-28525c5a10bc.json
+++ b/change/@fluentui-react-77edb3b8-d438-427c-8034-28525c5a10bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add live region for BasePicker item removal, fix focused tag styles",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -67,7 +67,6 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -45,6 +45,31 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -8,6 +8,31 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -9,6 +9,31 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
       onFocus={[Function]}
       onKeyDown={[Function]}
     >
+      <div
+        aria-live="assertive"
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              white-space: nowrap;
+              width: 1px;
+            }
+        id="selected-suggestion-alert-id__0"
+      >
+         
+        
+      </div>
       <span
         hidden={true}
         id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -31,7 +31,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
             }
         id="selected-suggestion-alert-id__0"
       >
-         
         
       </div>
       <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -8,6 +8,31 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -32,7 +32,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
             }
         id="selected-suggestion-alert-id__0"
       >
-         
         
       </div>
       <div

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -11,6 +11,31 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
       onKeyDown={[Function]}
     >
       <div
+        aria-live="assertive"
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              white-space: nowrap;
+              width: 1px;
+            }
+        id="selected-suggestion-alert-id__0"
+      >
+         
+        
+      </div>
+      <div
         className=
             ms-BasePicker-text
             {

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -8,6 +8,31 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -8,6 +8,31 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
           }
       id="selected-suggestion-alert-id__0"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -8,6 +8,31 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__0"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__0-label"

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -173,7 +173,6 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
           }
       id="selected-suggestion-alert-id__1"
     >
-       
       
     </div>
     <span
@@ -302,7 +301,6 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
           }
       id="selected-suggestion-alert-id__2"
     >
-       
       
     </div>
     <span

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -151,6 +151,31 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__1"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__1-label"
@@ -255,6 +280,31 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__2"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__2-label"

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
@@ -19,6 +19,31 @@ exports[`Component Examples renders TagPicker.Inline.Example.tsx correctly 1`] =
     onFocus={[Function]}
     onKeyDown={[Function]}
   >
+    <div
+      aria-live="assertive"
+      className=
+
+          {
+            border: 0px;
+            height: 1px;
+            margin-bottom: -1px;
+            margin-left: -1px;
+            margin-right: -1px;
+            margin-top: -1px;
+            overflow: hidden;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
+      id="selected-suggestion-alert-id__1"
+    >
+       
+      
+    </div>
     <span
       hidden={true}
       id="selected-items-id__1-label"

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Inline.Example.tsx.shot
@@ -41,7 +41,6 @@ exports[`Component Examples renders TagPicker.Inline.Example.tsx correctly 1`] =
           }
       id="selected-suggestion-alert-id__1"
     >
-       
       
     </div>
     <span

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -280,7 +280,7 @@ export class BasePeopleSelectedItemsList extends BaseSelectedItemsList<IExtended
 }
 
 // @public (undocumented)
-export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Component<P, IBasePickerState> implements IBasePicker<T> {
+export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Component<P, IBasePickerState<T>> implements IBasePicker<T> {
     constructor(basePickerProps: P);
     // (undocumented)
     protected addItem: (item: T) => void;
@@ -297,7 +297,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Compon
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentDidUpdate(oldProps: P, oldState: IBasePickerState): void;
+    componentDidUpdate(oldProps: P, oldState: IBasePickerState<T>): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
@@ -314,8 +314,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Compon
     static getDerivedStateFromProps(newProps: IBasePickerProps<any>): {
         items: any[];
     } | null;
-    // (undocumented)
-    protected getSuggestionsAlert(suggestionAlertClassName?: string): JSX.Element | undefined;
     // (undocumented)
     protected input: React_2.RefObject<IAutofill>;
     // (undocumented)
@@ -353,11 +351,13 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Compon
     // (undocumented)
     refocusSuggestions: (keyCode: KeyCodes) => void;
     // (undocumented)
-    protected removeItem: (item: IPickerItemProps<T>, focusNextItem?: boolean | undefined) => void;
+    protected removeItem: (item: T) => void;
     // (undocumented)
     protected removeItems: (itemsToRemove: any[]) => void;
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    protected renderCustomAlert(alertClassName?: string): JSX.Element;
     // (undocumented)
     protected renderItems(): JSX.Element[];
     // (undocumented)
@@ -1589,11 +1589,12 @@ export interface IBasePickerProps<T> extends React_2.Props<any> {
     selectionAriaLabel?: string;
     selectionRole?: string;
     styles?: IStyleFunctionOrObject<IBasePickerStyleProps, IBasePickerStyles>;
+    suggestionRemovedText?: string;
     theme?: ITheme;
 }
 
 // @public (undocumented)
-export interface IBasePickerState {
+export interface IBasePickerState<T> {
     // (undocumented)
     isFocused?: boolean;
     // (undocumented)
@@ -1608,6 +1609,8 @@ export interface IBasePickerState {
     moreSuggestionsAvailable?: boolean;
     // (undocumented)
     selectedIndices?: number[];
+    // (undocumented)
+    selectionRemoved?: T;
     // (undocumented)
     suggestedDisplayValue?: string;
     // (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -314,6 +314,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React_2.Compon
     static getDerivedStateFromProps(newProps: IBasePickerProps<any>): {
         items: any[];
     } | null;
+    // @deprecated (undocumented)
+    protected getSuggestionsAlert(suggestionAlertClassName?: string): JSX.Element | undefined;
     // (undocumented)
     protected input: React_2.RefObject<IAutofill>;
     // (undocumented)

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -913,7 +913,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
 
     return (
       <div className={alertClassName} id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
-        {this.getSuggestionsAlert(alertClassName)}
+        {
+          // eslint-disable-next-line deprecation/deprecation
+          this.getSuggestionsAlert(alertClassName)
+        }
         {removedItemText}
       </div>
     );

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -886,6 +886,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     return currentIndex > -1 && !this.state.suggestionsLoading ? 'sug-' + currentIndex : undefined;
   }
 
+  /** @deprecated use renderCustomAlert instead */
   protected getSuggestionsAlert(suggestionAlertClassName: string = legacyStyles.screenReaderOnly) {
     const currentIndex = this.suggestionStore.currentIndex;
     if (this.props.enableSelectedSuggestionAlert) {

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -4,6 +4,7 @@ import {
   KeyCodes,
   css,
   elementContains,
+  format,
   getId,
   classNamesFunction,
   styled,
@@ -885,26 +886,33 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     return currentIndex > -1 && !this.state.suggestionsLoading ? 'sug-' + currentIndex : undefined;
   }
 
-  protected renderCustomAlert(alertClassName: string = legacyStyles.screenReaderOnly) {
-    const { enableSelectedSuggestionAlert, suggestionRemovedText = 'removed' } = this.props;
-    let selectedSuggestionAlertText = '';
-    let removedItemText = '';
-
-    if (enableSelectedSuggestionAlert) {
-      const currentIndex = this.suggestionStore.currentIndex;
+  protected getSuggestionsAlert(suggestionAlertClassName: string = legacyStyles.screenReaderOnly) {
+    const currentIndex = this.suggestionStore.currentIndex;
+    if (this.props.enableSelectedSuggestionAlert) {
       const selectedSuggestion =
         currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
-      selectedSuggestionAlertText =
-        selectedSuggestion && selectedSuggestion.ariaLabel ? selectedSuggestion.ariaLabel : '';
+      const selectedSuggestionAlertText = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
+      // keeping the id/className here for legacy support
+      return (
+        <div id={this._ariaMap.selectedSuggestionAlert} className={suggestionAlertClassName}>
+          {`${selectedSuggestionAlertText} `}
+        </div>
+      );
     }
+  }
+
+  protected renderCustomAlert(alertClassName: string = legacyStyles.screenReaderOnly) {
+    const { suggestionRemovedText = 'removed {0}' } = this.props;
+    let removedItemText = '';
 
     if (this.state.selectionRemoved) {
-      removedItemText = `${suggestionRemovedText} ${this._getTextFromItem(this.state.selectionRemoved, '')}`;
+      const itemName = this._getTextFromItem(this.state.selectionRemoved, '');
+      removedItemText = format(suggestionRemovedText, itemName);
     }
 
     return (
       <div className={alertClassName} id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
-        {`${selectedSuggestionAlertText} `}
+        {this.getSuggestionsAlert(alertClassName)}
         {removedItemText}
       </div>
     );

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -175,7 +175,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
 
   /**
    * The text that will be announced when a suggestion is removed. A default value is only provided for English.
-   * @default "removed"
+   * @default "removed {0}"
    */
   suggestionRemovedText?: string;
 

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -175,7 +175,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
 
   /**
    * The text that will be announced when a suggestion is removed. A default value is only provided for English.
-   * @default "removed {0}"
+   * @default 'removed \{0\}'
    */
   suggestionRemovedText?: string;
 

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -174,6 +174,12 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   removeButtonAriaLabel?: string;
 
   /**
+   * The text that will be announced when a suggestion is removed. A default value is only provided for English.
+   * @default "removed"
+   */
+  suggestionRemovedText?: string;
+
+  /**
    * Optional aria-label that will be placed on the element that has the role "combobox"
    * attached. Additionally aria-labelled by will get added to the supporting input element contained
    * with in the combobox container

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -7,6 +7,31 @@ exports[`PeoplePicker renders correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          white-space: nowrap;
+          width: 1px;
+        }
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"
@@ -105,6 +130,31 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          white-space: nowrap;
+          width: 1px;
+        }
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`PeoplePicker renders correctly 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span
@@ -152,7 +151,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -38,7 +38,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
         minWidth: 0, // needed to prevent long tags from overflowing container
         borderRadius: effects.roundedCorner2,
         color: semanticColors.inputText,
-        background: !selected || disabled ? palette.neutralLighter : palette.themePrimary,
+        background: palette.neutralLighter,
         selectors: {
           ':hover': [
             !disabled &&
@@ -52,7 +52,12 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
                 },
               },
             disabled && { background: palette.neutralLighter },
-            selected && !disabled && { background: palette.themePrimary },
+          ],
+          ':focus-within': [
+            !disabled && {
+              background: palette.themePrimary,
+              color: palette.white,
+            },
           ],
           [HighContrastSelector]: {
             border: `1px solid ${!selected ? 'WindowText' : 'WindowFrame'}`,
@@ -66,13 +71,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
           },
         },
       },
-      selected &&
-        !disabled && [
-          classNames.isSelected,
-          {
-            color: palette.white,
-          },
-        ],
+      selected && !disabled && [classNames.isSelected],
       className,
     ],
     text: [
@@ -107,18 +106,17 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
             background: palette.neutralQuaternaryAlt,
             color: palette.neutralPrimary,
           },
+          ':focus': {
+            color: palette.white,
+            background: palette.themePrimary,
+          },
+          ':focus:hover': {
+            color: palette.white,
+            background: palette.themeDark,
+          },
           ':active': {
             color: palette.white,
             backgroundColor: palette.themeDark,
-          },
-        },
-      },
-      selected && {
-        color: palette.white,
-        selectors: {
-          ':hover': {
-            color: palette.white,
-            background: palette.themeDark,
           },
         },
       },

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -51,6 +51,10 @@ exports[`TagItem accepts title override 1`] = `
       &:hover .ms-TagItem-close {
         color: #323130;
       }
+      &:focus-within {
+        background: #0078d4;
+        color: #ffffff;
+      }
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
       }
@@ -141,8 +145,16 @@ exports[`TagItem accepts title override 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
+        &:focus {
+          background: #0078d4;
+          color: #ffffff;
+        }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        &:focus:hover {
+          background: #005a9e;
           color: #ffffff;
         }
     data-is-focusable={true}
@@ -249,6 +261,10 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
       }
       &:hover .ms-TagItem-close {
         color: #323130;
+      }
+      &:focus-within {
+        background: #0078d4;
+        color: #ffffff;
       }
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
@@ -364,8 +380,16 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
+        &:focus {
+          background: #0078d4;
+          color: #ffffff;
+        }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        &:focus:hover {
+          background: #005a9e;
           color: #ffffff;
         }
     data-is-focusable={true}
@@ -473,6 +497,10 @@ exports[`TagItem renders correctly 1`] = `
       &:hover .ms-TagItem-close {
         color: #323130;
       }
+      &:focus-within {
+        background: #0078d4;
+        color: #ffffff;
+      }
       @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
         border: 1px solid WindowText;
       }
@@ -563,8 +591,16 @@ exports[`TagItem renders correctly 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
+        &:focus {
+          background: #0078d4;
+          color: #ffffff;
+        }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        &:focus:hover {
+          background: #005a9e;
           color: #ffffff;
         }
     data-is-focusable={true}

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -7,6 +7,31 @@ exports[`TagPicker renders correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          white-space: nowrap;
+          width: 1px;
+        }
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"
@@ -104,6 +129,10 @@ exports[`TagPicker renders correctly 1`] = `
               &:hover .ms-TagItem-close {
                 color: #323130;
               }
+              &:focus-within {
+                background: #0078d4;
+                color: #ffffff;
+              }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
@@ -194,8 +223,16 @@ exports[`TagPicker renders correctly 1`] = `
                   border-color: Highlight;
                   color: Highlight;
                 }
+                &:focus {
+                  background: #0078d4;
+                  color: #ffffff;
+                }
                 &:active {
                   background-color: #005a9e;
+                  color: #ffffff;
+                }
+                &:focus:hover {
+                  background: #005a9e;
                   color: #ffffff;
                 }
             data-is-focusable={true}
@@ -315,6 +352,31 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          white-space: nowrap;
+          width: 1px;
+        }
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"
@@ -412,6 +474,10 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               &:hover .ms-TagItem-close {
                 color: #323130;
               }
+              &:focus-within {
+                background: #0078d4;
+                color: #ffffff;
+              }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
@@ -502,8 +568,16 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   border-color: Highlight;
                   color: Highlight;
                 }
+                &:focus {
+                  background: #0078d4;
+                  color: #ffffff;
+                }
                 &:active {
                   background-color: #005a9e;
+                  color: #ffffff;
+                }
+                &:focus:hover {
+                  background: #005a9e;
                   color: #ffffff;
                 }
             data-is-focusable={true}

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`TagPicker renders correctly 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span
@@ -374,7 +373,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -7,6 +7,13 @@ exports[`BasePicker renders correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"
@@ -67,6 +74,13 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
 >
+  <div
+    aria-live="assertive"
+    id="selected-suggestion-alert-id__0"
+  >
+     
+    
+  </div>
   <span
     hidden={true}
     id="selected-items-id__0-label"

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`BasePicker renders correctly 1`] = `
     aria-live="assertive"
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span
@@ -78,7 +77,6 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
     aria-live="assertive"
     id="selected-suggestion-alert-id__0"
   >
-     
     
   </div>
   <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12600](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12600), [12379](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12379)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I updated the BasePicker live region to add an announcement on removal of a selected item, and fixed the selected item focus styling for TagPicker -- previously it would keep its blue focus styles when focus left the item going backwards, but correctly update when moving focus forwards b/c of an issue with conflating focus styles with "selected" styles.
