### PR TITLE
ensure card has good default foreground text

### DIFF
--- a/change/@fluentui-web-components-66b00aa4-efa9-4c0c-8681-017ee0b3035d.json
+++ b/change/@fluentui-web-components-66b00aa4-efa9-4c0c-8681-017ee0b3035d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ensure card foreground color responds to fill color changes",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/card/card.styles.ts
+++ b/packages/web-components/src/card/card.styles.ts
@@ -7,7 +7,7 @@ import {
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { elevation } from '../styles';
-import { fillColor, layerCornerRadius } from '../design-tokens';
+import { fillColor, layerCornerRadius, neutralForegroundRest } from '../design-tokens';
 
 export const cardStyles: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ElementStyles =
   (context: ElementDefinitionContext, definition: FoundationElementDefinition) =>
@@ -20,6 +20,7 @@ export const cardStyles: (context: ElementDefinitionContext, definition: Foundat
         width: var(--card-width, 100%);
         box-sizing: border-box;
         background: ${fillColor};
+        color: ${neutralForegroundRest}
         border-radius: calc(${layerCornerRadius} * 1px);
         ${elevation}
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Ensures that we set the foreground color of text by default for card so it responds to the fill and its changes.

#### Focus areas to test

(optional)
