### PR TITLE
Chart will be readable by chart title property 

### DIFF
--- a/change/@fluentui-react-charting-a27640fe-9b04-4440-9d99-879fc4afb588.json
+++ b/change/@fluentui-react-charting-a27640fe-9b04-4440-9d99-879fc4afb588.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for Area and Line chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -113,12 +113,13 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
   }
 
   public render(): JSX.Element {
+    const { lineChartData, chartTitle } = this.props.data;
     const { colors, stackedInfo, calloutPoints } = this._createSet(this.props.data);
     this._calloutPoints = calloutPoints;
-    const isXAxisDateType = getXAxisType(this.props.data.lineChartData!);
+    const isXAxisDateType = getXAxisType(lineChartData!);
     this._colors = colors;
     this._stackedData = stackedInfo.stackedData;
-    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette, this.props.data.lineChartData!);
+    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette, lineChartData!);
 
     const tickParams = {
       tickValues: this.props.tickValues,
@@ -143,7 +144,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     return (
       <CartesianChart
         {...this.props}
-        points={this.props.data.lineChartData!}
+        chartTitle={chartTitle}
+        points={lineChartData!}
         chartType={ChartTypes.AreaChart}
         calloutProps={calloutProps}
         legendBars={legends}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -39,6 +39,9 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -363,6 +366,9 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -667,6 +673,9 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -846,6 +855,9 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1170,6 +1182,9 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1494,6 +1509,9 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1818,6 +1836,9 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -242,6 +242,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       >
         <FocusZone direction={focusDirection} {...svgFocusZoneProps}>
           <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }} {...svgProps}>
+            {this.props.chartTitle && <title>{this.props.chartTitle}</title>}
             <g
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -351,6 +351,11 @@ export interface IChildProps {
 // Only used for Cartesian chart base
 export interface IModifiedCartesianChartProps extends ICartesianChartProps {
   /**
+   * Define the chart title
+   */
+  chartTitle?: string;
+
+  /**
    * Only used for Area chart
    * Value used to draw y axis of that chart.
    */

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -99,7 +99,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 </FocusZone>
                 {points!.chartData![0].data && this._createBenchmark(points!)}
                 <FocusZone direction={FocusZoneDirection.horizontal}>
-                  <svg className={this._classNames.chart} role="list">
+                  <svg className={this._classNames.chart}>
+                    {points!.chartTitle && <title>{points!.chartTitle}</title>}
                     <g
                       id={keyVal}
                       key={keyVal}

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -99,7 +99,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 </FocusZone>
                 {points!.chartData![0].data && this._createBenchmark(points!)}
                 <FocusZone direction={FocusZoneDirection.horizontal}>
-                  <svg className={this._classNames.chart}>
+                  <svg className={this._classNames.chart} role="list">
                     <g
                       id={keyVal}
                       key={keyVal}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -194,8 +194,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
   }
 
   public render(): JSX.Element {
-    const { tickValues, tickFormat, eventAnnotationProps, legendProps } = this.props;
-    this._points = this._injectIndexPropertyInLineChartData(this.props.data.lineChartData);
+    const { tickValues, tickFormat, eventAnnotationProps, legendProps, data } = this.props;
+    this._points = this._injectIndexPropertyInLineChartData(data.lineChartData);
 
     const isXAxisDateType = getXAxisType(this._points);
     let points = this._points;
@@ -233,6 +233,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     return (
       <CartesianChart
         {...this.props}
+        chartTitle={data.chartTitle}
         points={points}
         chartType={ChartTypes.LineChart}
         isCalloutForStack

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -39,6 +39,9 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -354,6 +357,9 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -649,6 +655,9 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -819,6 +828,9 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1134,6 +1146,9 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1449,6 +1464,9 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1764,6 +1782,9 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -230,7 +230,9 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>{bars}</svg>
+            <svg className={this._classNames.chart} role="list">
+              {bars}
+            </svg>
           </div>
         </FocusZone>
       </div>

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -230,7 +230,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart} role="list">
+            <svg className={this._classNames.chart}>
+              {data!.chartTitle && <title>{data!.chartTitle}</title>}
               {bars}
             </svg>
           </div>

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -135,7 +135,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>
+            <svg className={this._classNames.chart} role="list">
               <g>{bars[0]}</g>
               <Callout
                 gapSpace={15}

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -135,7 +135,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart} role="list">
+            <svg className={this._classNames.chart}>
+              {data!.chartTitle && <title>{data!.chartTitle}</title>}
               <g>{bars[0]}</g>
               <Callout
                 gapSpace={15}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -92,8 +92,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -238,8 +240,10 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -455,8 +459,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout20"
@@ -597,8 +603,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout20"
@@ -818,8 +826,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout5"
@@ -964,8 +974,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout5"
@@ -1119,8 +1131,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout15"
@@ -1265,8 +1279,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout15"
@@ -1665,8 +1681,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout10"
@@ -1811,8 +1829,10 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   height: 16px;
                   width: 100%;
                 }
-            role="list"
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout10"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -237,6 +238,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -453,6 +455,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -594,6 +597,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -814,6 +818,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -959,6 +964,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -1113,6 +1119,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -1258,6 +1265,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -1657,6 +1665,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"
@@ -1802,6 +1811,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   height: 16px;
                   width: 100%;
                 }
+            role="list"
           >
             <g
               aria-label="Multi stacked bar chart"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -276,6 +277,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -438,6 +440,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -614,6 +617,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -760,6 +764,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -936,6 +941,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g
@@ -1082,6 +1088,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               margin-bottom: 12px;
               width: 100%;
             }
+        role="list"
       >
         <g>
           <g

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -100,8 +100,10 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -277,8 +279,10 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -440,8 +444,10 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -617,8 +623,10 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -764,8 +772,10 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -941,8 +951,10 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -1088,8 +1100,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               margin-bottom: 12px;
               width: 100%;
             }
-        role="list"
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -138,7 +138,7 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
     ];
 
     const chartData = {
-      chartTitle: 'Area chart multiple example',
+      chartTitle: 'Area chart Custom Accessibility example',
       lineChartData: chartPoints,
     };
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -147,7 +147,7 @@ export class LineChartCustomAccessibilityExample extends React.Component<
     ];
 
     const data: IChartProps = {
-      chartTitle: 'Line Chart',
+      chartTitle: 'Line Chart Custom Accessibility Example',
       lineChartData: points,
     };
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

1. For Stacked Bar Chart, Multi Stacked Bar Chart, Horizontal Bar Chart, Area Chart and Line Chart: Existing chart title property is used to describe the chart. So in narrator scan mode, when the focus goes to chart, it will read chart title, previously it read as "image".  

#### Focus areas to test
Area Chart
Line Chart
Stacked Bar Chart
Multi Stacked Bar chart
Horizontal Stacked Bar chart

**Before Changes:**

https://user-images.githubusercontent.com/29042635/128512033-99f2e920-2634-4a90-9ccc-d3e76433bd8a.mp4

**After Changes:**

https://user-images.githubusercontent.com/29042635/128512057-0029333c-fdf4-4fb5-87dd-1eb8f6547268.mp4




