### PR TITLE
Charting: CherryPick #19318 : Legends will be focusable in browser mode #19318

### DIFF
--- a/change/@uifabric-charting-bd7b1917-a06f-4263-81e4-75b5a2f6da37.json
+++ b/change/@uifabric-charting-bd7b1917-a06f-4263-81e4-75b5a2f6da37.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Legends will be focusable in browser mode",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -285,7 +285,6 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -547,7 +546,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="listbox"
+        role="group"
       >
         <div
           className=
@@ -600,7 +599,6 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -1055,7 +1053,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1108,7 +1106,6 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1387,7 +1384,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1440,7 +1437,6 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1719,7 +1715,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1772,7 +1768,6 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2051,7 +2046,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2104,7 +2099,6 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -227,7 +227,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -316,7 +315,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -537,7 +535,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -590,7 +588,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -679,7 +676,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1021,7 +1017,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1074,7 +1070,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1163,7 +1158,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1388,7 +1382,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1441,7 +1435,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1530,7 +1523,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -343,7 +343,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -432,7 +431,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -521,7 +519,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -841,7 +838,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="listbox"
+        role="group"
       >
         <div
           className=
@@ -894,7 +891,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -983,7 +979,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -1072,7 +1067,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -1643,7 +1637,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1696,7 +1690,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1785,7 +1778,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1874,7 +1866,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2211,7 +2202,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2264,7 +2255,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2353,7 +2343,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2442,7 +2431,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2779,7 +2767,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2832,7 +2820,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2921,7 +2908,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -3010,7 +2996,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -3347,7 +3332,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -3400,7 +3385,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -3489,7 +3473,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -3578,7 +3561,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -273,7 +273,6 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -540,7 +539,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -593,7 +592,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -682,7 +680,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1116,7 +1113,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1169,7 +1166,6 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1436,7 +1432,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1489,7 +1485,6 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -123,7 +123,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps, allowFocusOnLegends = true } = this.props;
     return (
       <OverflowSet
-        {...(allowFocusOnLegends && { role: 'listbox', 'aria-label': 'Legends' })}
+        {...(allowFocusOnLegends && { 'aria-label': 'Legends' })}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}
@@ -377,7 +377,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       <button
         {...(allowFocusOnLegends && {
           'aria-selected': this.state.selectedLegend === legend.title,
-          role: 'option',
           'aria-label': legend.title,
           'aria-setsize': data['aria-setsize'],
           'aria-posinset': data['aria-posinset'],

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -276,7 +276,6 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -529,7 +528,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="listbox"
+        role="group"
       >
         <div
           className=
@@ -582,7 +581,6 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -1019,7 +1017,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1072,7 +1070,6 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1342,7 +1339,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1395,7 +1392,6 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1665,7 +1661,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1718,7 +1714,6 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1988,7 +1983,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2041,7 +2036,6 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -360,7 +360,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             />
           </div>
         </div>
@@ -725,7 +725,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             />
           </div>
         </div>
@@ -1397,7 +1397,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1450,7 +1450,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1539,7 +1538,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1949,7 +1947,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             />
           </div>
         </div>

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1210,7 +1210,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1263,7 +1263,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1352,7 +1351,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -269,7 +269,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -358,7 +357,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -447,7 +445,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -693,7 +690,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="listbox"
+        role="group"
       >
         <div
           className=
@@ -746,7 +743,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -835,7 +831,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -924,7 +919,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -1347,7 +1341,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1400,7 +1394,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1489,7 +1482,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1578,7 +1570,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1841,7 +1832,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1894,7 +1885,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1983,7 +1973,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2072,7 +2061,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2335,7 +2323,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2388,7 +2376,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2477,7 +2464,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2566,7 +2552,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2829,7 +2814,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2882,7 +2867,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2971,7 +2955,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -3060,7 +3043,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -209,7 +209,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -298,7 +297,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -484,7 +482,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="listbox"
+        role="group"
       >
         <div
           className=
@@ -537,7 +535,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -626,7 +623,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
-            role="option"
           >
             <div
               className=
@@ -929,7 +925,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -982,7 +978,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1071,7 +1066,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1274,7 +1268,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1327,7 +1321,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1416,7 +1409,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1619,7 +1611,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -1672,7 +1664,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1761,7 +1752,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -1964,7 +1954,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2017,7 +2007,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2106,7 +2095,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2309,7 +2297,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -2362,7 +2350,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -2451,7 +2438,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=


### PR DESCRIPTION
### Original description
Cherry pick of [#19318](https://github.com/microsoft/fluentui/pull/19318)

#### Description of changes

In scan/browse mode, previously focus was not moving to other legends and overflow legends. 
But with these changes, the focus will move to legends and overflow legends, and visible data will be read by the narrator and NVDA. 

#### Focus areas to test

Legends

**Before Changes**

https://user-images.githubusercontent.com/29042635/128720096-2c4d77b8-22fa-43be-96eb-0e64d9019d10.mp4

**After Changes**

https://user-images.githubusercontent.com/29042635/128720421-be50f8ef-1b9b-4af0-9bf7-3ec288d5ef8c.mp4