### PR TITLE
fix(DropdownSearchInput): remove wrong aria-labelledby

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Skeleton` background colors @chassunc ([#19057](https://github.com/microsoft/fluentui/pull/19057))
 - Fix `Carousel` glitch in last slide @chassunc ([#19129](https://github.com/microsoft/fluentui/pull/19129))
 - Fix `FormTextArea` required styles @chassunc ([#19164](https://github.com/microsoft/fluentui/pull/19164))
+- Fix `Dropdown` creating unnecessary `aria-labelledby` for `DropdownSearchInput` @chassunc ([#19182](https://github.com/microsoft/fluentui/pull/19182))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -1125,6 +1125,7 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
             // https://github.com/facebook/react/issues/955#issuecomment-469352730
             setSearchQuery(e.target.value);
           },
+          'aria-labelledby': null,
         }),
       },
       // same story as above for getRootProps.

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -91,7 +91,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
   setStart();
   const {
     accessibilityComboboxProps,
-    accessibilityInputProps,
+    accessibilityInputProps: { 'aria-labelledby': ariaLabelledby, ...A11Yprops },
     inputRef,
     inline,
     placeholder,
@@ -103,7 +103,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
   } = props;
 
   const unhandledProps = useUnhandledProps(DropdownSearchInput.handledProps, props);
-
+  console.log('accessibilityInputProps', A11Yprops);
   const { styles: resolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
     className: dropdownSearchInputClassName,
     mapPropsToStyles: () => ({ inline }),
@@ -146,7 +146,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
         placeholder,
         onBlur: handleInputBlur,
         onKeyDown: handleInputKeyDown,
-        ...accessibilityInputProps,
+        ...A11Yprops,
         ...unhandledProps.input,
       }}
     />

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -91,7 +91,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
   setStart();
   const {
     accessibilityComboboxProps,
-    accessibilityInputProps: { 'aria-labelledby': ariaLabelledby, ...A11Yprops },
+    accessibilityInputProps,
     inputRef,
     inline,
     placeholder,
@@ -103,7 +103,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
   } = props;
 
   const unhandledProps = useUnhandledProps(DropdownSearchInput.handledProps, props);
-  console.log('accessibilityInputProps', A11Yprops);
+  delete accessibilityInputProps['aria-labelledby'];
   const { styles: resolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
     className: dropdownSearchInputClassName,
     mapPropsToStyles: () => ({ inline }),
@@ -146,7 +146,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
         placeholder,
         onBlur: handleInputBlur,
         onKeyDown: handleInputKeyDown,
-        ...A11Yprops,
+        ...accessibilityInputProps,
         ...unhandledProps.input,
       }}
     />

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -103,7 +103,7 @@ export const DropdownSearchInput: ComponentWithAs<'div', DropdownSearchInputProp
   } = props;
 
   const unhandledProps = useUnhandledProps(DropdownSearchInput.handledProps, props);
-  delete accessibilityInputProps['aria-labelledby'];
+
   const { styles: resolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
     className: dropdownSearchInputClassName,
     mapPropsToStyles: () => ({ inline }),


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18598
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

It seems like downshift generates a labelledby for the search input when we don't actually have a label for it therefore failing a11y tests in story book. This PR prevents this prop to be passed to the input. 

Applied solution proposed here: https://github.com/downshift-js/downshift/issues/1190