### PR TITLE
RFC: Configuring popper uniformly across v9

### DIFF
--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -209,7 +209,7 @@ This change can be made in a non-breaking way by deprecating all existing config
 - Fixes to positioned elements through extra configuration can be used across the library
 - Configuring positioned elements is consistent across components and clear for users
 - If a better underlying library than `Popper.js` exists, we can replace it by implementing the `PositioniningProps` interface
-- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
+- Technically a new `placement`prop is a breaking API change, but can be done in a non-breaking way
 
 #### Cons
 
@@ -217,7 +217,7 @@ This change can be made in a non-breaking way by deprecating all existing config
 - Adds extra code to resolve shorthand
 - Encourage users to use complicated solutions to their problems
 - Adding configuration required only by a single component is expensive
-- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
+- Technically a new `placement`prop is a breaking API change, but can be done in a non-breaking way
 
 ## Discarded Solutions
 

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -115,19 +115,13 @@ export type PositioningShorthandValue =
 export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
 
 export function resolvePositioningShorthand(shorthand: PositioningShorthand) {
-  if (typeof shorthand === 'object') {
-    return {
-      ...shorthand,
-    };
-  }
-
   if (typeof shorthand === 'string') {
     return {
       ...parseStringShorthand(shorthand),
     };
   }
 
-  return config;
+  return shorthand;
 }
 
 export function parseStringShorthand(shorthand) {

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -114,7 +114,7 @@ export type PositioningShorthandValue =
 
 export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
 
-export function resolvePositioningShorthand(shorthand: PositioningShorthand) {
+export function resolvePositioningShorthand(shorthand: PositioningShorthand): PositioningProps {
   if (typeof shorthand === 'string') {
     return {
       ...parseStringShorthand(shorthand),
@@ -124,7 +124,7 @@ export function resolvePositioningShorthand(shorthand: PositioningShorthand) {
   return shorthand;
 }
 
-export function parseStringShorthand(shorthand) {
+function parseStringShorthand(shorthand) {
   // Some way to parse string to the position and align props
   return {
     position,

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -131,6 +131,7 @@ export function resolvePositioningShorthand(shorthand: PositioningShorthand) {
 }
 
 export function parseStringShorthand(shorthand) {
+  // Some way to parse string to the position and align props
   return {
     position,
     align,

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -1,0 +1,148 @@
+# RFC:
+
+@ling1726
+
+## Summary
+
+In the v9 library, we have invested in [Popper.js](https://popper.js.org/) as the tool to managed positioned elements.
+The `usePopper` utility in `@fluentui/react-positioning` contains multiple configuration options for popper and custom
+popper modifiers that can be used in different scenarios. These configuration options were mainly taken from v0 from
+the different requirements for positioned elements in Teams.
+
+In v9, there is no uniform usage of the configuration options for all components apart from a small subset of necessary
+options that are required. This RFC proposes a way to configure popper uniformly in v9 components for consumers.
+
+## Background
+
+Configuring positioned props in both v0 and v8 are done inconsistently. Here are some examples
+
+v8:
+
+```tsx
+<Callout
+  {...props} // ICalloutProps interface
+/>
+
+<ContextualMenu
+  calloutProps={calloutProps} // ICalloutProps interface
+  // also can spread calloutProps
+  calloutMaxHeight
+  bounds
+  directionalHintFixed
+/>
+```
+
+v0:
+
+```tsx
+<Popup
+  align
+  position
+  offset
+/>
+
+<Menu
+  items={[
+    { menu: popper: { align, position, offset }}
+  ]}
+/>
+```
+
+## Problem statement
+
+There is a subset of `usePopper` options that are currently used by all converged components that need positioning.
+These options are spread into the component's props:
+
+```tsx
+<Tooltip position="bottom" align="center" />
+<Popover position="bottom" align="center" />
+<Menu position="bottom" align="center" />
+```
+
+There are other popper options that are used in some components but not others, examples of these options are:
+
+- `coverTarget` - allows the positioned element to cover the target
+
+There are also additional options that are not used by any converge component that might be used in the future like:
+
+- `autoSize` - Allows the positioned element to change size based on viewport size
+- `flipBoundary` - Determines what bounds to use to flip the positioning
+
+Issues and bugs can be triggered because certain use cases require more precise configuration of popper. The most likely
+result would be that a popper configuration is exposed for one component but not others.
+
+## Detailed Design or Proposal
+
+### Equal popper configuration
+
+Each converged component that uses popper should allow an equal level of configuration. This ensures that our positioned
+components can behave consistently across the library. Any fixes that require exposing another popper configuration will
+be available to **all** components that use popper.
+
+This proposal does not mean that all popper options must be public, but that if one component exposes a popper configuration,
+then all components should do so equally.
+
+We can achieve this with an agreement that the current `PositioningProps` would be supported by all v9 components, while
+internal popper options can still belong to `PopperOptions` type in the `react-positioning` package.
+
+```tsx
+import { PositioningProps } from '@fluentui/react-positioning';
+
+export interface TooltipProps extends PositioningProps {}
+
+export interface MenuProps extends PositioningProps {}
+
+export interface PopoverProps extends PositioningProps {}
+```
+
+### `positioning` configuration object
+
+The next step to this proposal is to make sure that all components which use a positioned element should allow users
+to configure popper through a `positioning` configuration object:
+
+```tsx
+import { PositioningProps } from '@fluentui/react-positioning';
+
+export interface TooltipProps {
+  positioning?: PositioningProps;
+}
+
+export interface MenuProps {
+  positioning?: PositioningProps;
+}
+
+export interface PopoverProps {
+  positioning?: PositioningProps;
+}
+```
+
+Slots that use popper should use a similar pattern if a top level `positioning` option is not clear enough:
+
+```tsx
+import { PositioningProps } from '@fluentui/react-positioning';
+
+export interface ComponentWithPositionedSlotProps {
+  positionedSlot: React.HTMLAttributes<HTMLElement> & { positioning?: PositioningProps };
+}
+```
+
+### Pros and Cons
+
+#### Pros
+
+- Positioning capability is consistent across the library
+- Fixes to positioned elements through extra configuration can be used across the library
+- Configuring positioned elements is consistent across components and clear for users
+- If a better underlying library than `Popper` exists, we can replace it by implementing the `PositioniningProps`interface
+- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
+
+#### Cons
+
+- Some components will not need all complex configuiration
+- Encourage users to use complicated solutions to their problems
+- Adding configuration required only by a single component is expensive
+- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
+
+## Discarded Solutions
+
+<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -189,7 +189,7 @@ This way we can safely configure `usePopper` internally with a simple object spr
 props are used by the component props:
 
 ```tsx
-// � Existing usage
+// 👎 Existing usage
 // Need to be aware of user props and make sure they are added to the hook usage
 usePopper({
   align: state.align,
@@ -199,7 +199,7 @@ usePopper({
   offset: state.offset,
 });
 
-// � Proposed usage
+// 👍 Proposed usage
 // Guaranteed to configure based on user props, and any component specific modifications after
 // However adds some extra logic to use shorthand correctly
 const popperOptions = resolvePopperOptions(placement, { offset: state.modifiedOffset });

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -1,6 +1,6 @@
 # RFC:
 
-@ling1726
+@ling1726 @layershifter @behowell
 
 ## Summary
 

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -85,16 +85,6 @@ then all components should do so equally.
 We can achieve this with an agreement that the current `PositioningProps` would be supported by all v9 components, while
 internal popper options can still belong to `PopperOptions` type in the `react-positioning` package.
 
-```tsx
-import { PositioningProps } from '@fluentui/react-positioning';
-
-export interface TooltipProps extends PositioningProps {}
-
-export interface MenuProps extends PositioningProps {}
-
-export interface PopoverProps extends PositioningProps {}
-```
-
 ### Shorthand `placement` configuration
 
 The next step to this proposal is to make sure that all components which use a positioned element should allow users

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -120,9 +120,26 @@ export interface PopoverProps {
 Example usage:
 
 ```tsx
+type PlacementShorthand =
+  | 'above'
+  | 'above-start'
+  | 'above-end'
+  | 'below'
+  | 'below-start'
+  | 'below-end'
+  | 'before'
+  | 'before-top'
+  | 'before-bottom'
+  | 'after'
+  | 'after-top'
+  | 'after-bottom';
+
 // Shorthand for `position` and `align` options
 <PositionedComponent placement="above-start">
 <PositionedComponent placemant={{position: 'above', align: 'start'}}>
+
+<PositionedComponent placement="above">
+<PositionedComponent placemant={{position: 'above'}}>
 
 // Also allows more complex configuration
 <PositionedComponent placement={{position: 'above', align: 'start', autoSize: true}}>
@@ -142,6 +159,7 @@ This way we can safely configure `usePopper` internally with a simple object spr
 props are used by the component props:
 
 ```tsx
+// � Existing usage
 // Need to be aware of user props and make sure they are added to the hook usage
 usePopper({
   align: state.align,
@@ -151,6 +169,7 @@ usePopper({
   offset: state.offset,
 });
 
+// � Proposed usage
 // Guaranteed to configure based on user props, and any component specific modifications after
 usePopper({
   ...placement,

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -105,10 +105,6 @@ The usage examples below will detail the usage of this shorthand.
 
 ```tsx
 // @fluentui/react-positioning
-export interface PositionedComponent {
-  placement: PositioningShorthand;
-}
-
 export type PositioningShorthandValue =
   | 'above'
   | 'above-start'
@@ -152,13 +148,19 @@ export function parseStringShorthand(shorthand) {
 ```
 
 ```tsx
-import { PositionedComponent } from '@fluentui/react-positioning';
+import { PositioningShorthand } from '@fluentui/react-positioning';
 
-export interface TooltipProps extends PositioninedComponent {}
+export interface TooltipProps extends PositioninedComponent {
+  placement: PositioningShorthand;
+}
 
-export interface MenuProps extends PositioninedComponent {}
+export interface MenuProps extends PositioninedComponent {
+  placement: PositioningShorthand;
+}
 
-export interface PopoverProps extends PositioninedComponent {}
+export interface PopoverProps extends PositioninedComponent {
+  placement: PositioningShorthand;
+}
 ```
 
 Example usage:

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-In the v9 library, we have invested in [Popper.js](https://popper.js.org/) as the tool to managed positioned elements.
+In the v9 library, we have invested in [Popper.js](https://popper.js.org/) as the tool to manage positioned elements.
 The `usePopper` utility in `@fluentui/react-positioning` contains multiple configuration options for popper and custom
 popper modifiers that can be used in different scenarios. These configuration options were mainly taken from v0 from
 the different requirements for positioned elements in Teams.

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -95,36 +95,72 @@ export interface MenuProps extends PositioningProps {}
 export interface PopoverProps extends PositioningProps {}
 ```
 
-### `positioning` configuration object
+### Shorhand `placement` configuration
 
 The next step to this proposal is to make sure that all components which use a positioned element should allow users
-to configure popper through a `positioning` configuration object:
+to configure popper through a `placement` prop that is behaves like a shorthand. The usage examples below will detail
+the usage of this shorthand.
 
 ```tsx
 import { PositioningProps } from '@fluentui/react-positioning';
 
 export interface TooltipProps {
-  positioning?: PositioningProps;
+  placement?: PositioningProps;
 }
 
 export interface MenuProps {
-  positioning?: PositioningProps;
+  placement?: PositioningProps;
 }
 
 export interface PopoverProps {
-  positioning?: PositioningProps;
+  placement?: PositioningProps;
 }
 ```
 
-Slots that use popper should use a similar pattern if a top level `positioning` option is not clear enough:
+Example usage:
+
+```tsx
+// Shorthand for `position` and `align` options
+<PositionedComponent placement="above-start">
+<PositionedComponent placemant={{position: 'above', align: 'start'}}>
+
+// Also allows more complex configuration
+<PositionedComponent placement={{position: 'above', align: 'start', autoSize: true}}>
+```
+
+Slots that use popper should use a similar pattern if a top level `placement` option is not clear enough:
 
 ```tsx
 import { PositioningProps } from '@fluentui/react-positioning';
 
 export interface ComponentWithPositionedSlotProps {
-  positionedSlot: React.HTMLAttributes<HTMLElement> & { positioning?: PositioningProps };
+  positionedSlot: React.HTMLAttributes<HTMLElement> & { placement?: PositioningProps };
 }
 ```
+
+This way we can safely configure `usePopper` internally with a simple object spread that does not require knowing what
+props are used by the component props:
+
+```tsx
+// Need to be aware of user props and make sure they are added to the hook usage
+usePopper({
+  align: state.align,
+  position: state.position,
+  target: state.target,
+  coverTarget: state.coverTarget,
+  offset: state.offset,
+});
+
+// Guaranteed to configure based on user props, and any component specific modifications after
+usePopper({
+  ...placement,
+  // add state specific overrides below
+  offset: state.modifiedOffset,
+});
+```
+
+This change can be made in a non-breaking way by deprecating all existing configuration props outside of the proposed
+`placement` prop and providing support until a specific release in the future (beta/initial release/next major).
 
 ### Pros and Cons
 
@@ -134,7 +170,7 @@ export interface ComponentWithPositionedSlotProps {
 - Fixes to positioned elements through extra configuration can be used across the library
 - Configuring positioned elements is consistent across components and clear for users
 - If a better underlying library than `Popper` exists, we can replace it by implementing the `PositioniningProps`interface
-- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
+- Technically a new `placement`prop is a breaking API change, but can be done in a non-breaking way
 
 #### Cons
 

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -63,7 +63,7 @@ There are other popper options that are used in some components but not others, 
 
 - `coverTarget` - allows the positioned element to cover the target
 
-There are also additional options that are not used by any converge component that might be used in the future like:
+There are also additional options that are not used by any converged component that might be used in the future like:
 
 - `autoSize` - Allows the positioned element to change size based on viewport size
 - `flipBoundary` - Determines what bounds to use to flip the positioning

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -85,11 +85,14 @@ then all components should do so equally.
 We can achieve this with an agreement that the current `PositioningProps` would be supported by all v9 components, while
 internal popper options can still belong to `PopperOptions` type in the `react-positioning` package.
 
-### Shorthand `placement` configuration
+### Shorthand `positioning` configuration
 
 The next step to this proposal is to make sure that all components which use a positioned element should allow users
-to configure popper through a `placement` prop that behaves like a shorthand. An extra helper will be required to resolve
-shorthand to full popper configuration internally, but the external API for `placement` is very clean for users.
+to configure popper through a `positioning` prop that behaves like a shorthand. An extra helper will be required to resolve
+shorthand to full popper configuration internally, but the external API for `positioning` is very clean for users.
+
+Shorthand _should not_ but used for the `usePopper` hook or any of the internals in `react-positioning` it is intended
+syntax for component developers to simplify the positioning options for end users.
 
 The usage examples below will detail the usage of this shorthand.
 
@@ -111,18 +114,16 @@ export type PositioningShorthandValue =
 
 export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
 
-export function resolvePopperOptions(shorthand: PositioningShorthand, config: PositioningProps) {
+export function resolvePositioningShorthand(shorthand: PositioningShorthand) {
   if (typeof shorthand === 'object') {
     return {
       ...shorthand,
-      ...config,
     };
   }
 
   if (typeof shorthand === 'string') {
     return {
       ...parseStringShorthand(shorthand),
-      ...config,
     };
   }
 
@@ -140,16 +141,16 @@ export function parseStringShorthand(shorthand) {
 ```tsx
 import { PositioningShorthand } from '@fluentui/react-positioning';
 
-export interface TooltipProps extends PositioninedComponent {
-  placement: PositioningShorthand;
+export interface TooltipProps {
+  positioning: PositioningShorthand;
 }
 
-export interface MenuProps extends PositioninedComponent {
-  placement: PositioningShorthand;
+export interface MenuProps {
+  positioning: PositioningShorthand;
 }
 
-export interface PopoverProps extends PositioninedComponent {
-  placement: PositioningShorthand;
+export interface PopoverProps {
+  positioning: PositioningShorthand;
 }
 ```
 
@@ -157,23 +158,23 @@ Example usage:
 
 ```tsx
 // Shorthand for `position` and `align` options
-<PositionedComponent placement="above-start">
-<PositionedComponent placement={{position: 'above', align: 'start'}}>
+<PositionedComponent positioning="above-start">
+<PositionedComponent positioning={{position: 'above', align: 'start'}}>
 
-<PositionedComponent placement="above">
-<PositionedComponent placement={{position: 'above'}}>
+<PositionedComponent positioning="above">
+<PositionedComponent positioning={{position: 'above'}}>
 
 // Also allows more complex configuration
-<PositionedComponent placement={{position: 'above', align: 'start', autoSize: true}}>
+<PositionedComponent positioning={{position: 'above', align: 'start', autoSize: true}}>
 ```
 
-Slots that use popper should use a similar pattern if a top level `placement` option is not clear enough:
+Slots that use popper should use a similar pattern if a top level `positioning` option is not clear enough:
 
 ```tsx
 import { PositioningProps } from '@fluentui/react-positioning';
 
 export interface ComponentWithPositionedSlotProps {
-  positionedSlot: React.HTMLAttributes<HTMLElement> & { placement?: PlacementShorthand };
+  positionedSlot: React.HTMLAttributes<HTMLElement> & { positioning?: PositioningShorthand };
 }
 ```
 
@@ -194,12 +195,13 @@ usePopper({
 // 👍 Proposed usage
 // Guaranteed to configure based on user props, and any component specific modifications after
 // However adds some extra logic to use shorthand correctly
-const popperOptions = resolvePopperOptions(placement, { offset: state.modifiedOffset });
+const popperOptions = resolvePositioningShorthand(state.positioning);
+popperOptions.offset = state.offset;
 usePopper(popperOptions);
 ```
 
 This change can be made in a non-breaking way by deprecating all existing configuration props outside of the proposed
-`placement` prop and providing support until a specific release in the future (beta/initial release/next major).
+`positioning` prop and providing support until a specific release in the future (beta/initial release/next major).
 
 ### Pros and Cons
 
@@ -209,7 +211,7 @@ This change can be made in a non-breaking way by deprecating all existing config
 - Fixes to positioned elements through extra configuration can be used across the library
 - Configuring positioned elements is consistent across components and clear for users
 - If a better underlying library than `Popper.js` exists, we can replace it by implementing the `PositioniningProps` interface
-- Technically a new `placement`prop is a breaking API change, but can be done in a non-breaking way
+- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
 
 #### Cons
 
@@ -217,7 +219,7 @@ This change can be made in a non-breaking way by deprecating all existing config
 - Adds extra code to resolve shorthand
 - Encourage users to use complicated solutions to their problems
 - Adding configuration required only by a single component is expensive
-- Technically a new `placement`prop is a breaking API change, but can be done in a non-breaking way
+- Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way
 
 ## Discarded Solutions
 

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -222,6 +222,7 @@ This change can be made in a non-breaking way by deprecating all existing config
 #### Cons
 
 - Some components will not need all complex configuration
+- Adds extra code to resolve shorthand
 - Encourage users to use complicated solutions to their problems
 - Adding configuration required only by a single component is expensive
 - Technically a new `positioning`prop is a breaking API change, but can be done in a non-breaking way

--- a/rfcs/convergence/exposing-popper-options.md
+++ b/rfcs/convergence/exposing-popper-options.md
@@ -88,7 +88,7 @@ internal popper options can still belong to `PopperOptions` type in the `react-p
 ### Shorthand `placement` configuration
 
 The next step to this proposal is to make sure that all components which use a positioned element should allow users
-to configure popper through a `placement` prop that is behaves like a shorthand. An extra helper will be required to resolve
+to configure popper through a `placement` prop that behaves like a shorthand. An extra helper will be required to resolve
 shorthand to full popper configuration internally, but the external API for `placement` is very clean for users.
 
 The usage examples below will detail the usage of this shorthand.


### PR DESCRIPTION
This RFC proposes a solution to address #19145

#### Pull request checklist

- [x] Addresses an existing issue: Fixes partially #19145
- [x] Include a change request file using `$ yarn change`

#### Description of changes

[PREVIEW LINK](https://github.com/ling1726/fluentui/blob/rfc/popper-options/rfcs/convergence/exposing-popper-options.md)

#### Focus areas to test

(optional)
