### PR TITLE
Combobox's CommandButton menu items should use isSelected for aria-Selected

### DIFF
--- a/change/@fluentui-react-d984b817-8dab-4b28-ad34-fe2edce99006.json
+++ b/change/@fluentui-react-d984b817-8dab-4b28-ad34-fe2edce99006.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "CommandButton items should use isSelected for aria-Selected",
+  "packageName": "@fluentui/react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1376,8 +1376,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           onMouseMove={this._onOptionMouseMove.bind(this, item.index)}
           onMouseLeave={this._onOptionMouseLeave}
           role="option"
-          // aria-selected should only be applied to checked items, not hovered items
-          aria-selected={isChecked ? 'true' : 'false'}
+          aria-selected={isSelected ? 'true' : 'false'}
           ariaLabel={item.ariaLabel}
           disabled={item.disabled}
           title={title}


### PR DESCRIPTION
#### Description of changes

When you add non-multiselect items to a combobox, aria-selected will ALWAYS be false since isOptionChecked has a 'this.props.multiselect' in it.

CommandButtons should use isSelected like they do in v7, since they cannot be "Checked" like a checkbox can.

This is consistent with how we set the 'checked' prop as well.