### PR TITLE
Role added for overflow legends

### DIFF
--- a/change/@fluentui-react-charting-2bbc5dd1-83a2-4b80-b702-2419e4e21325.json
+++ b/change/@fluentui-react-charting-2bbc5dd1-83a2-4b80-b702-2419e4e21325.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added role as a link for overflow legends message, so it will read like 7 more link collapsed",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -304,6 +304,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
           className={classNames.overflowIndicationTextStyle}
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           {...(allowFocusOnLegends && {
+            role: 'link',
             'aria-expanded': this.state.isHoverCardVisible,
             'aria-label': `${items.length} ${overflowString}`,
           })}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

For overflow legend, previously NVDA reading like '2 overflow item section', now NVDA will read as "2 overflow item link collapsed."

#### Focus areas to test

Legends 


**Before Change:**
![image](https://user-images.githubusercontent.com/29042635/127631989-076c8616-1692-499d-99c2-344da4d2b3b1.png)


**After Change**
![image](https://user-images.githubusercontent.com/29042635/127632184-88b68bc2-d010-4164-9bc3-7154990ddc29.png)
