### PR TITLE
Button: Handling children correctly and not as a slot

### DIFF
--- a/change/@fluentui-react-button-c699ad09-ad5e-4edd-b975-629ac750458c.json
+++ b/change/@fluentui-react-button-c699ad09-ad5e-4edd-b975-629ac750458c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Handling children correctly and not as a slot.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -17,7 +17,6 @@ export type ButtonDefaultedProps = 'icon' | 'size';
 
 // @public (undocumented)
 export type ButtonProps = ComponentPropsCompat & React_2.ButtonHTMLAttributes<HTMLElement> & {
-    children?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
     icon?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
     block?: boolean;
     circular?: boolean;
@@ -32,7 +31,7 @@ export type ButtonProps = ComponentPropsCompat & React_2.ButtonHTMLAttributes<HT
 };
 
 // @public (undocumented)
-export type ButtonShorthandPropsCompat = 'children' | 'icon';
+export type ButtonShorthandPropsCompat = 'icon';
 
 // @public
 export const buttonShorthandPropsCompat: ButtonShorthandPropsCompat[];
@@ -104,9 +103,7 @@ export interface MenuButtonState extends Omit<ButtonState, 'iconPosition'>, Comp
 
 // @public
 const renderButton: (state: ButtonState) => JSX.Element;
-
 export { renderButton }
-
 export { renderButton as renderToggleButton }
 
 // @public
@@ -166,7 +163,6 @@ export const useToggleButton: (props: ToggleButtonProps, ref: React_2.Ref<HTMLEl
 
 // @public (undocumented)
 export const useToggleButtonStyles: (state: ToggleButtonState) => ToggleButtonState;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -6,9 +6,6 @@ import { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from
  */
 export type ButtonProps = ComponentPropsCompat &
   React.ButtonHTMLAttributes<HTMLElement> & {
-    // Temporarily declare children as a shorthand slot until #18471 is fixed
-    children?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
-
     /**
      * Icon slot that, if specified, renders an icon either before or after the `children` as specified by the
      * `iconPosition` prop.
@@ -100,7 +97,7 @@ export type ButtonProps = ComponentPropsCompat &
 /**
  * {@docCategory Button}
  */
-export type ButtonShorthandPropsCompat = 'children' | 'icon';
+export type ButtonShorthandPropsCompat = 'icon';
 
 /**
  * {@docCategory Button}

--- a/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -6,10 +6,6 @@ exports[`Button renders a default button 1`] = `
   onClick={[Function]}
   onKeyDown={[Function]}
 >
-  <span
-    className=""
-  >
-    This is a button
-  </span>
+  This is a button
 </button>
 `;

--- a/packages/react-button/src/components/Button/renderButton.tsx
+++ b/packages/react-button/src/components/Button/renderButton.tsx
@@ -8,13 +8,13 @@ import { buttonShorthandPropsCompat } from './useButton';
  */
 export const renderButton = (state: ButtonState) => {
   const { slots, slotProps } = getSlotsCompat(state, buttonShorthandPropsCompat);
-  const { /*loading,*/ iconPosition, iconOnly } = state;
+  const { children, iconOnly, iconPosition } = state;
 
   return (
     <slots.root {...slotProps.root}>
       {/*{loading && <slots.loader {...slotProps.loader} />}*/}
       {iconPosition !== 'after' && <slots.icon {...slotProps.icon} />}
-      {!iconOnly && <slots.children {...slotProps.children} />}
+      {!iconOnly && children}
       {iconPosition === 'after' && <slots.icon {...slotProps.icon} />}
     </slots.root>
   );

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -6,7 +6,7 @@ import { useButtonState } from './useButtonState';
 /**
  * Consts listing which props are shorthand props.
  */
-export const buttonShorthandPropsCompat: ButtonShorthandPropsCompat[] = ['children', 'icon'];
+export const buttonShorthandPropsCompat: ButtonShorthandPropsCompat[] = ['icon'];
 
 const mergeProps = makeMergeProps<ButtonState>({ deepMerge: buttonShorthandPropsCompat });
 

--- a/packages/react-button/src/components/Button/useButtonState.ts
+++ b/packages/react-button/src/components/Button/useButtonState.ts
@@ -9,7 +9,7 @@ import { ButtonState } from './Button.types';
 export const useButtonState = (state: ButtonState): ButtonState => {
   const { as, children, disabled, disabledFocusable, icon, onClick, onKeyDown: onKeyDownCallback } = state;
 
-  const receivedChildren = !!children?.children;
+  const receivedChildren = !!children;
   const receivedIcon = !!icon?.children;
   state.iconOnly = receivedIcon && !receivedChildren;
 

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -24,6 +24,10 @@ const useRootStyles = makeStyles({
 
     maxWidth: '280px',
 
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+
     background: theme.alias.color.neutral.neutralBackground1,
     color: theme.alias.color.neutral.neutralForeground1,
 
@@ -31,7 +35,6 @@ const useRootStyles = makeStyles({
     borderStyle: 'solid',
     borderWidth: theme.global.strokeWidth.thin,
 
-    boxShadow: theme.alias.shadow.shadow4,
     outline: 'none',
 
     ':hover': {
@@ -39,7 +42,6 @@ const useRootStyles = makeStyles({
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
       color: theme.alias.color.neutral.neutralForeground1,
 
-      boxShadow: theme.alias.shadow.shadow4,
       cursor: 'pointer',
     },
 
@@ -48,7 +50,6 @@ const useRootStyles = makeStyles({
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
       color: theme.alias.color.neutral.neutralForeground1,
 
-      boxShadow: theme.alias.shadow.shadow2,
       outline: 'none',
     },
   }),
@@ -61,6 +62,10 @@ const useRootStyles = makeStyles({
     minWidth: '64px',
 
     borderRadius: theme.global.borderRadius.small,
+
+    fontSize: theme.global.type.fontSizes.base[200],
+    fontWeight: theme.global.type.fontWeights.regular,
+    lineHeight: theme.global.type.lineHeights.base[200],
   }),
   medium: theme => ({
     // TODO: remove unsafe property: https://caniuse.com/?search=gap
@@ -71,6 +76,10 @@ const useRootStyles = makeStyles({
     minWidth: '96px',
 
     borderRadius: theme.global.borderRadius.medium,
+
+    fontSize: theme.global.type.fontSizes.base[300],
+    fontWeight: theme.global.type.fontWeights.semibold,
+    lineHeight: theme.global.type.lineHeights.base[300],
   }),
   large: theme => ({
     // TODO: remove unsafe property: https://caniuse.com/?search=gap
@@ -81,6 +90,10 @@ const useRootStyles = makeStyles({
     minWidth: '96px',
 
     borderRadius: theme.global.borderRadius.medium,
+
+    fontSize: theme.global.type.fontSizes.base[400],
+    fontWeight: theme.global.type.fontWeights.semibold,
+    lineHeight: theme.global.type.lineHeights.base[400],
   }),
   block: {
     maxWidth: '100%',
@@ -105,22 +118,16 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForegroundOnBrand,
 
-    boxShadow: theme.alias.shadow.shadow4,
-
     ':hover': {
       background: theme.alias.color.neutral.brandBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundOnBrand,
-
-      boxShadow: theme.alias.shadow.shadow4,
     },
 
     ':active': {
       background: theme.alias.color.neutral.brandBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundOnBrand,
-
-      boxShadow: theme.alias.shadow.shadow2,
     },
   }),
   subtle: theme => ({
@@ -128,22 +135,16 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2,
 
-    boxShadow: 'none',
-
     ':hover': {
       background: theme.alias.color.neutral.subtleBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
-
-      boxShadow: 'none',
     },
 
     ':active': {
       background: theme.alias.color.neutral.subtleBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
-
-      boxShadow: 'none',
     },
   }),
   transparent: theme => ({
@@ -151,30 +152,22 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2,
 
-    boxShadow: 'none',
-
     ':hover': {
       background: theme.alias.color.neutral.transparentBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
-
-      boxShadow: 'none',
     },
 
     ':active': {
       background: theme.alias.color.neutral.transparentBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
-
-      boxShadow: 'none',
     },
   }),
   disabled: theme => ({
     background: theme.alias.color.neutral.neutralBackgroundDisabled,
     borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
     color: theme.alias.color.neutral.neutralForegroundDisabled,
-
-    boxShadow: 'none',
 
     cursor: 'not-allowed',
 
@@ -183,8 +176,6 @@ const useRootStyles = makeStyles({
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
 
-      boxShadow: 'none',
-
       cursor: 'not-allowed',
     },
 
@@ -192,8 +183,6 @@ const useRootStyles = makeStyles({
       background: theme.alias.color.neutral.neutralBackgroundDisabled,
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
-
-      boxShadow: 'none',
 
       cursor: 'not-allowed',
     },
@@ -288,29 +277,6 @@ const useRootIconOnlyStyles = makeStyles({
   },
 });
 
-const useChildrenStyles = makeStyles({
-  base: {
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-  },
-  small: theme => ({
-    fontSize: theme.global.type.fontSizes.base[200],
-    fontWeight: theme.global.type.fontWeights.regular,
-    lineHeight: theme.global.type.lineHeights.base[200],
-  }),
-  medium: theme => ({
-    fontSize: theme.global.type.fontSizes.base[300],
-    fontWeight: theme.global.type.fontWeights.semibold,
-    lineHeight: theme.global.type.lineHeights.base[300],
-  }),
-  large: theme => ({
-    fontSize: theme.global.type.fontSizes.base[400],
-    fontWeight: theme.global.type.fontWeights.semibold,
-    lineHeight: theme.global.type.lineHeights.base[400],
-  }),
-});
-
 const useIconStyles = makeStyles({
   base: {
     alignItems: 'center',
@@ -338,7 +304,6 @@ export const useButtonStyles = (state: ButtonState): ButtonState => {
   const rootStyles = useRootStyles();
   const rootFocusStyles = useRootFocusStyles();
   const rootIconOnlyStyles = useRootIconOnlyStyles();
-  const childrenStyles = useChildrenStyles();
   const iconStyles = useIconStyles();
 
   state.className = mergeClasses(
@@ -361,10 +326,6 @@ export const useButtonStyles = (state: ButtonState): ButtonState => {
     state.iconOnly && rootIconOnlyStyles[state.size],
     state.className,
   );
-
-  if (state.children) {
-    state.children.className = mergeClasses(childrenStyles.base, childrenStyles[state.size], state.children.className);
-  }
 
   state.icon.className = mergeClasses(iconStyles.base, iconStyles[state.size], state.icon.className);
 

--- a/packages/react-button/src/components/CompoundButton/renderCompoundButton.tsx
+++ b/packages/react-button/src/components/CompoundButton/renderCompoundButton.tsx
@@ -8,7 +8,7 @@ import { compoundButtonShorthandPropsCompat } from './useCompoundButton';
  */
 export const renderCompoundButton = (state: CompoundButtonState) => {
   const { slots, slotProps } = getSlotsCompat(state, compoundButtonShorthandPropsCompat);
-  const { /*loading,*/ iconPosition, iconOnly } = state;
+  const { children, iconOnly, iconPosition } = state;
 
   return (
     <slots.root {...slotProps.root}>
@@ -16,7 +16,7 @@ export const renderCompoundButton = (state: CompoundButtonState) => {
       {iconPosition !== 'after' && <slots.icon {...slotProps.icon} />}
       {!iconOnly && (
         <slots.contentContainer {...slotProps.contentContainer}>
-          <slots.children {...slotProps.children} />
+          {children}
           <slots.secondaryContent {...slotProps.secondaryContent} />
         </slots.contentContainer>
       )}

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -7,7 +7,6 @@ import { CompoundButtonProps, CompoundButtonShorthandPropsCompat, CompoundButton
  * Consts listing which props are shorthand props.
  */
 export const compoundButtonShorthandPropsCompat: CompoundButtonShorthandPropsCompat[] = [
-  'children',
   'contentContainer',
   'icon',
   'secondaryContent',

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -29,15 +29,24 @@ const useRootStyles = makeStyles({
       },
     },
   }),
-  small: {
+  small: theme => ({
     padding: buttonSpacing.medium,
-  },
-  medium: {
+
+    fontSize: theme.global.type.fontSizes.base[300],
+    lineHeight: theme.global.type.lineHeights.base[300],
+  }),
+  medium: theme => ({
     padding: buttonSpacing.large,
-  },
-  large: {
+
+    fontSize: theme.global.type.fontSizes.base[300],
+    lineHeight: theme.global.type.lineHeights.base[300],
+  }),
+  large: theme => ({
     padding: buttonSpacing.larger,
-  },
+
+    fontSize: theme.global.type.fontSizes.base[400],
+    lineHeight: theme.global.type.lineHeights.base[400],
+  }),
   primary: theme => ({
     [`& .${CompoundButtonClassNames.secondaryContent}`]: {
       color: theme.alias.color.neutral.neutralForegroundOnBrand,
@@ -129,21 +138,6 @@ const useRootIconOnlyStyles = makeStyles({
   },
 });
 
-const useChildrenStyles = makeStyles({
-  small: theme => ({
-    fontSize: theme.global.type.fontSizes.base[300],
-    lineHeight: theme.global.type.lineHeights.base[300],
-  }),
-  medium: theme => ({
-    fontSize: theme.global.type.fontSizes.base[300],
-    lineHeight: theme.global.type.lineHeights.base[300],
-  }),
-  large: theme => ({
-    fontSize: theme.global.type.fontSizes.base[400],
-    lineHeight: theme.global.type.lineHeights.base[400],
-  }),
-});
-
 const useIconStyles = makeStyles({
   base: {
     fontSize: '40px',
@@ -180,7 +174,6 @@ const useSecondaryContentStyles = makeStyles({
 export const useCompoundButtonStyles = (state: CompoundButtonState): CompoundButtonState => {
   const rootStyles = useRootStyles();
   const rootIconOnlyStyles = useRootIconOnlyStyles();
-  const childrenStyles = useChildrenStyles();
   const iconStyles = useIconStyles();
   const contentContainerStyles = useContentContainerStyles();
   const secondaryContentStyles = useSecondaryContentStyles();
@@ -195,10 +188,6 @@ export const useCompoundButtonStyles = (state: CompoundButtonState): CompoundBut
     state.iconOnly && rootIconOnlyStyles[state.size],
     state.className,
   );
-
-  if (state.children) {
-    state.children.className = mergeClasses(childrenStyles[state.size], state.children.className);
-  }
 
   state.icon.className = mergeClasses(iconStyles.base, state.icon.className);
 

--- a/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
@@ -8,12 +8,12 @@ import { menuButtonShorthandPropsCompat } from './useMenuButton';
  */
 export const renderMenuButton = (state: MenuButtonState) => {
   const { slots, slotProps } = getSlotsCompat(state, menuButtonShorthandPropsCompat);
-  const { iconOnly } = state;
+  const { children, iconOnly } = state;
 
   return (
     <slots.root {...slotProps.root}>
       <slots.icon {...slotProps.icon} />
-      {!iconOnly && <slots.children {...slotProps.children} />}
+      {!iconOnly && children}
       {!iconOnly && <slots.menuIcon {...slotProps.menuIcon} />}
     </slots.root>
   );

--- a/packages/react-button/src/components/MenuButton/useMenuButton.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButton.ts
@@ -6,7 +6,7 @@ import { useMenuButtonState } from './useMenuButtonState';
 /**
  * Consts listing which props are shorthand props.
  */
-export const menuButtonShorthandPropsCompat: MenuButtonShorthandPropsCompat[] = ['children', 'icon', 'menuIcon'];
+export const menuButtonShorthandPropsCompat: MenuButtonShorthandPropsCompat[] = ['icon', 'menuIcon'];
 
 const mergeProps = makeMergeProps<MenuButtonState>({ deepMerge: menuButtonShorthandPropsCompat });
 

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -10,22 +10,16 @@ const useRootStyles = makeStyles({
 
     borderWidth: theme.global.strokeWidth.thin,
 
-    boxShadow: theme.alias.shadow.shadow2,
-
     ':hover': {
       background: theme.alias.color.neutral.neutralBackground1Hover,
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
       color: theme.alias.color.neutral.neutralForeground1,
-
-      boxShadow: theme.alias.shadow.shadow4,
     },
 
     ':active': {
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
       color: theme.alias.color.neutral.neutralForeground1,
-
-      boxShadow: theme.alias.shadow.shadow2,
     },
   }),
   checkedOutline: theme => ({
@@ -44,22 +38,16 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForegroundOnBrand,
 
-    boxShadow: theme.alias.shadow.shadow2,
-
     ':hover': {
       background: theme.alias.color.neutral.brandBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundOnBrand,
-
-      boxShadow: theme.alias.shadow.shadow4,
     },
 
     ':active': {
       background: theme.alias.color.neutral.brandBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForegroundOnBrand,
-
-      boxShadow: theme.alias.shadow.shadow2,
     },
   }),
   checkedSubtle: theme => ({
@@ -67,22 +55,16 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2BrandSelected,
 
-    boxShadow: 'none',
-
     ':hover': {
       background: theme.alias.color.neutral.subtleBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
-
-      boxShadow: 'none',
     },
 
     ':active': {
       background: theme.alias.color.neutral.subtleBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
-
-      boxShadow: 'none',
     },
   }),
   checkedTransparent: theme => ({
@@ -90,22 +72,16 @@ const useRootStyles = makeStyles({
     borderColor: 'transparent',
     color: theme.alias.color.neutral.neutralForeground2BrandSelected,
 
-    boxShadow: 'none',
-
     ':hover': {
       background: theme.alias.color.neutral.transparentBackgroundHover,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandHover,
-
-      boxShadow: 'none',
     },
 
     ':active': {
       background: theme.alias.color.neutral.transparentBackgroundPressed,
       borderColor: 'transparent',
       color: theme.alias.color.neutral.neutralForeground2BrandPressed,
-
-      boxShadow: 'none',
     },
   }),
   disabled: theme => ({
@@ -113,22 +89,16 @@ const useRootStyles = makeStyles({
     borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
     color: theme.alias.color.neutral.neutralForegroundDisabled,
 
-    boxShadow: 'none',
-
     ':hover': {
       background: theme.alias.color.neutral.neutralBackgroundDisabled,
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
-
-      boxShadow: 'none',
     },
 
     ':active': {
       background: theme.alias.color.neutral.neutralBackgroundDisabled,
       borderColor: theme.alias.color.neutral.neutralStrokeDisabled,
       color: theme.alias.color.neutral.neutralForegroundDisabled,
-
-      boxShadow: 'none',
     },
   }),
   disabledPrimary: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18471
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes changes in all `Button` components to stop handling `children` as a slot but still maintain the correct styling.

It also makes a change to remove all `boxShadows` to match the latest design spec.