### PR TITLE
feat(tools): implement dynamic prompt behaviour to migration generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "danger": "^6.0.5",
     "del": "6.0.0",
     "enhanced-resolve": "5.8.2",
+    "enquirer": "2.3.6",
     "eslint": "7.25.0",
     "eslint-plugin-es": "4.1.0",
     "eslint-plugin-import": "2.22.1",
@@ -202,7 +203,8 @@
     "webpack-hot-middleware": "2.25.0",
     "webpack-merge": "5.7.3",
     "workspace-tools": "0.12.3",
-    "yargs": "13.3.2"
+    "yargs": "13.3.2",
+    "yargs-parser": "13.1.2"
   },
   "license": "MIT",
   "workspaces": {

--- a/tools/generators/migrate-converged-pkg/README.md
+++ b/tools/generators/migrate-converged-pkg/README.md
@@ -18,7 +18,7 @@ Workspace Generator for migrating converged packages to new DX (stage 1)[https:/
 
 - this generator will migrate existing stories for your package from `react-examples` to your migrated package
 - migrated stories source will be transformed (replacing absolute imports and adding required default export)
-- if your original stories (within react-examples) used non converged packages/tools (like old icons, css/scss for styling), you'll need to manually accommodate that for your migrated stories.
+- if your original stories (within react-examples) used non converged packages/tools (like old icons, css/scss for styling), you'll need to manually refactor your stories to remove any non converged dependencies.
 
 ## Usage
 
@@ -51,7 +51,7 @@ Get migration stats for how many packages have been migrated yet.
 > No actual migration will happen.
 
 ```sh
-yarn nx workspace-generator migrate-converged-pkg --stats --no-interactive
+yarn nx workspace-generator migrate-converged-pkg --stats
 ```
 
 ## Options
@@ -62,18 +62,16 @@ Type: `string`
 
 Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
 
+> NOTE: will trigger CLI prompt if you didn't provide this option
+
 #### `all`
 
 Type: `boolean`
 
 Run batch migration on all vNext packages
 
-> TIP: Use it with `--no-interactive` option to disable prompts.
-
 #### `stats`
 
 Type: `boolean`
 
 Get stats for migration progress.
-
-> TIP: Use it with `--no-interactive` option to disable prompts.

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -261,7 +261,6 @@ async function validateSchema(tree: Tree, schema: MigrateConvergedPkgGeneratorSc
 
   const shouldTriggerPrompt = arePromptsEnabled() && shouldValidateNameInput();
 
-  // console.error(newSchema, parsedArgs);
   if (shouldTriggerPrompt) {
     const schemaPromptsResponse = await triggerDynamicPrompts();
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -18,7 +18,7 @@ import { serializeJson } from '@nrwl/workspace';
 import * as path from 'path';
 
 import { PackageJson, TsConfig } from '../../types';
-import { parseArgs, prompt, updateJestConfig } from '../../utils';
+import { arePromptsEnabled, prompt, updateJestConfig } from '../../utils';
 
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
 
@@ -257,8 +257,8 @@ async function validateSchema(tree: Tree, schema: MigrateConvergedPkgGeneratorSc
   const shouldValidateNameInput = () => {
     return !newSchema.name && !(newSchema.all || newSchema.stats);
   };
-  const parsedArgs = parseArgs<MigrateConvergedPkgGeneratorSchema>(process.argv.slice(2));
-  const shouldTriggerPrompt = parsedArgs.interactive && shouldValidateNameInput();
+
+  const shouldTriggerPrompt = arePromptsEnabled() && shouldValidateNameInput();
 
   // console.error(newSchema, parsedArgs);
   if (shouldTriggerPrompt) {
@@ -276,7 +276,6 @@ async function validateSchema(tree: Tree, schema: MigrateConvergedPkgGeneratorSc
 
     if (!isPackageConverged(tree, projectConfig)) {
       throw new Error(
-        // eslint-disable-next-line @fluentui/max-len
         `${newSchema.name} is not converged package. Make sure to run the migration on packages with version 9.x.x`,
       );
     }

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -230,13 +230,14 @@ function normalizeOptions(host: Tree, options: AssertedSchema) {
 
 /**
  *
- * narrows down Schema definition to true runtime shape after {@link validateSchema} is executed
+ * Narrows down Schema definition to true runtime shape after {@link validateSchema} is executed
+ * - also properly checks of truthiness of provided value
  */
 function hasSchemaFlag<T extends MigrateConvergedPkgGeneratorSchema, K extends keyof T>(
   schema: T,
   flag: K,
 ): schema is T & Record<K, NonNullable<T[K]>> {
-  return schema[flag] !== undefined;
+  return Boolean(schema[flag]);
 }
 
 async function validateSchema(tree: Tree, schema: MigrateConvergedPkgGeneratorSchema) {

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -11,7 +11,6 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "Which converged package would you like migrate to new DX? (ex: @fluentui/react-menu)",
       "pattern": "^[a-zA-Z].*$"
     },
     "stats": {

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -24,7 +24,7 @@ export async function prompt<T extends Record<string, unknown>>(questions: Param
  *
  * This should be used if, and only if, you need to setup manual dynamic prompts within your generator.
  *
- * - prompts should be turned off whenever`--no-interactive` is used
+ * - prompts should be turned off whenever `--no-interactive` is used
  * - turning off prompts is usually what is expected when invoking generator via Nx Console
  * - within tests:
  *   - you should mock `enquirer` accordingly via `jest.mock('enquirer',()=>({ async prompt()=>{} }))`

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -10,7 +10,7 @@ import type * as Enquirer from 'enquirer';
  * @param questions
  */
 export async function prompt<T extends Record<string, unknown>>(questions: Parameters<Enquirer['prompt']>[0]) {
-  const EnquirerLazy = await await import('enquirer');
+  const EnquirerLazy = await import('enquirer');
 
   const response = await EnquirerLazy.prompt<T>(questions);
 

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,0 +1,38 @@
+import * as yargsParser from 'yargs-parser';
+import type * as Enquirer from 'enquirer';
+
+/**
+ *
+ * Manual parser of CLI flags which follows similar definition like nx tao. @see https://github.com/nrwl/nx/blob/master/packages/tao/src/commands/generate.ts#L41
+ *
+ * Use this only if you need to setup manual dynamic prompts within your generator.
+ * - prompts should be turned off whenever`--no-interactive` is used
+ * - turning off prompts is usually what is expected when invoking generator via Nx Console
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseArgs<T extends Record<string, any>>(args: string[]) {
+  type ParsedArguments = yargsParser.Arguments &
+    T & {
+      interactive: boolean;
+    };
+
+  const parsedArguments = yargsParser(args, {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    boolean: ['interactive'],
+    default: {
+      interactive: process.env.NODE_ENV !== 'test',
+    },
+  }) as ParsedArguments;
+
+  return parsedArguments;
+}
+
+export async function prompt<T extends Record<string, unknown>>(questions: Parameters<Enquirer['prompt']>[0]) {
+  const enquirer = await await import('enquirer');
+
+  const response = await enquirer.prompt<T>(questions);
+
+  return response;
+}
+
+export { updateJestConfig } from '@nrwl/jest/src/generators/jest-project/lib/update-jestconfig';

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -2,8 +2,49 @@ import * as yargsParser from 'yargs-parser';
 import type * as Enquirer from 'enquirer';
 
 /**
+ * CLI prompts abstraction to trigger dynamic prompts within a generator
+ *
+ * @remarks
+ * - lazy loads enquirer only when needed making CLI programs faster to load/execute
+ *
+ * @param questions
+ */
+export async function prompt<T extends Record<string, unknown>>(questions: Parameters<Enquirer['prompt']>[0]) {
+  const EnquirerLazy = await await import('enquirer');
+
+  const response = await EnquirerLazy.prompt<T>(questions);
+
+  return response;
+}
+
+/**
+ * Determine if manual dynamic prompts should be enabled within generator
+ *
+ * @remarks
+ *
+ * This should be used IFF you need to setup manual dynamic prompts within your generator.
+ *
+ * - prompts should be turned off whenever`--no-interactive` is used
+ * - turning off prompts is usually what is expected when invoking generator via Nx Console
+ * - within tests:
+ *   - you should mock `enquirer` accordingly via `jest.mock('enquirer',()=>({ async prompt()=>{} }))`
+ *   - then within test suite mock implementation based on your needs:
+ *        `const promptSpy = jest.spyOn(Enquirer, 'prompt').mockImplementation(...)`
+ *
+ * @param [args=process.argv.slice(2)] - command-line arguments passed when the Node.js process was launched (https://nodejs.org/docs/latest/api/process.html#process_process_argv). Default value is `process.argv.slice(2)`
+ */
+export function arePromptsEnabled(args = process.argv.slice(2)) {
+  const parsedArgs = parseArgs(args);
+  return parsedArgs.interactive;
+}
+
+/**
  *
  * Manual parser of CLI flags which follows similar definition like nx tao. @see https://github.com/nrwl/nx/blob/master/packages/tao/src/commands/generate.ts#L41
+ *
+ * @remarks
+ *
+ * This is a low level implementation. What you want to use is {@link arePromptsEnabled}
  *
  * Use this only if you need to setup manual dynamic prompts within your generator.
  * - prompts should be turned off whenever`--no-interactive` is used
@@ -20,19 +61,11 @@ export function parseArgs<T extends Record<string, any>>(args: string[]) {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     boolean: ['interactive'],
     default: {
-      interactive: process.env.NODE_ENV !== 'test',
+      interactive: true,
     },
   }) as ParsedArguments;
 
   return parsedArguments;
-}
-
-export async function prompt<T extends Record<string, unknown>>(questions: Parameters<Enquirer['prompt']>[0]) {
-  const enquirer = await await import('enquirer');
-
-  const response = await enquirer.prompt<T>(questions);
-
-  return response;
 }
 
 export { updateJestConfig } from '@nrwl/jest/src/generators/jest-project/lib/update-jestconfig';

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -22,7 +22,7 @@ export async function prompt<T extends Record<string, unknown>>(questions: Param
  *
  * @remarks
  *
- * This should be used IFF you need to setup manual dynamic prompts within your generator.
+ * This should be used if, and only if, you need to setup manual dynamic prompts within your generator.
  *
  * - prompts should be turned off whenever`--no-interactive` is used
  * - turning off prompts is usually what is expected when invoking generator via Nx Console

--- a/yarn.lock
+++ b/yarn.lock
@@ -12166,19 +12166,19 @@ enhanced-resolve@^5.7.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enquirer@2.3.6, enquirer@^2.3.6, enquirer@~2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 enquirer@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.5.tgz#3ab2b838df0a9d8ab9e7dff235b0e8712ef92381"
   integrity sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==
   dependencies:
     ansi-colors "^3.2.1"
-
-enquirer@^2.3.6, enquirer@~2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
 
 ent@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Implements partially #19103 
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

When using build in nx tao CLI functionality to trigger prompts based on json.schema `x-prompt`, it is not possible to invoke prompts dynamically based on our custom logic. 

As our generator contains only mutual exclusive option flags and because we wanna provide best possible DX we needed to opt out from DECLARATIVE `x-prompt` configuration and instead IMPERATIVELY invoke `prompts`.

_Notes:_
- `enquired` is used by `nx` thus using the same prompt library is an obvious choice

**BEFORE**

https://user-images.githubusercontent.com/1223799/127309122-2f319f18-58fa-490c-9dde-fa46b0674e7c.mov


**AFTER**

https://user-images.githubusercontent.com/1223799/127309102-57319c03-3fa4-4772-91ee-207f421efd38.mov

**Additional changes:**
- FHL week demo how to use dynamic prompts within nx generators when needed
- more robust test coverage

#### Focus areas to test

(optional)

---

Co-authored-by: @andrefcdias
Co-authored-by: @tringakrasniqi 
