### PR TITLE
Fix local Screener run

### DIFF
--- a/apps/vr-tests/screener.local.config.js
+++ b/apps/vr-tests/screener.local.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
+  /*
+    We need to force version 5, regardless of our current version.
+    This is due to an implementation limitation on the `storybook-screener` package.
+    Read more about it here: https://github.com/microsoft/fluentui/pull/19257
+  */
   storybookVersion: '5',
   storybookBinPath: '../../node_modules/.bin/',
   apiKey: process.env.SCREENER_API_KEY,

--- a/apps/vr-tests/screener.local.config.js
+++ b/apps/vr-tests/screener.local.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
+  storybookVersion: '5',
+  storybookBinPath: '../../node_modules/.bin/',
   apiKey: process.env.SCREENER_API_KEY,
   resolution: '1024x768',
   baseBranch: 'master',


### PR DESCRIPTION
#### Pull request checklist

~- Addresses an existing issue: Fixes #0000~
~- Include a change request file using `$ yarn change`~

#### Description of changes

For a while, running our VR tests locally with Screener was an impossibility. After some reverse engineering with the help of @Hotell (thanks!) we figured out several issues.

##### Issue 1:
Screener automatically assumes your `start-storybook` binary is located in it's own folder. As such, this probably stopped working whenever we moved the dependencies out of `vr-tests`.
To fix this, we added the `storybookBinPath` config to manually tell Screener where to get the binary from.

##### Issue 2:
Using the custom bin path now requires us to define our Storybook version. This can be achieved by using the `storybookVersion` prop but, due to [this](https://github.com/screener-io/screener-storybook/blob/master/src/storybook.js#L221) we cannot define our version to be 6 (which is what we use).
After an extensive look at the `screener-storybook` and `screener-runner` code, it seems like there's no issue with defining version 5 and all our tests worked.
This means, however, that we have a "wrong" version in our config, but that's what's needed on our side for it to work, until that gets fixed by Screener.

#### Future plans

As is, we still have to manually change the API key and branch in this .json file. In the future, we plan to create an nx generator to automate this with prompts and make the DX a dream 🤩

#### Focus areas to test

`yarn workspace vr-tests screener:local`

![image](https://user-images.githubusercontent.com/39736248/128207460-d7f41f04-df56-4eb0-b721-08008235d1df.png)

