### PR TITLE
Charting: CherryPick  #19178: Charting: Callout issue resolved in bar charts. #19178

### DIFF
--- a/change/@uifabric-charting-c20573f6-ed55-4c62-a7c0-148dcb6cb1a0.json
+++ b/change/@uifabric-charting-c20573f6-ed55-4c62-a7c0-148dcb6cb1a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "callout issue resolved by adding preventDismissOnLostFocus prop to callout props",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -155,6 +155,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
           directionalHint={DirectionalHint.rightTopEdge}
           id={this._calloutId}
           onDismiss={this._closeCallout}
+          preventDismissOnLostFocus={true}
           {...this.props.calloutProps!}
           {...this._getAccessibleDataObject(this.state.callOutAccessibilityData)}
         >

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -146,6 +146,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
                 directionalHint={DirectionalHint.topRightEdge}
                 id={this._calloutId}
                 onDismiss={this._closeCallout}
+                preventDismissOnLostFocus={true}
                 {...this.props.calloutProps!}
                 {...this._getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false)}
               >

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -119,6 +119,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       XValue: this.state.xCalloutValue,
       YValue: this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard,
       onDismiss: this._closeCallout,
+      preventDismissOnLostFocus: true,
       ...this.props.calloutProps,
       ...getAccessibleDataObject(this.state.callOutAccessibilityData),
     };

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -156,6 +156,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       YValueHover: this.state.YValueHover,
       hoverXValue: this.state.hoverXValue,
       onDismiss: this._closeCallout,
+      preventDismissOnLostFocus: true,
       ...this.props.calloutProps,
       ...getAccessibleDataObject(this.state.callOutAccessibilityData),
     };


### PR DESCRIPTION
### Original description
Cherry pick of [#19178](https://github.com/microsoft/fluentui/pull/19178)

#### Description of changes

While adding callout dismiss on escape, we need add one more prop to enable callout again.

### Focus areas to test
Grouped vertical bar chart
Vertical stacked bar chart
Vertical bar chart
Horizontal bar chart

(give an overview)
