### PR TITLE
Callout: Allowing for user-set maxHeight to be respected

### DIFF
--- a/change/@fluentui-react-391cc362-c477-49ea-9e43-874dbcbc5141.json
+++ b/change/@fluentui-react-391cc362-c477-49ea-9e43-874dbcbc5141.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Callout: Allowing for user-set maxHeight to be respected.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -497,10 +497,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     }
 
     const getContentMaxHeight: number | undefined = maxHeight ? maxHeight + heightOffset : undefined;
-    const contentMaxHeight: number | undefined =
-      calloutMaxHeight! && getContentMaxHeight && calloutMaxHeight! < getContentMaxHeight
-        ? calloutMaxHeight!
-        : getContentMaxHeight!;
+    const contentMaxHeight: number | undefined = calloutMaxHeight || getContentMaxHeight;
     const overflowYHidden = hideOverflow;
 
     const beakVisible = isBeakVisible && !!target;
@@ -518,8 +515,8 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     });
 
     const overflowStyle: React.CSSProperties = {
-      ...style,
       maxHeight: contentMaxHeight,
+      ...style,
       ...(overflowYHidden && { overflowY: 'hidden' }),
     };
 
@@ -544,11 +541,11 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
             onRestoreFocus={props.onRestoreFocus}
             ariaDescribedBy={ariaDescribedBy}
             ariaLabelledBy={ariaLabelledBy}
-            className={classNames.calloutMain}
             onDismiss={props.onDismiss}
             onScroll={onScroll}
             shouldRestoreFocus={shouldRestoreFocus}
             style={overflowStyle}
+            className={classNames.calloutMain}
             onMouseDown={mouseDownOnPopup}
             onMouseUp={mouseUpOnPopup}
           >

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -537,17 +537,17 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
           {beakVisible && <div className={classNames.beakCurtain} />}
           <Popup
             {...getNativeProps(props, ARIA_ROLE_ATTRIBUTES)}
-            ariaLabel={ariaLabel}
-            onRestoreFocus={props.onRestoreFocus}
             ariaDescribedBy={ariaDescribedBy}
+            ariaLabel={ariaLabel}
             ariaLabelledBy={ariaLabelledBy}
+            className={classNames.calloutMain}
             onDismiss={props.onDismiss}
+            onMouseDown={mouseDownOnPopup}
+            onMouseUp={mouseUpOnPopup}
+            onRestoreFocus={props.onRestoreFocus}
             onScroll={onScroll}
             shouldRestoreFocus={shouldRestoreFocus}
             style={overflowStyle}
-            className={classNames.calloutMain}
-            onMouseDown={mouseDownOnPopup}
-            onMouseUp={mouseUpOnPopup}
           >
             {children}
           </Popup>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18381
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Callout` component did not always respect any of the ways a user might have tried to set a `maxHeight` to the component (via `style`, `styles` or `calloutMaxHeight`), instead overriding the value with the one that was calculated if it was smaller than the one passed by the user. This PR changes this so that the user-provided `maxHeight` to be respected.
