### PR TITLE
(react-checkbox) - Adding stopPropagation

### DIFF
--- a/change/@fluentui-react-checkbox-6ceea7cf-85e0-4218-8b28-540a1591555d.json
+++ b/change/@fluentui-react-checkbox-6ceea7cf-85e0-4218-8b28-540a1591555d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adding stopPropagation to the input change event.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, RenderResult } from '@testing-library/react';
+import { render, RenderResult, fireEvent, screen } from '@testing-library/react';
 import { Checkbox } from './Checkbox';
 import { mount, ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
@@ -128,6 +128,22 @@ describe('Checkbox', () => {
     input = component.find('input');
     expect(input.prop('checked')).toBe(false);
     expect(checkboxRef.current?.checked).toBe(false);
+  });
+
+  it('calls onChange with the correct value', () => {
+    const eventHandler = jest.fn();
+
+    render(<Checkbox checked onChange={eventHandler} />);
+    const input = screen.getByRole('checkbox');
+
+    expect(eventHandler).toBeCalledTimes(0);
+
+    fireEvent.click(input);
+    fireEvent.click(input);
+    fireEvent.click(input);
+
+    expect(eventHandler).toBeCalledTimes(3);
+    expect(eventHandler.mock.calls[2][1]).toEqual({ checked: false });
   });
 
   it("doesn't remove controlled mixed when no onChange provided", () => {

--- a/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -78,6 +78,7 @@ export const useCheckbox = (props: CheckboxProps, ref: React.Ref<HTMLElement>): 
 
   const userOnChange = state.input.onChange;
   state.input.onChange = useEventCallback(ev => {
+    ev.stopPropagation();
     userOnChange?.(ev);
     setChecked(ev, ev.currentTarget.indeterminate ? 'mixed' : ev.currentTarget.checked);
   });


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Adding `ev.stopPropagation()` to the Checkbox component's input change event. This prevents the events from bubbling up and calling multiple onChange events.

#### Before:
![](https://i.imgur.com/hA0leYP.gif)

#### After:
![](https://i.imgur.com/0Il6I7r.gif)
