### PR TITLE
fix(Combobox): Add aria-selected to single-select combobox, fix scroll-to-view behavior on open

### DIFF
--- a/change/@fluentui-react-fefe26e6-3f62-4aaf-960c-63cc828c623f.json
+++ b/change/@fluentui-react-fefe26e6-3f62-4aaf-960c-63cc828c623f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix selected semantics and scroll-to-view on Combobox, remove select-on-hover behavior, remove unneeded aria-checked on checkbox",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -60,7 +60,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -225,7 +224,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="true"
       checked={true}
       className=
 
@@ -356,7 +354,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="false"
       aria-disabled={true}
       checked={false}
       className=
@@ -488,7 +485,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="true"
       aria-disabled={true}
       checked={true}
       className=

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -66,7 +66,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
-      aria-checked="mixed"
       checked={false}
       className=
 
@@ -245,7 +244,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
-      aria-checked="mixed"
       checked={true}
       className=
 
@@ -393,7 +391,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
-      aria-checked="mixed"
       aria-disabled={true}
       checked={false}
       className=
@@ -577,7 +574,6 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
-      aria-checked="mixed"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -66,6 +66,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
+      aria-checked="mixed"
       checked={false}
       className=
 
@@ -244,6 +245,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
+      aria-checked="mixed"
       checked={true}
       className=
 
@@ -391,6 +393,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
+      aria-checked="mixed"
       aria-disabled={true}
       checked={false}
       className=
@@ -574,6 +577,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         }
   >
     <input
+      aria-checked="mixed"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -69,7 +69,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="true"
       checked={true}
       className=
 
@@ -229,7 +228,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -387,7 +385,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -588,7 +585,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1170,7 +1170,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           }
     >
       <input
-        aria-checked="true"
         checked={true}
         className=
 

--- a/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -60,7 +60,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           }
     >
       <input
-        aria-checked="false"
         checked={false}
         className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -321,7 +320,6 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2096,7 +2096,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -2253,7 +2252,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -321,7 +320,6 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -321,7 +320,6 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -321,7 +320,6 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1516,7 +1516,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -1673,7 +1672,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 
@@ -321,7 +320,6 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         }
   >
     <input
-      aria-checked="false"
       checked={false}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -69,7 +69,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
-      aria-checked="true"
       checked={true}
       className=
 

--- a/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ThemeProvider.Basic.Example.tsx.shot
@@ -61,7 +61,6 @@ exports[`Component Examples renders ThemeProvider.Basic.Example.tsx correctly 1`
         }
   >
     <input
-      aria-checked="true"
       checked={true}
       className=
 

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -77,12 +77,6 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
 
     const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
 
-    const ariaChecked: React.InputHTMLAttributes<HTMLInputElement>['aria-checked'] = isIndeterminate
-      ? 'mixed'
-      : isChecked
-      ? 'true'
-      : 'false';
-
     const mergedInputProps: React.InputHTMLAttributes<HTMLInputElement> = {
       className: classNames.input,
       type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
@@ -100,7 +94,6 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       'aria-describedby': ariaDescribedBy,
       'aria-posinset': ariaPositionInSet,
       'aria-setsize': ariaSetSize,
-      'aria-checked': ariaChecked,
     };
 
     return (

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -77,6 +77,10 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
 
     const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
 
+    const ariaChecked: React.InputHTMLAttributes<HTMLInputElement>['aria-checked'] = isIndeterminate
+      ? 'mixed'
+      : undefined;
+
     const mergedInputProps: React.InputHTMLAttributes<HTMLInputElement> = {
       className: classNames.input,
       type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
@@ -94,6 +98,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       'aria-describedby': ariaDescribedBy,
       'aria-posinset': ariaPositionInSet,
       'aria-setsize': ariaSetSize,
+      'aria-checked': ariaChecked,
     };
 
     return (

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -78,9 +78,6 @@ describe('Checkbox', () => {
 
     const input = component.find('input');
     expect(input.prop('checked')).toBe(false);
-    // Mainly testing aria-checked because later in the indeterminate cases, it's the only way to
-    // tell from a rendered prop that the checkbox is indeterminate
-    expect(input.prop('aria-checked')).toBe('false');
     expect(checkbox!.checked).toBe(false);
     expect(checkbox!.indeterminate).toBe(false);
   });
@@ -90,7 +87,6 @@ describe('Checkbox', () => {
 
     const input = component.find('input');
     expect(input.prop('checked')).toBe(true);
-    expect(input.prop('aria-checked')).toBe('true');
     expect(checkbox!.checked).toBe(true);
   });
 
@@ -112,7 +108,6 @@ describe('Checkbox', () => {
 
     const input = component.find('input');
     expect(input.prop('checked')).toBe(true);
-    expect(input.prop('aria-checked')).toBe('true');
     expect(checkbox!.checked).toBe(true);
   });
 
@@ -157,27 +152,24 @@ describe('Checkbox', () => {
   it('respects defaultIndeterminate prop', () => {
     component = mount(<Checkbox defaultIndeterminate componentRef={checkboxRef} />);
 
-    expect(component.find('input').prop('aria-checked')).toBe('mixed');
     expect(checkbox!.indeterminate).toEqual(true);
   });
 
   it('respects defaultIndeterminate prop when defaultChecked is true', () => {
     component = mount(<Checkbox defaultIndeterminate defaultChecked componentRef={checkboxRef} />);
 
-    expect(component.find('input').prop('aria-checked')).toBe('mixed');
     expect(checkbox!.indeterminate).toEqual(true);
   });
 
   it('ignores defaultIndeterminate updates', () => {
     component = mount(<Checkbox defaultIndeterminate componentRef={checkboxRef} />);
     component.setProps({ defaultIndeterminate: false });
-    expect(component.find('input').prop('aria-checked')).toBe('mixed');
     expect(checkbox!.indeterminate).toEqual(true);
     component.unmount();
 
     component = mount(<Checkbox componentRef={checkboxRef} />);
     component.setProps({ defaultIndeterminate: true });
-    expect(component.find('input').prop('aria-checked')).toBe('false');
+    expect(checkbox!.checked).toBe(false);
     expect(checkbox!.indeterminate).toEqual(false);
   });
 
@@ -185,7 +177,6 @@ describe('Checkbox', () => {
     component = mount(<Checkbox defaultIndeterminate componentRef={checkboxRef} />);
 
     let input = component.find('input');
-    expect(input.prop('aria-checked')).toBe('mixed');
     expect(input.prop('checked')).toBe(false);
     expect(checkbox!.indeterminate).toEqual(true);
 
@@ -193,7 +184,6 @@ describe('Checkbox', () => {
 
     // get an updated ReactWrapper for the input (otherwise it would be out of sync)
     input = component.find('input');
-    expect(input.prop('aria-checked')).toBe('false');
     expect(input.prop('checked')).toBe(false);
     expect(checkbox!.indeterminate).toEqual(false);
   });
@@ -203,13 +193,11 @@ describe('Checkbox', () => {
 
     let input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(true);
-    expect(input.prop('aria-checked')).toBe('mixed');
 
     input.simulate('change', { target: { checked: true } });
 
     input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(false);
-    expect(input.prop('aria-checked')).toBe('false');
   });
 
   it('removes controlled indeterminate', () => {
@@ -218,14 +206,12 @@ describe('Checkbox', () => {
     let input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(true);
     expect(checkbox!.checked).toEqual(false);
-    expect(input.prop('aria-checked')).toBe('mixed');
 
     input.simulate('change');
 
     input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(false);
     expect(checkbox!.checked).toEqual(false);
-    expect(input.prop('aria-checked')).toBe('false');
   });
 
   it("doesn't remove controlled indeterminate when no onChange provided", () => {
@@ -233,12 +219,10 @@ describe('Checkbox', () => {
 
     let input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(true);
-    expect(input.prop('aria-checked')).toBe('mixed');
 
     input.simulate('change');
 
     input = component.find('input');
     expect(checkbox!.indeterminate).toEqual(true);
-    expect(input.prop('aria-checked')).toBe('mixed');
   });
 });

--- a/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -215,6 +215,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       }
 >
   <input
+    aria-checked="mixed"
     checked={false}
     className=
 

--- a/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`Checkbox renders checked correctly 1`] = `
       }
 >
   <input
-    aria-checked="true"
     checked={true}
     className=
 
@@ -216,7 +215,6 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       }
 >
   <input
-    aria-checked="mixed"
     checked={false}
     className=
 
@@ -395,7 +393,6 @@ exports[`Checkbox renders unchecked correctly 1`] = `
       }
 >
   <input
-    aria-checked="false"
     checked={false}
     className=
 

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -210,6 +210,16 @@ describe('ComboBox', () => {
     });
   });
 
+  it('Applies correct attributes to the selected option', () => {
+    safeMount(<ComboBox options={DEFAULT_OPTIONS} defaultSelectedKey="2" />, wrapper => {
+      // open combobox to check options list
+      wrapper.find('button').simulate('click');
+
+      const options = wrapper.find(BUTTON_OPTION);
+      expect(options.at(1).prop('aria-selected')).toEqual('true');
+    });
+  });
+
   it('Renders a placeholder', () => {
     const placeholder = 'Select an option';
     safeCreate(<ComboBox options={DEFAULT_OPTIONS} placeholder={placeholder} />, container => {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1269,7 +1269,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     // need to call this again here to get the correct scroll parent dimensions
     // when the callout is first opened
-    setTimeout(() => {
+    this._async.setTimeout(() => {
       this._scrollIntoView();
     }, 0);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1267,6 +1267,12 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _onLayerMounted = () => {
     this._onCalloutLayerMounted();
 
+    // need to call this again here to get the correct scroll parent dimensions
+    // when the callout is first opened
+    setTimeout(() => {
+      this._scrollIntoView();
+    }, 0);
+
     if (this.props.calloutProps && this.props.calloutProps.onLayerMounted) {
       this.props.calloutProps.onLayerMounted();
     }
@@ -1377,7 +1383,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           onMouseLeave={this._onOptionMouseLeave}
           role="option"
           // aria-selected should only be applied to checked items, not hovered items
-          aria-selected={isChecked ? 'true' : 'false'}
+          aria-selected={isSelected ? 'true' : 'false'}
           ariaLabel={item.ariaLabel}
           disabled={item.disabled}
           title={title}
@@ -1442,7 +1448,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * we do not have a valid index and we currently have a pending input value,
    * otherwise use the selected index
    * */
-  private _isOptionSelected(index: number | undefined): boolean {
+  private _isOptionHighlighted(index: number | undefined): boolean {
     const { currentPendingValueValidIndexOnHover } = this.state;
 
     // If the hover state is set to clearAll, don't show a selected index.
@@ -1451,7 +1457,13 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       return false;
     }
 
-    return this._getPendingSelectedIndex(true /* includePendingValue */) === index ? true : false;
+    return currentPendingValueValidIndexOnHover >= 0
+      ? currentPendingValueValidIndexOnHover === index
+      : this._isOptionSelected(index);
+  }
+
+  private _isOptionSelected(index: number | undefined): boolean {
+    return this._getPendingSelectedIndex(true /* includePendingValue */) === index;
   }
 
   private _isOptionChecked(index: number | undefined): boolean {
@@ -1465,17 +1477,15 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   }
 
   /**
-   * Gets the pending selected index taking into account hover, valueValidIndex, and selectedIndex
+   * Gets the pending selected index taking into account valueValidIndex and selectedIndex
    * @param includeCurrentPendingValue - Should we include the currentPendingValue when
    * finding the index
    */
   private _getPendingSelectedIndex(includeCurrentPendingValue: boolean): number {
-    const { currentPendingValueValidIndexOnHover, currentPendingValueValidIndex, currentPendingValue } = this.state;
+    const { currentPendingValueValidIndex, currentPendingValue } = this.state;
 
-    return currentPendingValueValidIndexOnHover >= 0
-      ? currentPendingValueValidIndexOnHover
-      : currentPendingValueValidIndex >= 0 ||
-        (includeCurrentPendingValue && currentPendingValue !== null && currentPendingValue !== undefined)
+    return currentPendingValueValidIndex >= 0 ||
+      (includeCurrentPendingValue && currentPendingValue !== null && currentPendingValue !== undefined)
       ? currentPendingValueValidIndex
       : this.props.multiSelect
       ? 0
@@ -2161,7 +2171,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       customStylesForCurrentOption,
       this._isPendingOption(item),
       item.hidden,
-      this._isOptionSelected(item.index),
+      this._isOptionHighlighted(item.index),
     );
   }
 

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -978,7 +978,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   role="separator"
                 />
                 <button
-                  aria-selected="false"
+                  aria-selected="true"
                   class=
                       ms-Button
                       ms-Button--action
@@ -1668,7 +1668,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                   title="Option 1"
                 >
                   <input
-                    aria-checked="false"
                     aria-selected="false"
                     class=
 
@@ -1883,7 +1882,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                   title="Option 2"
                 >
                   <input
-                    aria-checked="true"
                     aria-selected="true"
                     checked=""
                     class=

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -625,7 +625,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                         }
                   >
                     <input
-                      aria-checked="true"
                       aria-posinset="1"
                       aria-selected="true"
                       aria-setsize="2"
@@ -877,7 +876,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                   title="test"
                 >
                   <input
-                    aria-checked="false"
                     aria-posinset="2"
                     aria-selected="false"
                     aria-setsize="2"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19264
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The Combobox currently doesn't apply `aria-selected` to the selected option for single-select combos. While fixing that, I ran into a number of interrelated issues that I also fixed:
- Removed `aria-checked={true/false}` on Checkbox (it's redundant to `checked`, and adds an undesired aria-checked to multiselect Combobox)
- Removed hover-to-select and -focus behavior on Combobox -- the selected state was mixed up with the hover state internally, and also the behavior creates a pretty awful trap for keyboard and SR users, where they essentially get yanked around if they accidentally bump their trackpad. Or just have their cursor in the wrong place on open 😅.
- Fixed the scroll-to-active-option behavior, which was broken b/c of timing issues with Combobox's update vs. Callout's mount.
- Fixed the `aria-selected` logic on single-select Combo.
