### PR TITLE
DetailsRowFields: export getCellText

### DIFF
--- a/change/@fluentui-react-b65d34aa-3651-4355-a8bb-80fa8166a5e8.json
+++ b/change/@fluentui-react-b65d34aa-3651-4355-a8bb-80fa8166a5e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "DetailsRowFields: export getCellText",
+  "packageName": "@fluentui/react",
+  "email": "jendowns@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1159,6 +1159,9 @@ export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boo
 // @public (undocumented)
 export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | Rectangle | null, targetWindow: IWindowWithSegments): IRectangle;
 
+// @public (undocumented)
+export const getCellText: (item: any, column: IColumn) => string;
+
 // @public
 export function getColorFromHSV(hsv: IHSV, a?: number): IColor;
 

--- a/packages/react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRowFields.tsx
@@ -4,7 +4,7 @@ import { css } from '../../Utilities';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 
-const getCellText = (item: any, column: IColumn): string => {
+export const getCellText = (item: any, column: IColumn): string => {
   let value = item && column && column.fieldName ? item[column.fieldName] : '';
 
   if (value === null || value === undefined) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- exports `getCellText` from `DetailsRowFields`

Context: we have a situation where we are creating a series of gridcells inside a `DetailsRow`, and we'd like to import this function instead of copying & pasting it into our code 😅

I understand that this particular function is not complex, but since it is such a pivotal piece of rendering a cell, it would be nice for consuming libraries like ours to remain as consistent as possible with this library by using the exact same method to render cells. I think in this case it is worthwhile updating the API to export this function because it is how cells are rendered, and exporting it will support teams like ours who have a specific reason to render our own.

Thank you!
