### PR TITLE
fix(Callout): check preventDismissOnEvent before dismissing for all dismiss triggers

### DIFF
--- a/change/@fluentui-react-d9c85ed1-5885-443e-993f-2ce9c43a544b.json
+++ b/change/@fluentui-react-d9c85ed1-5885-443e-993f-2ce9c43a544b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "check preventDismissOnEvent before dismissing the callout for all dismiss triggers",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -166,6 +166,41 @@ describe('Callout', () => {
     });
   });
 
+  it('prevents dismiss when preventDismissOnEvent is passed', () => {
+    jest.useFakeTimers();
+    let threwException = false;
+    const onDismiss = jest.fn();
+    const preventAllDismiss = () => true;
+
+    try {
+      ReactTestUtils.act(() => {
+        ReactDOM.render<HTMLDivElement>(
+          <div>
+            <button id="focustarget"> button </button>
+            <Callout target="#target" preventDismissOnEvent={preventAllDismiss} onDismiss={onDismiss}>
+              <div>Content</div>
+            </Callout>
+          </div>,
+          realDom,
+        );
+      });
+    } catch (e) {
+      threwException = true;
+    }
+    expect(threwException).toEqual(false);
+
+    ReactTestUtils.act(() => {
+      const focusTarget = document.querySelector('#focustarget') as HTMLButtonElement;
+
+      // Move focus
+      jest.runAllTimers();
+
+      focusTarget.focus();
+
+      expect(onDismiss.mock.calls.length).toEqual(0);
+    });
+  });
+
   it('will correctly return focus to element that spawned it', () => {
     jest.useFakeTimers();
 

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -334,7 +334,7 @@ function useDismissHandlers(
     };
 
     const dismissOnResize = (ev: Event) => {
-      if (!preventDismissOnResize) {
+      if (!preventDismissOnResize && !(preventDismissOnEvent && preventDismissOnEvent(ev))) {
         onDismiss?.(ev);
       }
     };
@@ -364,6 +364,9 @@ function useDismissHandlers(
             dismissOnTargetClick ||
             (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
       ) {
+        if (preventDismissOnEvent && preventDismissOnEvent(ev)) {
+          return;
+        }
         onDismiss?.(ev);
       }
     };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Callout was previously only calling `preventDismissOnEvent` for the `targetWindowBlur` dismissal, rather than anywhere `onDismiss` was called. This PR checks for it before each time `onDismiss` is called.

This fixes an issue a team was running into, where they could not prevent the ContextualMenu from dismissing after a window focus event.
