### PR TITLE
Reverting : Legends will be focusable in browser mode

### DIFF
--- a/change/@fluentui-react-charting-d6d058d3-c6c5-4fd0-ae05-ae45d379fef5.json
+++ b/change/@fluentui-react-charting-d6d058d3-c6c5-4fd0-ae05-ae45d379fef5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reverting: Legends will be focusable in browser mode",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -281,6 +281,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -537,7 +538,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               justify-content: unset;
               position: relative;
             }
-        role="group"
+        role="listbox"
       >
         <div
           className=
@@ -591,6 +592,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -1043,7 +1045,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1097,6 +1099,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1370,7 +1373,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1424,6 +1427,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1697,7 +1701,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1751,6 +1755,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2024,7 +2029,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2078,6 +2083,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                     justify-content: center;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -223,6 +223,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -312,6 +313,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -527,7 +529,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                     justify-content: center;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -581,6 +583,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -670,6 +673,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1009,7 +1013,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                     justify-content: center;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1063,6 +1067,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1152,6 +1157,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1371,7 +1377,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                     justify-content: center;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1425,6 +1431,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1514,6 +1521,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -336,6 +336,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -425,6 +426,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -514,6 +516,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -825,7 +828,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               justify-content: unset;
               position: relative;
             }
-        role="group"
+        role="listbox"
       >
         <div
           className=
@@ -879,6 +882,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -968,6 +972,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -1057,6 +1062,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -1619,7 +1625,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1673,6 +1679,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1762,6 +1769,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1851,6 +1859,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2179,7 +2188,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2233,6 +2242,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2322,6 +2332,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2411,6 +2422,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2739,7 +2751,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2793,6 +2805,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2882,6 +2895,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2971,6 +2985,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -3299,7 +3314,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -3353,6 +3368,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -3442,6 +3458,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -3531,6 +3548,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -266,6 +266,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -524,7 +525,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -578,6 +579,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -667,6 +669,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1092,7 +1095,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1146,6 +1149,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1404,7 +1408,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1458,6 +1462,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -123,7 +123,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps, allowFocusOnLegends = true } = this.props;
     return (
       <OverflowSet
-        {...(allowFocusOnLegends && { 'aria-label': 'Legends' })}
+        {...(allowFocusOnLegends && { role: 'listbox', 'aria-label': 'Legends' })}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}
@@ -377,6 +377,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       <button
         {...(allowFocusOnLegends && {
           'aria-selected': this.state.selectedLegend === legend.title,
+          role: 'option',
           'aria-label': legend.title,
           'aria-setsize': data['aria-setsize'],
           'aria-posinset': data['aria-posinset'],

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -272,6 +272,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -519,7 +520,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               justify-content: unset;
               position: relative;
             }
-        role="group"
+        role="listbox"
       >
         <div
           className=
@@ -573,6 +574,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -1007,7 +1009,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1061,6 +1063,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1325,7 +1328,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1379,6 +1382,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1643,7 +1647,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1697,6 +1701,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1961,7 +1966,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2015,6 +2020,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -358,7 +358,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             />
           </div>
         </div>
@@ -721,7 +721,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             />
           </div>
         </div>
@@ -1397,7 +1397,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1451,6 +1451,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1540,6 +1541,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1947,7 +1949,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             />
           </div>
         </div>

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1223,7 +1223,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1277,6 +1277,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1366,6 +1367,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -205,6 +205,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -294,6 +295,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -383,6 +385,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -563,7 +566,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               justify-content: unset;
               position: relative;
             }
-        role="group"
+        role="listbox"
       >
         <div
           className=
@@ -617,6 +620,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -706,6 +710,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -795,6 +800,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -1095,7 +1101,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1149,6 +1155,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1238,6 +1245,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1327,6 +1335,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1524,7 +1533,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1578,6 +1587,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1667,6 +1677,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1756,6 +1767,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1953,7 +1965,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2007,6 +2019,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2096,6 +2109,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2185,6 +2199,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2382,7 +2397,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2436,6 +2451,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2525,6 +2541,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2614,6 +2631,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -202,6 +202,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -291,6 +292,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -468,7 +470,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               justify-content: unset;
               position: relative;
             }
-        role="group"
+        role="listbox"
       >
         <div
           className=
@@ -522,6 +524,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -611,6 +614,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
             onFocus={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
+            role="option"
           >
             <div
               className=
@@ -905,7 +909,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -959,6 +963,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1048,6 +1053,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1242,7 +1248,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1296,6 +1302,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1385,6 +1392,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1579,7 +1587,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1633,6 +1641,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1722,6 +1731,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -1916,7 +1926,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -1970,6 +1980,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2059,6 +2070,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2253,7 +2265,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                     justify-content: unset;
                     position: relative;
                   }
-              role="group"
+              role="listbox"
             >
               <div
                 className=
@@ -2307,6 +2319,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=
@@ -2396,6 +2409,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
+                  role="option"
                 >
                   <div
                     className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The original issue exists in NVDA tool itself, solving the issue that created the Fastpass issue in charts. So reverting the changes. 
The same issue has been raised on the NVDA GitHub page

#### Focus areas to test
Legends
