### PR TITLE
Legends will be focusable in browser mode

### DIFF
--- a/change/@fluentui-react-charting-74c1ea24-c3d7-4ec8-9d91-103429dd95fb.json
+++ b/change/@fluentui-react-charting-74c1ea24-c3d7-4ec8-9d91-103429dd95fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Legends will be focusable in browser mode",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -123,7 +123,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps, allowFocusOnLegends = true } = this.props;
     return (
       <OverflowSet
-        {...(allowFocusOnLegends && { role: 'listbox', 'aria-label': 'Legends' })}
+        {...(allowFocusOnLegends && { 'aria-label': 'Legends' })}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}
@@ -377,7 +377,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       <button
         {...(allowFocusOnLegends && {
           'aria-selected': this.state.selectedLegend === legend.title,
-          role: 'option',
           'aria-label': legend.title,
           'aria-setsize': data['aria-setsize'],
           'aria-posinset': data['aria-posinset'],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In scan/browse mode, previously focus was not moving to other legends and overflow legends. 
But with these changes, the focus will move to legends and overflow legends, and visible data will be read by the narrator and NVDA. 

#### Focus areas to test

Legends

**Before Changes**

https://user-images.githubusercontent.com/29042635/128720096-2c4d77b8-22fa-43be-96eb-0e64d9019d10.mp4

**After Changes**

https://user-images.githubusercontent.com/29042635/128720421-be50f8ef-1b9b-4af0-9bf7-3ec288d5ef8c.mp4

