### PR TITLE
fix(Dialog): fix contrast ratio for Dialog in dark v2

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Datepicker` input @yuanboxue-amber ([#19261](https://github.com/microsoft/fluentui/pull/19261))
 - Fix `Dialog` styles border radius changed @bcalvery ([#19328](https://github.com/microsoft/fluentui/pull/19328))
 - Fix `Card` HC styles on hover @chassunc ([#19382](https://github.com/microsoft/fluentui/pull/19382))
+- Fix `Dialog` background in teams dark v2  @chassunc ([#19434](https://github.com/microsoft/fluentui/pull/19434))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/componentVariables.ts
@@ -2,3 +2,4 @@ export { chatMessageVariables as ChatMessage } from './components/Chat/chatMessa
 export { chatMessageDetailsVariables as ChatMessageDetails } from './components/Chat/chatMessageDetailsVariables';
 export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';
 export { textVariables as Text } from './components/Text/textVariables';
+export { dialogVariables as Dialog } from './components/Dialog/dialogVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Dialog/dialogVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark-v2/components/Dialog/dialogVariables.ts
@@ -1,0 +1,5 @@
+import { DialogVariables } from './../../../teams/components/Dialog/dialogVariables';
+
+export const dialogVariables = (siteVars): Partial<DialogVariables> => ({
+  rootBackground: siteVars.colorScheme.default.background,
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix contrast ratio for `Dialog` containing error `Text` in Dark V2

<img width="719" alt="Screenshot (4)" src="https://user-images.githubusercontent.com/86579954/129898119-ef895ee6-96d1-4ab9-80a5-b73006814ae1.png">


#### Focus areas to test

(optional)
