### PR TITLE
Added Chart Title property for all charts

### DIFF
--- a/change/@fluentui-react-charting-2fcb1235-6837-4146-b92f-55717509a84a.json
+++ b/change/@fluentui-react-charting-2fcb1235-6837-4146-b92f-55717509a84a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for remaining charts, title will describe the chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -103,6 +103,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
             <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
+              {data?.chartTitle && <title>{data?.chartTitle}</title>}
               <Pie
                 width={this.state._width!}
                 height={this.state._height!}

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -38,6 +38,9 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -391,6 +394,9 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -744,6 +750,9 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -865,6 +874,9 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -1218,6 +1230,9 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
@@ -10,6 +10,10 @@ import {
 
 export interface IGroupedVerticalBarChartProps extends ICartesianChartProps {
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+  /**
    * Data to render in the chart.
    */
   data: IGroupedVerticalBarChartData[];

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.types.ts
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.types.ts
@@ -11,6 +11,10 @@ import { IHeatMapChartData } from '../../types/IDataPoint';
 
 export interface IHeatMapChartProps extends Pick<ICartesianChartProps, Exclude<keyof ICartesianChartProps, 'styles'>> {
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+  /**
    * data to provide for Heat Map
    */
   data: IHeatMapChartData[];

--- a/packages/react-charting/src/components/PieChart/Pie/Pie.tsx
+++ b/packages/react-charting/src/components/PieChart/Pie/Pie.tsx
@@ -33,7 +33,7 @@ export class Pie extends React.Component<IPieProps, {}> {
 
   public render(): JSX.Element {
     // const getClassNames = classNamesFunction<IPieProps, IPieStyles>();
-    const { pie, colors, data, width, height } = this.props;
+    const { pie, colors, data, width, height, chartTitle } = this.props;
 
     this.colors = scale.scaleOrdinal().range(colors!);
 
@@ -42,6 +42,7 @@ export class Pie extends React.Component<IPieProps, {}> {
 
     return (
       <svg width={width} height={height}>
+        {chartTitle && <title>{chartTitle}</title>}
         <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i))}</g>
       </svg>
     );

--- a/packages/react-charting/src/components/PieChart/Pie/Pie.types.ts
+++ b/packages/react-charting/src/components/PieChart/Pie/Pie.types.ts
@@ -27,6 +27,10 @@ export interface IPieProps {
    */
   colors?: string[];
   /**
+   * Title to apply to the whole chart.
+   */
+  chartTitle?: string;
+  /**
    * shape for pie.
    */
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/react-charting/src/components/PieChart/PieChart.base.tsx
+++ b/packages/react-charting/src/components/PieChart/PieChart.base.tsx
@@ -14,7 +14,7 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
   private _classNames: IProcessedStyleSet<IPieChartStyles>;
 
   public render(): JSX.Element {
-    const { data, width, height, colors } = this.props;
+    const { data, width, height, colors, chartTitle } = this.props;
 
     const { theme, className, styles } = this.props;
     this._classNames = getClassNames(styles!, {
@@ -29,7 +29,15 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
     return (
       <div className={this._classNames.root}>
         {this.props.chartTitle && <p className={this._classNames.chartTitle}>{this.props.chartTitle}</p>}
-        <Pie width={width!} height={height!} outerRadius={outerRadius} innerRadius={0} data={data!} colors={colors!} />
+        <Pie
+          width={width!}
+          height={height!}
+          outerRadius={outerRadius}
+          innerRadius={0}
+          data={data!}
+          colors={colors!}
+          chartTitle={chartTitle!}
+        />
       </div>
     );
   }

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
@@ -29,6 +29,11 @@ export interface IVerticalBarChartProps extends ICartesianChartProps {
   colors?: string[];
 
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+
+  /**
    * Legend text for the line datapoint in the chart
    */
   lineLegendText?: string;

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -51,6 +51,11 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
   colors?: string[];
 
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+
+  /**
    * To display multi stack callout or single callout
    * @default flase
    */

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Basic.Example.tsx
@@ -12,10 +12,8 @@ export class DonutChartBasicExample extends React.Component<IDonutChartProps, {}
       { legend: 'second', data: 39000, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart basic example',
       chartData: points,
     };
     return (

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
@@ -24,10 +24,8 @@ export class DonutChartCustomAccessibilityExample extends React.Component<IDonut
       },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart custom accessibility example',
       chartData: points,
       chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Donut chart' },
     };

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomCallout.Example.tsx
@@ -12,10 +12,8 @@ export class DonutChartCustomCalloutExample extends React.Component<IDonutChartP
       { legend: 'second', data: 39000, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart custom callout example',
       chartData: points,
     };
     return (

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
@@ -37,10 +37,8 @@ export class DonutChartDynamicExample extends React.Component<IDonutChartProps, 
   }
 
   public render(): JSX.Element {
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart dynamic example',
       chartData: this.state.dynamicData,
     };
     return (

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -124,6 +124,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart basic example"
             data={data}
             height={this.state.height}
             width={this.state.width}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -152,6 +152,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart custom accessibility example"
             data={data}
             height={this.state.height}
             width={this.state.width}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
@@ -109,6 +109,7 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<{}, IG
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart styled example"
             data={data}
             width={this.state.width}
             height={this.state.height}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Truncated.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Truncated.Example.tsx
@@ -86,6 +86,7 @@ export class GroupedVerticalBarChartTruncatedExample extends React.Component<{},
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart truncated example"
             data={data}
             height={this.state.height}
             width={this.state.width}

--- a/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
@@ -366,6 +366,7 @@ export class HeatMapChartCustomAccessibilityExample extends React.Component<{}, 
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>
           <HeatMapChart
+            chartTitle="Heat map chart custom accessibility example"
             data={HeatMapData}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisStringFormatter={(point: string) => ypointMapping[point as string]}

--- a/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.Example.tsx
@@ -305,6 +305,7 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>
           <HeatMapChart
+            chartTitle="Heat map chart basic example"
             data={HeatMapData}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisStringFormatter={(point: string) => ypointMapping[point as string]}

--- a/packages/react-examples/src/react-charting/PieChart/PieChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/PieChart/PieChart.Basic.Example.tsx
@@ -14,6 +14,6 @@ export class PieChartBasicExample extends React.Component<IPieChartProps, {}> {
       { y: 25, x: 'C' },
     ];
     const colors = [DefaultPalette.red, DefaultPalette.blue, DefaultPalette.green];
-    return <PieChart data={points} chartTitle="Pie Chart" colors={colors} />;
+    return <PieChart data={points} chartTitle="Pie Chart basic example" colors={colors} />;
   }
 }

--- a/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
@@ -46,7 +46,7 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
   public render(): JSX.Element {
     return (
       <div>
-        <PieChart data={this.state.dynamicData} chartTitle="Pie Chart" colors={this.state.colors} />
+        <PieChart data={this.state.dynamicData} chartTitle="Pie Chart dynamic example" colors={this.state.colors} />
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
       </div>

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
@@ -61,6 +61,7 @@ export class VerticalBarChartTooltipExample extends React.Component<{}, IVertica
         </div>
         <div style={rootStyle}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart axis tooltip example "
             data={points}
             height={350}
             width={650}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -159,11 +159,11 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
         />
         <div style={rootStyle}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart basic example "
             data={points}
             width={this.state.width}
             useSingleColor={this.state.useSingleColor}
             height={this.state.height}
-            chartLabel={'Basic Chart with Numeric Axes'}
             lineLegendText={'just line'}
             lineLegendColor={'brown'}
             {...(this.state.isCalloutselected && {

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx
@@ -65,6 +65,7 @@ export class VerticalBarChartCustomAccessibilityExample extends React.Component<
         />
         <div style={{ width: '800px', height: '400px' }}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart custom accessibility example "
             data={points}
             width={800}
             height={400}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -44,9 +44,9 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
     return (
       <div style={{ width: '650px', height: '400px' }}>
         <VerticalBarChart
+          chartTitle="Vertical bar chart dynamic example "
           data={this.state.dynamicData}
           colors={this.state.colors}
-          chartLabel={'Chart with Dynamic Data'}
           hideLegend={true}
           hideTooltip={true}
           yMaxValue={50}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Styled.Example.tsx
@@ -51,6 +51,7 @@ export class VerticalBarChartStyledExample extends React.Component<IVerticalBarC
         />
         <div style={{ width: '800px', height: '400px' }}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart styled example "
             data={points}
             width={800}
             height={400}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
@@ -63,6 +63,7 @@ export class VerticalStackedBarChartTooltipExample extends React.Component<{}, I
         </div>
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart axis tooltip example"
             data={data}
             height={350}
             width={650}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -212,11 +212,11 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart basic example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
-            chartLabel="Card title"
             legendProps={{
               allowFocusOnLegends: true,
             }}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
@@ -215,12 +215,12 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart callout example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
             yAxisTickCount={10}
-            chartLabel="Card title"
             isCalloutForStack={
               this.state.selectedCallout === 'MultiCallout' || this.state.selectedCallout === 'MultiCustomCallout'
             }

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -176,11 +176,11 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart custom accessibility example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
-            chartLabel="Card title"
             legendProps={{
               allowFocusOnLegends: true,
             }}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -153,6 +153,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
         </div>
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart styled example"
             data={data}
             {...this.state}
             yAxisTickCount={10}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously chart title property was missed in other charts. Now chart title property is available for all charts, which will be used by the narrator to describe the chart.

#### Focus areas to test

All charts

**After Change**
![image](https://user-images.githubusercontent.com/29042635/128699745-544a8226-92ed-4da9-82e2-d4831817d710.png)

