### PR TITLE
Charting: CherryPick #19072: Accessibility change for VerticalStackedBar chart #19072

### DIFF
--- a/change/@fluentui-react-examples-e1050c28-82fb-4a6f-a32b-c5574f2b4edb.json
+++ b/change/@fluentui-react-examples-e1050c28-82fb-4a6f-a32b-c5574f2b4edb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Vertical stacked bar chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-31463d51-cc17-4407-9878-0fabd3c22d8e.json
+++ b/change/@uifabric-charting-31463d51-cc17-4407-9878-0fabd3c22d8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Vertical stacked bar chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -14,6 +14,7 @@ import { IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { ILegend, Legends } from '../Legends/index';
 import {
+  IAccessibilityProps,
   CartesianChart,
   ChartHoverCard,
   IBasestate,
@@ -29,7 +30,13 @@ import {
   IModifiedCartesianChartProps,
 } from '../../index';
 import { FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartTypes, XAxisTypes, getTypeOfAxis, tooltipOfXAxislabels } from '../../utilities/index';
+import {
+  ChartTypes,
+  getAccessibleDataObject,
+  XAxisTypes,
+  getTypeOfAxis,
+  tooltipOfXAxislabels,
+} from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IVerticalStackedBarChartStyleProps, IVerticalStackedBarChartStyles>();
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -61,6 +68,7 @@ export interface IVerticalStackedBarChartState extends IBasestate {
   dataPointCalloutProps?: IVSChartDataPoint;
   stackCalloutProps?: IVerticalStackedChartProps;
   activeXAxisDataPoint: number | string;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 export class VerticalStackedBarChartBase extends React.Component<
   IVerticalStackedBarChartProps,
@@ -149,6 +157,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       hoverXValue: this.state.hoverXValue,
       onDismiss: this._closeCallout,
       ...this.props.calloutProps,
+      ...getAccessibleDataObject(this.state.callOutAccessibilityData),
     };
     const tickParams = {
       tickValues: this.props.tickValues,
@@ -191,7 +200,7 @@ export class VerticalStackedBarChartBase extends React.Component<
   }
 
   /**
-   * This function tells us what to foucs either the whole stack as focusable item.
+   * This function tells us what to focus either the whole stack as focusable item.
    * or each individual item in the stack as focusable item. basically it depends
    * on the prop `isCalloutForStack` if it's false user can focus each individual bar
    * within the bar if it's true then user can focus whole bar as item.
@@ -541,6 +550,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         xCalloutValue: point.xAxisCalloutData ? point.xAxisCalloutData : xAxisPoint,
         yCalloutValue: point.yAxisCalloutData,
         dataPointCalloutProps: point,
+        callOutAccessibilityData: point.callOutAccessibilityData,
       });
     }
   }
@@ -594,6 +604,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       hoverXValue: stack.xAxisPoint,
       stackCalloutProps: stack,
       activeXAxisDataPoint: stack.xAxisPoint,
+      callOutAccessibilityData: stack.stackCallOutAccessibilityData,
     });
   }
 
@@ -748,6 +759,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             fill={color}
             ref={e => (ref.refElement = e)}
             {...rectFocusProps}
+            role="text"
           />
         );
       });
@@ -761,6 +773,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         onFocus: this._onStackFocus.bind(this, singleChartData, groupRef),
         onBlur: this._handleMouseOut,
         onClick: this._onClick.bind(this, singleChartData),
+        role: 'text',
       };
       return (
         <g

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -389,6 +389,11 @@ export interface IVSChartDataPoint {
    * This is an optional prop, If haven't given data will take
    */
   yAxisCalloutData?: string;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IVerticalStackedChartProps {
@@ -411,6 +416,10 @@ export interface IVerticalStackedChartProps {
    * line data to render lines on stacked bar chart
    */
   lineData?: ILineDataInVerticalStackedBarChart[];
+  /**
+   * Accessibility data for Whole stack callout
+   */
+  stackCallOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface ILineDataInVerticalStackedBarChart {

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,192 @@
+import * as React from 'react';
+import { IVSChartDataPoint, IVerticalStackedChartProps, VerticalStackedBarChart } from '@uifabric/charting';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+
+interface IVerticalStackedBarState {
+  width: number;
+  height: number;
+  barGapMax: number;
+  showLine: boolean;
+}
+
+export class VerticalStackedBarChartCustomAccessibilityExample extends React.Component<{}, IVerticalStackedBarState> {
+  constructor(props: IVerticalStackedChartProps) {
+    super(props);
+    this.state = {
+      width: 650,
+      height: 350,
+      showLine: true,
+      barGapMax: 2,
+    };
+  }
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _onShowLineChange = (ev: React.FormEvent<HTMLElement>, checked: boolean): void => {
+    this.setState({ showLine: checked });
+  };
+
+  private _basicExample(): JSX.Element {
+    const { showLine } = this.state;
+    const firstChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 40,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '40%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-1 of 4, 2020/04/30 40%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 5,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '5%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-2 of 4, 2020/04/30 5%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 20,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '20%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 1-3 of 4, 2020/04/30 20%' },
+      },
+    ];
+
+    const secondChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 30,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-1 of 4, 2020/04/30 30%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 20,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '20%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-2 of 4, 2020/04/30 20%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 40,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '40%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 2-3 of 4, 2020/04/30 40%' },
+      },
+    ];
+
+    const thirdChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 44,
+        color: DefaultPalette.accent,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '44%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-1 of 4, 2020/04/30 44%' },
+      },
+      {
+        legend: 'Metadata2',
+        data: 28,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '28%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-2 of 4, 2020/04/30 28%' },
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+        callOutAccessibilityData: { ariaLabel: 'Bar series 3-3 of 4, 2020/04/30 30%' },
+      },
+    ];
+
+    const data: IVerticalStackedChartProps[] = [
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 0,
+
+        ...(showLine && {
+          lineData: [
+            { y: 42, legend: 'Supported Builds', color: DefaultPalette.magenta },
+            { y: 10, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 1 of 6' },
+      },
+      {
+        chartData: secondChartPoints,
+        xAxisPoint: 20,
+        ...(showLine && {
+          lineData: [{ y: 33, legend: 'Supported Builds', color: DefaultPalette.magenta }],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 2 of 6' },
+      },
+      {
+        chartData: thirdChartPoints,
+        xAxisPoint: 40,
+        ...(showLine && {
+          lineData: [
+            { y: 60, legend: 'Supported Builds', color: DefaultPalette.magenta },
+            { y: 20, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+        stackCallOutAccessibilityData: { ariaLabel: 'Bar stack series 3 of 6' },
+      },
+    ];
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <label>BarGapMax:</label>
+        <input
+          type="range"
+          value={this.state.barGapMax}
+          min={0}
+          max={10}
+          onChange={e => this.setState({ barGapMax: +e.target.value })}
+        />
+        <Checkbox
+          label="show the lines (hide or show the lines)"
+          checked={this.state.showLine}
+          onChange={this._onShowLineChange}
+          styles={{ root: { marginTop: '20px' } }}
+        />
+        <div style={rootStyle}>
+          <VerticalStackedBarChart
+            barGapMax={this.state.barGapMax}
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            chartLabel="Card title"
+            legendProps={{
+              allowFocusOnLegends: true,
+            }}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
@@ -6,12 +6,13 @@ import { VerticalStackedBarChartBasicExample } from './VerticalStackedBarChart.B
 import { VerticalStackedBarChartStyledExample } from './VerticalStackedBarChart.Styled.Example';
 import { VerticalStackedBarChartCalloutExample } from './VerticalStackedBarChart.Callout.Example';
 import { VerticalStackedBarChartTooltipExample } from './VerticalStackedBarChart.AxisTooltip.Example';
+import { VerticalStackedBarChartCustomAccessibilityExample } from './VerticalStackedBarChart.CustomAccessibility.Example';
 
 const VerticalBarChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx') as string;
 const VerticalBarChartStyledExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx') as string;
 const VerticalBarChartCalloutExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx') as string;
 const VerticalBarChartTooltipExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example') as string;
-
+const VerticalBarChartCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example') as string;
 export class VerticalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (
@@ -31,6 +32,12 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
             </ExampleCard>
             <ExampleCard title="VerticalStackedBarChart Callout" code={VerticalBarChartTooltipExampleCode}>
               <VerticalStackedBarChartTooltipExample />
+            </ExampleCard>
+            <ExampleCard
+              title="VerticalStackedBarChart Custom Accessibility"
+              code={VerticalBarChartCustomAccessibilityExampleCode}
+            >
+              <VerticalStackedBarChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
### Original description
Cherry pick of[ #19072](https://github.com/microsoft/fluentui/pull/19072)



#### Description of changes
Changes are related to Vertical Stacked Bar Chart accessibility

1. Accessibility Data prop added for the Chart Data Callout content and whole stack callout content. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
3. Custom Accessibility example is added.

**Before Change**

1. For Rectangle 
 
![image](https://user-images.githubusercontent.com/29042635/126650126-15bde3b5-cc0f-446d-bd51-8f63dd9aee44.png)

2. For Stack

![image](https://user-images.githubusercontent.com/29042635/126650374-fdc8534b-6de7-461b-b21a-f43ef4511cec.png)


**After Change**

1. For Rectangle

![image](https://user-images.githubusercontent.com/29042635/126651323-93d89383-08f9-4725-ae84-6b57be304d18.png)

2. For Stack

![image](https://user-images.githubusercontent.com/29042635/126651576-9ae8158f-fafd-45d1-bf9c-dff47646c575.png)


(give an overview)

#### Focus areas to test

(optional)

