### PR TITLE
Fix Callout positioning bug when the target element has changed.

### DIFF
--- a/change/@fluentui-react-8886f0c5-7c30-4f86-92aa-357aa55aae27.json
+++ b/change/@fluentui-react-8886f0c5-7c30-4f86-92aa-357aa55aae27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Callout positioning bug when the target element has changed.",
+  "packageName": "@fluentui/react",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -26,7 +26,7 @@ import {
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import { AnimationClassNames } from '../../Styling';
-import { useMergedRefs, useAsync, useConst, useTarget } from '@fluentui/react-hooks';
+import { useMergedRefs, useAsync, useConst, useTarget, Target } from '@fluentui/react-hooks';
 
 const COMPONENT_NAME = 'CalloutContentBase';
 
@@ -203,6 +203,7 @@ function usePositions(
 ) {
   const [positions, setPositions] = React.useState<ICalloutPositionedInfo>();
   const positionAttempts = React.useRef(0);
+  const previousTarget = React.useRef<Target>();
   const async = useAsync();
   const { hidden, target, finalHeight, onPositioned, directionalHint } = props;
 
@@ -219,11 +220,14 @@ function usePositions(
             target: targetRef.current!,
             bounds: getBounds(),
           };
+
+          const previousPositions = previousTarget.current === target ? positions : undefined;
+
           // If there is a finalHeight given then we assume that the user knows and will handle
           // additional positioning adjustments so we should call positionCard
           const newPositions: ICalloutPositionedInfo = finalHeight
-            ? positionCard(currentProps, hostElement.current, calloutElement.current, positions)
-            : positionCallout(currentProps, hostElement.current, calloutElement.current, positions);
+            ? positionCard(currentProps, hostElement.current, calloutElement.current, previousPositions)
+            : positionCallout(currentProps, hostElement.current, calloutElement.current, previousPositions);
           // Set the new position only when the positions are not exists or one of the new callout positions
           // are different. The position should not change if the position is within 2 decimal places.
           if (
@@ -258,6 +262,8 @@ function usePositions(
     props,
     target,
   ]);
+
+  previousTarget.current = target;
 
   return positions;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is a port of my earlier fix (#18803) in the v7 branch to `master`.  In v8, the `CalloutContent` control has been reimplemented as a function component. Therefore, I couldn't do a cherry-pick merge at that time. 

However, the idea of the fix is the same. Within the logic to position the callout, if the `target` element has changed, we must not reuse the current `positions` object. 

#### Focus areas to test

Tooltip positioning.