### PR TITLE
Charting: CherryPick #19202: On focus, border will be visible for Stacked bar and multi-stacked bar chart #19202

### DIFF
--- a/change/@uifabric-charting-cfb8ccb5-c54b-416e-ba85-9c0fdfad9770.json
+++ b/change/@uifabric-charting-cfb8ccb5-c54b-416e-ba85-9c0fdfad9770.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Border will be visible on rect focus",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -37,12 +37,24 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       cursor: href ? 'pointer' : 'default',
       stroke: theme.palette.white,
       strokeWidth: 2,
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     placeHolderOnHover: {
       opacity: shouldHighlight ? '' : '0.1',
       cursor: 'default',
       stroke: theme.palette.white,
       strokeWidth: '2',
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     legendContainer: {
       marginTop: '5px',

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -44,6 +44,12 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       cursor: href ? 'pointer' : 'default',
       stroke: theme.palette.white,
       strokeWidth: 2,
+      selectors: {
+        '&:focus': {
+          stroke: theme.palette.black,
+          strokeWidth: '2px',
+        },
+      },
     },
     ratioNumerator: {
       fontSize: FontSizes.small,

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -104,6 +104,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -130,6 +134,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -241,6 +249,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -267,6 +279,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -457,6 +473,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -483,6 +503,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -590,6 +614,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -616,6 +644,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -810,6 +842,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -836,6 +872,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -947,6 +987,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -973,6 +1017,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1093,6 +1141,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1119,6 +1171,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1230,6 +1286,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1256,6 +1316,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={true}
               onBlur={[Function]}
@@ -1629,6 +1693,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={false}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1655,6 +1723,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={false}
               onBlur={[Function]}
@@ -1766,6 +1838,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     stroke-width: 2px;
                     stroke: #ffffff;
                   }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
+                  }
               data-is-focusable={false}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1792,6 +1868,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     opacity: ;
                     stroke-width: 2px;
                     stroke: #ffffff;
+                  }
+                  &:focus {
+                    stroke-width: 2px;
+                    stroke: #000000;
                   }
               data-is-focusable={false}
               onBlur={[Function]}

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -140,6 +144,10 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -281,6 +289,10 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -308,6 +320,10 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -435,6 +451,10 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -462,6 +482,10 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -603,6 +627,10 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -630,6 +658,10 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -741,6 +773,10 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -768,6 +804,10 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}
@@ -909,6 +949,10 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={false}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -936,6 +980,10 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={false}
             onBlur={[Function]}
@@ -1047,6 +1095,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   stroke-width: 2px;
                   stroke: #ffffff;
                 }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
+                }
             data-is-focusable={true}
             onBlur={[Function]}
             onFocus={[Function]}
@@ -1074,6 +1126,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   opacity: ;
                   stroke-width: 2px;
                   stroke: #ffffff;
+                }
+                &:focus {
+                  stroke-width: 2px;
+                  stroke: #000000;
                 }
             data-is-focusable={true}
             onBlur={[Function]}


### PR DESCRIPTION
### Original description
Cherry-pick of [#19202](https://github.com/microsoft/fluentui/pull/19202)

#### Description of changes

Focus visual for rectangles will be visible, border added on focus for Stacked bar and multi-stacked bar.

#### Focus areas to test

Stacked Bar Chart
Multi-Stacked Bar Chart

**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/127648889-97aa742c-b9d5-4275-a59d-cf3bda2380d1.png)


**After Changes**
![image](https://user-images.githubusercontent.com/29042635/127648584-0c80e2c5-99de-42e6-9b97-192815008c84.png)