### PR TITLE
Fix isPivotItem check for IE11

### DIFF
--- a/change/@fluentui-react-c86cdc5d-eaf2-4c9e-b25a-980786d19cb4.json
+++ b/change/@fluentui-react-c86cdc5d-eaf2-4c9e-b25a-980786d19cb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Pivot's isPivotItem check for IE11 compatibility",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -56,7 +56,7 @@ const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection 
 };
 
 const isPivotItem = (item: React.ReactNode): item is PivotItem => {
-  return ((item as React.ReactElement)?.type as React.ComponentType)?.name === PivotItem.name;
+  return !!item && ((item as React.ReactElement).type as React.ComponentType)?.name === PivotItem.name;
 };
 
 export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<HTMLDivElement, IPivotProps>(

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -56,7 +56,7 @@ const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection 
 };
 
 const isPivotItem = (item: React.ReactNode): item is PivotItem => {
-  return !!item && ((item as React.ReactElement).type as React.ComponentType)?.name === PivotItem.name;
+  return React.isValidElement(item) && (item.type as React.ComponentType)?.name === PivotItem.name;
 };
 
 export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<HTMLDivElement, IPivotProps>(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19190
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `isPivotItem` check relies on the Function.name prop to check the type of `PivotItem`; however, that is not available in IE11. The v7 version most likely works because it includes a falsey-check for `item` as well, so it doesn't return true for null/undefined items. In v8, that falsey check was removed and it relies only on the Function.name prop.

Fix: add a `React.isValidElement` check to `isPivotItem` so it doesn't return true for null or non-react items. It'll still incorrectly return true for non-PivotItems on IE11. However, that type of error is a developer mistake and generates a warning on newer browsers.