### PR TITLE
chore(react-tabster): Upgrade tabster to 1.0.0

### DIFF
--- a/change/@fluentui-react-tabster-8a607686-779a-4fc5-bfb2-6c03ecb57961.json
+++ b/change/@fluentui-react-tabster-8a607686-779a-4fc5-bfb2-6c03ecb57961.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore(react-tabster): Upgrade tabster to 1.0.0",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -29,11 +29,11 @@ export interface UseArrowNavigationGroupOptions {
 
 // @public
 export const useFocusFinders: () => {
-    findAllFocusable: (root: HTMLElement, matcher: (el: HTMLElement) => boolean) => HTMLElement[];
-    findFirstFocusable: (root: HTMLElement) => HTMLElement | null | undefined;
-    findLastFocusable: (root: HTMLElement) => HTMLElement | null | undefined;
-    findNextFocusable: (current: HTMLElement) => HTMLElement | null | undefined;
-    findPrevFocusable: (current: HTMLElement) => HTMLElement | null | undefined;
+    findAllFocusable: (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) => HTMLElement[];
+    findFirstFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
+    findLastFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
+    findNextFocusable: (currentElement: HTMLElement) => HTMLElement | null | undefined;
+    findPrevFocusable: (currentElement: HTMLElement) => HTMLElement | null | undefined;
 };
 
 // @public
@@ -53,7 +53,6 @@ export interface UseModalAttributesOptions {
 
 // @public
 export const useTabsterAttributes: (props: Types.TabsterAttributeProps) => Types.TabsterDOMAttribute;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -39,7 +39,7 @@
     "keyborg": "^0.7.1",
     "@fluentui/react-shared-contexts": "^9.0.0-alpha.19",
     "@fluentui/react-utilities": "^9.0.0-alpha.35",
-    "tabster": "^0.7.4",
+    "tabster": "^1.0.0-alpha.2",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -1,4 +1,5 @@
-import { Types } from 'tabster';
+import { Types, getMover } from 'tabster';
+import { useTabster } from './useTabster';
 import { useTabsterAttributes } from './useTabsterAttributes';
 
 export interface UseArrowNavigationGroupOptions {
@@ -18,23 +19,24 @@ export interface UseArrowNavigationGroupOptions {
  * @param options - Options to configure keyboard navigation
  */
 export const useArrowNavigationGroup = (options?: UseArrowNavigationGroupOptions) => {
+  const tabster = useTabster();
+  if (tabster) {
+    getMover(tabster);
+  }
   return useTabsterAttributes({
-    focusable: {
-      mover: {
-        axis: axisToMoverAxis(options?.axis ?? 'vertical'),
-        navigationType: Types.MoverKeys.Arrows,
-        cyclic: !!options?.circular,
-      },
+    mover: {
+      cyclic: !!options?.circular,
+      direction: axisToMoverDirection(options?.axis ?? 'vertical'),
     },
   });
 };
 
-function axisToMoverAxis(axis: UseArrowNavigationGroupOptions['axis']) {
+function axisToMoverDirection(axis: UseArrowNavigationGroupOptions['axis']) {
   switch (axis) {
     case 'horizontal':
-      return Types.MoverAxis.Horizontal;
+      return Types.MoverDirections.Horizontal;
     case 'vertical':
     default:
-      return Types.MoverAxis.Vertical;
+      return Types.MoverDirections.Vertical;
   }
 }

--- a/packages/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-tabster/src/hooks/useFocusFinders.ts
@@ -9,17 +9,25 @@ export const useFocusFinders = () => {
 
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
-    (root: HTMLElement, matcher: (el: HTMLElement) => boolean) => tabster?.focusable.findAll(root, matcher) || [],
+    (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) =>
+      tabster?.focusable.findAll({ container, acceptCondition }) || [],
     [tabster],
   );
-  const findFirstFocusable = React.useCallback((root: HTMLElement) => tabster?.focusable.findFirst(root), [tabster]);
-  const findLastFocusable = React.useCallback((root: HTMLElement) => tabster?.focusable.findLast(root), [tabster]);
-  const findNextFocusable = React.useCallback((current: HTMLElement) => tabster?.focusable.findNext(current), [
+  const findFirstFocusable = React.useCallback(
+    (container: HTMLElement) => tabster?.focusable.findFirst({ container }),
+    [tabster],
+  );
+  const findLastFocusable = React.useCallback((container: HTMLElement) => tabster?.focusable.findLast({ container }), [
     tabster,
   ]);
-  const findPrevFocusable = React.useCallback((current: HTMLElement) => tabster?.focusable.findPrev(current), [
-    tabster,
-  ]);
+  const findNextFocusable = React.useCallback(
+    (currentElement: HTMLElement) => tabster?.focusable.findNext({ currentElement }),
+    [tabster],
+  );
+  const findPrevFocusable = React.useCallback(
+    (currentElement: HTMLElement) => tabster?.focusable.findPrev({ currentElement }),
+    [tabster],
+  );
 
   return {
     findAllFocusable,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16431,6 +16431,11 @@ keyborg@^0.7.1:
   resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-0.7.1.tgz#6ee90d616a472e6b028a33b2fcb26f419e203eab"
   integrity sha512-6qap3S5enGXdpjLQ6Q6bIjmTpewc8Ur+zYWJstinWDHtDe8eF6hqxpC/e7MA8g1TS1yk6sEopokq/ZnFBSLZ7w==
 
+keyborg@^1.0.0-alpha.0:
+  version "1.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.0.0-alpha.0.tgz#169b8f459fbe2f815977d02ead3468a4a6a8b891"
+  integrity sha512-rj8gF5biTksQnGpA2oqRXzm1Qiq5QkMyz2WN/3wssX8csn/v6Vwtcf+F4WqWKmozf9e3Tr3aHinvLLpObQHvaA==
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -24084,12 +24089,12 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-0.7.4.tgz#8d8ddafc82962517e7a4fe325e426ea2f2e2314f"
-  integrity sha512-9LtbJ2r0yL5eMK5Hu8IqDjeGryB042nqRdGQbgiGeWHzxLyZ+dTVI+BEUcYY3deoKQvKac5PnL251+K01AZS2Q==
+tabster@^1.0.0-alpha.2:
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.0-alpha.2.tgz#694a2eb3d3f14762124482cbea35998ff212fe0e"
+  integrity sha512-CxG6AJTdAZoZasE3q9UIqHJ3KFc7OkXy/T6OLq2Xp6dvXL9C/aG3WDD0y8INz5Qg9pxd2dbT5BoPrP4QauOBOg==
   dependencies:
-    keyborg "^0.7.1"
+    keyborg "^1.0.0-alpha.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Following breaking changes for react-tabster:
* focus finders signature change to options object instead of args
* `mover` API changed in `useArrowNavigationGroup`

Following breaking changes for react-accordion:
* Groupper no longer handles keyboard navigation - keyboarding is broken 

#### Focus areas to test

(optional)
