### PR TITLE
Improve calendar selection border

### DIFF
--- a/apps/vr-tests/src/stories/Calendar.stories.tsx
+++ b/apps/vr-tests/src/stories/Calendar.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorFixedWidth } from '../utilities/index';
-import { Fabric, Calendar } from '@fluentui/react';
+import { Fabric, Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
 
 const date = new Date(2010, 1, 12);
 storiesOf('Calendar', module)
@@ -32,5 +32,24 @@ storiesOf('Calendar - No Month Option', module)
   .addStory('Show Month as Overlay and no Go To Today', () => (
     <Fabric>
       <Calendar value={date} showGoToToday={false} showMonthPickerAsOverlay={true} />
+    </Fabric>
+  ))
+  .addStory('Show Week selection type', () => (
+    <Fabric>
+      <Calendar value={date} dateRangeType={DateRangeType.Week} />
+    </Fabric>
+  ))
+  .addStory('Show Month selection type', () => (
+    <Fabric>
+      <Calendar value={date} dateRangeType={DateRangeType.Month} />
+    </Fabric>
+  ))
+  .addStory('Show Work Week selection type', () => (
+    <Fabric>
+      <Calendar
+        value={date}
+        dateRangeType={DateRangeType.WorkWeek}
+        workWeekDays={[DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Friday]}
+      />
     </Fabric>
   ));

--- a/change/@fluentui-react-59477c5e-6027-46d2-b7b8-61bd58df3848.json
+++ b/change/@fluentui-react-59477c5e-6027-46d2-b7b8-61bd58df3848.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "improve calendar selection border by making an after element to not adjust cell spacing, and remove borders between selected days in contiguous ranges",
+  "packageName": "@fluentui/react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2024,6 +2024,13 @@ export interface ICalendarDayGridStyles {
     bottomLeftCornerDate?: IStyle;
     // (undocumented)
     bottomRightCornerDate?: IStyle;
+    datesAbove?: IStyle;
+    // (undocumented)
+    datesBelow?: IStyle;
+    // (undocumented)
+    datesLeft?: IStyle;
+    // (undocumented)
+    datesRight?: IStyle;
     dayButton?: IStyle;
     dayCell?: IStyle;
     dayIsToday?: IStyle;

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -179,7 +179,8 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
             day.isSelected,
           );
 
-        const style = calculateRoundedStyles(classNames, above, below, left, right);
+        let style = calculateRoundedStyles(classNames, above, below, left, right);
+        style = style.concat(calculateBorderStyles(classNames, above, below, left, right));
 
         weekCornersStyled[weekIndex + '_' + dayIndex] = style;
       });
@@ -220,6 +221,31 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
       style = getRTL()
         ? style.concat(classNames.bottomLeftCornerDate + ' ')
         : style.concat(classNames.bottomRightCornerDate + ' ');
+    }
+
+    return style;
+  };
+
+  const calculateBorderStyles = (
+    classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
+    above: boolean,
+    below: boolean,
+    left: boolean,
+    right: boolean,
+  ): string => {
+    let style = '';
+
+    if (above) {
+      style = style.concat(classNames.datesAbove + ' ');
+    }
+    if (below) {
+      style = style.concat(classNames.datesBelow + ' ');
+    }
+    if (left) {
+      style = getRTL() ? style.concat(classNames.datesRight + ' ') : style.concat(classNames.datesLeft + ' ');
+    }
+    if (right) {
+      style = getRTL() ? style.concat(classNames.datesLeft + ' ') : style.concat(classNames.datesRight + ' ');
     }
 
     return style;

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -179,7 +179,7 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
             day.isSelected,
           );
 
-        let style = [];
+        const style = [];
         style.push(calculateRoundedStyles(classNames, above, below, left, right));
         style.push(calculateBorderStyles(classNames, above, below, left, right));
 
@@ -197,7 +197,7 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
     left: boolean,
     right: boolean,
   ): string => {
-    let style = [];
+    const style = [];
     const roundedTopLeft = !above && !left;
     const roundedTopRight = !above && !right;
     const roundedBottomLeft = !below && !left;
@@ -226,7 +226,7 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
     left: boolean,
     right: boolean,
   ): string => {
-    let style = [];
+    const style = [];
 
     if (!above) {
       style.push(classNames.datesAbove);

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -179,10 +179,11 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
             day.isSelected,
           );
 
-        let style = calculateRoundedStyles(classNames, above, below, left, right);
-        style = style.concat(calculateBorderStyles(classNames, above, below, left, right));
+        let style = [];
+        style.push(calculateRoundedStyles(classNames, above, below, left, right));
+        style.push(calculateBorderStyles(classNames, above, below, left, right));
 
-        weekCornersStyled[weekIndex + '_' + dayIndex] = style;
+        weekCornersStyled[weekIndex + '_' + dayIndex] = style.join(' ');
       });
     });
 
@@ -196,34 +197,26 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
     left: boolean,
     right: boolean,
   ): string => {
-    let style = '';
+    let style = [];
     const roundedTopLeft = !above && !left;
     const roundedTopRight = !above && !right;
     const roundedBottomLeft = !below && !left;
     const roundedBottomRight = !below && !right;
 
     if (roundedTopLeft) {
-      style = getRTL()
-        ? style.concat(classNames.topRightCornerDate + ' ')
-        : style.concat(classNames.topLeftCornerDate + ' ');
+      style.push(getRTL() ? classNames.topRightCornerDate : classNames.topLeftCornerDate);
     }
     if (roundedTopRight) {
-      style = getRTL()
-        ? style.concat(classNames.topLeftCornerDate + ' ')
-        : style.concat(classNames.topRightCornerDate + ' ');
+      style.push(getRTL() ? classNames.topLeftCornerDate : classNames.topRightCornerDate);
     }
     if (roundedBottomLeft) {
-      style = getRTL()
-        ? style.concat(classNames.bottomRightCornerDate + ' ')
-        : style.concat(classNames.bottomLeftCornerDate + ' ');
+      style.push(getRTL() ? classNames.bottomRightCornerDate : classNames.bottomLeftCornerDate);
     }
     if (roundedBottomRight) {
-      style = getRTL()
-        ? style.concat(classNames.bottomLeftCornerDate + ' ')
-        : style.concat(classNames.bottomRightCornerDate + ' ');
+      style.push(getRTL() ? classNames.bottomLeftCornerDate : classNames.bottomRightCornerDate);
     }
 
-    return style;
+    return style.join(' ');
   };
 
   const calculateBorderStyles = (
@@ -233,22 +226,22 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
     left: boolean,
     right: boolean,
   ): string => {
-    let style = '';
+    let style = [];
 
-    if (above) {
-      style = style.concat(classNames.datesAbove + ' ');
+    if (!above) {
+      style.push(classNames.datesAbove);
     }
-    if (below) {
-      style = style.concat(classNames.datesBelow + ' ');
+    if (!below) {
+      style.push(classNames.datesBelow);
     }
-    if (left) {
-      style = getRTL() ? style.concat(classNames.datesRight + ' ') : style.concat(classNames.datesLeft + ' ');
+    if (!left) {
+      style.push(getRTL() ? classNames.datesRight : classNames.datesLeft);
     }
-    if (right) {
-      style = getRTL() ? style.concat(classNames.datesLeft + ' ') : style.concat(classNames.datesRight + ' ');
+    if (!right) {
+      style.push(getRTL() ? classNames.datesLeft : classNames.datesRight);
     }
 
-    return style;
+    return style.join(' ');
   };
 
   const isInSameHoverRange = (date1: Date, date2: Date, date1Selected: boolean, date2Selected: boolean): boolean => {

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -150,14 +150,13 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       dateRangeType !== DateRangeType.Month && {
         backgroundColor: palette.neutralLight + '!important',
         selectors: {
-          ['&:after']: {
+          '&:after': {
             content: '""',
             position: 'absolute',
             top: 0,
             bottom: 0,
             left: 0,
             right: 0,
-            border: `1px solid ${palette.neutralSecondary}`,
           },
           ['&:hover, &.' + classNames.hoverStyle + ', &.' + classNames.pressedStyle]: {
             backgroundColor: palette.neutralLight + '!important',
@@ -296,23 +295,23 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       borderBottomLeftRadius: '2px',
     },
     datesAbove: {
-      ['&:after']: {
-        borderTop: 'none!important',
+      '&:after': {
+        borderTop: `1px solid ${palette.neutralSecondary}`,
       },
     },
     datesBelow: {
-      ['&:after']: {
-        borderBottom: 'none!important',
+      '&:after': {
+        borderBottom: `1px solid ${palette.neutralSecondary}`,
       },
     },
     datesLeft: {
-      ['&:after']: {
-        borderLeft: 'none!important',
+      '&:after': {
+        borderLeft: `1px solid ${palette.neutralSecondary}`,
       },
     },
     datesRight: {
-      ['&:after']: {
-        borderRight: 'none!important',
+      '&:after': {
+        borderRight: `1px solid ${palette.neutralSecondary}`,
       },
     },
   };

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -149,8 +149,16 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
     daySelected: [
       dateRangeType !== DateRangeType.Month && {
         backgroundColor: palette.neutralLight + '!important',
-        border: `1px solid ${palette.neutralSecondary}`,
         selectors: {
+          ['&:after']: {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            border: `1px solid ${palette.neutralSecondary}`,
+          },
           ['&:hover, &.' + classNames.hoverStyle + ', &.' + classNames.pressedStyle]: {
             backgroundColor: palette.neutralLight + '!important',
             [HighContrastSelector]: {
@@ -286,6 +294,26 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
     },
     bottomLeftCornerDate: {
       borderBottomLeftRadius: '2px',
+    },
+    datesAbove: {
+      ['&:after']: {
+        borderTop: 'none!important',
+      },
+    },
+    datesBelow: {
+      ['&:after']: {
+        borderBottom: 'none!important',
+      },
+    },
+    datesLeft: {
+      ['&:after']: {
+        borderLeft: 'none!important',
+      },
+    },
+    datesRight: {
+      ['&:after']: {
+        borderRight: 'none!important',
+      },
     },
   };
 };

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -312,4 +312,12 @@ export interface ICalendarDayGridStyles {
   topLeftCornerDate?: IStyle;
   bottomRightCornerDate?: IStyle;
   bottomLeftCornerDate?: IStyle;
+
+  /**
+   * The styles to apply to days for focus borders. Can apply multiple if there are multiple focused days around the current focused date
+   */
+  datesAbove?: IStyle;
+  datesBelow?: IStyle;
+  datesLeft?: IStyle;
+  datesRight?: IStyle;
 }

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -314,7 +314,8 @@ export interface ICalendarDayGridStyles {
   bottomLeftCornerDate?: IStyle;
 
   /**
-   * The styles to apply to days for focus borders. Can apply multiple if there are multiple focused days around the current focused date
+   * The styles to apply to days for focus borders. Can apply multiple if there are multiple focused days
+   * around the current focused date
    */
   datesAbove?: IStyle;
   datesBelow?: IStyle;

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -1968,7 +1968,15 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   background-color: #edebe9!important;
+                }
+                &:after {
                   border: 1px solid #605e5c;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
                 }
                 &:hover {
                   background-color: #edebe9!important;
@@ -4914,7 +4922,15 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   background-color: #edebe9!important;
+                }
+                &:after {
                   border: 1px solid #605e5c;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
                 }
                 &:hover {
                   background-color: #edebe9!important;

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -1390,7 +1390,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
         >
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -1448,6 +1448,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -1519,7 +1531,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -1577,6 +1589,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -1648,7 +1672,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -1706,6 +1730,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -1777,7 +1813,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -1835,6 +1871,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -1906,7 +1954,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
                 ms-CalendarDay-daySelected
                 {
                   border-radius: 100%!important;
@@ -1966,11 +2013,22 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 {
                   border-bottom-right-radius: 2px;
                 }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
+                }
                 {
                   background-color: #edebe9!important;
                 }
                 &:after {
-                  border: 1px solid #605e5c;
                   bottom: 0px;
                   content: "";
                   left: 0px;
@@ -2088,7 +2146,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -2146,6 +2204,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}
@@ -2213,7 +2283,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -2271,6 +2341,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}
@@ -4602,7 +4684,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
         >
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -4660,6 +4742,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -4731,7 +4825,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -4789,6 +4883,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
                 {
                   color: #605e5c;
@@ -4860,7 +4966,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
                 ms-CalendarDay-daySelected
                 {
                   border-radius: 100%!important;
@@ -4920,11 +5025,22 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 {
                   border-bottom-right-radius: 2px;
                 }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
+                }
                 {
                   background-color: #edebe9!important;
                 }
                 &:after {
-                  border: 1px solid #605e5c;
                   bottom: 0px;
                   content: "";
                   left: 0px;
@@ -5042,7 +5158,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -5100,6 +5216,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}
@@ -5167,7 +5295,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -5225,6 +5353,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}
@@ -5292,7 +5432,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -5350,6 +5490,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}
@@ -5417,7 +5569,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             className=
-                
+
                 {
                   border-radius: 100%!important;
                   color: #323130;
@@ -5475,6 +5627,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 }
                 {
                   border-bottom-right-radius: 2px;
+                }
+                &:after {
+                  border-top: 1px solid #605e5c;
+                }
+                &:after {
+                  border-bottom: 1px solid #605e5c;
+                }
+                &:after {
+                  border-left: 1px solid #605e5c;
+                }
+                &:after {
+                  border-right: 1px solid #605e5c;
                 }
             onClick={[Function]}
             onMouseDown={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Commit fc6cc7d73c8d61587e26cd19b3bc9db3abd077a6 added an accessibility fix for focus rectangles around selected dates to improve contrast.

The border change caused cells to shift when clicked due to increasing the size of cells, and there were unnecessary borders between ranges of contiguous cells (like in Week selection).

This change utilizes the same logic as rounding the corners to see if there are contiguous selected cells in a region, and if cells are next to each other, removes the borders between them. It also moves the border to an :after element so that the cells don't change sizes on selection.

Before fix:
![image](https://user-images.githubusercontent.com/8549582/127718690-463862db-737d-4b0a-97b5-5538da6583a1.png)

After fix:
![image](https://user-images.githubusercontent.com/8549582/127718709-16e606f9-45e0-4cfb-8d03-1ae198b9a4d0.png)

#### Focus areas to test

(optional)
