### PR TITLE
Charting: CherryPick #19199: Role added for overflow legends #19199

### DIFF
--- a/change/@uifabric-charting-33ef6ab3-ec52-4021-8304-61c4a1ead27d.json
+++ b/change/@uifabric-charting-33ef6ab3-ec52-4021-8304-61c4a1ead27d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added role as a link for overflow legends message, so it will read like 7 more link collapsed",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -304,6 +304,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
           className={classNames.overflowIndicationTextStyle}
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           {...(allowFocusOnLegends && {
+            role: 'link',
             'aria-expanded': this.state.isHoverCardVisible,
             'aria-label': `${items.length} ${overflowString}`,
           })}


### PR DESCRIPTION
### Original description
Cherry pick of [#19199](https://github.com/microsoft/fluentui/pull/19199)

#### Description of changes

For overflow legend, previously NVDA reading like '2 overflow item section', now NVDA will read as "2 overflow item link collapsed."

#### Focus areas to test

Legends 


**Before Change:**
![image](https://user-images.githubusercontent.com/29042635/127631989-076c8616-1692-499d-99c2-344da4d2b3b1.png)


**After Change**
![image](https://user-images.githubusercontent.com/29042635/127632184-88b68bc2-d010-4164-9bc3-7154990ddc29.png)