### PR TITLE
feat(tools): add --all flag to run migrations in batch

### DIFF
--- a/tools/generators/migrate-converged-pkg/README.md
+++ b/tools/generators/migrate-converged-pkg/README.md
@@ -1,6 +1,6 @@
 # migrate-converged-pkg
 
-Workspace Generator for migrating converged packages to new DX (stage 1)
+Workspace Generator for migrating converged packages to new DX (stage 1)[https://github.com/microsoft/fluentui/issues/18579]
 
 <!-- toc -->
 
@@ -9,6 +9,7 @@ Workspace Generator for migrating converged packages to new DX (stage 1)
   - [Examples](#examples)
 - [Options](#options)
   - [`name`](#name)
+  - [`all`](#all)
   - [`stats`](#stats)
 
 <!-- tocstop -->
@@ -39,6 +40,12 @@ Run migration on package named `@fluentui/example`
 yarn nx workspace-generator migrate-converged-pkg --name='@fluentui/example'
 ```
 
+Run migration on all vNext packages
+
+```sh
+yarn nx workspace-generator migrate-converged-pkg --all
+```
+
 Get migration stats for how many packages have been migrated yet.
 
 > No actual migration will happen.
@@ -54,6 +61,14 @@ yarn nx workspace-generator migrate-converged-pkg --stats --no-interactive
 Type: `string`
 
 Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
+
+#### `all`
+
+Type: `boolean`
+
+Run batch migration on all vNext packages
+
+> TIP: Use it with `--no-interactive` option to disable prompts.
 
 #### `stats`
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -26,7 +26,7 @@ describe('migrate-converged-pkg generator', () => {
   const noop = () => {};
 
   let tree: Tree;
-  const options = { name: '@proj/react-dummy' };
+  const options = { name: '@proj/react-dummy' } as const;
 
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -637,6 +637,50 @@ describe('migrate-converged-pkg generator', () => {
 
       expect(loggerInfoSpy.mock.calls[2][0]).toEqual('Migrated (1):');
       expect(loggerInfoSpy.mock.calls[5][0]).toEqual(`Not migrated (2):`);
+    });
+  });
+
+  describe(`--all`, () => {
+    beforeEach(() => {
+      setupDummyPackage(tree, { name: '@proj/react-foo', version: '9.0.22' });
+      setupDummyPackage(tree, { name: '@proj/react-bar', version: '9.0.31' });
+      setupDummyPackage(tree, { name: '@proj/react-moo', version: '9.0.12' });
+      setupDummyPackage(tree, { name: '@proj/react-old', version: '8.0.1' });
+    });
+
+    it('should throw if --name && --all are both specified', async () => {
+      await expect(
+        generator(tree, {
+          ...options,
+          all: true,
+        }),
+      ).rejects.toMatchInlineSnapshot(`[Error: --name and --all are mutually exclusive]`);
+    });
+
+    it(`should run migration on all vNext packages in batch`, async () => {
+      const projects = [
+        options.name,
+        '@proj/react-examples',
+        '@proj/react-foo',
+        '@proj/react-bar',
+        '@proj/react-moo',
+        '@proj/react-old',
+      ] as const;
+
+      await generator(tree, { all: true });
+
+      const configs = projects.reduce((acc, projectName) => {
+        acc[projectName] = readProjectConfiguration(tree, projectName);
+
+        return acc;
+      }, {} as Record<typeof projects[number], ReturnType<typeof readProjectConfiguration>>);
+
+      expect(configs['@proj/react-foo'].sourceRoot).toBeDefined();
+      expect(configs['@proj/react-bar'].sourceRoot).toBeDefined();
+      expect(configs['@proj/react-moo'].sourceRoot).toBeDefined();
+      expect(configs['@proj/react-dummy'].sourceRoot).toBeDefined();
+      expect(configs['@proj/react-old'].sourceRoot).not.toBeDefined();
+      expect(configs['@proj/react-examples'].sourceRoot).not.toBeDefined();
     });
   });
 });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -43,14 +43,41 @@ type UserLog = Array<{ type: keyof typeof logger; message: string }>;
 export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorSchema) {
   const userLog: UserLog = [];
 
+  validateUserInput(tree, schema);
+
   if (schema.stats) {
     printStats(tree, schema);
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
 
-  validateUserInput(tree, schema);
+  if (schema.all) {
+    runBatchMigration(tree, userLog);
+  } else {
+    runMigrationOnProject(tree, schema, userLog);
+  }
 
+  await formatFiles(tree);
+
+  return () => {
+    printUserLogs(userLog);
+  };
+}
+
+function runBatchMigration(tree: Tree, userLog: UserLog) {
+  const projects = getProjects(tree);
+
+  projects.forEach((project, projectName) => {
+    if (!isPackageConverged(tree, project)) {
+      userLog.push({ type: 'error', message: `${projectName} is not converged package. Skipping migration...` });
+      return;
+    }
+
+    runMigrationOnProject(tree, { name: projectName }, userLog);
+  });
+}
+
+function runMigrationOnProject(tree: Tree, schema: AssertedSchema, userLog: UserLog) {
   const options = normalizeOptions(tree, schema);
 
   // 1. update TsConfigs
@@ -73,12 +100,6 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
   updateApiExtractorForLocalBuilds(tree, options);
 
   updateNxWorkspace(tree, options);
-
-  await formatFiles(tree);
-
-  return () => {
-    printUserLogs(userLog);
-  };
 }
 
 // ==== helpers ====
@@ -202,16 +223,30 @@ function normalizeOptions(host: Tree, options: AssertedSchema) {
 }
 
 function validateUserInput(tree: Tree, options: MigrateConvergedPkgGeneratorSchema): asserts options is AssertedSchema {
-  if (!options.name) {
+  if (options.name && options.stats) {
+    throw new Error('--name and --stats are mutually exclusive');
+  }
+
+  if (options.name && options.all) {
+    throw new Error('--name and --all are mutually exclusive');
+  }
+
+  if (options.stats && options.all) {
+    throw new Error('--stats and --all are mutually exclusive');
+  }
+
+  if (!options.name && !(options.all || options.stats)) {
     throw new Error(`--name cannot be empty. Please provide name of the package.`);
   }
 
-  const projectConfig = readProjectConfiguration(tree, options.name);
+  if (options.name) {
+    const projectConfig = readProjectConfiguration(tree, options.name);
 
-  if (!isPackageConverged(tree, projectConfig)) {
-    throw new Error(
-      `${options.name} is not converged package. Make sure to run the migration on packages with version 9.x.x`,
-    );
+    if (!isPackageConverged(tree, projectConfig)) {
+      throw new Error(
+        `${options.name} is not converged package. Make sure to run the migration on packages with version 9.x.x`,
+      );
+    }
   }
 }
 

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -17,6 +17,10 @@
     "stats": {
       "type": "boolean",
       "description": "Get statistics for how many projects have been migrated"
+    },
+    "all": {
+      "type": "boolean",
+      "description": "Run generator on all vNext packages"
     }
   },
   "required": []

--- a/tools/generators/migrate-converged-pkg/schema.ts
+++ b/tools/generators/migrate-converged-pkg/schema.ts
@@ -7,4 +7,8 @@ export interface MigrateConvergedPkgGeneratorSchema {
    * Get statistics for how many projects have been migrated
    */
   stats?: boolean;
+  /**
+   * Run generator on all vNext packages
+   */
+  all?: boolean;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: implements partially https://github.com/microsoft/fluentui/issues/19103
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- implements `--all` flag to run batch migration thus keeping project setups up to date and in sync
  -  ![2021-07-23 at 13 21](https://user-images.githubusercontent.com/1223799/126775022-f281778b-580e-46f2-b6be-811393cec78f.png)
  - ![2021-07-23 at 13 20](https://user-images.githubusercontent.com/1223799/126774939-bcc18252-bc79-48a6-8639-67137268c1be.png)
 
- handle mutually exclusive flags 
  - ![2021-07-23 at 13 18](https://user-images.githubusercontent.com/1223799/126774825-7f19b0b0-4080-4d51-9449-46edc93fbadd.png)


#### Focus areas to test

(optional)
