### PR TITLE
fix(Textfield): Callback to fix unexpected container scroll on autoAdjustHeight

### DIFF
--- a/change/@fluentui-react-93efd278-7a3a-41b8-aec3-e8a390aa7304.json
+++ b/change/@fluentui-react-93efd278-7a3a-41b8-aec3-e8a390aa7304.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Callback to update container scroll position on text height update",
+  "packageName": "@fluentui/react",
+  "email": "mevilapa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-93efd278-7a3a-41b8-aec3-e8a390aa7304.json
+++ b/change/@fluentui-react-93efd278-7a3a-41b8-aec3-e8a390aa7304.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "fix: Callback to update container scroll position on text height update",
+  "comment": "TextField: Add callback to update container scroll position on text height update",
   "packageName": "@fluentui/react",
   "email": "mevilapa@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-examples/src/react/TextField/TextField.Multiline.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Multiline.Example.tsx
@@ -14,29 +14,57 @@ const columnProps: Partial<IStackProps> = {
 
 export const TextFieldMultilineExample: React.FunctionComponent = () => {
   const [multiline, { toggle: toggleMultiline }] = useBoolean(false);
+  const [containerScroll, setContainerScroll] = React.useState<number | undefined>();
+  const [value, setValue] = React.useState<string>();
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newText: string): void => {
     const newMultiline = newText.length > 50;
     if (newMultiline !== multiline) {
       toggleMultiline();
     }
   };
-  return (
-    <Stack horizontal tokens={stackTokens} styles={stackStyles}>
-      <Stack {...columnProps}>
-        <TextField label="Standard" multiline rows={3} />
-        <TextField label="Disabled" multiline rows={3} disabled defaultValue={dummyText} />
-        <TextField label="Non-resizable" multiline resizable={false} />
-      </Stack>
+  const onMultilineChange = React.useCallback(
+    (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+      setValue(ev.currentTarget.value);
+      setContainerScroll(containerRef.current?.scrollTop);
+    },
+    [containerRef],
+  );
+  const onAdjustHeight = React.useCallback(
+    (_screenHeight: number) => {
+      if (containerRef.current && containerScroll) {
+        containerRef.current.scrollTop = containerScroll;
+      }
+    },
+    [containerRef, containerScroll],
+  );
 
-      <Stack {...columnProps}>
-        <TextField label="With auto adjusting height" multiline autoAdjustHeight />
-        <TextField
-          label="Switches from single to multiline if more than 50 characters are entered"
-          multiline={multiline}
-          // eslint-disable-next-line react/jsx-no-bind
-          onChange={onChange}
-        />
+  return (
+    <div ref={containerRef} style={{ height: 600, overflowY: 'scroll' }}>
+      <Stack horizontal tokens={stackTokens} styles={stackStyles}>
+        <Stack {...columnProps}>
+          <TextField label="Standard" multiline rows={3} />
+          <TextField label="Disabled" multiline rows={3} disabled defaultValue={dummyText} />
+          <TextField label="Non-resizable" multiline resizable={false} />
+        </Stack>
+
+        <Stack {...columnProps}>
+          <TextField
+            label="With auto adjusting height"
+            value={value}
+            onChange={onMultilineChange}
+            multiline
+            autoAdjustHeight
+            onAdjustHeight={onAdjustHeight}
+          />
+          <TextField
+            label="Switches from single to multiline if more than 50 characters are entered"
+            multiline={multiline}
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={onChange}
+          />
+        </Stack>
       </Stack>
-    </Stack>
+    </div>
   );
 };

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8113,6 +8113,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     inputClassName?: string;
     label?: string;
     multiline?: boolean;
+    onAdjustHeight?: (scrollHeight: number) => void;
     onChange?: (event: React_2.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
     onNotifyValidationResult?: (errorMessage: string | JSX.Element, value: string | undefined) => void;

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -615,6 +615,7 @@ export class TextFieldBase
       const textField = this._textElement.current;
       textField.style.height = '';
       textField.style.height = textField.scrollHeight + 'px';
+      this.props.onAdjustHeight?.(textField.scrollHeight);
     }
   }
 }

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -76,6 +76,13 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   autoAdjustHeight?: boolean;
 
   /**
+   * Callback for when text field height is adjusted
+   * This is called for multiline fields for which autoAdjustHeight is true.
+   * @defaultvalue false
+   */
+  onAdjustHeight?: (scrollHeight: number) => void;
+
+  /**
    * Whether or not the text field is underlined.
    * @defaultvalue false
    */

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -76,9 +76,8 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   autoAdjustHeight?: boolean;
 
   /**
-   * Callback for when text field height is adjusted
-   * This is called for multiline fields for which autoAdjustHeight is true.
-   * @defaultvalue false
+   * Callback for when text field height is adjusted.
+   * This is only called for multiline fields for which `autoAdjustHeight` is true.
    */
   onAdjustHeight?: (scrollHeight: number) => void;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #16653
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Added onAdjustHeight callback to allow parent component to reset container scroll that moves unexpectedly on adding/deleting content in multiline TextField with autoAdjustHeight set.

[Demo of using the new prop](https://codesandbox.io/s/textfield-onadjustheight-example-g3kvp?file=/src/index.tsx)