### PR TITLE
Add prop to allow user defined Tooltip to be rendered by itself

### DIFF
--- a/change/@fluentui-react-201571c1-4a8c-4e02-b25c-26437246703a.json
+++ b/change/@fluentui-react-201571c1-4a8c-4e02-b25c-26437246703a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add prop to allow user defined Tooltip to be rendered without default Tooltip being rendered",
+  "packageName": "@fluentui/react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4919,6 +4919,7 @@ export interface IFacepileProps extends React_2.ClassAttributes<FacepileBase> {
     personas: IFacepilePersona[];
     personaSize?: PersonaSize;
     showAddButton?: boolean;
+    showTooltip?: boolean;
     styles?: IStyleFunctionOrObject<IFacepileStyleProps, IFacepileStyles>;
     theme?: ITheme;
 }

--- a/packages/react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/react/src/components/Facepile/Facepile.base.tsx
@@ -50,7 +50,7 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
       overflowPersonas,
       showAddButton,
       ariaLabel,
-      showTooltip = false,
+      showTooltip = true,
     } = this.props;
 
     const { _classNames } = this;

--- a/packages/react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/react/src/components/Facepile/Facepile.base.tsx
@@ -50,6 +50,7 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
       overflowPersonas,
       showAddButton,
       ariaLabel,
+      showTooltip = false,
     } = this.props;
 
     const { _classNames } = this;
@@ -74,7 +75,11 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
         <div className={_classNames.itemContainer}>
           {showAddButton ? this._getAddNewElement() : null}
           <ul className={_classNames.members} aria-label={ariaLabel}>
-            {this._onRenderVisiblePersonas(personasPrimary, personasOverflow.length === 0 && personas.length === 1)}
+            {this._onRenderVisiblePersonas(
+              personasPrimary,
+              personasOverflow.length === 0 && personas.length === 1,
+              showTooltip,
+            )}
           </ul>
           {overflowButtonProps ? this._getOverflowElement(personasOverflow) : null}
         </div>
@@ -98,7 +103,11 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
     );
   }
 
-  private _onRenderVisiblePersonas(personas: IFacepilePersona[], singlePersona: boolean): JSX.Element[] {
+  private _onRenderVisiblePersonas(
+    personas: IFacepilePersona[],
+    singlePersona: boolean,
+    showTooltip: boolean,
+  ): JSX.Element[] {
     const { onRenderPersona = this._getPersonaControl, onRenderPersonaCoin = this._getPersonaCoinControl } = this.props;
     return personas.map((persona: IFacepilePersona, index: number) => {
       const personaControl: JSX.Element | null = singlePersona
@@ -107,8 +116,8 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
       return (
         <li key={`${singlePersona ? 'persona' : 'personaCoin'}-${index}`} className={this._classNames.member}>
           {persona.onClick
-            ? this._getElementWithOnClickEvent(personaControl, persona, index)
-            : this._getElementWithoutOnClickEvent(personaControl, persona, index)}
+            ? this._getElementWithOnClickEvent(personaControl, persona, showTooltip, index)
+            : this._getElementWithoutOnClickEvent(personaControl, persona, showTooltip, index)}
         </li>
       );
     });
@@ -154,13 +163,14 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
   private _getElementWithOnClickEvent(
     personaControl: JSX.Element | null,
     persona: IFacepilePersona,
+    showTooltip: boolean,
     index: number,
   ): JSX.Element {
     const { keytipProps } = persona;
     return (
       <FacepileButton
         {...getNativeProps(persona, buttonProperties)}
-        {...this._getElementProps(persona, index)}
+        {...this._getElementProps(persona, showTooltip, index)}
         keytipProps={keytipProps}
         // eslint-disable-next-line react/jsx-no-bind
         onClick={this._onPersonaClick.bind(this, persona)}
@@ -173,10 +183,11 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
   private _getElementWithoutOnClickEvent(
     personaControl: JSX.Element | null,
     persona: IFacepilePersona,
+    showTooltip: boolean,
     index: number,
   ): JSX.Element {
     return (
-      <div {...getNativeProps(persona, buttonProperties)} {...this._getElementProps(persona, index)}>
+      <div {...getNativeProps(persona, buttonProperties)} {...this._getElementProps(persona, showTooltip, index)}>
         {personaControl}
       </div>
     );
@@ -184,6 +195,7 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
 
   private _getElementProps(
     persona: IFacepilePersona,
+    showTooltip: boolean,
     index: number,
   ): { key: React.Key; ['data-is-focusable']: boolean } & React.HTMLAttributes<HTMLDivElement> {
     const { _classNames } = this;
@@ -192,7 +204,7 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
       key: (persona.imageUrl ? 'i' : '') + index,
       'data-is-focusable': true,
       className: _classNames.itemButton,
-      title: persona.personaName,
+      title: showTooltip ? persona.personaName : undefined,
       onMouseMove: this._onPersonaMouseMove.bind(this, persona),
       onMouseOut: this._onPersonaMouseOut.bind(this, persona),
     };

--- a/packages/react/src/components/Facepile/Facepile.types.ts
+++ b/packages/react/src/components/Facepile/Facepile.types.ts
@@ -23,7 +23,7 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
 
   /**
    * Whether the default Tooltip is shown using the title prop or a user defined Tooltip is shown
-   * @defaultvalue false
+   * @defaultvalue true
    */
   showTooltip?: boolean;
 

--- a/packages/react/src/components/Facepile/Facepile.types.ts
+++ b/packages/react/src/components/Facepile/Facepile.types.ts
@@ -22,7 +22,8 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
   componentRef?: IRefObject<IFacepile>;
 
   /**
-   * Whether the default Tooltip is shown using the title prop or a user defined Tooltip is shown
+   * Whether the default tooltip (the persona name) is shown using the `title` prop.
+   * Set this to false if you'd like to display a custom tooltip, for example using a custom renderer and TooltipHost
    * @defaultvalue true
    */
   showTooltip?: boolean;

--- a/packages/react/src/components/Facepile/Facepile.types.ts
+++ b/packages/react/src/components/Facepile/Facepile.types.ts
@@ -22,6 +22,12 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
   componentRef?: IRefObject<IFacepile>;
 
   /**
+   * Whether the default Tooltip is shown using the title prop or a user defined Tooltip is shown
+   * @defaultvalue false
+   */
+  showTooltip?: boolean;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IFacepileStyleProps, IFacepileStyles>;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17503 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `showTooltip` prop to `IFacepileProps` in order to allow users to render their own `Tooltip` using `TooltipHost` without the default tooltip rendering as well.

#### Focus areas to test

(optional)
