### PR TITLE
fix(Commandbar): add role="none" to intermediate divs, add primary/secondary group labels

### DIFF
--- a/change/@fluentui-react-2d0bd842-371a-43a4-bf57-2a071e273762.json
+++ b/change/@fluentui-react-2d0bd842-371a-43a4-bf57-2a071e273762.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add role=none to fix CommandBar hierarchy, add optional group labels to primary/secondary command groups",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-b133d68b-f431-4609-a999-6ccccd7d58f4.json
+++ b/change/@fluentui-react-charting-b133d68b-f431-4609-a999-6ccccd7d58f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshots updates for tooltip change",
+  "packageName": "@fluentui/react-charting",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-6547cf8b-0ee4-486f-a324-78019f591667.json
+++ b/change/@fluentui-react-experiments-6547cf8b-0ee4-486f-a324-78019f591667.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Snapshot updates for tooltip change",
+  "packageName": "@fluentui/react-experiments",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -540,6 +541,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="metaData1"
@@ -1040,6 +1042,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -1364,6 +1367,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -1688,6 +1692,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -2012,6 +2017,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="first"
@@ -264,6 +265,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="second"
@@ -530,6 +532,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="first"
@@ -619,6 +622,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="second"
@@ -1006,6 +1010,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="first"
@@ -1095,6 +1100,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="second"
@@ -1365,6 +1371,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="first"
@@ -1454,6 +1461,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="second"

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -291,6 +291,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData1"
@@ -380,6 +381,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData2"
@@ -469,6 +471,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData3"
@@ -834,6 +837,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="MetaData1"
@@ -923,6 +927,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="MetaData2"
@@ -1012,6 +1017,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="MetaData3"
@@ -1628,6 +1634,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData1"
@@ -1717,6 +1724,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData2"
@@ -1806,6 +1814,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData3"
@@ -2188,6 +2197,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData1"
@@ -2277,6 +2287,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData2"
@@ -2366,6 +2377,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData3"
@@ -2748,6 +2760,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData1"
@@ -2837,6 +2850,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData2"
@@ -2926,6 +2940,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData3"
@@ -3308,6 +3323,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData1"
@@ -3397,6 +3413,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData2"
@@ -3486,6 +3503,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="MetaData3"

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -221,6 +221,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Execllent (0-200)"
@@ -533,6 +534,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Execllent (0-200)"
@@ -622,6 +624,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Nasty"
@@ -1101,6 +1104,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Execllent (0-200)"
@@ -1413,6 +1417,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Execllent (0-200)"

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -224,6 +224,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -522,6 +523,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="metaData1"
@@ -1004,6 +1006,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -1319,6 +1322,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -1634,6 +1638,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"
@@ -1949,6 +1954,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="metaData1"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1382,6 +1382,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Debit card numbers (EU and USA)"
@@ -1471,6 +1472,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Passport numbers (USA)"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1211,6 +1211,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="first Lorem ipsum dolor sit amet"
@@ -1300,6 +1301,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Winter is coming"

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="First"
@@ -306,6 +307,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Second"
@@ -395,6 +397,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Third"
@@ -686,6 +689,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="First"
@@ -775,6 +779,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="Second"
@@ -864,6 +869,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="Third"
@@ -1332,6 +1338,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="First"
@@ -1421,6 +1428,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Second"
@@ -1510,6 +1518,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Third"
@@ -1818,6 +1827,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="First"
@@ -1907,6 +1917,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Second"
@@ -1996,6 +2007,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Third"
@@ -2304,6 +2316,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="First"
@@ -2393,6 +2406,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Second"
@@ -2482,6 +2496,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Third"
@@ -2790,6 +2805,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="First"
@@ -2879,6 +2895,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Second"
@@ -2968,6 +2985,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Third"

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -246,6 +247,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"
@@ -477,6 +479,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="Metadata1"
@@ -566,6 +569,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             aria-label="Metadata2"
@@ -914,6 +918,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -1003,6 +1008,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"
@@ -1251,6 +1257,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -1340,6 +1347,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"
@@ -1588,6 +1596,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -1677,6 +1686,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"
@@ -1925,6 +1935,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -2014,6 +2025,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"
@@ -2262,6 +2274,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata1"
@@ -2351,6 +2364,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-label="Metadata2"

--- a/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
@@ -12,7 +12,9 @@ export const CommandBarBasicExample: React.FunctionComponent = () => {
         overflowItems={_overflowItems}
         overflowButtonProps={overflowProps}
         farItems={_farItems}
-        ariaLabel="Use left and right arrow keys to navigate between commands"
+        ariaLabel="Inbox actions"
+        primaryGroupAriaLabel="Email actions"
+        secondaryGroupAriaLabel="More actions"
       />
     </div>
   );

--- a/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
@@ -14,7 +14,7 @@ export const CommandBarBasicExample: React.FunctionComponent = () => {
         farItems={_farItems}
         ariaLabel="Inbox actions"
         primaryGroupAriaLabel="Email actions"
-        secondaryGroupAriaLabel="More actions"
+        farItemsGroupAriaLabel="More actions"
       />
     </div>
   );

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -419,6 +419,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 2
                   </div>
@@ -586,6 +587,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 3
                   </div>
@@ -675,6 +677,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 4 (non-clickable)
                   </div>
@@ -842,6 +845,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 5
                   </div>
@@ -1009,6 +1013,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 6
                   </div>
@@ -1176,6 +1181,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 7
                   </div>
@@ -1343,6 +1349,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 8
                   </div>
@@ -1510,6 +1517,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 9
                   </div>
@@ -1677,6 +1685,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 10
                   </div>
@@ -1845,6 +1854,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 11
                   </div>
@@ -2261,6 +2271,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 3
                   </div>
@@ -2350,6 +2361,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 4 (non-clickable)
                   </div>
@@ -2506,6 +2518,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 5
                   </div>
@@ -2741,6 +2754,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Files
                   </div>
@@ -2908,6 +2922,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 1
                   </div>
@@ -2997,6 +3012,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 2
                   </div>
@@ -3232,6 +3248,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Files
                   </div>
@@ -3247,6 +3264,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   <span
                     aria-hidden="true"
@@ -3393,6 +3411,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 1
                   </div>
@@ -3408,6 +3427,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   <span
                     aria-hidden="true"
@@ -3476,6 +3496,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 2
                   </div>
@@ -3904,6 +3925,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 7
                   </div>
@@ -4071,6 +4093,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 8
                   </div>
@@ -4238,6 +4261,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 9
                   </div>
@@ -4405,6 +4429,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 10
                   </div>
@@ -4573,6 +4598,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Folder 11
                   </div>

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -226,6 +226,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Files
                   </div>
@@ -393,6 +394,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 1
                   </div>
@@ -560,6 +562,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 2 with a long name
                   </div>
@@ -727,6 +730,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 3 long
                   </div>
@@ -816,6 +820,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is non-clickable folder 4
                   </div>
@@ -984,6 +989,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 5
                   </div>
@@ -1412,6 +1418,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 3 long
                   </div>
@@ -1501,6 +1508,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is non-clickable folder 4
                   </div>
@@ -1669,6 +1677,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 5
                   </div>
@@ -1904,6 +1913,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Files
                   </div>
@@ -2265,6 +2275,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 5
                   </div>

--- a/packages/react-examples/src/react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -395,6 +395,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 3 long
                   </div>
@@ -484,6 +485,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is non-clickable folder 4
                   </div>
@@ -652,6 +654,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     This is folder 5
                   </div>

--- a/packages/react-examples/src/react/__snapshots__/Button.IconWithTooltip.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Button.IconWithTooltip.Example.tsx.shot
@@ -13,6 +13,7 @@ exports[`Component Examples renders Button.IconWithTooltip.Example.tsx correctly
     onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    role="none"
   >
     <button
       aria-label="Emoji"

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -20,7 +20,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Use left and right arrow keys to navigate between commands"
+          aria-label="Inbox actions"
           className=
               ms-FocusZone
               ms-CommandBar
@@ -48,6 +48,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
           role="menubar"
         >
           <div
+            aria-label="Email actions"
             className=
                 ms-OverflowSet
                 ms-CommandBar-primaryCommand
@@ -58,7 +59,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="none"
+            role="group"
           >
             <div
               className=
@@ -67,6 +68,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 aria-controls={null}
@@ -290,6 +292,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <a
                 className=
@@ -469,6 +472,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 className=
@@ -648,6 +652,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 className=
@@ -982,6 +987,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
             </div>
           </div>
           <div
+            aria-label="More actions"
             className=
                 ms-OverflowSet
                 ms-CommandBar-secondaryCommand
@@ -992,7 +998,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="none"
+            role="group"
           >
             <div
               className=
@@ -1001,6 +1007,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <div
                 className=
@@ -1013,6 +1020,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 <button
                   aria-label="Grid view"
@@ -1168,6 +1176,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <div
                 className=
@@ -1180,6 +1189,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 <button
                   aria-label="Info"

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="none"
+          role="group"
         >
           <div
             className=
@@ -66,6 +66,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               aria-controls={null}
@@ -290,6 +291,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <a
               className=
@@ -470,6 +472,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -650,6 +653,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -995,7 +999,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="none"
+          role="group"
         >
           <div
             className=
@@ -1004,6 +1008,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <div
               className=
@@ -1016,6 +1021,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              role="none"
             >
               <button
                 aria-label="Grid view"
@@ -1171,6 +1177,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <div
               className=
@@ -1183,6 +1190,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              role="none"
             >
               <button
                 aria-label="Info"

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -66,6 +66,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -245,6 +246,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -424,6 +426,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <div>
               <button
@@ -1172,6 +1175,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
@@ -66,6 +66,7 @@ exports[`Component Examples renders CommandBar.Lazy.Example.tsx correctly 1`] = 
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 className=
@@ -209,6 +210,7 @@ exports[`Component Examples renders CommandBar.Lazy.Example.tsx correctly 1`] = 
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 aria-controls={null}

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -67,6 +67,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <div
                 aria-expanded={false}
@@ -490,6 +491,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <div
                 aria-disabled={true}
@@ -921,6 +923,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <button
                 aria-disabled={true}
@@ -1102,6 +1105,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     display: inherit;
                     flex-shrink: 0;
                   }
+              role="none"
             >
               <div
                 className=
@@ -1114,6 +1118,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 <button
                   aria-disabled={true}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -82,6 +82,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   className=
@@ -261,6 +262,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   className=
@@ -440,6 +442,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       display: inherit;
                       flex-shrink: 0;
                     }
+                role="none"
               >
                 <button
                   aria-controls={null}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1914,6 +1914,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -2374,6 +2375,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -2834,6 +2836,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -3294,6 +3297,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -3754,6 +3758,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -4214,6 +4219,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -4674,6 +4680,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -5134,6 +5141,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -5594,6 +5602,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"
@@ -6054,6 +6063,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              role="none"
                             >
                               <img
                                 alt="accdb file icon"

--- a/packages/react-examples/src/react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -56,7 +56,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="none"
+          role="group"
         >
           <div
             className=
@@ -65,6 +65,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               aria-describedby="ktp-layer-id ktp-j"
@@ -247,6 +248,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               aria-describedby="ktp-layer-id ktp-m"
@@ -434,7 +436,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="none"
+          role="group"
         >
           <div
             className=
@@ -443,6 +445,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               aria-controls={null}

--- a/packages/react-examples/src/react/__snapshots__/Keytips.Overflow.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Keytips.Overflow.Example.tsx.shot
@@ -24,6 +24,7 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
             display: inherit;
             flex-shrink: 0;
           }
+      role="none"
     >
       <button
         aria-describedby="ktp-layer-id ktp-q"
@@ -167,6 +168,7 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
             display: inherit;
             flex-shrink: 0;
           }
+      role="none"
     >
       <button
         aria-describedby="ktp-layer-id ktp-w"
@@ -310,6 +312,7 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
             display: inherit;
             flex-shrink: 0;
           }
+      role="none"
     >
       <button
         aria-describedby="ktp-layer-id ktp-e"

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -20,6 +20,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=
@@ -105,6 +106,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=
@@ -190,6 +192,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -163,6 +163,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=
@@ -248,6 +249,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=
@@ -333,6 +335,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -20,6 +20,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <div
       className=
@@ -187,6 +188,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       aria-controls={null}
@@ -407,6 +409,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=
@@ -583,6 +586,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <button
       className=

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -21,6 +21,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <div
       className=
@@ -33,6 +34,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      role="none"
     >
       <button
         aria-label="Add"
@@ -186,6 +188,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <div
       className=
@@ -198,6 +201,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      role="none"
     >
       <button
         aria-label="Upload"
@@ -351,6 +355,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           display: inherit;
           flex-shrink: 0;
         }
+    role="none"
   >
     <div
       className=
@@ -363,6 +368,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      role="none"
     >
       <button
         aria-label="Share"
@@ -528,6 +534,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      role="none"
     >
       <button
         aria-controls={null}

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -418,6 +418,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Annie Lindqvist
                 </div>
@@ -446,6 +447,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Designer
                 </div>
@@ -475,6 +477,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   In a meeting
                 </div>
@@ -504,6 +507,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Available at 4:00pm
                 </div>
@@ -796,6 +800,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Aaron Reid
                 </div>
@@ -824,6 +829,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Designer
                 </div>
@@ -853,6 +859,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   In a meeting
                 </div>
@@ -882,6 +889,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Available at 4:00pm
                 </div>
@@ -1180,6 +1188,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Alex Lundberg
                 </div>
@@ -1208,6 +1217,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Software Developer
                 </div>
@@ -1237,6 +1247,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   In a meeting
                 </div>
@@ -1266,6 +1277,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Available at 4:00pm
                 </div>
@@ -1577,6 +1589,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Roko Kolar
                 </div>
@@ -1605,6 +1618,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Financial Analyst
                 </div>
@@ -1634,6 +1648,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   In a meeting
                 </div>
@@ -1663,6 +1678,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Available at 4:00pm
                 </div>
@@ -1961,6 +1977,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Christian Bergqvist
                 </div>
@@ -1989,6 +2006,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Sr. Designer
                 </div>
@@ -2018,6 +2036,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   In a meeting
                 </div>
@@ -2047,6 +2066,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   Available at 4:00pm
                 </div>

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -309,6 +309,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Annie Lindqvist
                     </div>
@@ -338,6 +339,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Designer
                     </div>
@@ -367,6 +369,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       In a meeting
                     </div>
@@ -396,6 +399,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Available at 4:00pm
                     </div>
@@ -755,6 +759,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Aaron Reid
                     </div>
@@ -784,6 +789,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Designer
                     </div>
@@ -813,6 +819,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       In a meeting
                     </div>
@@ -842,6 +849,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Available at 4:00pm
                     </div>
@@ -1201,6 +1209,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Alex Lundberg
                     </div>
@@ -1230,6 +1239,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Software Developer
                     </div>
@@ -1259,6 +1269,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       In a meeting
                     </div>
@@ -1288,6 +1299,7 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Available at 4:00pm
                     </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -174,6 +174,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Reid
         </div>
@@ -206,6 +207,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -235,6 +237,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -264,6 +267,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -422,6 +426,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Reid
         </div>
@@ -454,6 +459,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -483,6 +489,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -512,6 +519,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -696,6 +704,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Reid
         </div>
@@ -728,6 +737,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer (Available)
         </div>
@@ -757,6 +767,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -786,6 +797,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -328,6 +328,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -357,6 +358,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -386,6 +388,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -415,6 +418,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -584,6 +588,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -613,6 +618,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -642,6 +648,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -671,6 +678,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -879,6 +887,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist (Available)
         </div>
@@ -908,6 +917,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -937,6 +947,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -966,6 +977,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1174,6 +1186,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist (Available)
         </div>
@@ -1203,6 +1216,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -1232,6 +1246,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1261,6 +1276,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1496,6 +1512,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -1524,6 +1541,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -1553,6 +1571,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1582,6 +1601,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1809,6 +1829,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -1837,6 +1858,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -1866,6 +1888,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1895,6 +1918,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2128,6 +2152,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -2156,6 +2181,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -2185,6 +2211,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2214,6 +2241,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2447,6 +2475,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -2475,6 +2504,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -2504,6 +2534,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2533,6 +2564,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2793,6 +2825,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -2821,6 +2854,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -2850,6 +2884,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2879,6 +2914,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -3114,6 +3150,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -3142,6 +3179,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Software Engineer
         </div>
@@ -3171,6 +3209,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -3200,6 +3239,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.Colors.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Colors.Example.tsx.shot
@@ -172,6 +172,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             green10
           </div>
@@ -350,6 +351,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             darkGreen20
           </div>
@@ -528,6 +530,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             teal10
           </div>
@@ -706,6 +709,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             cyan30
           </div>
@@ -884,6 +888,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             lightBlue30
           </div>
@@ -1062,6 +1067,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             blue20
           </div>
@@ -1240,6 +1246,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             darkBlue10
           </div>
@@ -1418,6 +1425,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             violet10
           </div>
@@ -1596,6 +1604,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             purple10
           </div>
@@ -1774,6 +1783,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             magenta10
           </div>
@@ -1952,6 +1962,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             lightPink10
           </div>
@@ -2130,6 +2141,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             pink10
           </div>
@@ -2308,6 +2320,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             pinkRed10
           </div>
@@ -2486,6 +2499,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             red10
           </div>
@@ -2664,6 +2678,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             darkRed20
           </div>
@@ -2842,6 +2857,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             orange10
           </div>
@@ -3020,6 +3036,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             orange30
           </div>
@@ -3198,6 +3215,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             orangeYellow20
           </div>
@@ -3376,6 +3394,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             gray30
           </div>
@@ -3554,6 +3573,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            role="none"
           >
             gray20
           </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -213,6 +213,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Ted Randall
         </div>
@@ -241,6 +242,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Project Manager
         </div>
@@ -284,6 +286,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -238,6 +238,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lindqvist
         </div>
@@ -302,6 +303,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -331,6 +333,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -152,6 +152,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Kat Larrson
         </div>
@@ -181,6 +182,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -210,6 +212,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -239,6 +242,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -375,6 +379,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie
         </div>
@@ -404,6 +409,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -433,6 +439,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -462,6 +469,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -598,6 +606,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Lind
         </div>
@@ -627,6 +636,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -656,6 +666,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -685,6 +696,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -821,6 +833,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Boyl Lind
         </div>
@@ -850,6 +863,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -879,6 +893,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -908,6 +923,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1044,6 +1060,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           David (The man) Goff
         </div>
@@ -1073,6 +1090,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -1102,6 +1120,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1131,6 +1150,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1267,6 +1287,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           David Goff [The man]
         </div>
@@ -1296,6 +1317,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -1325,6 +1347,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1354,6 +1377,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1490,6 +1514,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           David (The man) Goff &lt;David.Goff@example.com&gt;
         </div>
@@ -1519,6 +1544,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -1548,6 +1574,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1577,6 +1604,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1713,6 +1741,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Annie Boyl Carrie Lindqvist
         </div>
@@ -1741,6 +1770,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -1770,6 +1800,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -1799,6 +1830,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -1949,6 +1981,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           +1 (111) 123-4567 X4567
         </div>
@@ -1977,6 +2010,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -2006,6 +2040,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2035,6 +2070,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2171,6 +2207,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           +1 (555) 123-4567 X4567
         </div>
@@ -2199,6 +2236,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -2228,6 +2266,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2257,6 +2296,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2407,6 +2447,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           宋智洋
         </div>
@@ -2435,6 +2476,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -2464,6 +2506,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2493,6 +2536,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2643,6 +2687,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           남궁 성종
         </div>
@@ -2671,6 +2716,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -2700,6 +2746,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2729,6 +2776,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -2879,6 +2927,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           خسرو رحیمی
         </div>
@@ -2907,6 +2956,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -2936,6 +2986,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -2965,6 +3016,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -3101,6 +3153,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Maor Sharett
         </div>
@@ -3129,6 +3182,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -3158,6 +3212,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -3187,6 +3242,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -3323,6 +3379,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Maor Sharett
         </div>
@@ -3351,6 +3408,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -3380,6 +3438,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -3409,6 +3468,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>
@@ -3563,6 +3623,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Maor Sharett
         </div>
@@ -3591,6 +3652,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -3620,6 +3682,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           In a meeting
         </div>
@@ -3649,6 +3712,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Available at 4:00pm
         </div>

--- a/packages/react-examples/src/react/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -166,6 +166,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Maor Sharett
         </div>
@@ -194,6 +195,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -372,6 +374,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Kat Larrson
         </div>
@@ -400,6 +403,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Designer
         </div>
@@ -429,6 +433,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           Unverified sender
         </div>

--- a/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -41,6 +41,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -217,6 +218,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -393,6 +395,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -569,6 +572,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -745,6 +749,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -921,6 +926,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1097,6 +1103,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1273,6 +1280,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1449,6 +1457,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1625,6 +1634,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1801,6 +1811,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -1977,6 +1988,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -2153,6 +2165,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -2329,6 +2342,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -2505,6 +2519,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -2681,6 +2696,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -2857,6 +2873,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -3033,6 +3050,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -3209,6 +3227,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -3385,6 +3404,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=

--- a/packages/react-examples/src/react/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
@@ -45,6 +45,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -222,6 +223,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -399,6 +401,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -576,6 +579,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -753,6 +757,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -930,6 +935,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1107,6 +1113,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1284,6 +1291,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1461,6 +1469,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1638,6 +1647,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1815,6 +1825,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -1992,6 +2003,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -2169,6 +2181,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -2346,6 +2359,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -2523,6 +2537,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -2700,6 +2715,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -2877,6 +2893,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -3054,6 +3071,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -3231,6 +3249,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=
@@ -3408,6 +3427,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                 display: inherit;
                 flex-shrink: 0;
               }
+          role="none"
         >
           <button
             className=

--- a/packages/react-examples/src/react/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -458,6 +458,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      role="none"
                     >
                       Group One
                     </div>

--- a/packages/react-examples/src/react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -77,6 +77,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           <i
             aria-label="Info tooltip"
@@ -284,6 +285,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
           onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          role="none"
         >
           <i
             aria-label="Info tooltip"

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -939,6 +939,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      role="none"
     >
       <button
         aria-label="last page"

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -346,6 +346,7 @@ Array [
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 Person A
               </div>
@@ -877,6 +878,7 @@ Array [
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 Person B
               </div>
@@ -1413,6 +1415,7 @@ Array [
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 Person A
               </div>
@@ -1944,6 +1947,7 @@ Array [
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="none"
               >
                 Person B
               </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -617,6 +617,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        role="none"
                       >
                         Annie Lindqvist
                       </div>
@@ -646,6 +647,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        role="none"
                       >
                         Designer
                       </div>
@@ -675,6 +677,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        role="none"
                       >
                         In a meeting
                       </div>
@@ -704,6 +707,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        role="none"
                       >
                         Available at 4:00pm
                       </div>

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3158,7 +3158,9 @@ export interface ICommandBarProps extends React_2.HTMLAttributes<HTMLDivElement>
     overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowButtonProps?: IButtonProps;
     overflowItems?: ICommandBarItemProps[];
+    primaryGroupAriaLabel?: string;
     resizeGroupAs?: IComponentAs<IResizeGroupProps>;
+    secondaryGroupAriaLabel?: string;
     shiftOnReduce?: boolean;
     styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
     theme?: ITheme;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3150,6 +3150,7 @@ export interface ICommandBarProps extends React_2.HTMLAttributes<HTMLDivElement>
     componentRef?: IRefObject<ICommandBar>;
     dataDidRender?: (renderedData: any) => void;
     farItems?: ICommandBarItemProps[];
+    farItemsGroupAriaLabel?: string;
     items: ICommandBarItemProps[];
     onDataGrown?: (movedItem: ICommandBarItemProps) => void;
     onDataReduced?: (movedItem: ICommandBarItemProps) => void;
@@ -3160,7 +3161,6 @@ export interface ICommandBarProps extends React_2.HTMLAttributes<HTMLDivElement>
     overflowItems?: ICommandBarItemProps[];
     primaryGroupAriaLabel?: string;
     resizeGroupAs?: IComponentAs<IResizeGroupProps>;
-    secondaryGroupAriaLabel?: string;
     shiftOnReduce?: boolean;
     styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
     theme?: ITheme;
@@ -8336,6 +8336,7 @@ export interface ITooltipHostProps extends React_2.HTMLAttributes<HTMLDivElement
     id?: string;
     onTooltipToggle?(isTooltipVisible: boolean): void;
     overflowMode?: TooltipOverflowMode;
+    // @deprecated
     setAriaDescribedBy?: boolean;
     styles?: IStyleFunctionOrObject<ITooltipHostStyleProps, ITooltipHostStyles>;
     theme?: ITheme;

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -289,6 +289,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText3
                 </div>
@@ -378,6 +379,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText4
                 </div>
@@ -507,6 +509,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText1
                 </div>
@@ -596,6 +599,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText2
                 </div>
@@ -685,6 +689,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText3
                 </div>
@@ -774,6 +779,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText4
                 </div>
@@ -903,6 +909,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText1
                 </div>
@@ -965,6 +972,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText2
                 </div>
@@ -1027,6 +1035,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText3
                 </div>
@@ -1089,6 +1098,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText4
                 </div>
@@ -1218,6 +1228,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText1
                 </div>
@@ -1963,6 +1974,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText3
                 </div>
@@ -2052,6 +2064,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText4
                 </div>
@@ -2181,6 +2194,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText1
                 </div>
@@ -2462,6 +2476,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="none"
                 >
                   TestText4
                 </div>

--- a/packages/react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.base.tsx
@@ -118,16 +118,20 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
   }
 
   private _onRenderData = (data: ICommandBarData): JSX.Element => {
+    const { ariaLabel, primaryGroupAriaLabel, secondaryGroupAriaLabel } = this.props;
+    const hasSecondSet = data.farItems && data.farItems.length > 0;
+
     return (
       <FocusZone
         className={css(this._classNames.root)}
         direction={FocusZoneDirection.horizontal}
         role={'menubar'}
-        aria-label={this.props.ariaLabel}
+        aria-label={ariaLabel}
       >
         {/*Primary Items*/}
         <OverflowSet
-          role="none"
+          role={hasSecondSet ? 'group' : 'none'}
+          aria-label={hasSecondSet ? primaryGroupAriaLabel : undefined}
           componentRef={this._overflowSet}
           className={css(this._classNames.primarySet)}
           items={data.primaryItems}
@@ -137,9 +141,10 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
         />
 
         {/*Secondary Items*/}
-        {data.farItems && data.farItems.length > 0 && (
+        {hasSecondSet && (
           <OverflowSet
-            role="none"
+            role="group"
+            aria-label={secondaryGroupAriaLabel}
             className={css(this._classNames.secondarySet)}
             items={data.farItems}
             onRenderItem={this._onRenderItem}
@@ -172,7 +177,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
 
     if (item.iconOnly && (itemText !== undefined || item.tooltipHostProps)) {
       return (
-        <TooltipHost content={itemText} {...item.tooltipHostProps}>
+        <TooltipHost role="none" content={itemText} setAriaDescribedBy={false} {...item.tooltipHostProps}>
           {this._commandButton(item, commandButtonProps)}
         </TooltipHost>
       );

--- a/packages/react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.base.tsx
@@ -118,7 +118,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
   }
 
   private _onRenderData = (data: ICommandBarData): JSX.Element => {
-    const { ariaLabel, primaryGroupAriaLabel, secondaryGroupAriaLabel } = this.props;
+    const { ariaLabel, primaryGroupAriaLabel, farItemsGroupAriaLabel } = this.props;
     const hasSecondSet = data.farItems && data.farItems.length > 0;
 
     return (
@@ -144,7 +144,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
         {hasSecondSet && (
           <OverflowSet
             role="group"
-            aria-label={secondaryGroupAriaLabel}
+            aria-label={farItemsGroupAriaLabel}
             className={css(this._classNames.secondarySet)}
             items={data.farItems}
             onRenderItem={this._onRenderItem}

--- a/packages/react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/react/src/components/CommandBar/CommandBar.types.ts
@@ -117,6 +117,20 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   ariaLabel?: string;
 
   /**
+   * When using farItems, primaryGroupAriaLabel and secondaryGroupAriaLabel function as
+   * labels for each group that are exposed to screen reader users.
+   * This helps clarify when a screen reader user is entering or leaving each group.
+   */
+  primaryGroupAriaLabel?: string;
+
+  /**
+   * When using farItems, primaryGroupAriaLabel and secondaryGroupAriaLabel function as
+   * labels for each group that are exposed to screen reader users.
+   * This helps clarify when a screen reader user is entering or leaving each group.
+   */
+  secondaryGroupAriaLabel?: string;
+
+  /**
    * Customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;

--- a/packages/react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/react/src/components/CommandBar/CommandBar.types.ts
@@ -117,18 +117,18 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   ariaLabel?: string;
 
   /**
-   * When using farItems, primaryGroupAriaLabel and secondaryGroupAriaLabel function as
+   * When using farItems, primaryGroupAriaLabel and farItemsGroupAriaLabel function as
    * labels for each group that are exposed to screen reader users.
    * This helps clarify when a screen reader user is entering or leaving each group.
    */
   primaryGroupAriaLabel?: string;
 
   /**
-   * When using farItems, primaryGroupAriaLabel and secondaryGroupAriaLabel function as
+   * When using farItems, primaryGroupAriaLabel and farItemsGroupAriaLabel function as
    * labels for each group that are exposed to screen reader users.
    * This helps clarify when a screen reader user is entering or leaving each group.
    */
-  secondaryGroupAriaLabel?: string;
+  farItemsGroupAriaLabel?: string;
 
   /**
    * Customized styling that will layer on top of the variant rules.

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -210,6 +211,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -209,6 +210,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -416,6 +418,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=
@@ -558,6 +561,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                   display: inherit;
                   flex-shrink: 0;
                 }
+            role="none"
           >
             <button
               className=

--- a/packages/react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -60,7 +60,7 @@ export const OverflowSetBase: React.FunctionComponent<IOverflowSetProps> = React
       {overflowSide === 'start' && showOverflow && <OverflowButton {...props} className={classNames.overflowButton} />}
       {items &&
         items.map((item, i) => (
-          <div className={classNames.item} key={item.key}>
+          <div className={classNames.item} key={item.key} role="none">
             {onRenderItem(item)}
           </div>
         ))}

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -328,6 +329,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -527,6 +529,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -707,6 +710,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -1147,6 +1151,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1175,6 +1180,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1204,6 +1210,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1233,6 +1240,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>
@@ -1334,6 +1342,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1362,6 +1371,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1391,6 +1401,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1420,6 +1431,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>
@@ -1656,6 +1668,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1684,6 +1697,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1713,6 +1727,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1742,6 +1757,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>

--- a/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -330,6 +331,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -328,6 +329,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -527,6 +529,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -707,6 +710,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Kat Larrson
       </div>
@@ -1147,6 +1151,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1175,6 +1180,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1204,6 +1210,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1233,6 +1240,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>
@@ -1334,6 +1342,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1362,6 +1371,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1391,6 +1401,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1420,6 +1431,7 @@ exports[`Persona renders Persona which calls onRenderPersonaCoin callback with c
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>
@@ -1656,6 +1668,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Swapnil Vaibhav
       </div>
@@ -1684,6 +1697,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Software Engineer
       </div>
@@ -1713,6 +1727,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         In a meeting
       </div>
@@ -1742,6 +1757,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="none"
       >
         Available at 4:00pm
       </div>

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -99,6 +99,8 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
         onMouseEnter={this._onTooltipMouseEnter}
         onMouseLeave={this._onTooltipMouseLeave}
         onKeyDown={this._onTooltipKeyDown}
+        role="none"
+        // WARNING: aria-describedby on this node provides no value, since it isn't allowed generic elements
         aria-describedby={ariaDescribedBy}
       >
         {children}
@@ -121,7 +123,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
           />
         )}
         {isAriaPlaceholderRendered && (
-          <div id={tooltipId} style={hiddenContentStyle as React.CSSProperties}>
+          <div id={tooltipId} role="none" style={hiddenContentStyle as React.CSSProperties}>
             {content}
           </div>
         )}

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -70,6 +70,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       directionalHintForRTL,
       hostClassName: className,
       id,
+      // eslint-disable-next-line deprecation/deprecation
       setAriaDescribedBy = true,
       tooltipProps,
       styles,

--- a/packages/react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/react/src/components/Tooltip/TooltipHost.types.ts
@@ -105,9 +105,12 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
 
   /**
    * Whether or not to mark the TooltipHost root element as described by the tooltip.
-   * If not specified, the caller should pass an `id` to the TooltipHost (to be passed through to
-   * the Tooltip) and mark the appropriate element as `aria-describedby` the `id`.
+   * Since this applies aria-describedby to a generic <div>, the description will not be
+   * read by screen readers. Instead, the caller should pass an `id` to the TooltipHost
+   * (to be passed through to the Tooltip) and mark the appropriate element as `aria-describedby`
+   * with the `id`.
    * @defaultvalue true
+   * @deprecated use aria-describedby on the appropriate element instead
    */
   setAriaDescribedBy?: boolean;
 

--- a/packages/react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
@@ -12,5 +12,6 @@ exports[`TooltipHost renders correctly 1`] = `
   onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  role="none"
 />
 `;

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -428,6 +428,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Annie Lindqvist
                   </div>
@@ -457,6 +458,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Designer
                   </div>
@@ -486,6 +488,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     In a meeting
                   </div>
@@ -515,6 +518,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    role="none"
                   >
                     Available at 4:00pm
                   </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11832
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Fixes the incorrect index problem by adding `role="none"` where needed
- Adds optional `primaryGroupAriaLabel` and `secondaryGroupAriaLabel` props to label the primary/secondary command groups. Labels and group semantics are only applied if the secondary group exists.
