### PR TITLE
fix(buttonStyles): fix iconOnly hover styles when disabledFocusable

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Skeleton` background colors @chassunc ([#19057](https://github.com/microsoft/fluentui/pull/19057))
 - Fix `Carousel` glitch in last slide @chassunc ([#19129](https://github.com/microsoft/fluentui/pull/19129))
 - Fix `FormTextArea` required styles @chassunc ([#19164](https://github.com/microsoft/fluentui/pull/19164))
+- Fix `Button` icon only styles when disabledFocusable @chassunc ([#19180](https://github.com/microsoft/fluentui/pull/19180))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -247,13 +247,14 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
         minWidth: v.height,
         padding: 0,
 
-        ...(!p.inverted && {
-          ':hover': {
-            ...getIconFillOrOutlineStyles({ outline: false }),
-            color: v.textColorIconOnlyHover,
-            background: v.backgroundColorIconOnlyHover,
-          },
-        }),
+        ...(!p.inverted &&
+          !p.disabledFocusable && {
+            ':hover': {
+              ...getIconFillOrOutlineStyles({ outline: false }),
+              color: v.textColorIconOnlyHover,
+              background: v.backgroundColorIconOnlyHover,
+            },
+          }),
 
         ...(p.size === 'small' && {
           minWidth: v.sizeSmallHeight,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18913
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix incorrect hover styles for icon only buttons when `disableFocusable` 