### PR TITLE
Fix default styling for button on focus

### DIFF
--- a/change/@fluentui-react-button-07671e9e-e062-491d-bc90-15ce48a6d69f.json
+++ b/change/@fluentui-react-button-07671e9e-e062-491d-bc90-15ce48a6d69f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix default styling for button on focus",
+  "packageName": "@fluentui/react-button",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -246,7 +246,7 @@ const useRootFocusStyles = makeStyles({
     borderColor: 'transparent',
     boxShadow: `
       ${theme.alias.shadow.shadow4},
-      0 0 0 2px ${theme.alias.color.neutral.neutralBackground1Hover}
+      0 0 0 2px ${theme.alias.color.neutral.neutralStrokeAccessiblePressed}
     `,
   })),
   circular: createFocusIndicatorStyleRule(theme => ({
@@ -254,7 +254,7 @@ const useRootFocusStyles = makeStyles({
   })),
   primary: createFocusIndicatorStyleRule(theme => ({
     borderColor: theme.alias.color.neutral.neutralForegroundOnBrand,
-    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.neutralBackground1Hover}`,
+    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.neutralStrokeAccessiblePressed}`,
   })),
 });
 

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -246,7 +246,7 @@ const useRootFocusStyles = makeStyles({
     borderColor: 'transparent',
     boxShadow: `
       ${theme.alias.shadow.shadow4},
-      0 0 0 2px ${theme.alias.color.neutral.neutralStrokeAccessiblePressed}
+      0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}
     `,
   })),
   circular: createFocusIndicatorStyleRule(theme => ({
@@ -254,7 +254,7 @@ const useRootFocusStyles = makeStyles({
   })),
   primary: createFocusIndicatorStyleRule(theme => ({
     borderColor: theme.alias.color.neutral.neutralForegroundOnBrand,
-    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.neutralStrokeAccessiblePressed}`,
+    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}`,
   })),
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR is to update the default styling for the vNext button on focus, that got changed due to #19118. It fixes the default styling while maintaining the fixed hc focus styling

**Before**
![image](https://user-images.githubusercontent.com/66456876/129983483-931a6864-dcb9-472b-81f2-44bd848e1e71.png)
![image](https://user-images.githubusercontent.com/66456876/129983562-94823e3e-a83d-4034-b97e-a570b6521d82.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/129984010-66765a13-07f1-469d-83b5-dc96e739af2d.png)
![image](https://user-images.githubusercontent.com/66456876/129984036-46aaa2ab-3331-4ad9-aefe-e859139fea6e.png)


#### Focus areas to test

(optional)
