### PR TITLE
RFC: Internal stories for E2E testing

### DIFF
--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -383,8 +383,7 @@ ButtonPrimary.args = {
 };
 ButtonPrimary.storyName = 'Better story name';
 ```
-3. If the internal story is broken out into its own file, then the file should mirror the name of the story, which will include the `Internal` keyword for
-IDE search.
+3. If an internal story is broken out into its own file, then the file should mirror the name of the story, which will include the `Internal` keyword and a `.internal.stories` suffix for easier IDE search.
 
 ### 9. UX of stories
 
@@ -451,7 +450,7 @@ the value to the story id.
 We propose to use an extra filename extension and naming convention for internal stories:
 
 ```ts
-// MenuTabstopsInternal.stories.tsx
+// MenuTabstopsInternal.internal.stories.tsx
 // Deep link /story/components-menu--tabstops-internal
 // Does not appear in the sidebar or docs page
 export const TabstopsInternal = () => {

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -21,6 +21,7 @@ _List contributors to the proposal:_ @hotell, @miroslavstastny, @ling1726, @andr
     - [first story is called default](#first-story-is-called-default)
     - [appearance of stories](#appearance-of-stories)
     - [story code should be useful](#story-code-should-be-useful)
+  - [10. Internal stories for testing](#10-internal-stories-for-testing)
   - [Pros and Cons](#pros-and-cons)
 - [Discarded Solutions](#discarded-solutions)
 - [Open Issues](#open-issues)
@@ -427,6 +428,48 @@ export const Default = (props: PopoverProps) => (
   </Popover>
 );
 ```
+
+### 10. Internal stories for testing
+
+As mentioned in for E2E testing, we should ensure maximum coverage for all publicly viewable stories by our consumers.
+For more complex scenarios that need to be tested we should make sure that stories exist for E2E tests but should not be
+easily accessible publicly.
+
+Storybook has proposed a feature for this in [storybookjs/storybook#9209](https://github.com/storybookjs/storybook/issues/9209)
+which will configure stories to exist in deeplink URL format, but do not appear in the nav tree or the docs page. As stated in the issue,
+we can workaround before the release of this feature by modifying `manager-head.html` and set `display:none`for all
+stories with a specific DOM `id` attribute. Storybook uses the `id` attribute for each link in the nav tree, and sets
+the value to the story id.
+
+We propose to use an extra filename extension and naming convention for internal stories:
+
+```ts
+// MenuTabstops.internal.stories.tsx
+// Deep link /story/components-menu--tabstops-internal
+// Does not appear in the sidebar or docs page
+export const TabstopsInternal = () => {
+  // story
+};
+```
+
+The filename extension `.internal.` is used for IDE searchability and codebase readability.
+
+The naming convention of the story simply adds the `Internal` keyword to the Pascal case story name. This will match the
+filename. More importantly the generated id will contain `menu-tabstops-internal`.
+
+We can simply use a css wildcard query selector:
+
+```css
+[id*='internal'] {
+  display: none;
+}
+```
+
+This means that `Internal` will be a reserved keyword in our stories which will determine visibility. This does not cause
+any conflicts with current stories, since this word is never used in any story name.
+
+This solution will only need to be applied within `react-components` storybook configuration since that is the storybook currently targeted for
+public use. Individual component storybooks are only used for local development, so there is no need to hide internal stories from their nav trees.
 
 #### story code should be useful
 

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -429,6 +429,11 @@ export const Default = (props: PopoverProps) => (
 );
 ```
 
+#### story code should be useful
+
+Public stories should only contain code, which is useful for users to see after clicking on “Show code” in documentation.
+Extra markup (e.g., container with CSS styles) can be added via [Decorators](https://storybook.js.org/docs/react/writing-stories/decorators).
+
 ### 10. Internal stories for testing
 
 As mentioned in for E2E testing, we should ensure maximum coverage for all publicly viewable stories by our consumers.
@@ -470,11 +475,6 @@ any conflicts with current stories, since this word is never used in any story n
 
 This solution will only need to be applied within `react-components` storybook configuration since that is the storybook currently targeted for
 public use. Individual component storybooks are only used for local development, so there is no need to hide internal stories from their nav trees.
-
-#### story code should be useful
-
-Public stories should only contain code, which is useful for users to see after clicking on “Show code” in documentation.
-Extra markup (e.g., container with CSS styles) can be added via [Decorators](https://storybook.js.org/docs/react/writing-stories/decorators).
 
 ### Pros and Cons
 

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -449,7 +449,7 @@ the value to the story id.
 We propose to use an extra filename extension and naming convention for internal stories:
 
 ```ts
-// MenuTabstops.internal.stories.tsx
+// TabstopsInternal.stories.tsx
 // Deep link /story/components-menu--tabstops-internal
 // Does not appear in the sidebar or docs page
 export const TabstopsInternal = () => {
@@ -457,7 +457,8 @@ export const TabstopsInternal = () => {
 };
 ```
 
-The filename extension `.internal.` is used for IDE searchability and codebase readability.
+If the internal story is broken out into its own file, then the file should mirror the name of the story, which will include the `Internal` keyword for
+IDE search.
 
 The naming convention of the story simply adds the `Internal` keyword to the Pascal case story name. This will match the
 filename. More importantly the generated id will contain `menu-tabstops-internal`.

--- a/rfcs/convergence/authoring-stories.md
+++ b/rfcs/convergence/authoring-stories.md
@@ -383,6 +383,8 @@ ButtonPrimary.args = {
 };
 ButtonPrimary.storyName = 'Better story name';
 ```
+3. If the internal story is broken out into its own file, then the file should mirror the name of the story, which will include the `Internal` keyword for
+IDE search.
 
 ### 9. UX of stories
 
@@ -449,16 +451,13 @@ the value to the story id.
 We propose to use an extra filename extension and naming convention for internal stories:
 
 ```ts
-// TabstopsInternal.stories.tsx
+// MenuTabstopsInternal.stories.tsx
 // Deep link /story/components-menu--tabstops-internal
 // Does not appear in the sidebar or docs page
 export const TabstopsInternal = () => {
   // story
 };
 ```
-
-If the internal story is broken out into its own file, then the file should mirror the name of the story, which will include the `Internal` keyword for
-IDE search.
 
 The naming convention of the story simply adds the `Internal` keyword to the Pascal case story name. This will match the
 filename. More importantly the generated id will contain `menu-tabstops-internal`.


### PR DESCRIPTION
#### Description of changes

Adds relevant proposal from #18895 for hiding certain stories only
required for internal e2e testing to our storybook.

[**PREVIEW**](https://github.com/ling1726/fluentui/blob/rfc/internal-stories/rfcs/convergence/authoring-stories.md)
#### Focus areas to test

(optional)
