### PR TITLE
Charting: CherryPick #19245: Accessibility change for Area Chart and Line chart #19245

### DIFF
--- a/change/@fluentui-react-examples-d780f035-74aa-451d-a517-aded00c64e6e.json
+++ b/change/@fluentui-react-examples-d780f035-74aa-451d-a517-aded00c64e6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Area chart and line chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-5f2e26ab-3145-4094-9d1e-9fecb8b44eb0.json
+++ b/change/@uifabric-charting-5f2e26ab-3145-4094-9d1e-9fecb8b44eb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accessibility change for Area chart and line chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/charting/src/components/AreaChart/AreaChart.base.tsx
@@ -7,6 +7,7 @@ import { classNamesFunction, getId, find } from 'office-ui-fabric-react/lib/Util
 import { IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
 import {
+  IAccessibilityProps,
   CartesianChart,
   IChartProps,
   ICustomizedCalloutData,
@@ -62,6 +63,7 @@ export interface IAreaChartState extends IBasestate {
   dataPointCalloutProps?: ICustomizedCalloutData;
   stackCalloutProps?: ICustomizedCalloutData;
   nearestCircleToHighlight: number | string | Date | null;
+  xAxisCalloutAccessibilityData?: IAccessibilityProps;
 }
 
 export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartState> {
@@ -135,6 +137,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       isBeakVisible: false,
       setInitialFocus: true,
       onDismiss: this._closeCallout,
+      'data-is-focusable': true,
+      xAxisCalloutAccessibilityData: this.state.xAxisCalloutAccessibilityData,
       ...this.props.calloutProps,
     };
     return (
@@ -225,7 +229,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
           break;
       }
     }
-    const xAxisCalloutData = lineChartData![0].data[index as number].xAxisCalloutData;
+    const { xAxisCalloutData, xAxisCalloutAccessibilityData } = lineChartData![0].data[index as number];
     const formattedDate = pointToHighlight instanceof Date ? pointToHighlight.toLocaleDateString() : pointToHighlight;
     const modifiedXVal = pointToHighlight instanceof Date ? pointToHighlight.getTime() : pointToHighlight;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -247,6 +251,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         YValueHover: found.values,
         dataPointCalloutProps: found!,
         hoverXValue: xAxisCalloutData ? xAxisCalloutData : formattedDate,
+        xAxisCalloutAccessibilityData,
       });
     } else {
       this.setState({

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -13,6 +13,7 @@ import {
   ChartHoverCard,
   createNumericXAxis,
   createStringXAxis,
+  getAccessibleDataObject,
   getDomainNRangeValues,
   createDateXAxis,
   createYAxis,
@@ -292,7 +293,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
     );
   }
 
-  // TO DO: Write a common funtional component for Multi value callout and divide sub count method
+  // TO DO: Write a common functional component for Multi value callout and divide sub count method
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _multiValueCallout = (calloutProps: any) => {
     const yValueHoverSubCountsExists: boolean = this._yValueHoverSubCountsExists(calloutProps.YValueHover);
@@ -302,7 +303,12 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
           className={this._classNames.calloutDateTimeContainer}
           style={yValueHoverSubCountsExists ? { marginBottom: '11px' } : {}}
         >
-          <div className={this._classNames.calloutContentX}>{calloutProps!.hoverXValue} </div>
+          <div
+            className={this._classNames.calloutContentX}
+            {...getAccessibleDataObject(calloutProps!.xAxisCalloutAccessibilityData)}
+          >
+            {calloutProps!.hoverXValue}{' '}
+          </div>
         </div>
         <div
           className={this._classNames.calloutInfoContainer}
@@ -314,6 +320,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
               const { shouldDrawBorderBottom = false } = yValue;
               return (
                 <div
+                  {...getAccessibleDataObject(yValue.callOutAccessibilityData)}
                   key={`callout-content-${index}`}
                   style={
                     yValueHoverSubCountsExists

--- a/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -5,7 +5,7 @@ import { IOverflowSetProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IFocusZoneProps, FocusZoneDirection } from '@fluentui/react-focus';
 import { ICalloutProps } from 'office-ui-fabric-react/lib/Callout';
 import { ILegendsProps } from '../Legends/index';
-import { IMargins } from '../../types/index';
+import { IAccessibilityProps, IMargins } from '../../types/index';
 import { ChartTypes, IChartHoverCardProps, XAxisTypes, YAxisType } from '../../utilities/index';
 
 export interface ICartesianChartStyleProps {
@@ -336,6 +336,7 @@ export interface IYValueHover {
   shouldDrawBorderBottom?: boolean;
   yAxisCalloutData?: string | { [id: string]: number };
   index?: number;
+  callOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IChildProps {

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -4,6 +4,7 @@ import { select as d3Select } from 'd3-selection';
 import { ILegend, Legends } from '../Legends/index';
 import { classNamesFunction, getId, find } from 'office-ui-fabric-react/lib/Utilities';
 import {
+  IAccessibilityProps,
   CartesianChart,
   IBasestate,
   IChildProps,
@@ -119,8 +120,10 @@ export interface ILineChartState extends IBasestate {
   dataPointCalloutProps?: ICustomizedCalloutData;
   // This value will be used as Customized callout props - For stack callout.
   stackCalloutProps?: ICustomizedCalloutData;
-  // active or hoverd point
+  // active or hovered point
   activePoint?: string;
+  // x-axis callout accessibility data
+  xAxisCalloutAccessibilityData?: IAccessibilityProps;
 }
 
 export class LineChartBase extends React.Component<ILineChartProps, ILineChartState> {
@@ -218,6 +221,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         this.props.getCalloutDescriptionMessage && this.state.stackCalloutProps
           ? this.props.getCalloutDescriptionMessage(this.state.stackCalloutProps)
           : undefined,
+      'data-is-focusable': true,
+      xAxisCalloutAccessibilityData: this.state.xAxisCalloutAccessibilityData,
       ...this.props.calloutProps,
     };
     const tickParams = {
@@ -489,9 +494,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       const { activePoint } = this.state;
       const { theme } = this.props;
       if (this._points[i].data.length === 1) {
-        const x1 = this._points[i].data[0].x;
-        const y1 = this._points[i].data[0].y;
-        const xAxisCalloutData = this._points[i].data[0].xAxisCalloutData;
+        const { x: x1, y: y1, xAxisCalloutData, xAxisCalloutAccessibilityData } = this._points[i].data[0];
         const circleId = `${this._circleId}${i}`;
         pointsForLine.push(
           <circle
@@ -501,8 +504,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             cx={this._xAxisScale(x1)}
             cy={this._yAxisScale(y1)}
             fill={activePoint === circleId ? theme!.palette.white : lineColor}
-            onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
-            onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+            onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+            onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
             onMouseOut={this._handleMouseOut}
             strokeWidth={activePoint === circleId ? 2 : 0}
             stroke={activePoint === circleId ? lineColor : ''}
@@ -521,11 +524,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         const lineId = `${this._lineId}${i}${j}`;
         const borderId = `${this._borderId}${i}${j}`;
         const circleId = `${this._circleId}${i}${j}`;
-        const x1 = this._points[i].data[j - 1].x;
-        const y1 = this._points[i].data[j - 1].y;
-        const x2 = this._points[i].data[j].x;
-        const y2 = this._points[i].data[j].y;
-        const xAxisCalloutData = this._points[i].data[j - 1].xAxisCalloutData;
+        const { x: x1, y: y1, xAxisCalloutData, xAxisCalloutAccessibilityData } = this._points[i].data[j - 1];
+        const { x: x2, y: y2 } = this._points[i].data[j];
         let path = this._getPath(this._xAxisScale(x1), this._yAxisScale(y1), circleId, j, false, this._points[i].index);
         const strokeWidth =
           this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
@@ -564,8 +564,20 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 ref={(e: SVGLineElement | null) => {
                   this._refCallback(e!, lineId);
                 }}
-                onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
-                onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+                onMouseOver={this._handleHover.bind(
+                  this,
+                  x1,
+                  xAxisCalloutData,
+                  circleId,
+                  xAxisCalloutAccessibilityData,
+                )}
+                onMouseMove={this._handleHover.bind(
+                  this,
+                  x1,
+                  xAxisCalloutData,
+                  circleId,
+                  xAxisCalloutAccessibilityData,
+                )}
                 onMouseOut={this._handleMouseOut}
                 stroke={lineColor}
                 strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
@@ -583,10 +595,10 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               key={circleId}
               d={path}
               data-is-focusable={i === 0 ? true : false}
-              onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
-              onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId)}
+              onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+              onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
               onMouseOut={this._handleMouseOut}
-              onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId)}
+              onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
               onBlur={this._handleMouseOut}
               onClick={this._onDataPointClick.bind(this, this._points[i].data[j - 1].onDataPointClick)}
               visibility={hideNonActiveDots ? 'hidden' : 'visible'}
@@ -607,17 +619,34 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               true,
               this._points[i].index,
             );
-            const lastCirlceXCallout = this._points[i].data[j].xAxisCalloutData;
+            const {
+              xAxisCalloutData: lastCirlceXCallout,
+              xAxisCalloutAccessibilityData: lastCirlceXCalloutAccessibilityData,
+            } = this._points[i].data[j];
             pointsForLine.push(
               <path
                 id={lastCircleId}
                 key={lastCircleId}
                 d={path}
                 data-is-focusable={i === 0 ? true : false}
-                onMouseOver={this._handleHover.bind(this, x2, lastCirlceXCallout, lastCircleId)}
-                onMouseMove={this._handleHover.bind(this, x2, lastCirlceXCallout, lastCircleId)}
+                onMouseOver={this._handleHover.bind(
+                  this,
+                  x2,
+                  lastCirlceXCallout,
+                  lastCircleId,
+                  lastCirlceXCalloutAccessibilityData,
+                )}
+                onMouseMove={this._handleHover.bind(
+                  this,
+                  x2,
+                  lastCirlceXCallout,
+                  lastCircleId,
+                  lastCirlceXCalloutAccessibilityData,
+                )}
                 onMouseOut={this._handleMouseOut}
-                onFocus={() => this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId)}
+                onFocus={() =>
+                  this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId, lastCirlceXCalloutAccessibilityData)
+                }
                 onBlur={this._handleMouseOut}
                 onClick={this._onDataPointClick.bind(this, this._points[i].data[j].onDataPointClick)}
                 visibility={hideNonActiveDots ? 'hidden' : 'visible'}
@@ -762,6 +791,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
 
     xAxisCalloutData: string | undefined,
     circleId: string,
+    xAxisCalloutAccessibilityData?: IAccessibilityProps,
   ) => {
     this._uniqueCallOutID = circleId;
     const formattedData = x instanceof Date ? x.toLocaleDateString() : x;
@@ -784,6 +814,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             stackCalloutProps: found!,
             dataPointCalloutProps: found!,
             activePoint: circleId,
+            xAxisCalloutAccessibilityData,
           });
         }
       });
@@ -798,6 +829,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     x: number | Date,
     xAxisCalloutData: string,
     circleId: string,
+    xAxisCalloutAccessibilityData: IAccessibilityProps,
     mouseEvent: React.MouseEvent<SVGElement>,
   ) => {
     mouseEvent.persist();
@@ -819,6 +851,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         stackCalloutProps: found!,
         dataPointCalloutProps: found!,
         activePoint: circleId,
+        xAxisCalloutAccessibilityData,
       });
     } else {
       this.setState({

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -223,6 +223,16 @@ export interface ILineChartDataPoint {
    * Whether to hide callout data for the point.
    */
   hideCallout?: boolean;
+
+  /**
+   * Accessibility data for callout
+   */
+  callOutAccessibilityData?: IAccessibilityProps;
+
+  /**
+   * X axis Accessibility data for callout
+   */
+  xAxisCalloutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface ILineChartGap {

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -302,6 +302,7 @@ type DataPoint = {
   color: string;
   yAxisCalloutData: string;
   index?: number;
+  callOutAccessibilityData?: IAccessibilityProps;
 };
 
 export function calloutData(values: (ILineChartPoints & { index?: number })[]) {
@@ -311,6 +312,7 @@ export function calloutData(values: (ILineChartPoints & { index?: number })[]) {
     x: number | Date | string;
     color: string;
     yAxisCalloutData?: string | { [id: string]: number };
+    callOutAccessibilityData?: IAccessibilityProps;
   }[] = [];
 
   values.forEach((element: { data: ILineChartDataPoint[]; legend: string; color: string; index?: number }) => {
@@ -326,7 +328,14 @@ export function calloutData(values: (ILineChartPoints & { index?: number })[]) {
   combinedResult.forEach((e1: DataPoint, index: number) => {
     e1.x = e1.x instanceof Date ? e1.x.getTime() : e1.x;
     const filteredValues = [
-      { legend: e1.legend, y: e1.y, color: e1.color, yAxisCalloutData: e1.yAxisCalloutData, index: e1.index },
+      {
+        legend: e1.legend,
+        y: e1.y,
+        color: e1.color,
+        yAxisCalloutData: e1.yAxisCalloutData,
+        callOutAccessibilityData: e1.callOutAccessibilityData,
+        index: e1.index,
+      },
     ];
     combinedResult.slice(index + 1).forEach((e2: DataPoint) => {
       e2.x = e2.x instanceof Date ? e2.x.getTime() : e2.x;
@@ -336,6 +345,7 @@ export function calloutData(values: (ILineChartPoints & { index?: number })[]) {
           y: e2.y,
           color: e2.color,
           yAxisCalloutData: e2.yAxisCalloutData,
+          callOutAccessibilityData: e2.callOutAccessibilityData,
           index: e2.index,
         });
       }

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import { AreaChart } from '@uifabric/charting';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+import * as d3 from 'd3-format';
+import { ILineChartProps } from '@uifabric/charting';
+
+interface IAreaChartCustomAccessibilityState {
+  width: number;
+  height: number;
+}
+
+export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAreaChartCustomAccessibilityState> {
+  constructor(props: ILineChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _basicExample(): JSX.Element {
+    const chart1Points = [
+      {
+        x: 20,
+        y: 9,
+        xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 20' },
+        callOutAccessibilityData: { ariaLabel: 'Line series 1 of 5 Point 1 First 9' },
+      },
+      {
+        x: 40,
+        y: 20,
+        xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 40' },
+        callOutAccessibilityData: { ariaLabel: 'Line series 2 of 5 Point 1 First 20' },
+      },
+      {
+        x: 55,
+        y: 27,
+        xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 55' },
+        callOutAccessibilityData: { ariaLabel: 'Line series 3 of 5 Point 1 First 27' },
+      },
+      {
+        x: 60,
+        y: 37,
+        xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 60' },
+        callOutAccessibilityData: { ariaLabel: 'Line series 4 of 5 Point 1 First 37' },
+      },
+      {
+        x: 65,
+        y: 51,
+        xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 65' },
+        callOutAccessibilityData: { ariaLabel: 'Line series 5 of 5 Point 1 First 51' },
+      },
+    ];
+
+    const chart2Points = [
+      {
+        x: 20,
+        y: 21,
+        callOutAccessibilityData: { ariaLabel: 'Point 2 Second 21' },
+      },
+      {
+        x: 40,
+        y: 25,
+        callOutAccessibilityData: { ariaLabel: 'Point 2 Second 25' },
+      },
+      {
+        x: 55,
+        y: 23,
+        callOutAccessibilityData: { ariaLabel: 'Point 2 Second 23' },
+      },
+      {
+        x: 60,
+        y: 7,
+        callOutAccessibilityData: { ariaLabel: 'Point 2 Second 7' },
+      },
+      {
+        x: 65,
+        y: 55,
+        callOutAccessibilityData: { ariaLabel: 'Point 2 Second 55' },
+      },
+    ];
+
+    const chart3Points = [
+      {
+        x: 20,
+        y: 30,
+        callOutAccessibilityData: { ariaLabel: 'Point 3 Third 30' },
+      },
+      {
+        x: 40,
+        y: 35,
+        callOutAccessibilityData: { ariaLabel: 'Point 3 Third 35' },
+      },
+      {
+        x: 55,
+        y: 33,
+        callOutAccessibilityData: { ariaLabel: 'Point 3 Third 33' },
+      },
+      {
+        x: 60,
+        y: 40,
+        callOutAccessibilityData: { ariaLabel: 'Point 3 Third 40' },
+      },
+      {
+        x: 65,
+        y: 10,
+        callOutAccessibilityData: { ariaLabel: 'Point 3 Third 10' },
+      },
+    ];
+
+    const chartPoints = [
+      {
+        legend: 'First',
+        data: chart1Points,
+        color: DefaultPalette.accent,
+      },
+      {
+        legend: 'Second',
+        data: chart2Points,
+        color: DefaultPalette.blueLight,
+      },
+      {
+        legend: 'Third',
+        data: chart3Points,
+        color: DefaultPalette.blueDark,
+      },
+    ];
+
+    const chartData = {
+      chartTitle: 'Area chart multiple example',
+      lineChartData: chartPoints,
+    };
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div style={rootStyle}>
+          <AreaChart
+            height={this.state.height}
+            width={this.state.width}
+            data={chartData}
+            legendsOverflowText={'Overflow Items'}
+            yAxisTickFormat={d3.format('$,')}
+            legendProps={{
+              allowFocusOnLegends: true,
+            }}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/charting/AreaChart/AreaChartPage.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChartPage.tsx
@@ -5,11 +5,12 @@ import { ComponentPage, ExampleCard, IComponentDemoPageProps, PropertiesTableSet
 import { AreaChartBasicExample } from './AreaChart.Basic.Example';
 import { AreaChartMultipleExample } from './AreaChart.Multiple.Example';
 import { AreaChartStyledExample } from './AreaChart.Styled.Example';
+import { AreaChartCustomAccessibilityExample } from './AreaChart.CustomAccessibility.Example';
 
 const AreaChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/AreaChart/AreaChart.Basic.Example.tsx') as string;
 const AreaChartMultipleExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/AreaChart/AreaChart.Multiple.Example.tsx') as string;
 const AreaChartStyledExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/AreaChart/AreaChart.Styled.Example.tsx') as string;
-
+const AreaChartCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx') as string;
 export class AreaChart extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (
@@ -26,6 +27,9 @@ export class AreaChart extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title="Styled Area chart" code={AreaChartStyledExampleCode}>
               <AreaChartStyledExample />
+            </ExampleCard>
+            <ExampleCard title="Area chart custom Accessibility" code={AreaChartCustomAccessibilityExampleCode}>
+              <AreaChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }

--- a/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import { IChartProps, ILineChartProps, ILineChartPoints, LineChart } from '@uifabric/charting';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+
+interface ILineChartCustomAccessibilityExampleState {
+  width: number;
+  height: number;
+  allowMultipleShapes: boolean;
+}
+
+export class LineChartCustomAccessibilityExample extends React.Component<
+  {},
+  ILineChartCustomAccessibilityExampleState
+> {
+  constructor(props: ILineChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+      allowMultipleShapes: false,
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <Toggle
+          label="Enabled  multiple shapes for each line"
+          onText="On"
+          offText="Off"
+          onChange={this._onShapeChange}
+          checked={this.state.allowMultipleShapes}
+        />
+        <div>{this._styledExample()}</div>
+      </>
+    );
+  }
+
+  private _onShapeChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+    this.setState({ allowMultipleShapes: checked });
+  };
+
+  private _onLegendClickHandler = (selectedLegend: string | null): void => {
+    if (selectedLegend !== null) {
+      console.log(`Selected legend - ${selectedLegend}`);
+    }
+  };
+
+  private _styledExample(): JSX.Element {
+    const points: ILineChartPoints[] = [
+      {
+        data: [
+          {
+            x: new Date('2018/01/01'),
+            y: 10,
+            xAxisCalloutData: '2018/01/01',
+            yAxisCalloutData: '10%',
+            xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 2018/01/01' },
+            callOutAccessibilityData: { ariaLabel: 'Line series 1 of 5 Point 1 First 10%' },
+          },
+          {
+            x: new Date('2018/02/01'),
+            y: 30,
+            xAxisCalloutData: '2018/01/15',
+            yAxisCalloutData: '18%',
+            xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 2018/01/15' },
+            callOutAccessibilityData: { ariaLabel: 'Line series 2 of 5 Point 1 First 18%' },
+          },
+          {
+            x: new Date('2018/03/01'),
+            y: 10,
+            xAxisCalloutData: '2018/01/28',
+            yAxisCalloutData: '24%',
+            xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 2018/01/28' },
+            callOutAccessibilityData: { ariaLabel: 'Line series 3 of 5 Point 1 First 24%' },
+          },
+          {
+            x: new Date('2018/04/01'),
+            y: 30,
+            xAxisCalloutData: '2018/02/01',
+            yAxisCalloutData: '25%',
+            xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 2018/02/01' },
+            callOutAccessibilityData: { ariaLabel: 'Line series 4 of 5 Point 1 First 25%' },
+          },
+          {
+            x: new Date('2018/05/01'),
+            y: 10,
+            xAxisCalloutData: '2018/03/01',
+            yAxisCalloutData: '15%',
+            xAxisCalloutAccessibilityData: { ariaLabel: 'x-Axis 2018/03/01' },
+            callOutAccessibilityData: { ariaLabel: 'Line series 5 of 5 Point 1 First 15%' },
+          },
+        ],
+        legend: 'First',
+        color: DefaultPalette.blue,
+        onLegendClick: this._onLegendClickHandler,
+      },
+      {
+        data: [
+          {
+            x: new Date('2018/01/01'),
+            y: 30,
+            callOutAccessibilityData: { ariaLabel: 'Point 2 Second 30' },
+          },
+          {
+            x: new Date('2018/02/01'),
+            y: 50,
+            callOutAccessibilityData: { ariaLabel: 'Point 2 Second 50' },
+          },
+          {
+            x: new Date('2018/03/01'),
+            y: 30,
+            callOutAccessibilityData: { ariaLabel: 'Point 2 Second 30' },
+          },
+          {
+            x: new Date('2018/04/01'),
+            y: 50,
+            callOutAccessibilityData: { ariaLabel: 'Point 2 Second 50' },
+          },
+          {
+            x: new Date('2018/05/01'),
+            y: 30,
+            callOutAccessibilityData: { ariaLabel: 'Point 2 Second 30' },
+          },
+        ],
+        legend: 'Second',
+        color: DefaultPalette.green,
+        onLegendClick: this._onLegendClickHandler,
+      },
+      {
+        data: [
+          { x: new Date('2018/01/01'), y: 50, callOutAccessibilityData: { ariaLabel: 'Point 3 Third 50' } },
+          { x: new Date('2018/02/01'), y: 70, callOutAccessibilityData: { ariaLabel: 'Point 3 Third 70' } },
+          { x: new Date('2018/03/01'), y: 50, callOutAccessibilityData: { ariaLabel: 'Point 3 Third 50' } },
+          { x: new Date('2018/04/01'), y: 70, callOutAccessibilityData: { ariaLabel: 'Point 3 Third 70' } },
+          { x: new Date('2018/05/01'), y: 50, callOutAccessibilityData: { ariaLabel: 'Point 3 Third 50' } },
+        ],
+        legend: 'Third',
+        color: DefaultPalette.red,
+        onLegendClick: this._onLegendClickHandler,
+      },
+    ];
+
+    const data: IChartProps = {
+      chartTitle: 'Line Chart',
+      lineChartData: points,
+    };
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    const timeFormat = '%m/%d';
+    // Passing tick values is optional, for more control.
+    // If you do not pass them the line chart will render them for you based on D3's standard.
+    const tickValues: Date[] = [
+      new Date('01-01-2018'),
+      new Date('02-01-2018'),
+      new Date('03-01-2018'),
+      new Date('04-01-2018'),
+      new Date('05-01-2018'),
+    ];
+    const colorFillBarData = [
+      {
+        legend: 'Time range 1',
+        color: 'blue',
+        data: [
+          {
+            startX: new Date('2018/01/06'),
+            endX: new Date('2018/01/25'),
+          },
+        ],
+      },
+      {
+        legend: 'Time range 2',
+        color: 'red',
+        data: [
+          {
+            startX: new Date('2018/01/18'),
+            endX: new Date('2018/02/20'),
+          },
+          {
+            startX: new Date('2018/04/17'),
+            endX: new Date('2018/05/10'),
+          },
+        ],
+        applyPattern: true,
+      },
+    ];
+    return (
+      <div style={rootStyle}>
+        <LineChart
+          data={data}
+          strokeWidth={4}
+          tickFormat={timeFormat}
+          tickValues={tickValues}
+          height={this.state.height}
+          width={this.state.width}
+          legendProps={{ canSelectMultipleLegends: true, allowFocusOnLegends: true }}
+          colorFillBars={colorFillBarData}
+          allowMultipleShapesForPoints={this.state.allowMultipleShapes}
+        />
+      </div>
+    );
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+}

--- a/packages/react-examples/src/charting/LineChart/LineChartPage.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChartPage.tsx
@@ -6,12 +6,13 @@ import { LineChartBasicExample } from './LineChart.Basic.Example';
 import { LineChartStyledExample } from './LineChart.Styled.Example';
 import { LineChartMultipleExample } from './LineChart.Multiple.Example';
 import { LineChartEventsExample } from './LineChart.Events.Example';
+import { LineChartCustomAccessibilityExample } from './LineChart.CustomAccessibility.Example';
 
 const LineChartBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx') as string;
 const LineChartStyledExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/LineChart/LineChart.Styled.Example.tsx') as string;
 const MultipleLineChartExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/LineChart/LineChart.Multiple.Example.tsx') as string;
 const LineChartEventsExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/LineChart/LineChart.Events.Example.tsx') as string;
-
+const LineChartCustomAccessibilityExampleCode = require('!raw-loader!@fluentui/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx') as string;
 export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
     return (
@@ -31,6 +32,9 @@ export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> 
             </ExampleCard>
             <ExampleCard title="LineChart with events" code={LineChartEventsExampleCode}>
               <LineChartEventsExample />
+            </ExampleCard>
+            <ExampleCard title="LineChart Custom Accessibility" code={LineChartCustomAccessibilityExampleCode}>
+              <LineChartCustomAccessibilityExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
### Original description
Cherry pick of [#19245](https://github.com/microsoft/fluentui/pull/19245)

#### Description of changes

Changes are related to Line Chart accessibility and Area Chart Accessibility

1. Accessibility Data prop added for the Chart Data Callout and X-Axis Callout data. Accessibility Data props contain ariaLabel, ariaLabelledBy, and ariaDescribedBy props.
2. If the user is sending any custom accessibility data, then that will be used. else only visible data will be used by the narrator.
3. Custom Accessibility example is added for both the charts.

#### Focus areas to test
Area chart
Line chart

### Before Changes

**Area Chart**

![image](https://user-images.githubusercontent.com/29042635/128142027-fccb0198-05ba-43e2-b307-6fa462ed9674.png)


**Line Chart**

![image](https://user-images.githubusercontent.com/29042635/128142189-7950bc5a-842c-446f-87b4-b54a26363bc5.png)



### After Changes

**Area Chart**

![image](https://user-images.githubusercontent.com/29042635/128142421-1615141b-dc12-4cbc-8abe-661f0046eb5b.png)

**Line Chart**

![image](https://user-images.githubusercontent.com/29042635/128142527-7ef9fdc5-1695-47fc-99fb-f5fa43288d17.png)

