### PR TITLE
fix(react-slider): use compat version of shorthands

### DIFF
--- a/packages/react-slider/etc/react-slider.api.md
+++ b/packages/react-slider/etc/react-slider.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentPropsCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public
@@ -17,7 +17,7 @@ export const Slider: React_2.ForwardRefExoticComponent<SliderProps & React_2.Ref
 export type SliderDefaultedProps = never;
 
 // @public
-export interface SliderProps extends ComponentProps, React_2.HTMLAttributes<HTMLElement> {
+export interface SliderProps extends ComponentPropsCompat, React_2.HTMLAttributes<HTMLElement> {
 }
 
 // @public
@@ -31,7 +31,6 @@ export const useSlider: (props: SliderProps, ref: React_2.Ref<HTMLElement>, defa
 
 // @public
 export const useSliderStyles: (state: any) => any;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.3.3",
-    "@fluentui/jest-serializer-merge-styles": "^8.0.9",
+    "@fluentui/jest-serializer-make-styles": "^9.0.0-alpha.30",
     "@fluentui/react-conformance": "^0.4.4",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentPropsCompat } from '@fluentui/react-utilities';
 
 /**
  * Slider Props
  */
-export interface SliderProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+export interface SliderProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /*
    * TODO Add props and slots here
    * Any slot property should be listed in the sliderShorthandProps array below

--- a/packages/react-slider/src/components/Slider/renderSlider.tsx
+++ b/packages/react-slider/src/components/Slider/renderSlider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+import { getSlotsCompat } from '@fluentui/react-utilities';
 // import { SliderState } from './Slider.types';
 import { sliderShorthandProps } from './useSlider';
 
@@ -8,7 +8,7 @@ import { sliderShorthandProps } from './useSlider';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const renderSlider = (state: any) => {
-  const { slots, slotProps } = getSlots(state, sliderShorthandProps);
+  const { slots, slotProps } = getSlotsCompat(state, sliderShorthandProps);
 
   return (
     <slots.root {...slotProps.root}>


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

`react-slider` is wrongly using the newest version of `getSlots` and `ComponentProps`. This PR modifies it to use compat version instead