### PR TITLE
perf(webpack-loader): early return on files without makeStyles() calls

### DIFF
--- a/change/@fluentui-make-styles-webpack-loader-4d1b1fa5-0598-4790-93cd-887c501b3694.json
+++ b/change/@fluentui-make-styles-webpack-loader-4d1b1fa5-0598-4790-93cd-887c501b3694.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "perf: early return on files without makeStyles() calls",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
@@ -165,8 +165,9 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
 describe('shouldTransformSourceCode', () => {
   it('handles defaults', () => {
     expect(shouldTransformSourceCode(`import { makeStyles } from "@fluentui/react-make-styles"`, undefined)).toBe(true);
-
     expect(shouldTransformSourceCode(`import { makeStyles } from "@fluentui/react-components"`, undefined)).toBe(true);
+
+    expect(shouldTransformSourceCode(`import { Button } from "@fluentui/react"`, undefined)).toBe(false);
   });
 
   it('handles options', () => {
@@ -175,12 +176,17 @@ describe('shouldTransformSourceCode', () => {
         { moduleSource: '@fluentui/react-make-styles', importName: 'makeStyles' },
       ]),
     ).toBe(true);
-
     expect(
       shouldTransformSourceCode(`import { createStyles } from "make-styles"`, [
         { moduleSource: 'make-styles', importName: 'createStyles' },
       ]),
     ).toBe(true);
+
+    expect(
+      shouldTransformSourceCode(`import { Button } from "@fluentui/react"`, [
+        { moduleSource: '@fluentui/react-make-styles', importName: 'makeStyles' },
+      ]),
+    ).toBe(false);
   });
 });
 

--- a/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
@@ -6,6 +6,7 @@ import * as webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
 import type { WebpackLoaderOptions } from './webpackLoader';
+import { shouldTransformSourceCode } from './webpackLoader';
 
 type CompileOptions = {
   loaderOptions?: WebpackLoaderOptions;
@@ -160,6 +161,28 @@ function testFixture(fixtureName: string, options: CompileOptions = {}) {
     }
   });
 }
+
+describe('shouldTransformSourceCode', () => {
+  it('handles defaults', () => {
+    expect(shouldTransformSourceCode(`import { makeStyles } from "@fluentui/react-make-styles"`, undefined)).toBe(true);
+
+    expect(shouldTransformSourceCode(`import { makeStyles } from "@fluentui/react-components"`, undefined)).toBe(true);
+  });
+
+  it('handles options', () => {
+    expect(
+      shouldTransformSourceCode(`import { makeStyles } from "@fluentui/react-make-styles"`, [
+        { moduleSource: '@fluentui/react-make-styles', importName: 'makeStyles' },
+      ]),
+    ).toBe(true);
+
+    expect(
+      shouldTransformSourceCode(`import { createStyles } from "make-styles"`, [
+        { moduleSource: 'make-styles', importName: 'createStyles' },
+      ]),
+    ).toBe(true);
+  });
+});
 
 describe('webpackLoader', () => {
   // Integration fixtures for base functionality, all scenarios are tested in "babel-make-styles"


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

During tryouts in Teams codebase of loader I noticed significant performance penalty caused by the loader: ~370 seconds vs ~580 seconds for a build. This happened because we process an each file and building AST by Babel, even if a file does not contain `makeStyles()` calls.

This PR uses the same trick as Linaria to skip files without `makeStyles()` calls: https://github.com/callstack/linaria/blob/ff1268faf92408caf80ca272f5f87c306f75df79/packages/babel/src/transform.ts#L44-L46. It's not 100% accurate as checks via AST, but it's enough good to improve loader's perf.