### PR TITLE
fix: use Button to compose FormButton

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -3,9 +3,7 @@ import { commonPropTypes } from '../../utils';
 import { Button, ButtonProps } from '../Button/Button';
 import { _FormFieldBase, FormFieldBaseProps } from './utils/formFieldBase';
 
-interface FormButtonOwnProps extends ButtonProps {
-  type?: string;
-}
+interface FormButtonOwnProps extends ButtonProps {}
 type SelectedFormFieldCustomProps = Omit<
   FormFieldBaseProps,
   'control' | 'styles' | 'accessibility' | 'design' | 'variables'
@@ -18,7 +16,7 @@ export const formButtonClassName = 'ui-form__button';
 /**
  * An FormButton renders a Button wrapped by FormField.
  */
-export const FormButton = compose<'div', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
+export const FormButton = compose<'button', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
   _FormFieldBase,
   {
     className: formButtonClassName,

--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps } from '../Button/Button';
 import { _FormFieldBase, FormFieldBaseProps } from './utils/formFieldBase';
 
 interface FormButtonOwnProps extends ButtonProps {
-  type: string;
+  type?: string;
 }
 type SelectedFormFieldCustomProps = Omit<
   FormFieldBaseProps,

--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -22,9 +22,6 @@ export const FormButton = compose<'button', FormButtonProps, FormButtonStylesPro
     className: formButtonClassName,
     displayName: 'FormButton',
     overrideStyles: true,
-    slots: {
-      control: Button,
-    },
   },
 );
 

--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -22,6 +22,7 @@ export const FormButton = compose<'button', FormButtonProps, FormButtonStylesPro
     className: formButtonClassName,
     displayName: 'FormButton',
     overrideStyles: true,
+    slots: {},
   },
 );
 

--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -1,7 +1,7 @@
 import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import { Button, ButtonProps } from '../Button/Button';
-import { _FormFieldBase, FormFieldBaseProps } from './utils/formFieldBase';
+import { FormFieldBaseProps } from './utils/formFieldBase';
 
 interface FormButtonOwnProps extends ButtonProps {}
 type SelectedFormFieldCustomProps = Omit<
@@ -16,8 +16,8 @@ export const formButtonClassName = 'ui-form__button';
 /**
  * An FormButton renders a Button wrapped by FormField.
  */
-export const FormButton = compose<'div', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
-  _FormFieldBase,
+export const FormButton = compose<'button', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
+  Button,
   {
     className: formButtonClassName,
     displayName: 'FormButton',

--- a/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormButton.tsx
@@ -1,9 +1,11 @@
 import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import { Button, ButtonProps } from '../Button/Button';
-import { FormFieldBaseProps } from './utils/formFieldBase';
+import { _FormFieldBase, FormFieldBaseProps } from './utils/formFieldBase';
 
-interface FormButtonOwnProps extends ButtonProps {}
+interface FormButtonOwnProps extends ButtonProps {
+  type: string;
+}
 type SelectedFormFieldCustomProps = Omit<
   FormFieldBaseProps,
   'control' | 'styles' | 'accessibility' | 'design' | 'variables'
@@ -16,13 +18,15 @@ export const formButtonClassName = 'ui-form__button';
 /**
  * An FormButton renders a Button wrapped by FormField.
  */
-export const FormButton = compose<'button', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
-  Button,
+export const FormButton = compose<'div', FormButtonProps, FormButtonStylesProps, SelectedFormFieldCustomProps, {}>(
+  _FormFieldBase,
   {
     className: formButtonClassName,
     displayName: 'FormButton',
     overrideStyles: true,
-    slots: {},
+    slots: {
+      control: Button,
+    },
   },
 );
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19081
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Compose `FormButton`  with button to allow the right props to be passed

#### Focus areas to test

(optional)
