### PR TITLE
Overlay onclick type

### DIFF
--- a/change/@fluentui-react-0c00e5b1-2145-4f97-a331-c8a6eec95640.json
+++ b/change/@fluentui-react-0c00e5b1-2145-4f97-a331-c8a6eec95640.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Overlay to use more accurate React.HTMLAttribute typings for onClick",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6009,7 +6009,7 @@ export interface IModalProps extends React_2.RefAttributes<HTMLDivElement>, IAcc
     isModeless?: boolean;
     isOpen?: boolean;
     layerProps?: ILayerProps;
-    onDismiss?: (ev?: React_2.MouseEvent<HTMLButtonElement>) => any;
+    onDismiss?: (ev?: React_2.MouseEvent<HTMLButtonElement | HTMLElement>) => any;
     onDismissed?: () => any;
     // @deprecated
     onLayerDidMount?: () => void;
@@ -6224,8 +6224,6 @@ export interface IOverlayProps extends React_2.HTMLAttributes<HTMLElement> {
     className?: string;
     componentRef?: IRefObject<IOverlay>;
     isDarkThemed?: boolean;
-    // (undocumented)
-    onClick?: () => void;
     styles?: IStyleFunctionOrObject<IOverlayStyleProps, IOverlayStyles>;
     theme?: ITheme;
 }

--- a/packages/react/src/components/Modal/Modal.types.ts
+++ b/packages/react/src/components/Modal/Modal.types.ts
@@ -88,7 +88,7 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
   /**
    * A callback function for when the Modal is dismissed light dismiss, before the animation completes.
    */
-  onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
+  onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement | HTMLElement>) => any;
 
   /**
    * A callback function which is called after the Modal is dismissed and the animation is complete.

--- a/packages/react/src/components/Overlay/Overlay.types.ts
+++ b/packages/react/src/components/Overlay/Overlay.types.ts
@@ -38,8 +38,6 @@ export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
    */
   isDarkThemed?: boolean;
 
-  onClick?: () => void;
-
   /**
    * Allow body scroll on touch devices. Changing after mounting has no effect.
    * @defaultvalue false


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18643
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix typings for Overlay's `onClick` prop to match all other event handlers.

Since `onClick` (and all other handlers) are treated as plain JSX attributes, it should keep the default DOM Attribute typings that come with React. Modal had to update its typings as well, but previously they were silently incorrect, so this seems better :)
