### PR TITLE
Fix crash in ContextualMenu when Callout component is loaded asynchronously

### DIFF
--- a/change/@fluentui-react-26f9c974-48e2-4dc3-a7c2-a5e8647b32c0.json
+++ b/change/@fluentui-react-26f9c974-48e2-4dc3-a7c2-a5e8647b32c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix crash in ContextualMenu when Callout component is loaded asynchronously",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -48,7 +48,7 @@ import {
 import { IProcessedStyleSet, concatStyleSetsWithProps } from '../../Styling';
 import { IContextualMenuItemStyleProps, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import { getItemStyles } from './ContextualMenu.classNames';
-import { useTarget, usePrevious, useMergedRefs } from '@fluentui/react-hooks';
+import { useTarget, usePrevious } from '@fluentui/react-hooks';
 import { useResponsiveMode, ResponsiveMode } from '../../ResponsiveMode';
 import { IPopupRestoreFocusParams } from '../../Popup';
 import { MenuContext } from '../../utilities/MenuContext/index';
@@ -193,9 +193,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
   IContextualMenuProps
 >((propsWithoutDefaults, forwardedRef) => {
   const { ref, ...props } = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
-  const rootRef = React.useRef<HTMLDivElement>(null);
-
-  const hostElement: React.RefObject<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
+  const hostElement = React.useRef<HTMLDivElement>(null);
 
   const [targetRef, targetWindow] = useTarget(props.target, hostElement);
   const [expandedMenuItemKey, submenuTarget, expandedByMouseClick, openSubMenu, closeSubMenu] = useSubMenuState(props);
@@ -210,6 +208,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
       {...props}
       hoisted={{
         hostElement,
+        forwardedRef,
         targetRef,
         targetWindow,
         expandedMenuItemKey,
@@ -230,6 +229,7 @@ ContextualMenuBase.displayName = 'ContextualMenuBase';
 interface IContextualMenuInternalProps extends IContextualMenuProps {
   hoisted: {
     hostElement: React.RefObject<HTMLDivElement>;
+    forwardedRef: React.Ref<HTMLDivElement>;
     targetRef: React.RefObject<Element | MouseEvent | Point | null>;
     targetWindow: Window | undefined;
     expandedMenuItemKey?: string;
@@ -368,7 +368,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       focusZoneProps,
       // eslint-disable-next-line deprecation/deprecation
       getMenuClassNames,
-      hoisted: { expandedMenuItemKey, targetRef, onMenuFocusCapture, hostElement },
+      hoisted: { expandedMenuItemKey, targetRef, onMenuFocusCapture, hostElement, forwardedRef },
     } = this.props;
 
     this._classNames = getMenuClassNames
@@ -470,10 +470,11 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
               directionalHintFixed={directionalHintFixed}
               alignTargetEdge={alignTargetEdge}
               hidden={this.props.hidden || menuContext.hidden}
-              ref={hostElement}
+              ref={forwardedRef}
             >
               <div
                 style={contextMenuStyle}
+                ref={hostElement}
                 id={id}
                 className={this._classNames.container}
                 tabIndex={shouldFocusOnContainer ? 0 : -1}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue
  - Fixes #19058
  - Fixes #19083
- [x] Include a change request file using `$ yarn change`

#### Description of changes

PR #15625 moved the `hostElement` ref from an inner `div` of ContextualMenu, to the root `Callout` element. However, when the Callout component is loaded asynchronously, this can cause a crash when the ref doesn't refer to a fully loaded element.

This change un-merges the `forwardedRef` and `hostElement` ref. It still applies the forwarded ref to the root Callout (to maintain the fix from #15625), but puts the `hostElement` ref  back to the inner `div`.