### PR TITLE
Charting: CherryPick #18865: Accessibility change for Donut chart #18865  

### DIFF
--- a/change/@fluentui-react-examples-a33c974e-ad43-48d0-9c87-60adac7c318c.json
+++ b/change/@fluentui-react-examples-a33c974e-ad43-48d0-9c87-60adac7c318c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "CherryPick: Accessibility change for Donut chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-4ed3350b-3dc7-47a1-91ef-4fa2686b8fed.json
+++ b/change/@uifabric-charting-4ed3350b-3dc7-47a1-91ef-4fa2686b8fed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "CherryPick: Accessibility change for Donut chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -56,6 +56,7 @@ export class Arc extends React.Component<IArcProps, IArcState> {
           opacity={opacity}
           onClick={href ? this._redirectToUrl.bind(this, href) : this.props.data?.data.onClick}
           aria-labelledby={this.props.calloutId}
+          role="text"
         />
         <text textAnchor={'middle'} className={classNames.insideDonutString} y={5}>
           {this.props.valueInsideDonut!}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -5,8 +5,9 @@ import { classNamesFunction, getId } from 'office-ui-fabric-react/lib/Utilities'
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { Pie } from './Pie/index';
-import { ChartHoverCard, ILegend, Legends } from '../../index';
+import { IAccessibilityProps, ChartHoverCard, ILegend, Legends } from '../../index';
 import { IChartDataPoint, IChartProps, IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles } from './index';
+import { getAccessibleDataObject } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IDonutChartStyleProps, IDonutChartStyles>();
 
@@ -24,6 +25,7 @@ export interface IDonutChartState {
   focusedArcId?: string;
   selectedLegend: string;
   dataPointCalloutProps?: IChartDataPoint;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChartState> {
@@ -134,6 +136,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
           onDismiss={this._closeCallout}
           preventDismissOnLostFocus={true}
           {...this.props.calloutProps!}
+          {...getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false)}
         >
           {this.props.onRenderCalloutPerDataPoint ? (
             this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps!)
@@ -234,6 +237,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       yCalloutValue: data.yAxisCalloutData!,
       focusedArcId: id,
       dataPointCalloutProps: data,
+      callOutAccessibilityData: data.callOutAccessibilityData!,
     });
   };
 
@@ -249,6 +253,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       yCalloutValue: data.yAxisCalloutData!,
       activeLegend: data.legend,
       dataPointCalloutProps: data,
+      callOutAccessibilityData: data.callOutAccessibilityData!,
     });
   };
   private _onBlur = (): void => {

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -98,6 +99,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -425,6 +427,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -459,6 +462,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -786,6 +790,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -820,6 +825,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -905,6 +911,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -939,6 +946,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -1266,6 +1274,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=
@@ -1302,6 +1311,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
+              role="text"
             />
             <text
               className=

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { DonutChart, IDonutChartProps, IChartProps, IChartDataPoint } from '@uifabric/charting';
+
+export class DonutChartCustomAccessibilityExample extends React.Component<IDonutChartProps, {}> {
+  constructor(props: IDonutChartProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const points: IChartDataPoint[] = [
+      {
+        legend: 'first',
+        data: 20000,
+        color: '#E5E5E5',
+        xAxisCalloutData: '2020/04/30',
+        callOutAccessibilityData: { ariaLabel: 'Pia chart 1 of 2 2020/04/30' },
+      },
+      {
+        legend: 'second',
+        data: 39000,
+        color: '#0078D4',
+        xAxisCalloutData: '2020/04/20',
+        callOutAccessibilityData: { ariaLabel: 'Pia chart 2 of 2 2020/04/20' },
+      },
+    ];
+
+    const chartTitle = 'Stacked Bar chart example';
+
+    const data: IChartProps = {
+      chartTitle: chartTitle,
+      chartData: points,
+      chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Donut chart' },
+    };
+    return (
+      <DonutChart
+        data={data}
+        innerRadius={55}
+        href={'https://developer.microsoft.com/en-us/'}
+        legendsOverflowText={'overflow Items'}
+        hideLegend={true}
+        height={220}
+        width={176}
+        valueInsideDonut={39000}
+      />
+    );
+  }
+}

--- a/packages/react-examples/src/charting/DonutChart/DonutChartPage.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChartPage.tsx
@@ -10,7 +10,7 @@ import { DonutChartCustomAccessibilityExample } from './DonutChart.CustomAccessi
 const DonutChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx') as string;
 const DonutChartDynamicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.Dynamic.Example.tsx') as string;
 const DonutChartCustomCalloutExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.CustomCallout.Example.tsx') as string;
-const DonutChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx') as string;
+const DonutChartCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx') as string;
 export class DonutChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (

--- a/packages/react-examples/src/charting/DonutChart/DonutChartPage.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChartPage.tsx
@@ -5,11 +5,12 @@ import { ComponentPage, ExampleCard, IComponentDemoPageProps, PropertiesTableSet
 import { DonutChartBasicExample } from './DonutChart.Basic.Example';
 import { DonutChartDynamicExample } from './DonutChart.Dynamic.Example';
 import { DonutChartCustomCalloutExample } from './DonutChart.CustomCallout.Example';
+import { DonutChartCustomAccessibilityExample } from './DonutChart.CustomAccessibility.Example';
 
 const DonutChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx') as string;
 const DonutChartDynamicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.Dynamic.Example.tsx') as string;
 const DonutChartCustomCalloutExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/DonutChart/DonutChart.CustomCallout.Example.tsx') as string;
-
+const DonutChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx') as string;
 export class DonutChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (
@@ -26,6 +27,9 @@ export class DonutChartPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard title="DonutChart Custom Callout" code={DonutChartCustomCalloutExampleCode}>
               <DonutChartCustomCalloutExample />
+            </ExampleCard>
+            <ExampleCard title="DonutChart Custom Accessibility" code={DonutChartCustomAccessibilityExampleCode}>
+              <DonutChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
### Original description

Cherry pick of [#18865](https://github.com/microsoft/fluentui/pull/18865)  

#### Description of changes
Changes are related to Donut Chart accessibility

1. Accessibility Data prop added for the chart title and Callout. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
Custom Accessibility example is added for Donut chart.

**Without Custom Accessibility Data:**

![image](https://user-images.githubusercontent.com/29042635/124931109-87176f00-e01f-11eb-8a0e-17cc2bf1994c.png)

**With Custom Accessibility Data:**

![image](https://user-images.githubusercontent.com/29042635/124931376-c80f8380-e01f-11eb-9bd2-98dfaa0867e6.png)

