### PR TITLE
Fix horizontal scrollbar detection in MarqueeSelection

### DIFF
--- a/change/@fluentui-react-2ed65004-21d3-4d85-936c-d4e88831ff56.json
+++ b/change/@fluentui-react-2ed65004-21d3-4d85-936c-d4e88831ff56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix horizontal scrollbar detection in MarqueeSelection",
+  "packageName": "@fluentui/react",
+  "email": "sebastian.oettl@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -118,8 +118,9 @@ export class MarqueeSelectionBase extends React.Component<IMarqueeSelectionProps
   private _isMouseEventOnScrollbar(ev: MouseEvent): boolean {
     const targetElement = ev.target as HTMLElement;
     const targetScrollbarWidth = targetElement.offsetWidth - targetElement.clientWidth;
+    const targetScrollbarHeight = targetElement.offsetHeight - targetElement.clientHeight;
 
-    if (targetScrollbarWidth) {
+    if (targetScrollbarWidth || targetScrollbarHeight) {
       const targetRect = targetElement.getBoundingClientRect();
 
       // Check vertical scroll


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
If the page has a horizontal scrollbar (but not a vertical scrollbar), and the user has at least one item selected in a `DetailsList` wrapped with `MarqueeSelection`, these items will unexpectedly be unselected when the user drags the horizontal scrollbar to move the currently visible viewport.

This issue is fixed by extending `MarqueeSelection`'s scrollbar detection to include the horizontal scrollbar.