### PR TITLE
fix(Detailslist): set correct focus target when column header has no focusable child

### DIFF
--- a/change/@fluentui-react-fa9343ef-d793-4210-ac39-3e0da4046737.json
+++ b/change/@fluentui-react-fa9343ef-d793-4210-ac39-3e0da4046737.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix DetailsList columnheader focus target when it does not contain a button; remove aria-haspopup when false",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -620,6 +620,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="name"
               draggable={false}
               role="columnheader"
@@ -642,7 +643,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -673,7 +673,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header4-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -416,6 +416,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -438,7 +439,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -469,7 +469,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1125,7 +1125,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-thumbnail-tooltip"
-                  aria-haspopup={false}
                   aria-label="thumbnail"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1160,7 +1159,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-thumbnail"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1410,7 +1409,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1441,7 +1439,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={false}
                   id="header11-key"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1645,7 +1642,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-name-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-name-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1677,7 +1673,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1882,7 +1878,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-description-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-description-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1914,7 +1909,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-description"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2119,7 +2114,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-color-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-color-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -2151,7 +2145,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-color"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2356,7 +2350,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-shape-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-shape-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -2388,7 +2381,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-shape"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2593,7 +2586,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-location-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-location-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -2625,7 +2617,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-location"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2830,7 +2822,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-width-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-width-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -2862,7 +2853,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-width"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -3067,7 +3058,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <span
                   aria-describedby="header11-height-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header11-height-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -3099,7 +3089,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header11-height"
                   onClick={[Function]}
                   onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -416,6 +416,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column1"
             draggable={false}
             role="columnheader"
@@ -438,7 +439,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -469,7 +469,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -606,6 +605,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column2"
             draggable={false}
             role="columnheader"
@@ -628,7 +628,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -659,7 +658,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -644,6 +644,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="column1"
                 draggable={false}
                 role="columnheader"
@@ -666,7 +667,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -697,7 +697,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header4-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -834,6 +833,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="column2"
                 draggable={false}
                 role="columnheader"
@@ -856,7 +856,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -887,7 +886,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header4-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
@@ -1034,6 +1034,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="0"
                 draggable={false}
                 role="columnheader"
@@ -1056,7 +1057,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1087,7 +1087,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header17-0"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1224,6 +1223,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="1"
                 draggable={false}
                 role="columnheader"
@@ -1246,7 +1246,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1277,7 +1276,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header17-1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1414,6 +1412,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="2"
                 draggable={false}
                 role="columnheader"
@@ -1436,7 +1435,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1467,7 +1465,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header17-2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1604,6 +1601,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="3"
                 draggable={false}
                 role="columnheader"
@@ -1626,7 +1624,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1657,7 +1654,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header17-3"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -2346,6 +2342,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="0"
                 draggable={false}
                 role="columnheader"
@@ -2368,7 +2365,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -2399,7 +2395,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header21-0"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -2536,6 +2531,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="1"
                 draggable={false}
                 role="columnheader"
@@ -2558,7 +2554,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -2589,7 +2584,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header21-1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -2726,6 +2720,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="2"
                 draggable={false}
                 role="columnheader"
@@ -2748,7 +2743,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -2779,7 +2773,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header21-2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -2916,6 +2909,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="3"
                 draggable={false}
                 role="columnheader"
@@ -2938,7 +2932,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -2969,7 +2962,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header21-3"
                     onClick={[Function]}
                     onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -628,6 +628,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="column1"
                 draggable={false}
                 role="columnheader"
@@ -650,7 +651,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -681,7 +681,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header4-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -818,6 +817,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="column2"
                 draggable={false}
                 role="columnheader"
@@ -840,7 +840,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -871,7 +870,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header4-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -438,7 +438,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             >
               <span
                 aria-describedby="header1-thumbnail-tooltip"
-                aria-haspopup={false}
                 aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -470,7 +469,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -596,7 +595,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -628,7 +626,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -731,7 +729,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -763,7 +760,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -866,7 +863,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-description-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -898,7 +894,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-description"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1001,7 +997,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-color-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -1033,7 +1028,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-color"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1136,7 +1131,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-shape-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -1168,7 +1162,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-shape"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1271,7 +1265,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-location-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -1303,7 +1296,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-location"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1406,7 +1399,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-width-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -1438,7 +1430,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-width"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1541,7 +1533,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 aria-labelledby="header1-height-name"
                 className=
                     ms-DetailsHeader-cellTitle
@@ -1573,7 +1564,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
+                data-is-focusable="true"
                 id="header1-height"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -415,6 +415,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column1"
             draggable={false}
             role="columnheader"
@@ -437,7 +438,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -468,7 +468,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -605,6 +604,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column2"
             draggable={false}
             role="columnheader"
@@ -627,7 +627,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -658,7 +657,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -708,6 +708,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="thumbnail"
               draggable={false}
               role="columnheader"
@@ -730,7 +731,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -761,7 +761,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-thumbnail"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -898,6 +897,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="key"
               draggable={false}
               role="columnheader"
@@ -920,7 +920,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -951,7 +950,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-key"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1088,6 +1086,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="name"
               draggable={false}
               role="columnheader"
@@ -1110,7 +1109,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1141,7 +1139,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1278,6 +1275,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="description"
               draggable={false}
               role="columnheader"
@@ -1300,7 +1298,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1331,7 +1328,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-description"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1468,6 +1464,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="color"
               draggable={false}
               role="columnheader"
@@ -1490,7 +1487,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1521,7 +1517,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-color"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1658,6 +1653,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="shape"
               draggable={false}
               role="columnheader"
@@ -1680,7 +1676,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1711,7 +1706,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-shape"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1848,6 +1842,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="location"
               draggable={false}
               role="columnheader"
@@ -1870,7 +1865,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1901,7 +1895,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-location"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2038,6 +2031,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="width"
               draggable={false}
               role="columnheader"
@@ -2060,7 +2054,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2091,7 +2084,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-width"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -2228,6 +2220,7 @@ Array [
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="height"
               draggable={false}
               role="columnheader"
@@ -2250,7 +2243,6 @@ Array [
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2281,7 +2273,6 @@ Array [
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header2-height"
                   onClick={[Function]}
                   onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -390,6 +390,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="thumbnail"
             draggable={false}
             role="columnheader"
@@ -412,7 +413,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -443,7 +443,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -580,6 +579,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -602,7 +602,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -633,7 +632,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -770,6 +768,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -792,7 +791,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -823,7 +821,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -960,6 +957,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="description"
             draggable={false}
             role="columnheader"
@@ -982,7 +980,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1013,7 +1010,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-description"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1150,6 +1146,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="color"
             draggable={false}
             role="columnheader"
@@ -1172,7 +1169,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1203,7 +1199,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-color"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1340,6 +1335,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="shape"
             draggable={false}
             role="columnheader"
@@ -1362,7 +1358,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1393,7 +1388,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-shape"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1530,6 +1524,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="location"
             draggable={false}
             role="columnheader"
@@ -1552,7 +1547,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1583,7 +1577,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-location"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1720,6 +1713,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="width"
             draggable={false}
             role="columnheader"
@@ -1742,7 +1736,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1773,7 +1766,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-width"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1910,6 +1902,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="height"
             draggable={false}
             role="columnheader"
@@ -1932,7 +1925,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1963,7 +1955,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-height"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -728,7 +728,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               >
                 <span
                   aria-describedby="header6-column1-tooltip"
-                  aria-haspopup={false}
                   aria-label="File Type"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -763,7 +762,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header6-column1"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -948,7 +947,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               >
                 <span
                   aria-describedby="header6-column2-tooltip"
-                  aria-haspopup={false}
                   aria-labelledby="header6-column2-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -980,7 +978,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header6-column2"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1193,7 +1191,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-haspopup={false}
                   aria-labelledby="header6-column3-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1225,7 +1222,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header6-column3"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1384,7 +1381,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-haspopup={false}
                   aria-labelledby="header6-column4-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1416,7 +1412,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header6-column4"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1575,7 +1571,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-haspopup={false}
                   aria-labelledby="header6-column5-name"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -1607,7 +1602,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
+                  data-is-focusable="true"
                   id="header6-column5"
                   onClick={[Function]}
                   onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -902,6 +902,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="name"
               draggable={false}
               role="columnheader"
@@ -924,7 +925,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -955,7 +955,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header6-name"
                   onClick={[Function]}
                   onContextMenu={[Function]}
@@ -1092,6 +1091,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   }
               data-automationid="ColumnsHeaderColumn"
               data-is-draggable={false}
+              data-is-focusable="true"
               data-item-key="color"
               draggable={false}
               role="columnheader"
@@ -1114,7 +1114,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                     }
               >
                 <span
-                  aria-haspopup={false}
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1145,7 +1144,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         top: 1px;
                         z-index: 1;
                       }
-                  data-is-focusable={true}
                   id="header6-color"
                   onClick={[Function]}
                   onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -501,6 +501,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -523,7 +524,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -554,7 +554,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -691,6 +690,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -713,7 +713,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -744,7 +743,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -415,6 +415,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="filepath"
             draggable={false}
             role="columnheader"
@@ -437,7 +438,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -468,7 +468,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-filepath"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -549,6 +548,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="size"
             draggable={false}
             role="columnheader"
@@ -571,7 +571,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -602,7 +601,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-size"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -416,6 +416,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column1"
             draggable={false}
             role="columnheader"
@@ -438,7 +439,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -469,7 +469,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -702,6 +701,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column2"
             draggable={false}
             role="columnheader"
@@ -724,7 +724,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -755,7 +754,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -892,6 +890,7 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column3"
             draggable={false}
             role="columnheader"
@@ -914,7 +913,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -945,7 +943,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column3"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -324,6 +324,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="thumbnail"
                 draggable={false}
                 role="columnheader"
@@ -346,7 +347,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -380,7 +380,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-thumbnail"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -513,6 +512,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="key"
                 draggable={false}
                 role="columnheader"
@@ -535,7 +535,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -566,7 +565,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-key"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -647,6 +645,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="name"
                 draggable={false}
                 role="columnheader"
@@ -669,7 +668,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -700,7 +698,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-name"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -781,6 +778,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="description"
                 draggable={false}
                 role="columnheader"
@@ -803,7 +801,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -834,7 +831,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-description"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -915,6 +911,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="color"
                 draggable={false}
                 role="columnheader"
@@ -937,7 +934,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -968,7 +964,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-color"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1049,6 +1044,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="shape"
                 draggable={false}
                 role="columnheader"
@@ -1071,7 +1067,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1102,7 +1097,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-shape"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1183,6 +1177,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="location"
                 draggable={false}
                 role="columnheader"
@@ -1205,7 +1200,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1236,7 +1230,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-location"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1317,6 +1310,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="width"
                 draggable={false}
                 role="columnheader"
@@ -1339,7 +1333,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1370,7 +1363,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-width"
                     onClick={[Function]}
                     onContextMenu={[Function]}
@@ -1451,6 +1443,7 @@ Array [
                     }
                 data-automationid="ColumnsHeaderColumn"
                 data-is-draggable={false}
+                data-is-focusable="true"
                 data-item-key="height"
                 draggable={false}
                 role="columnheader"
@@ -1473,7 +1466,6 @@ Array [
                       }
                 >
                   <span
-                    aria-haspopup={false}
                     className=
                         ms-DetailsHeader-cellTitle
                         {
@@ -1504,7 +1496,6 @@ Array [
                           top: 1px;
                           z-index: 1;
                         }
-                    data-is-focusable={true}
                     id="header2-height"
                     onClick={[Function]}
                     onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -146,6 +146,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column1"
             draggable={false}
             role="columnheader"
@@ -168,7 +169,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -199,7 +199,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -336,6 +335,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column2"
             draggable={false}
             role="columnheader"
@@ -358,7 +358,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -389,7 +388,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -146,6 +146,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column1"
             draggable={false}
             role="columnheader"
@@ -168,7 +169,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -199,7 +199,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -336,6 +335,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column2"
             draggable={false}
             role="columnheader"
@@ -358,7 +358,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -389,7 +388,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column2"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -119,6 +119,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
           {...(!hasInnerButton && accNameDescription)}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
           aria-colindex={columnIndex}
+          // when the column is not disabled and has no inner button, this node should be in the focus order
           data-is-focusable={
             !hasInnerButton && column.columnActionsMode !== ColumnActionsMode.disabled ? 'true' : undefined
           }
@@ -149,6 +150,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                 <span
                   id={`${parentId}-${column.key}`}
                   className={classNames.cellTitle}
+                  // this node should only be focusable when it is a button
                   data-is-focusable={
                     hasInnerButton && column.columnActionsMode !== ColumnActionsMode.disabled ? 'true' : undefined
                   }

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -119,6 +119,9 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
           {...(!hasInnerButton && accNameDescription)}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
           aria-colindex={columnIndex}
+          data-is-focusable={
+            !hasInnerButton && column.columnActionsMode !== ColumnActionsMode.disabled ? 'true' : undefined
+          }
           className={classNames.root}
           data-is-draggable={isDraggable}
           draggable={isDraggable}
@@ -146,12 +149,14 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                 <span
                   id={`${parentId}-${column.key}`}
                   className={classNames.cellTitle}
-                  data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
+                  data-is-focusable={
+                    hasInnerButton && column.columnActionsMode !== ColumnActionsMode.disabled ? 'true' : undefined
+                  }
                   role={hasInnerButton ? 'button' : undefined}
                   {...(hasInnerButton && accNameDescription)}
                   onContextMenu={this._onColumnContextMenu}
                   onClick={this._onColumnClick}
-                  aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
+                  aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown ? 'menu' : undefined}
                   aria-expanded={
                     column.columnActionsMode === ColumnActionsMode.hasDropdown ? !!column.isMenuOpen : undefined
                   }

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -347,6 +347,7 @@ exports[`DetailsHeader can render 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="a"
     draggable={false}
     role="columnheader"
@@ -369,7 +370,6 @@ exports[`DetailsHeader can render 1`] = `
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -400,7 +400,6 @@ exports[`DetailsHeader can render 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header0-a"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -538,6 +537,7 @@ exports[`DetailsHeader can render 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="b"
     draggable={false}
     role="columnheader"
@@ -560,7 +560,6 @@ exports[`DetailsHeader can render 1`] = `
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -591,7 +590,6 @@ exports[`DetailsHeader can render 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header0-b"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -759,6 +757,7 @@ exports[`DetailsHeader can render 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="c"
     draggable={false}
     role="columnheader"
@@ -782,7 +781,7 @@ exports[`DetailsHeader can render 1`] = `
     >
       <span
         aria-expanded={false}
-        aria-haspopup={true}
+        aria-haspopup="menu"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -813,7 +812,6 @@ exports[`DetailsHeader can render 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header0-c"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -1135,6 +1133,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="a"
     draggable={false}
     role="columnheader"
@@ -1157,7 +1156,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1188,7 +1186,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header2-a"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -1326,6 +1323,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="b"
     draggable={false}
     role="columnheader"
@@ -1348,7 +1346,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1379,7 +1376,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header2-b"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -1547,6 +1543,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="c"
     draggable={false}
     role="columnheader"
@@ -1570,7 +1567,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     >
       <span
         aria-expanded={false}
-        aria-haspopup={true}
+        aria-haspopup="menu"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1601,7 +1598,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header2-c"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -2085,6 +2081,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="a"
     draggable={false}
     role="columnheader"
@@ -2107,7 +2104,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2138,7 +2134,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header6-a"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -2277,6 +2272,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="b"
     draggable={false}
     role="columnheader"
@@ -2299,7 +2295,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           }
     >
       <span
-        aria-haspopup={false}
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2330,7 +2325,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header6-b"
         onClick={[Function]}
         onContextMenu={[Function]}
@@ -2524,6 +2518,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         }
     data-automationid="ColumnsHeaderColumn"
     data-is-draggable={false}
+    data-is-focusable="true"
     data-item-key="c"
     draggable={false}
     role="columnheader"
@@ -2547,7 +2542,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <span
         aria-expanded={false}
-        aria-haspopup={true}
+        aria-haspopup="menu"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2578,7 +2573,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               top: 1px;
               z-index: 1;
             }
-        data-is-focusable={true}
         id="header6-c"
         onClick={[Function]}
         onContextMenu={[Function]}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2238,6 +2238,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -2260,7 +2261,6 @@ exports[`DetailsList renders List correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2291,7 +2291,6 @@ exports[`DetailsList renders List correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -2428,6 +2427,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -2450,7 +2450,6 @@ exports[`DetailsList renders List correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2481,7 +2480,6 @@ exports[`DetailsList renders List correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -2618,6 +2616,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -2640,7 +2639,6 @@ exports[`DetailsList renders List correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2671,7 +2669,6 @@ exports[`DetailsList renders List correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3230,6 +3227,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
             role="columnheader"
@@ -3252,7 +3250,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3283,7 +3280,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3388,6 +3384,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
             role="columnheader"
@@ -3410,7 +3407,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3441,7 +3437,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3546,6 +3541,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
             role="columnheader"
@@ -3568,7 +3564,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3599,7 +3594,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3704,6 +3698,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
             role="columnheader"
@@ -3726,7 +3721,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3757,7 +3751,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3862,6 +3855,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
             role="columnheader"
@@ -3884,7 +3878,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3915,7 +3908,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -4441,6 +4433,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -4463,7 +4456,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4494,7 +4486,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header33-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -4631,6 +4622,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -4653,7 +4645,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4684,7 +4675,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header33-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -4821,6 +4811,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -4843,7 +4834,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4874,7 +4864,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header33-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -5433,6 +5422,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -5455,7 +5445,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5486,7 +5475,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -5623,6 +5611,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -5645,7 +5634,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5676,7 +5664,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -5813,6 +5800,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -5835,7 +5823,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -5866,7 +5853,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -6425,6 +6411,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
             role="columnheader"
@@ -6447,7 +6434,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6478,7 +6464,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -6586,6 +6571,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
             role="columnheader"
@@ -6608,7 +6594,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6639,7 +6624,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -6747,6 +6731,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
             role="columnheader"
@@ -6769,7 +6754,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6800,7 +6784,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -6908,6 +6891,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
             role="columnheader"
@@ -6930,7 +6914,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -6961,7 +6944,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -7069,6 +7051,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
             role="columnheader"
@@ -7091,7 +7074,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -7122,7 +7104,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -7490,6 +7471,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -7512,7 +7494,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -7543,7 +7524,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header37-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -7680,6 +7660,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -7702,7 +7683,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -7733,7 +7713,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header37-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -7870,6 +7849,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -7892,7 +7872,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -7923,7 +7902,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header37-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -390,6 +390,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -412,7 +413,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -443,7 +443,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -524,6 +523,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -546,7 +546,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -577,7 +576,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -658,6 +656,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -680,7 +679,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -711,7 +709,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1233,6 +1230,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -1255,7 +1253,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1286,7 +1283,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1367,6 +1363,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -1389,7 +1386,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1420,7 +1416,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -1501,6 +1496,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -1523,7 +1519,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1554,7 +1549,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header13-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -2597,6 +2591,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -2619,7 +2614,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2650,7 +2644,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -2731,6 +2724,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -2753,7 +2747,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2784,7 +2777,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -2865,6 +2857,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -2887,7 +2880,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2918,7 +2910,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header5-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3440,6 +3431,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="key"
             draggable={false}
             role="columnheader"
@@ -3462,7 +3454,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3493,7 +3484,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3574,6 +3564,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="name"
             draggable={false}
             role="columnheader"
@@ -3596,7 +3587,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3627,7 +3617,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
@@ -3708,6 +3697,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="value"
             draggable={false}
             role="columnheader"
@@ -3730,7 +3720,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-haspopup={false}
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3761,7 +3750,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable={true}
                 id="header9-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13779, [12377](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12377)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This does two things:
1. Fixes the focus target when a columnheader's child is not a button (where previously it had been going onto the generic `<span>` element)
2. Does not set `aria-haspopup` if the value is false, and updates the `true` value to `menu` (which is what "true" functionally means).

Came across the second while investigating an issue that turned out to be unrelated, and it's mostly just housekeeping/better code practice. The first is the actual a11y fix.