### PR TITLE
Opacity of non selected legends removed, to pass the accessibility luminosity ratio. 

### DIFF
--- a/change/@fluentui-react-charting-028db1e8-c569-4685-908d-18da89ca1c93.json
+++ b/change/@fluentui-react-charting-028db1e8-c569-4685-908d-18da89ca1c93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "opacity removed for unselected legends border, opacity was causing accessibility luminosity ratio issue",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -292,7 +292,6 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -602,7 +601,6 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1108,7 +1106,6 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1435,7 +1432,6 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1762,7 +1758,6 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2089,7 +2084,6 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -234,7 +234,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -323,7 +322,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -592,7 +590,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -681,7 +678,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1074,7 +1070,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1163,7 +1158,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1436,7 +1430,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1525,7 +1518,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -347,7 +347,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -436,7 +435,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -525,7 +523,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -890,7 +887,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -979,7 +975,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1068,7 +1063,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1684,7 +1678,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1773,7 +1766,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1862,7 +1854,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2244,7 +2235,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2333,7 +2323,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2422,7 +2411,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2804,7 +2792,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2893,7 +2880,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2982,7 +2968,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3364,7 +3349,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3453,7 +3437,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3542,7 +3525,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -277,7 +277,6 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -589,7 +588,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -678,7 +676,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1157,7 +1154,6 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1469,7 +1465,6 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -403,8 +403,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     legend: ILegend,
     color: string,
   ): React.ReactNode | string {
-    const { theme } = this.props;
-    const { palette } = theme!;
     const svgParentProps: React.SVGAttributes<SVGElement> = {
       className: classNames.shape,
     };
@@ -412,7 +410,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       fill: color,
       strokeWidth: 2,
       stroke: legend.color,
-      opacity: color === palette.white ? 0.6 : legend.opacity ? legend.opacity : '',
     };
     return (
       <Shape

--- a/packages/react-charting/src/components/Legends/Legends.styles.ts
+++ b/packages/react-charting/src/components/Legends/Legends.styles.ts
@@ -47,7 +47,6 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       marginRight: '8px',
       border: '1px solid',
       borderColor: props.borderColor ? props.borderColor : theme?.semanticColors.buttonBorder,
-      opacity: props.colorOnSelectedState === palette.white ? '0.6' : props.opacity ? props.opacity : '',
       content: props.stripePattern
         ? // eslint-disable-next-line @fluentui/max-len
           `repeating-linear-gradient(135deg, transparent, transparent 3px, ${props.colorOnSelectedState} 1px, ${props.colorOnSelectedState} 4px)`

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -283,7 +283,6 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -584,7 +583,6 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1072,7 +1070,6 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1390,7 +1387,6 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1708,7 +1704,6 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2026,7 +2021,6 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1462,7 +1462,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1551,7 +1550,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1288,7 +1288,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1377,7 +1376,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -216,7 +216,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -305,7 +304,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -394,7 +392,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -628,7 +625,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -717,7 +713,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -806,7 +801,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1160,7 +1154,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1249,7 +1242,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1338,7 +1330,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1589,7 +1580,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1678,7 +1668,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1767,7 +1756,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2018,7 +2006,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2107,7 +2094,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2196,7 +2182,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2447,7 +2432,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2536,7 +2520,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2625,7 +2608,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -213,7 +213,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -302,7 +301,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -533,7 +531,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -622,7 +619,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     content: ;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -970,7 +966,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1059,7 +1054,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1307,7 +1301,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1396,7 +1389,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1644,7 +1636,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1733,7 +1724,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1981,7 +1971,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2070,7 +2059,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2318,7 +2306,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2407,7 +2394,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           content: ;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChartWithPlaceHolder.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChartWithPlaceHolder.Example.tsx
@@ -3,14 +3,14 @@ import { IChartDataPoint, MultiStackedBarChart, IChartProps } from '@fluentui/re
 
 export const MultiStackedBarChartWithPlaceholderExample: React.FunctionComponent<{}> = () => {
   const firstChartPoints: IChartDataPoint[] = [
-    { legend: 'Malware', data: 40, color: '#00AE56' },
+    { legend: 'Malware', data: 40, color: '#0A7D3C' },
     { legend: 'Phishing', data: 23, color: '#662D91' },
     { legend: 'Spam and bulk', data: 35, color: '#0078D4' },
     { data: 87, placeHolder: true },
   ];
 
   const secondChartPoints: IChartDataPoint[] = [
-    { legend: 'Malicious links', data: 40, color: '#FFAA44' },
+    { legend: 'Malicious links', data: 40, color: '#BE4A1C' },
     { legend: 'Malicious attachments', data: 23, color: '#038387' },
     { data: 106, placeHolder: true },
   ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Previously opacity=0.6 was added for non-selected legends, which was causing a luminosity ratio issue.
Now opacity removed, so whatever color user has passed that will directly use.
It's totally up to the user, legends color is passing the luminosity ratio or not. 
  
#### Focus areas to test
Legends

**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/129918518-f6acd7d1-0411-4fcc-91fd-6fc2da1c38f0.png)


**After Changes:**
![image](https://user-images.githubusercontent.com/29042635/129919110-8fcc95d3-5400-48c5-a2a3-16c0ef36ab40.png)

