### PR TITLE
fix(MenuPopover): Remove min-height value

### DIFF
--- a/change/@fluentui-react-menu-0799b9c7-d4a8-430b-82f0-c3ca6941aa64.json
+++ b/change/@fluentui-react-menu-0799b9c7-d4a8-430b-82f0-c3ca6941aa64.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(MenuPopover): Remove min-height value",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -5,7 +5,6 @@ const useStyles = makeStyles({
   root: theme => ({
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
     minWidth: '128px',
-    minHeight: '48px',
     maxWidth: '300px',
     width: 'max-content',
     boxShadow: `${theme.alias.shadow.shadow16}`,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19320
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The design spec min height was actually calculated with a single menu item and relevant padding, so the min height set in CSS is actually not necessary and even wrong.

#### Focus areas to test

(optional)
