### PR TITLE
feat(useOnClickOutside): Handle clicks into an iframe

### DIFF
--- a/change/@fluentui-react-utilities-450575b0-4723-4f81-b7cd-4f36f18ded4c.json
+++ b/change/@fluentui-react-utilities-450575b0-4723-4f81-b7cd-4f36f18ded4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(useOnClickOutside): Handle clicks into an iframe",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -2,7 +2,11 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useOnClickOutside } from './useOnClickOutside';
 
 describe('useOnClickOutside', () => {
-  const supportedEvents = ['click', 'touchstart'];
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const supportedEvents = ['click', 'touchstart', 'fuiframefocus'];
 
   it.each(supportedEvents)('should add %s listener', event => {
     // Arrange
@@ -12,7 +16,7 @@ describe('useOnClickOutside', () => {
     renderHook(() => useOnClickOutside({ element, callback: jest.fn(), refs: [] }));
 
     // Assert
-    expect(element.addEventListener).toHaveBeenCalledTimes(2);
+    expect(element.addEventListener).toHaveBeenCalledTimes(3);
     expect(element.addEventListener).toHaveBeenCalledWith(event, expect.anything(), true);
   });
 
@@ -25,7 +29,7 @@ describe('useOnClickOutside', () => {
     unmount();
 
     // Assert
-    expect(element.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(element.removeEventListener).toHaveBeenCalledTimes(3);
     expect(element.removeEventListener).toHaveBeenCalledWith(event, expect.anything(), true);
   });
 
@@ -38,5 +42,21 @@ describe('useOnClickOutside', () => {
 
     // Assert
     expect(element.addEventListener).toHaveBeenCalledTimes(0);
+  });
+
+  it('should invoke callback when active eleemnt is an iframe', () => {
+    // Arrange
+    jest.useFakeTimers();
+    const iframe = document.createElement('iframe');
+    const callback = jest.fn();
+    document.body.appendChild(iframe);
+    renderHook(() => useOnClickOutside({ element: document, callback, refs: [] }));
+
+    // Act
+    iframe.focus();
+    jest.runOnlyPendingTimers();
+
+    // Assert
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -44,7 +44,7 @@ describe('useOnClickOutside', () => {
     expect(element.addEventListener).toHaveBeenCalledTimes(0);
   });
 
-  it('should invoke callback when active eleemnt is an iframe', () => {
+  it('should invoke callback when active element is an iframe', () => {
     // Arrange
     jest.useFakeTimers();
     const iframe = document.createElement('iframe');

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -35,6 +35,7 @@ export interface UseOnClickOrScrollOutsideOptions {
 export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => {
   const { refs, callback, element, disabled, contains: containsProp } = options;
   const timeoutId = React.useRef<number | undefined>(undefined);
+  useIFrameFocus(!disabled, element, callback as (e: Event) => void);
 
   const listener = useEventCallback((ev: MouseEvent | TouchEvent) => {
     const contains: UseOnClickOrScrollOutsideOptions['contains'] =
@@ -95,4 +96,64 @@ const getWindowEvent = (target: Node | Window): Event | undefined => {
   }
 
   return undefined;
+};
+
+const FUI_FRAME_EVENT = 'fuiframefocus';
+
+/**
+ * Since click events do not propagate past iframes, we use focus to detect if a
+ * click has happened inside an iframe, since the only ways of focusing inside an
+ * iframe are:
+ *   - clicking inside
+ *   - tabbing inside
+ *
+ * Polls the value of `document.activeElement`. If it is an iframe, then dispatch
+ * a custom DOM event. When the custom event is received call the provided callback
+ *
+ * @param enableFrameFocusDispatch - boolean flag to start dispatching events
+ * @param targetDocument - the document to dispatch events and set timeouts
+ * @param pollDuration  - in milliseconds
+ */
+const useIFrameFocus = (
+  enableFrameFocusDispatch: boolean,
+  targetDocument: Document | undefined,
+  callback: (e: Event) => void,
+  pollDuration: number = 1000,
+) => {
+  const timeoutRef = React.useRef<number>();
+
+  const listener = React.useCallback(
+    (e: Event) => {
+      if (callback) {
+        callback(e);
+      }
+    },
+    [callback],
+  );
+
+  // Adds listener to the custom iframe focus event
+  React.useEffect(() => {
+    if (enableFrameFocusDispatch) {
+      targetDocument?.addEventListener(FUI_FRAME_EVENT, listener, true);
+    }
+    return () => {
+      targetDocument?.removeEventListener(FUI_FRAME_EVENT, listener, true);
+    };
+  }, [targetDocument, enableFrameFocusDispatch, listener]);
+
+  // Starts polling for the active element
+  React.useEffect(() => {
+    if (enableFrameFocusDispatch) {
+      timeoutRef.current = targetDocument?.defaultView?.setInterval(() => {
+        const activeElement = targetDocument?.activeElement;
+        if (activeElement?.tagName === 'IFRAME') {
+          const event = new CustomEvent(FUI_FRAME_EVENT, { bubbles: true });
+          activeElement.dispatchEvent(event);
+        }
+      }, pollDuration);
+    }
+    return () => {
+      targetDocument?.defaultView?.clearTimeout(timeoutRef.current);
+    };
+  }, [targetDocument, enableFrameFocusDispatch, pollDuration]);
 };

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -122,14 +122,11 @@ const useIFrameFocus = (
 ) => {
   const timeoutRef = React.useRef<number>();
 
-  const listener = React.useCallback(
-    (e: Event) => {
-      if (callback) {
-        callback(e);
-      }
-    },
-    [callback],
-  );
+  const listener = useEventCallback((e: Event) => {
+    if (callback) {
+      callback(e);
+    }
+  });
 
   // Adds listener to the custom iframe focus event
   React.useEffect(() => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`useOnClickOutside` currently does not handle clicks into an `iframe` since events do not bubble from inside an `iframe` to its parent document.

To ensure that clicks into an iframe close popovers/tooltips/menus, add a custom DOM event on iframe focus to run the same action that a click would, since an iframe can only be focused if a user:

* clicks inside
* tabs inside

The same functionality exists in N*, https://github.com/microsoft/fluentui/pull/18893.

#### Focus areas to test

(optional)
