### PR TITLE
fix(react-positioning): fix types

### DIFF
--- a/change/@fluentui-react-popover-1e9b9806-4209-42fd-881c-220c074333f7.json
+++ b/change/@fluentui-react-popover-1e9b9806-4209-42fd-881c-220c074333f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use PositioningProps type",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-37abff55-efc3-42aa-911d-c671e42986bf.json
+++ b/change/@fluentui-react-positioning-37abff55-efc3-42aa-911d-c671e42986bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "cleanup types, do not export PopperOptions",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -8,9 +8,9 @@ import { ComponentPropsCompat } from '@fluentui/react-utilities';
 import { ComponentStateCompat } from '@fluentui/react-utilities';
 import { Context } from '@fluentui/react-context-selector';
 import { ContextSelector } from '@fluentui/react-context-selector';
-import { PopperOptions } from '@fluentui/react-positioning';
 import { PopperVirtualElement } from '@fluentui/react-positioning';
 import { PortalProps } from '@fluentui/react-portal';
+import { PositioningProps } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
 
 // @public (undocumented)
@@ -37,7 +37,7 @@ export interface PopoverContextValue extends Pick<PopoverState, 'open' | 'setOpe
 export type PopoverDefaultedProps = never;
 
 // @public
-export interface PopoverProps extends Pick<PopperOptions, 'position' | 'align' | 'offset' | 'coverTarget' | 'target'>, Pick<PortalProps, 'mountNode'> {
+export interface PopoverProps extends Pick<PositioningProps, 'position' | 'align' | 'offset' | 'coverTarget' | 'target'>, Pick<PortalProps, 'mountNode'> {
     brand?: boolean;
     // (undocumented)
     children: React_2.ReactNode;
@@ -128,7 +128,6 @@ export const usePopoverSurfaceStyles: (state: PopoverSurfaceState) => PopoverSur
 
 // @public
 export const usePopoverTrigger: (props: PopoverTriggerProps, defaultProps?: PopoverTriggerProps | undefined) => PopoverTriggerState;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PopperOptions, PopperVirtualElement } from '@fluentui/react-positioning';
+import { PositioningProps, PopperVirtualElement } from '@fluentui/react-positioning';
 import { PortalProps } from '@fluentui/react-portal';
 import { ComponentStateCompat } from '@fluentui/react-utilities';
 
@@ -12,7 +12,7 @@ export type PopoverSize = 'small' | 'medium' | 'large';
  * Popover Props
  */
 export interface PopoverProps
-  extends Pick<PopperOptions, 'position' | 'align' | 'offset' | 'coverTarget' | 'target'>,
+  extends Pick<PositioningProps, 'position' | 'align' | 'offset' | 'coverTarget' | 'target'>,
     Pick<PortalProps, 'mountNode'> {
   children: React.ReactNode;
   /**

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -33,14 +33,6 @@ export type OffsetFunctionParam = {
 };
 
 // @public (undocumented)
-export interface PopperOptions extends PositioningProps {
-    enabled?: boolean;
-    // (undocumented)
-    onStateUpdate?: (state: Partial<PopperJs.State>) => void;
-    positioningDependencies?: React_2.DependencyList;
-}
-
-// @public (undocumented)
 export type PopperRefHandle = {
     updatePosition: () => void;
 };
@@ -56,11 +48,11 @@ export interface PositioningProps {
     align?: Alignment;
     arrowPadding?: number;
     autoSize?: AutoSize;
-    containerRef?: React_2.Ref<PopperRefHandle>;
     coverTarget?: boolean;
     flipBoundary?: Boundary;
     offset?: Offset;
     overflowBoundary?: Boundary;
+    popperRef?: React_2.Ref<PopperRefHandle>;
     position?: Position;
     positionFixed?: boolean;
     target?: HTMLElement | PopperVirtualElement | null;
@@ -68,6 +60,8 @@ export interface PositioningProps {
     unstable_pinned?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "PopperOptions" needs to be exported by the entry point index.d.ts
+//
 // @public
 export function usePopper(options?: PopperOptions): {
     targetRef: React_2.MutableRefObject<any>;
@@ -77,7 +71,6 @@ export function usePopper(options?: PopperOptions): {
 
 // @public
 export const usePopperMouseTarget: (initialState?: PopperJs.VirtualElement | (() => PopperJs.VirtualElement) | undefined) => readonly [PopperJs.VirtualElement | undefined, (event: React_2.MouseEvent | MouseEvent | undefined | null) => void];
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -23,9 +23,7 @@ export type PopperRefHandle = { updatePosition: () => void };
 export type PopperVirtualElement = PopperJs.VirtualElement;
 
 export interface PositioningProps {
-  /**
-   * Alignment for the component.
-   */
+  /** Alignment for the component. */
   align?: Alignment;
 
   /** The element which will define the boundaries of the popper position for the flip behavior. */
@@ -35,7 +33,7 @@ export interface PositioningProps {
   overflowBoundary?: Boundary;
 
   /** An imperative handle to Popper methods. */
-  containerRef?: React.Ref<PopperRefHandle>;
+  popperRef?: React.Ref<PopperRefHandle>;
 
   /**
    * Position for the component. Position has higher priority than align. If position is vertical ('above' | 'below')
@@ -96,19 +94,4 @@ export interface PositioningProps {
    * Modifies position and alignment to cover the target
    */
   coverTarget?: boolean;
-}
-
-export interface PopperOptions extends PositioningProps {
-  /**
-   * If false, delays Popper's creation.
-   * @default true
-   */
-  enabled?: boolean;
-
-  /**
-   * Array of conditions to be met in order to trigger a subsequent render to reposition the elements.
-   */
-  positioningDependencies?: React.DependencyList;
-
-  onStateUpdate?: (state: Partial<PopperJs.State>) => void;
 }

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -12,8 +12,19 @@ import {
 import * as PopperJs from '@popperjs/core';
 import * as React from 'react';
 
-import { PopperOptions } from './types';
+import { PositioningProps } from './types';
+
 type PopperInstance = PopperJs.Instance & { isFirstRun?: boolean };
+
+interface PopperOptions extends PositioningProps {
+  /**
+   * If false, delays Popper's creation.
+   * @default true
+   */
+  enabled?: boolean;
+
+  onStateUpdate?: (state: Partial<PopperJs.State>) => void;
+}
 
 //
 // Dev utils to detect if nodes have "autoFocus" props.
@@ -372,7 +383,7 @@ export function usePopper(
   const arrowRef = useCallbackRef<HTMLElement | null>(null, handlePopperUpdate, true);
 
   React.useImperativeHandle(
-    options.containerRef,
+    options.popperRef,
     () => ({
       updatePosition: () => {
         popperInstanceRef.current?.update();


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR is partially based on discussions in #19147.

- `PopperOptions` is not longer exported as it's private type, currently it was used in `react-popover` 😮 Interfaces are very similar with `PositioningProps`, but I want to prevent leaking private APIs
- `PopperOptions.containerRef` was renamed to `PopperOptions.popperRef`:
  - `usePopper()` already returns `containerRef`
  - if we will to expose `PopperOptions` (#19147), `containerRef` will be very confusing name
- `PopperOptions.positioningDependencies` was removed, as it's not implemented and will not be