### PR TITLE
Fix bug where ContextualMenu's onMenuDismissed is called twice

### DIFF
--- a/change/@fluentui-react-30edeeb6-4f28-49a0-9aec-4ed7601e4962.json
+++ b/change/@fluentui-react-30edeeb6-4f28-49a0-9aec-4ed7601e4962.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where ContextualMenu's onMenuDismissed is called twice",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -327,10 +327,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   // Invoked immediately before a component is unmounted from the DOM.
   public componentWillUnmount() {
-    if (this.props.onMenuDismissed) {
-      this.props.onMenuDismissed(this.props);
-    }
-
     this._events.dispose();
     this._async.dispose();
     this._mounted = false;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19123
- [x] Include a change request file using `$ yarn change`

#### Description of changes

PR #14513 added a call to `useEffect` that invokes `onMenuDismissed` when the menu is unmounted, but didn't remove the call in `componentWillUnmount`, so now it's called in two places. Remove the `onMenuDismissed` call from `componentWillUnmount` to avoid duplicate calls
