### PR TITLE
Housekeeping workflow - auto-assign milestone

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,5 +1,8 @@
 name: Pull-Request Houskeeping 🧹
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   milestone-assignment:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Assign to milestone
+      - name: Assign to current milestone
         uses: andrefcdias/add-to-milestone@v1.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,12 +1,12 @@
 name: Pull-Request Houskeeping 🧹
 on: [pull_request]
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   milestone-assignment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Assign to milestone
         uses: andrefcdias/add-to-milestone@v1.0

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,5 +1,5 @@
 name: Pull-Request Houskeeping 🧹
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   milestone-assignment:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign to milestone
-        uses: andrefcdias/add-to-milestone@v0.5
+        uses: andrefcdias/add-to-milestone@v1.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           use-expression: true

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,13 @@
+name: Pull-Request Houskeeping 🧹
+on: [pull_request]
+
+jobs:
+  milestone-assignment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to milestone
+        uses: andrefcdias/add-to-milestone@v0.5
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          use-expression: true
+          milestone: '* Project Cycle *'


### PR DESCRIPTION
### The why

The aim of this workflow is to automate some work with the creation of our pull requests. This will hopefully simplify the developer's life by removing some organizational responsibilities.

### The what

This PR only addresses the assignment of the PR to the current milestone. We do this by using a Github action I've worked on that does exactly that.
It uses globs for pattern matching and as such will pick up the milestone for as long as we maintain the same pattern.
By default, it'll also ignore any milestones that have already passed their due date, making it pick only no due date/due date in the future milestones.

#### Focus areas to test

Automatic assignment of the Github bot to our milestone.