### PR TITLE
On focus, border will be visible for Stacked bar and multi-stacked bar chart

### DIFF
--- a/change/@fluentui-react-charting-a9e84a89-ee4a-40a1-8ed1-4033b6631ec6.json
+++ b/change/@fluentui-react-charting-a9e84a89-ee4a-40a1-8ed1-4033b6631ec6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Border will be visible on rect focus",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -37,12 +37,24 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       cursor: href ? 'pointer' : 'default',
       stroke: theme.palette.white,
       strokeWidth: 2,
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     placeHolderOnHover: {
       opacity: shouldHighlight ? '' : '0.1',
       cursor: 'default',
       stroke: theme.palette.white,
       strokeWidth: '2',
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     legendContainer: {
       marginTop: '5px',

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -44,6 +44,12 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       cursor: href ? 'pointer' : 'default',
       stroke: theme.palette.white,
       strokeWidth: 2,
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     ratioNumerator: {
       fontSize: FontSizes.small,

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -104,6 +104,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -130,6 +134,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -241,6 +249,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -267,6 +279,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -449,6 +465,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -475,6 +495,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -582,6 +606,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -608,6 +636,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -794,6 +826,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -820,6 +856,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -931,6 +971,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -957,6 +1001,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1077,6 +1125,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1103,6 +1155,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1214,6 +1270,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1240,6 +1300,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1605,6 +1669,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={false}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1631,6 +1699,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={false}
               onBlur={[Function]}
@@ -1742,6 +1814,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={false}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1768,6 +1844,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={false}
               onBlur={[Function]}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -140,6 +144,10 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -281,6 +289,10 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -308,6 +320,10 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -435,6 +451,10 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -462,6 +482,10 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -603,6 +627,10 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -630,6 +658,10 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -741,6 +773,10 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -768,6 +804,10 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -909,6 +949,10 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={false}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -936,6 +980,10 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={false}
             onBlur={[Function]}
@@ -1047,6 +1095,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1074,6 +1126,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Focus visual for rectangles will be visible, border added on focus for Stacked bar and multi-stacked bar.

#### Focus areas to test

Stacked Bar Chart
Multi-Stacked Bar Chart

**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/127648889-97aa742c-b9d5-4275-a59d-cf3bda2380d1.png)


**After Changes**
![image](https://user-images.githubusercontent.com/29042635/127648584-0c80e2c5-99de-42e6-9b97-192815008c84.png)


(optional)
