### PR TITLE
Charting: CherryPick #19293: Chart will be readable by chart title property #19293

### DIFF
--- a/change/@fluentui-react-examples-83a1cb68-b9ab-4838-ad86-f44660ebd66e.json
+++ b/change/@fluentui-react-examples-83a1cb68-b9ab-4838-ad86-f44660ebd66e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for Area and Line chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-be6c9ea5-ccef-4dd2-8f33-f563f903b1d7.json
+++ b/change/@uifabric-charting-be6c9ea5-ccef-4dd2-8f33-f563f903b1d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for Area and Line chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/charting/src/components/AreaChart/AreaChart.base.tsx
@@ -114,12 +114,13 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
   }
 
   public render(): JSX.Element {
+    const { lineChartData, chartTitle } = this.props.data;
     const { colors, stackedInfo, calloutPoints } = this._createSet(this.props.data);
     this._calloutPoints = calloutPoints;
-    const isXAxisDateType = getXAxisType(this.props.data.lineChartData!);
+    const isXAxisDateType = getXAxisType(lineChartData!);
     this._colors = colors;
     this._stackedData = stackedInfo.stackedData;
-    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette, this.props.data.lineChartData!);
+    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette, lineChartData!);
 
     const tickParams = {
       tickValues: this.props.tickValues,
@@ -144,7 +145,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     return (
       <CartesianChart
         {...this.props}
-        points={this.props.data.lineChartData!}
+        chartTitle={chartTitle}
+        points={lineChartData!}
         chartType={ChartTypes.AreaChart}
         calloutProps={calloutProps}
         legendBars={legends}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -39,6 +39,9 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -371,6 +374,9 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -683,6 +689,9 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -862,6 +871,9 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1194,6 +1206,9 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1526,6 +1541,9 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 
@@ -1858,6 +1876,9 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        AreaChart
+      </title>
       <g
         className=
 

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -242,6 +242,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       >
         <FocusZone direction={focusDirection} {...svgFocusZoneProps}>
           <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }} {...svgProps}>
+            {this.props.chartTitle && <title>{this.props.chartTitle}</title>}
             <g
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;

--- a/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -351,6 +351,11 @@ export interface IChildProps {
 // Only used for Cartesian chart base
 export interface IModifiedCartesianChartProps extends ICartesianChartProps {
   /**
+   * Define the chart title
+   */
+  chartTitle?: string;
+
+  /**
    * Only used for Area chart
    * Value used to draw y axis of that chart.
    */

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -103,6 +103,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 {points!.chartData![0].data && this._createBenchmark(points!)}
                 <FocusZone direction={FocusZoneDirection.horizontal}>
                   <svg className={this._classNames.chart}>
+                    {points!.chartTitle && <title>{points!.chartTitle}</title>}
                     <g
                       id={keyVal}
                       key={keyVal}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -194,8 +194,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
   }
 
   public render(): JSX.Element {
-    const { tickValues, tickFormat, eventAnnotationProps, legendProps } = this.props;
-    this._points = this._injectIndexPropertyInLineChartData(this.props.data.lineChartData);
+    const { tickValues, tickFormat, eventAnnotationProps, legendProps, data } = this.props;
+    this._points = this._injectIndexPropertyInLineChartData(data.lineChartData);
 
     const isXAxisDateType = getXAxisType(this._points);
     let points = this._points;
@@ -233,6 +233,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     return (
       <CartesianChart
         {...this.props}
+        chartTitle={data.chartTitle}
         points={points}
         chartType={ChartTypes.LineChart}
         isCalloutForStack

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -39,6 +39,9 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -362,6 +365,9 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -665,6 +671,9 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -835,6 +844,9 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1158,6 +1170,9 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1481,6 +1496,9 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 
@@ -1804,6 +1822,9 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
+      <title>
+        LineChart
+      </title>
       <g
         className=
 

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -230,7 +230,10 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>{bars}</svg>
+            <svg className={this._classNames.chart}>
+              {data!.chartTitle && <title>{data!.chartTitle}</title>}
+              {bars}
+            </svg>
           </div>
         </FocusZone>
       </div>

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -136,6 +136,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
             <svg className={this._classNames.chart}>
+              {data!.chartTitle && <title>{data!.chartTitle}</title>}
               <g>{bars[0]}</g>
               <Callout
                 gapSpace={15}

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -93,6 +93,9 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -238,6 +241,9 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -462,6 +468,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout23"
@@ -603,6 +612,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout23"
@@ -831,6 +843,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
@@ -976,6 +991,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
@@ -1130,6 +1148,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout17"
@@ -1275,6 +1296,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout17"
@@ -1682,6 +1706,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
+            <title>
+              Monitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout11"
@@ -1827,6 +1854,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
+            <title>
+              Unmonitored
+            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout11"

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -101,6 +101,9 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -277,6 +280,9 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -439,6 +445,9 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -615,6 +624,9 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -761,6 +773,9 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -937,6 +952,9 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -1083,6 +1101,9 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               width: 100%;
             }
       >
+        <title>
+          Stacked bar chart 2nd example
+        </title>
         <g>
           <g
             aria-label="Stacked bar chart"

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -138,7 +138,7 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
     ];
 
     const chartData = {
-      chartTitle: 'Area chart multiple example',
+      chartTitle: 'Area chart Custom Accessibility example',
       lineChartData: chartPoints,
     };
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };

--- a/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -147,7 +147,7 @@ export class LineChartCustomAccessibilityExample extends React.Component<
     ];
 
     const data: IChartProps = {
-      chartTitle: 'Line Chart',
+      chartTitle: 'Line Chart Custom Accessibility Example',
       lineChartData: points,
     };
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };


### PR DESCRIPTION
### Original description
Cherry pick of [#19293](https://github.com/microsoft/fluentui/pull/19293)


#### Description of changes

1. For Stacked Bar Chart, Multi Stacked Bar Chart, Horizontal Bar Chart, Area Chart and Line Chart: Existing chart title property is used to describe the chart. So in narrator scan mode, when the focus goes to chart, it will read chart title, previously it read as "image".  

#### Focus areas to test
Area Chart
Line Chart
Stacked Bar Chart
Multi Stacked Bar chart
Horizontal Stacked Bar chart

**Before Changes:**

https://user-images.githubusercontent.com/29042635/128512033-99f2e920-2634-4a90-9ccc-d3e76433bd8a.mp4

**After Changes:**

https://user-images.githubusercontent.com/29042635/128512057-0029333c-fdf4-4fb5-87dd-1eb8f6547268.mp4