### PR TITLE
fix(Menu, Popover): Clone ref correctly

### DIFF
--- a/change/@fluentui-react-menu-db8655b7-1e21-4be9-8877-36e8643e5b14.json
+++ b/change/@fluentui-react-menu-db8655b7-1e21-4be9-8877-36e8643e5b14.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(MenuTrigger): Retain original child ref",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-8f203e6f-a2b7-417a-9ea9-b24441bce5db.json
+++ b/change/@fluentui-react-popover-8f203e6f-a2b7-417a-9ea9-b24441bce5db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(PopoverTrigger): Retain original child ref",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { MenuTrigger } from './MenuTrigger';
 import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
 
@@ -41,5 +42,60 @@ describe('MenuTrigger', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('should retain original child callback ref', () => {
+    // Arrange
+    const ref = jest.fn();
+    render(
+      <MenuTrigger>
+        <button ref={ref}>Trigger</button>
+      </MenuTrigger>,
+    );
+
+    // Assert
+    expect(ref).toHaveBeenCalledTimes(1);
+    expect(ref.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          id=""
+        >
+          Trigger
+        </button>,
+      ]
+    `);
+  });
+
+  it('should retain original child ref', () => {
+    // Arrange
+    const cb = jest.fn();
+    const TestComponent = () => {
+      const ref = React.useRef(null);
+      React.useEffect(() => {
+        cb(ref.current);
+      }, []);
+      return (
+        <MenuTrigger>
+          <button ref={ref}>Trigger</button>
+        </MenuTrigger>
+      );
+    };
+    render(<TestComponent />);
+
+    // Assert
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          id=""
+        >
+          Trigger
+        </button>,
+      ]
+    `);
   });
 });

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -135,7 +135,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
 
   state.children = React.cloneElement(child, {
     ...triggerProps,
-    ref: useMergedRefs(((child as unknown) as { ref: React.Ref<unknown> }).ref, triggerRef),
+    ref: useMergedRefs(((child as unknown) as React.ReactElement & React.RefAttributes<unknown>).ref, triggerRef),
   });
 
   return state as MenuTriggerState;

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -135,7 +135,7 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
 
   state.children = React.cloneElement(child, {
     ...triggerProps,
-    ref: useMergedRefs(child.props.ref, triggerRef),
+    ref: useMergedRefs(((child as unknown) as { ref: React.Ref<unknown> }).ref, triggerRef),
   });
 
   return state as MenuTriggerState;

--- a/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -57,4 +57,57 @@ describe('PopoverTrigger', () => {
     // Assert
     expect(getByRole('button').getAttribute('aria-haspopup')).toEqual('true');
   });
+
+  it('should retain original child callback ref', () => {
+    // Arrange
+    const ref = jest.fn();
+    render(
+      <PopoverTrigger>
+        <button ref={ref}>Trigger</button>
+      </PopoverTrigger>,
+    );
+
+    // Assert
+    expect(ref).toHaveBeenCalledTimes(1);
+    expect(ref.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        <button
+          aria-haspopup="true"
+          data-tabster="{\\"deloser\\":{}}"
+        >
+          Trigger
+        </button>,
+      ]
+    `);
+  });
+
+  it('should retain original child ref', () => {
+    // Arrange
+    const cb = jest.fn();
+    const TestComponent = () => {
+      const ref = React.useRef(null);
+      React.useEffect(() => {
+        cb(ref.current);
+      }, []);
+      return (
+        <PopoverTrigger>
+          <button ref={ref}>Trigger</button>
+        </PopoverTrigger>
+      );
+    };
+    render(<TestComponent />);
+
+    // Assert
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        <button
+          aria-haspopup="true"
+          data-tabster="{\\"deloser\\":{}}"
+        >
+          Trigger
+        </button>,
+      ]
+    `);
+  });
 });

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -90,7 +90,7 @@ export const usePopoverTrigger = (
     onKeyDown,
     onMouseLeave,
     onContextMenu,
-    ref: useMergedRefs(((child as unknown) as { ref: React.Ref<unknown> }).ref, triggerRef),
+    ref: useMergedRefs(((child as unknown) as React.ReactElement & React.RefAttributes<unknown>).ref, triggerRef),
     ...triggerAttributes,
   });
 

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -90,7 +90,7 @@ export const usePopoverTrigger = (
     onKeyDown,
     onMouseLeave,
     onContextMenu,
-    ref: useMergedRefs(child.props.ref, triggerRef),
+    ref: useMergedRefs(((child as unknown) as { ref: React.Ref<unknown> }).ref, triggerRef),
     ...triggerAttributes,
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19380
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously trigger refs were cloned incorrectly using `child.props.ref`.
The correct property should be `child.ref` which is not correctly typed
by React

#### Focus areas to test

(optional)
