### PR TITLE
fix(useRefEffet): Make IE11 friendly

### DIFF
--- a/change/@fluentui-react-hooks-1a85762e-17e8-49c3-b29f-10111cbb6c76.json
+++ b/change/@fluentui-react-hooks-1a85762e-17e8-49c3-b29f-10111cbb6c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(useRefEffet): Make IE11 friendly",
+  "packageName": "@fluentui/react-hooks",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-hooks/src/useRefEffect.ts
+++ b/packages/react-hooks/src/useRefEffect.ts
@@ -35,34 +35,30 @@ export function useRefEffect<T>(callback: (value: T) => (() => void) | void, ini
     callback: (value: T) => (() => void) | void;
     cleanup?: (() => void) | void;
   };
-  const cleanup = React.useRef<RefData['cleanup']>();
-  const [ref] = React.useState(() => ({
-    // value
-    value: initial,
-    // last callback
+
+  const refCallback = (value: T | null) => {
+    if (data.ref.current !== value) {
+      if (data.cleanup) {
+        data.cleanup();
+        data.cleanup = undefined;
+      }
+
+      data.ref.current = value;
+
+      if (value !== null) {
+        data.cleanup = data.callback(value);
+      }
+    }
+  };
+
+  refCallback.current = initial;
+
+  const data = React.useRef<RefData>({
+    ref: refCallback,
     callback,
-    // "memoized" public interface
-    facade: {
-      get current() {
-        return ref.value;
-      },
-      set current(value) {
-        if (ref.value !== value) {
-          if (cleanup.current) {
-            cleanup.current();
-            cleanup.current = undefined;
-          }
+  }).current;
 
-          ref.value = value;
+  data.callback = callback;
 
-          if (value !== null) {
-            cleanup.current = ref.callback(value);
-          }
-        }
-      },
-    },
-  }));
-
-  ref.callback = callback;
-  return (ref.facade as unknown) as RefCallback<T>;
+  return data.ref;
 }

--- a/packages/react-hooks/src/useRefEffect.ts
+++ b/packages/react-hooks/src/useRefEffect.ts
@@ -36,25 +36,28 @@ export function useRefEffect<T>(callback: (value: T) => (() => void) | void, ini
     cleanup?: (() => void) | void;
   };
 
-  const refCallback = (value: T | null) => {
-    if (data.ref.current !== value) {
-      if (data.cleanup) {
-        data.cleanup();
-        data.cleanup = undefined;
-      }
+  const createRefCallback = () => {
+    const refCallback = (value: T | null) => {
+      if (data.ref.current !== value) {
+        if (data.cleanup) {
+          data.cleanup();
+          data.cleanup = undefined;
+        }
 
-      data.ref.current = value;
+        data.ref.current = value;
 
-      if (value !== null) {
-        data.cleanup = data.callback(value);
+        if (value !== null) {
+          data.cleanup = data.callback(value);
+        }
       }
-    }
+    };
+
+    refCallback.current = initial;
+    return refCallback;
   };
 
-  refCallback.current = initial;
-
   const data = React.useRef<RefData>({
-    ref: refCallback,
+    ref: createRefCallback(),
     callback,
   }).current;
 


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19181
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previous useRefEffect hook used `Object.assign` which is not supported
by IE11 without polyfills.

Modify the hook similar to remove `Object.assign`

#### Focus areas to test

(optional)
