### PR TITLE
Update hc focus styling for vNext button

### DIFF
--- a/change/@fluentui-react-button-36853289-ff23-460d-b07c-160138e12073.json
+++ b/change/@fluentui-react-button-36853289-ff23-460d-b07c-160138e12073.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update hc focus styling for vNext button",
+  "packageName": "@fluentui/react-button",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -246,7 +246,7 @@ const useRootFocusStyles = makeStyles({
     borderColor: 'transparent',
     boxShadow: `
       ${theme.alias.shadow.shadow4},
-      0 0 0 2px ${theme.alias.color.neutral.neutralForeground1}
+      0 0 0 2px ${theme.alias.color.neutral.neutralBackground1Hover}
     `,
   })),
   circular: createFocusIndicatorStyleRule(theme => ({
@@ -254,7 +254,7 @@ const useRootFocusStyles = makeStyles({
   })),
   primary: createFocusIndicatorStyleRule(theme => ({
     borderColor: theme.alias.color.neutral.neutralForegroundOnBrand,
-    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.neutralForeground1}`,
+    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.neutralBackground1Hover}`,
   })),
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19118 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

PR to update the tokens used for hc styling on focus for react-button

**Before**
![image](https://user-images.githubusercontent.com/66456876/129627114-3c258da8-9c3c-462d-930b-4f1777f42694.png)


**After**
![image](https://user-images.githubusercontent.com/66456876/129627055-9aad7278-1d09-47fd-a9b0-392f16ac8543.png)


#### Focus areas to test

(optional)
