### PR TITLE
(Callout) - Fixing a bug which caused onPositioned to not be called

### DIFF
--- a/change/@fluentui-react-8b96c7d5-7a6b-44ce-8a62-0fbf68553268.json
+++ b/change/@fluentui-react-8b96c7d5-7a6b-44ce-8a62-0fbf68553268.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing onPositioned bug in Callout component.",
+  "packageName": "@fluentui/react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -310,7 +310,7 @@ describe('Callout', () => {
 
       expect(calloutRef.current.getWidth()).toBe(100);
 
-      expect(onPositioned).toHaveBeenCalledTimes(1);
+      expect(onPositioned).toHaveBeenCalledTimes(2);
 
       // onPositioned is called after initial render and resize
       expect(currentPosition).toBeDefined();

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -221,9 +221,7 @@ function usePositions(
         (elementPositions === undefined && newElementPositions) ||
         (elementPositions && newElementPositions && !arePositionsEqual(elementPositions, newElementPositions))
       ) {
-        if (elementPositions !== undefined) {
-          onPositioned?.(newElementPositions);
-        }
+        onPositioned?.(newElementPositions);
 
         setElementPositions(newElementPositions);
       }

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -222,7 +222,6 @@ function usePositions(
         (elementPositions && newElementPositions && !arePositionsEqual(elementPositions, newElementPositions))
       ) {
         onPositioned?.(newElementPositions);
-
         setElementPositions(newElementPositions);
       }
     },


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Fixing a bug in the `Callout` component which caused the onPositioned property to not be called.

#### Focus areas to test
`Callout`
