### PR TITLE
[KeytipLayer] Pass triggering key sequence to onEnterKeytipMode callback

### DIFF
--- a/change/@fluentui-react-f8efb1f9-a90a-4b0d-b8cd-5275e1c0956f.json
+++ b/change/@fluentui-react-f8efb1f9-a90a-4b0d-b8cd-5275e1c0956f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[KeytipLayer] Pass triggering key sequence to onEnterKeytipMode callback",
+  "packageName": "@fluentui/react",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5514,7 +5514,7 @@ export interface IKeytipLayerProps extends React_2.ClassAttributes<IKeytipLayer>
     keytipExitSequences?: IKeytipTransitionKey[];
     keytipReturnSequences?: IKeytipTransitionKey[];
     keytipStartSequences?: IKeytipTransitionKey[];
-    onEnterKeytipMode?: () => void;
+    onEnterKeytipMode?: (transitionKey?: IKeytipTransitionKey) => void;
     onExitKeytipMode?: (ev?: React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>) => void;
     styles?: IStyleFunctionOrObject<IKeytipLayerStyleProps, IKeytipLayerStyles>;
 }

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -199,7 +199,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
     } else if (transitionKeysContain(this.props.keytipStartSequences!, transitionKey) && !currKtp) {
       // If key sequence is in 'entry sequences' and currentKeytip is null, we enter keytip mode
       this._keyHandled = true;
-      this._enterKeytipMode();
+      this._enterKeytipMode(transitionKey);
       this._warnIfDuplicateKeytips();
     }
   }
@@ -287,7 +287,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
   /**
    * Enters keytip mode for this layer
    */
-  private _enterKeytipMode(): void {
+  private _enterKeytipMode(transitionKey?: IKeytipTransitionKey): void {
     if (this._keytipManager.shouldEnterKeytipMode) {
       if (this._keytipManager.delayUpdatingKeytipChange) {
         this._buildTree();
@@ -300,7 +300,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
       this._setInKeytipMode(true /* inKeytipMode */);
 
       if (this.props.onEnterKeytipMode) {
-        this.props.onEnterKeytipMode();
+        this.props.onEnterKeytipMode(transitionKey);
       }
     }
   }

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -157,6 +157,10 @@ describe('KeytipLayer', () => {
     const onEnter = jest.fn();
     const onExit = jest.fn();
 
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     describe('processTransitionInput', () => {
       describe('with a default layer', () => {
         beforeEach(() => {
@@ -183,7 +187,7 @@ describe('KeytipLayer', () => {
 
         it('calls on enter keytip mode when we process alt + left win', () => {
           layerValue.processTransitionInput({ key: 'Meta', modifierKeys: [KeyCodes.alt] });
-          expect(onEnter).toBeCalled();
+          expect(onEnter).toBeCalledWith({ key: 'Meta', modifierKeys: [KeyCodes.alt] });
         });
 
         it('calls on exit keytip mode when we process alt + left win', () => {
@@ -228,8 +232,9 @@ describe('KeytipLayer', () => {
             onEnterKeytipMode={onEnter}
           />,
         );
+        layerValue = layerRef.current!;
         layerValue.processTransitionInput({ key: 'Meta' });
-        expect(onEnter).toBeCalled();
+        expect(onEnter).toBeCalledWith({ key: 'Meta' });
       });
     });
 

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -61,6 +61,10 @@ describe('KeytipLayer', () => {
     });
   }
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     if (ktpLayer) {
       ktpLayer.unmount();
@@ -156,10 +160,6 @@ describe('KeytipLayer', () => {
 
     const onEnter = jest.fn();
     const onExit = jest.fn();
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
 
     describe('processTransitionInput', () => {
       describe('with a default layer', () => {

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.types.ts
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.types.ts
@@ -48,8 +48,9 @@ export interface IKeytipLayerProps extends React.ClassAttributes<IKeytipLayer> {
 
   /**
    * Callback function triggered when keytip mode is entered
+   * @param transitionKey The key sequence that triggered keytip mode, if any.
    */
-  onEnterKeytipMode?: () => void;
+  onEnterKeytipMode?: (transitionKey?: IKeytipTransitionKey) => void;
 
   /**
    * (Optional) Call to provide customized styling.

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.types.ts
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.types.ts
@@ -48,7 +48,7 @@ export interface IKeytipLayerProps extends React.ClassAttributes<IKeytipLayer> {
 
   /**
    * Callback function triggered when keytip mode is entered
-   * @param transitionKey The key sequence that triggered keytip mode, if any.
+   * @param transitionKey - The key sequence that triggered keytip mode, if any.
    */
   onEnterKeytipMode?: (transitionKey?: IKeytipTransitionKey) => void;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR passes the triggering key sequence to `onEnterKeytipMode` callback, so external handler can receive information on which one sequence (out of potentially multiple ones) opened the keytip layer. Tests are updated to check callback arguments.

Also fixes an issue in `KeytipLayer.test` where mock functions `onEnter` and `onExit` are not reset after each test.
