### PR TITLE
Accessibility change for Line Chart

### DIFF
--- a/change/@fluentui-react-charting-45a863ac-198d-4812-b2db-b883bdbe5388.json
+++ b/change/@fluentui-react-charting-45a863ac-198d-4812-b2db-b883bdbe5388.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Line chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -218,6 +218,11 @@ export interface ILineChartDataPoint {
    * Whether to hide callout data for the point.
    */
   hideCallout?: boolean;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface ILineChartGap {

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { IChartProps, ILineChartProps, LineChart } from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+import { Toggle } from '@fluentui/react/lib/Toggle';
+
+interface ILineChartCustomAccessibilityState {
+  width: number;
+  height: number;
+  allowMultipleShapes: boolean;
+}
+
+export class LineChartCustomAccessibilityExample extends React.Component<{}, ILineChartCustomAccessibilityState> {
+  constructor(props: ILineChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+      allowMultipleShapes: false,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+  private _onShapeChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+    this.setState({ allowMultipleShapes: checked });
+  };
+
+  private _basicExample(): JSX.Element {
+    const data: IChartProps = {
+      chartTitle: 'Line Chart',
+      lineChartData: [
+        {
+          legend: 'From_Legacy_to_O365',
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 156000,
+              onDataPointClick: () => alert('click on 217000'),
+              callOutAccessibilityData: { ariaLabel: 'Line 1 point 1 of 5 156000 ' },
+            },
+            {
+              x: new Date('2020-03-03T10:00:00.000Z'),
+              y: 258123,
+              onDataPointClick: () => alert('click on 217123'),
+              callOutAccessibilityData: { ariaLabel: 'Point 2 of 5 258123 ' },
+            },
+            {
+              x: new Date('2020-03-07T00:00:00.000Z'),
+              y: 180000,
+              onDataPointClick: () => alert('click on 260000'),
+              callOutAccessibilityData: { ariaLabel: 'Point 3 of 5 180000 ' },
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 300000,
+              onDataPointClick: () => alert('click on 300000'),
+              callOutAccessibilityData: { ariaLabel: 'Point 4 of 5 180000 ' },
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 218000,
+              onDataPointClick: () => alert('click on 218000'),
+              callOutAccessibilityData: { ariaLabel: 'Point 5 of 5 180000 ' },
+            },
+          ],
+          color: DefaultPalette.blue,
+          onLineClick: () => console.log('From_Legacy_to_O365'),
+        },
+        {
+          legend: 'All',
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 226000,
+              callOutAccessibilityData: { ariaLabel: 'Line 2 point 1 of 3 226000 ' },
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 300000,
+              callOutAccessibilityData: { ariaLabel: 'Point 2 of 3 300000 ' },
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 278000,
+              callOutAccessibilityData: { ariaLabel: 'Point 3 of 3 278000 ' },
+            },
+          ],
+          color: DefaultPalette.green,
+        },
+      ],
+    };
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    const margins = { left: 35, top: 20, bottom: 35, right: 20 };
+
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <Toggle
+          label="Enabled  multiple shapes for each line"
+          onText="On"
+          offText="Off"
+          onChange={this._onShapeChange}
+          checked={this.state.allowMultipleShapes}
+        />
+        <div style={rootStyle}>
+          <LineChart
+            data={data}
+            legendsOverflowText={'Overflow Items'}
+            yMinValue={200}
+            yMaxValue={301}
+            height={this.state.height}
+            width={this.state.width}
+            margins={margins}
+            allowMultipleShapesForPoints={this.state.allowMultipleShapes}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
@@ -11,11 +11,13 @@ import { LineChartBasicExample } from './LineChart.Basic.Example';
 import { LineChartStyledExample } from './LineChart.Styled.Example';
 import { LineChartMultipleExample } from './LineChart.Multiple.Example';
 import { LineChartEventsExample } from './LineChart.Events.Example';
+import { LineChartCustomAccessibilityExample } from './LineChart.CustomAccessibility.Example';
 
 const LineChartBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx') as string;
 const LineChartStyledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx') as string;
 const MultipleLineChartExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx') as string;
 const LineChartEventsExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx') as string;
+const LineChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx') as string;
 
 export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -36,6 +38,9 @@ export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> 
             </ExampleCard>
             <ExampleCard title="LineChart with events" code={LineChartEventsExampleCode}>
               <LineChartEventsExample />
+            </ExampleCard>
+            <ExampleCard title="LineChart Custom Accessibility" code={LineChartCustomAccessibilityExampleCode}>
+              <LineChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changes are related to Line Chart accessibility

1. Accessibility Data prop added for the Chart Data Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
3. Custom Accessibility example is added.


**Before Change**

![image](https://user-images.githubusercontent.com/29042635/127140925-ba52dd22-b0cd-4df0-9435-f53e0eae47ba.png)

**After Change**

![image](https://user-images.githubusercontent.com/29042635/127141131-a6eca110-45c3-43bd-b0e5-893340e4b848.png)


(give an overview)

#### Focus areas to test

(optional)
