### PR TITLE
FloatingSuggestionsComposite: Update target element type and add gap space prop

### DIFF
--- a/change/@fluentui-react-experiments-0475f34b-8c38-4e19-836f-d9c413f9dc3c.json
+++ b/change/@fluentui-react-experiments-0475f34b-8c38-4e19-836f-d9c413f9dc3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "FloatingSuggestionsComposite: Update target element type and add gap space prop",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.Example.tsx
+++ b/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.Example.tsx
@@ -88,7 +88,7 @@ export const FloatingPeopleSuggestionsExample = (): JSX.Element => {
       <FloatingPeopleSuggestions
         suggestions={[...peopleSuggestions]}
         isSuggestionsVisible={true}
-        targetElement={null}
+        targetElement={{ left: 20, top: 20 }}
         /* eslint-disable react/jsx-no-bind */
         onSuggestionSelected={_onSuggestionSelected}
         onRemoveSuggestion={_onSuggestionRemoved}

--- a/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
+++ b/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
@@ -229,6 +229,7 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
           selectedSuggestionIndex={selectedSuggestionIndex}
           selectedFooterIndex={selectedFooterIndex}
           selectedHeaderIndex={selectedHeaderIndex}
+          gapSpace={20}
         />
       </>
     );

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
@@ -36,6 +36,7 @@ export const BaseFloatingSuggestions = <T extends {}>(props: IBaseFloatingSugges
     selectedHeaderIndex,
     onSuggestionsShown,
     onSuggestionsHidden,
+    gapSpace,
   } = props;
 
   // Picker shown/hidden callback logic
@@ -68,7 +69,7 @@ export const BaseFloatingSuggestions = <T extends {}>(props: IBaseFloatingSugges
         <Callout
           className={classNames.callout}
           isBeakVisible={false}
-          gapSpace={5}
+          gapSpace={gapSpace || 5}
           target={targetElement}
           onDismiss={hidePicker}
           onKeyDown={onKeyDown}

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -159,6 +159,8 @@ export interface IBaseFloatingSuggestionsProps<T> {
    * A callback for when the floating suggestions are hidden (on dismiss or selection)
    */
   onSuggestionsHidden?: () => void;
+
+  gapSpace?: number;
 }
 
 export interface IBaseFloatingPickerHeaderFooterProps {

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -8,6 +8,7 @@ import {
 } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { IRenderFunction, IRefObject } from '@fluentui/utilities';
 import { IFloatingSuggestionsHeaderFooterProps } from './FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
+import { Target } from '@fluentui/react-hooks';
 
 /**
  * FloatingSuggestions component props
@@ -67,7 +68,7 @@ export interface IBaseFloatingSuggestionsProps<T> {
    * Target element here callout should be mounted
    * Pass the element current value to position the callout
    */
-  targetElement: HTMLInputElement | undefined | null;
+  targetElement: HTMLInputElement | Target | undefined | null;
   /**
    * Callout width
    */

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -160,6 +160,10 @@ export interface IBaseFloatingSuggestionsProps<T> {
    */
   onSuggestionsHidden?: () => void;
 
+  /**
+   * Gap space for the callout
+   * Will be set to 5 if this prop is not set
+   */
   gapSpace?: number;
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- The targetElement prop is tied to the Callout target prop, which can take other types than an input element, which is what the prop type for the FSC is right now. I updated the type to take a Target type alternately, so that the picker is more flexible on anchoring. 
- I also added a gap space prop so that the gap space can be set to something different than the default of five.
- Added a different target type to one of the examples
- Added a non default gap to one of the examples
