### PR TITLE
Crude concatenated react-components changelog

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -77,6 +77,7 @@
     "request-promise-native": "^1.0.5",
     "resolve": "^1.7.1",
     "riceburn": "^1.3.1",
+    "semver": "^7.3.5",
     "through2": "^2.0.3",
     "ts-node": "^7.0.0"
   },

--- a/scripts/react-components-changelog.js
+++ b/scripts/react-components-changelog.js
@@ -32,7 +32,7 @@ function reactComponentsChangelog(fromVersion, toVersion) {
 
   dependencyNames.forEach(packageName => {
     const dirName = packageName.replace('@fluentui/', '');
-    const changelogJSON = require(`../../packages/${dirName}/CHANGELOG.json`);
+    const changelogJSON = require(`../packages/${dirName}/CHANGELOG.json`);
 
     const changelogEntries = changelogJSON.entries
       //

--- a/scripts/react-components-changelog/react-components-changelog.js
+++ b/scripts/react-components-changelog/react-components-changelog.js
@@ -1,0 +1,94 @@
+const cp = require('child_process');
+const semver = require('semver');
+
+/**
+ * Returns a single markdown changelog by concatenating of the react-* dependencies' changelogs in react-components
+ * between two versions of react-components. Useful for creating an "upgrade" guide from one version of react-components
+ * to another.
+ *
+ * @param fromVersion - The NPM package version of @fluentui/react-components to start from
+ * @param toVersion - The NPM package version of @fluentui/react-components to stop at
+ * @return {string} - Markdown
+ */
+function reactComponentsChangelog(fromVersion, toVersion) {
+  let markdown = [];
+
+  let fromDepsJSON;
+  let toDepsJSON;
+  try {
+    fromDepsJSON = JSON.parse(cp.execSync(`npm view @fluentui/react-components@${fromVersion} dependencies --json`));
+    toDepsJSON = JSON.parse(cp.execSync(`npm view @fluentui/react-components@${toVersion} dependencies --json`));
+  } catch (err) {
+    console.error(`Failed to get deps for @fluentui/react-components:`);
+    console.error(err);
+  }
+
+  const dependencyNames = Object.keys({ ...fromDepsJSON, ...toDepsJSON }).filter(packageName =>
+    packageName.startsWith('@fluentui/react-'),
+  );
+
+  markdown.push('# CHANGELOG - @fluentui/react-components');
+  markdown.push(`*${fromVersion} - ${toVersion}*`);
+
+  dependencyNames.forEach(packageName => {
+    const dirName = packageName.replace('@fluentui/', '');
+    const changelogJSON = require(`../../packages/${dirName}/CHANGELOG.json`);
+
+    const changelogEntries = changelogJSON.entries
+      //
+      // STEP 1: Only get changelog entries that are in range of react-components we care about
+      //
+      .filter(entry => {
+        return (
+          (semver.gt(entry.version, fromDepsJSON[packageName].replace(/\^/, '')) ||
+            semver.satisfies(entry.version, fromDepsJSON[packageName])) &&
+          semver.lt(entry.version, toDepsJSON[packageName].replace(/\^/, ''))
+        );
+      })
+      //
+      // STEP 2: remove "Bump ..." comments and entire comment sections with bumps only
+      //
+      .map(entry => {
+        entry.comments = Object.entries(entry.comments).reduce((acc, [commentType, commentObj]) => {
+          const commentsWithoutBumps = Object.values(commentObj).filter(
+            comment => !/^Bump .*? to v.*?$/.test(comment.comment),
+          );
+          if (commentsWithoutBumps.length > 0) {
+            acc[commentType] = commentsWithoutBumps;
+          }
+          return acc;
+        }, {});
+        return entry;
+      })
+      //
+      // STEP 3: Remove changelog entry sections with no comments
+      //
+      .filter(entry => {
+        return Object.keys(entry.comments).length > 0;
+      });
+
+    if (changelogEntries.length > 0) {
+      markdown.push(`\n## ${packageName}`);
+
+      const flatComments = changelogEntries.reduce((acc, entry) => {
+        Object.values(entry.comments).forEach(comments => {
+          comments.forEach(comment => {
+            acc.push(`- ${comment.comment} *(by ${comment.author} in v${entry.version})*`);
+          });
+        });
+        return acc;
+      }, []);
+
+      markdown.push(...flatComments);
+    }
+  });
+
+  markdown.push('\n');
+  return markdown.join('\n');
+}
+
+////////////////////////////////////////
+// Usage
+const markdownChangelog = reactComponentsChangelog('9.0.0-alpha.88', '9.0.0-alpha.89');
+
+console.log(markdownChangelog);

--- a/yarn.lock
+++ b/yarn.lock
@@ -22714,6 +22714,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`
- [ ] Remove example usage from script
- [ ] Wire into CI flow
- [ ] Show the output somewhere useful for beta

#### Description of changes

This is a temporary solution as we don't have resourcing to fully implement https://github.com/microsoft/fluentui/issues/19105 at this time.

This PR adds a function that generates a **_crude_** markdown changelog by concatenating all of the converged `react-*` dependency changelogs between two versions of `react-components`.

#### Usage
```tsx
const markdown = reactComponentsChangelog('9.0.0-alpha.88', '9.0.0-alpha.89');

console.log(markdown)
```

Output:
```markdown
# CHANGELOG - @fluentui/react-components
*9.0.0-alpha.88 - 9.0.0-alpha.89*

## @fluentui/react-avatar
- Replace default person icon with Fluent version *(by behowell@microsoft.com in v9.0.0-alpha.64)*

## @fluentui/react-utilities
- Fixing various typos in the react-utilities package. *(by czearing@outlook.com in v9.0.0-alpha.37)*
- Copying useMount and useUnmount hooks into the react-utilities package. *(by czearing@outlook.com in v9.0.0-alpha.37)*
```

#### Focus areas to test

I have included example usage of the function in the script itself. Try the following command from the root of the project:

```
node scripts/react-components-changelog.js
```
You should see the output on the console as shown above.