### PR TITLE
fix(Menu): merge `checkmark` slot for selectable menu items

### DIFF
--- a/change/@fluentui-react-menu-0ab41e1d-4be1-4b20-8d7b-9c9a4583369b.json
+++ b/change/@fluentui-react-menu-0ab41e1d-4be1-4b20-8d7b-9c9a4583369b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Menu): merge `checkmark` slot for selectable menu items",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
@@ -163,4 +163,19 @@ describe('MenuItemCheckbox', () => {
     // Assert
     expect(setOpen).toHaveBeenCalledTimes(0);
   });
+
+  it('should merge checkmark slot props', () => {
+    // Arrange
+    const className = 'foo';
+    const { container } = render(
+      <MenuItemCheckbox checkmark={{ className }} name="test" value="test">
+        Item
+      </MenuItemCheckbox>,
+    );
+
+    // Assert
+    const slot = container.querySelector(`.${className}`);
+    expect(slot).not.toBeNull();
+    expect(slot?.querySelector('svg')).not.toBeNull();
+  });
 });

--- a/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { resolveShorthand } from '@fluentui/react-utilities';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
 import { useMenuListContext } from '../../contexts/menuListContext';
 import { useMenuItem } from '../MenuItem/useMenuItem';
@@ -15,7 +16,14 @@ export const useMenuItemCheckbox = (
     persistOnClick: true,
   };
 
-  const state = useMenuItem({ ...checkboxProps, ...props }, ref) as MenuItemCheckboxState;
+  const state = useMenuItem(
+    {
+      ...checkboxProps,
+      ...props,
+      checkmark: resolveShorthand(props.checkmark, { children: <AcceptIcon /> }),
+    },
+    ref,
+  ) as MenuItemCheckboxState;
 
   const toggleCheckbox = useMenuListContext(context => context.toggleCheckbox);
   const { onClick: onClickOriginal } = state;

--- a/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.test.tsx
@@ -140,4 +140,19 @@ describe('MenuItemRadio', () => {
     // Assert
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should merge checkmark slot props', () => {
+    // Arrange
+    const className = 'foo';
+    const { container } = render(
+      <MenuItemRadio checkmark={{ className }} name="test" value="test">
+        Item
+      </MenuItemRadio>,
+    );
+
+    // Assert
+    const slot = container.querySelector(`.${className}`);
+    expect(slot).not.toBeNull();
+    expect(slot?.querySelector('svg')).not.toBeNull();
+  });
 });

--- a/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadio.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadio.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { resolveShorthand } from '@fluentui/react-utilities';
 import { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio.types';
 import { useMenuListContext } from '../../contexts/menuListContext';
 import { useMenuItem } from '../MenuItem/useMenuItem';
@@ -10,10 +11,16 @@ import { AcceptIcon } from '../../utils/DefaultIcons';
 export const useMenuItemRadio = (props: MenuItemRadioProps, ref: React.Ref<HTMLElement>): MenuItemRadioState => {
   const radioProps = {
     role: 'menuitemradio',
-    checkmark: { children: <AcceptIcon /> },
   };
 
-  const state = useMenuItem({ ...radioProps, ...props }, ref) as MenuItemRadioState;
+  const state = useMenuItem(
+    {
+      ...radioProps,
+      ...props,
+      checkmark: resolveShorthand(props.checkmark, { children: <AcceptIcon /> }),
+    },
+    ref,
+  ) as MenuItemRadioState;
 
   const selectRadio = useMenuListContext(context => context.selectRadio);
   const { onClick: onClickOriginal } = state;

--- a/packages/react-menu/src/components/MenuList/useMenuList.test.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuList.test.ts
@@ -127,7 +127,7 @@ describe('useMenuList', () => {
         useMenuList({ onCheckedValueChange: jest.fn(), checkedValues: { [name]: checkedItems } }, null),
       );
       const state = result.current;
-      state.toggleCheckbox(({} as unknown) as React.MouseEvent, name, value, checked);
+      act(() => state.toggleCheckbox(({} as unknown) as React.MouseEvent, name, value, checked));
 
       // Assert
       expect(state.onCheckedValueChange).toHaveBeenCalledTimes(1);
@@ -165,7 +165,7 @@ describe('useMenuList', () => {
         useMenuList({ onCheckedValueChange: jest.fn(), checkedValues: { [name]: checkedItems } }, null),
       );
       const state = result.current;
-      state.selectRadio(({} as unknown) as React.MouseEvent, name, value, true);
+      act(() => state.selectRadio(({} as unknown) as React.MouseEvent, name, value, true));
 
       // Assert
       expect(state.onCheckedValueChange).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19132
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Calls `resolveShorthand` for `checkmark` slot in the `useMenuItem` calls for menu item variants.

#### Focus areas to test

(optional)
