### PR TITLE
fix: add border and adjust padding to badge component

### DIFF
--- a/change/@fluentui-web-components-5dc3f7fb-7d68-4ca4-b499-a860985ffc30.json
+++ b/change/@fluentui-web-components-5dc3f7fb-7d68-4ca4-b499-a860985ffc30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add border and adjust padding to badge component",
+  "packageName": "@fluentui/web-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/badge/badge.styles.ts
+++ b/packages/web-components/src/badge/badge.styles.ts
@@ -8,6 +8,7 @@ import {
   foregroundOnAccentRest,
   neutralFillRest,
   neutralForegroundRest,
+  strokeWidth,
   typeRampMinus1FontSize,
   typeRampMinus1LineHeight,
 } from '../design-tokens';
@@ -26,7 +27,8 @@ export const badgeStyles: (
 
     .control {
       border-radius: calc(${controlCornerRadius} * 1px);
-      padding: calc(${designUnit} * 0.5px) calc(${designUnit} * 1px);
+      padding: calc(((${designUnit} * 0.5) - ${strokeWidth}) * 1px) calc((${designUnit} - ${strokeWidth}) * 1px);
+      border: calc(${strokeWidth} * 1px) solid transparent;
     }
 
     :host(.lightweight) .control {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Set a transparent border to badge so when the component is in forced colors the system will set a border to the component

before
![image](https://user-images.githubusercontent.com/37851220/128268587-833921bf-94f2-45f0-9c32-9ca250d5c5ee.png)

after
![image](https://user-images.githubusercontent.com/37851220/128268593-73473452-d598-460a-b59b-b3b14f077474.png)

#### Focus areas to test

(optional)
