### PR TITLE
fix(Tooltip): tooltip flicker in iframe

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Button` icon only styles when disabledFocusable @chassunc ([#19180](https://github.com/microsoft/fluentui/pull/19180))
 - Fix `Dropdown` creating unnecessary `aria-labelledby` for `DropdownSearchInput` @chassunc ([#19182](https://github.com/microsoft/fluentui/pull/19182))
 - Fix error color for `Text` @chassunc ([#19203](https://github.com/microsoft/fluentui/pull/19203))
+- Fix `Tooltip` flickering in multi-window use case @yuanboxue-amber ([#19235](https://github.com/microsoft/fluentui/pull/19235))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -210,7 +210,7 @@ export const Tooltip: React.FC<TooltipProps> &
   };
 
   const setTooltipOpen = (newOpen: boolean, e: React.MouseEvent | React.KeyboardEvent) => {
-    clearTimeout(closeTimeoutId.current);
+    context.target.defaultView.clearTimeout(closeTimeoutId.current);
 
     if (newOpen) {
       trySetOpen(true, e);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

## Description of changes

### Tooltip can flicker in multi-window use case, for example:
https://user-images.githubusercontent.com/28751745/128037587-89d302dd-0246-4a0b-b027-fdd69e8e3bd3.mov

### This flicker happens because:
Tooltip will open when mouse enters trigger, or mouse enters tooltip content.
Tooltip will close when mouse leaves trigger, or mouse leaves tooltip content.
There is a slight timeout for closing tooltip on mouse leave, by default it is 10s.

Tooltip is render right next to the trigger. So when user moves mouse to the edge between trigger and tooltip content, the below events can happen:
- mouseenter(1) trigger -> cause tooltip content render
- mouseleave trigger, mouseenter(2) tooltip content

The mouseleave will try to close the tooltip with a timeout: `setTimeout(() => {setOpen(false), mouseLeaveDelay})`
But the second mouseenter will clear the timeout. So the `setOpen(false)` is never called. 

We setTimeout by doing `context.target.defaultView.setTimeout` because of multi-window use case.
But we didn't do this for clearTimeout.
Therefore, in multi-window use case, clearing timeout will fail, and then the `setOpen(false)` will be called to close the tooltip and causes flickering.

### After fix, flickering disappear:

https://user-images.githubusercontent.com/28751745/128038199-40bd66da-eac0-4aa6-b1cc-7527c185469f.mov



#### Focus areas to test

(optional)
