### PR TITLE
Fix border styles when select control is active

### DIFF
--- a/change/@fluentui-web-components-028bc033-4b14-45d6-bbf1-eacc6664f876.json
+++ b/change/@fluentui-web-components-028bc033-4b14-45d6-bbf1-eacc6664f876.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix border styles when control is active",
+  "packageName": "@fluentui/web-components",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/select/select.styles.ts
+++ b/packages/web-components/src/select/select.styles.ts
@@ -153,15 +153,14 @@ export const selectStyles = (context, definition) =>
     :host(:not([disabled])) .control:active {
       background: ${neutralFillInputActive};
       border-color: ${neutralStrokeActive};
+      border-radius: calc(${controlCornerRadius} * 1px);
     }
 
-    :host([open][position='above']) .listbox,
-    :host([open][position='below']) .control {
+    :host([open][position='above']) .listbox {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
 
-    :host([open][position='above']) .control,
     :host([open][position='below']) .listbox {
       border-top-left-radius: 0;
       border-top-right-radius: 0;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes a subtle style bug when the select component is active. In the GIF, observe any of the corners as the mouse is depressed. This is the same fix that was applied to FAST's select control in: https://github.com/microsoft/fast/pull/5012

Before
![before](https://user-images.githubusercontent.com/55639/127507367-fc8bf741-1a6f-42e0-a4e2-36efdb34fe34.gif)

After
![after](https://user-images.githubusercontent.com/55639/127507388-0595018c-28d9-4c18-9169-8af4dc3251a8.gif)

#### Focus areas to test

(optional)
