### PR TITLE
[Calendar] Fix arrowing changing columns in WeeklyDayPicker

### DIFF
--- a/change/@fluentui-react-81d646be-2eda-4781-ad0c-e450e03f1487.json
+++ b/change/@fluentui-react-81d646be-2eda-4781-ad0c-e450e03f1487.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing arrowing in weekly day picker component not staying in correct column",
+  "packageName": "@fluentui/react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -54,9 +54,9 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
   let rowAnimationStyle: IRawStyle = {};
   if (animateBackwards !== undefined) {
     if (animationDirection === AnimationDirection.Horizontal) {
-      rowAnimationStyle = animateBackwards ? AnimationStyles.slideRightIn20 : AnimationStyles.slideLeftIn20;
+      rowAnimationStyle = animateBackwards ? AnimationStyles.slideRightIn10 : AnimationStyles.slideLeftIn10;
     } else {
-      rowAnimationStyle = animateBackwards ? AnimationStyles.slideDownIn20 : AnimationStyles.slideUpIn20;
+      rowAnimationStyle = animateBackwards ? AnimationStyles.slideDownIn10 : AnimationStyles.slideUpIn10;
     }
   }
 
@@ -64,8 +64,8 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
   let lastTransitionRowAnimationStyle: IRawStyle = {};
   if (animateBackwards !== undefined) {
     if (animationDirection !== AnimationDirection.Horizontal) {
-      firstTransitionRowAnimationStyle = animateBackwards ? { animationName: '' } : AnimationStyles.slideUpOut20;
-      lastTransitionRowAnimationStyle = animateBackwards ? AnimationStyles.slideDownOut20 : { animationName: '' };
+      firstTransitionRowAnimationStyle = animateBackwards ? { animationName: '' } : AnimationStyles.slideUpOut10;
+      lastTransitionRowAnimationStyle = animateBackwards ? AnimationStyles.slideDownOut10 : { animationName: '' };
     }
   }
 

--- a/packages/react/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/react/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -117,6 +117,9 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
       className,
       showFullMonth,
       weeksToShow,
+      // unused, but extract from calendarDayGridProps to avoid override
+      onSelectDate,
+      onNavigateDate,
       ...calendarDayGridProps
     } = this.props;
 


### PR DESCRIPTION
… column

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

2 small fixes for WeeklyDayPicker component.

First, WeeklyDayPicker allows consumer to pass onSelectDate and onNavigateDate callbacks and expects to call them in it's own custom callbacks, but the custom internal ones get overwritten by the passed props. Need those props to be extracted before passing through to children components.

Second, WeeklyDayPicker uses left/right animation. When arrowing down through a single column, when arrowing to future month, the column shifts to the right (and left when going to previous month). Debugging showed the issue was the GetBoundingClientRect call made in FocusZone when calculating the alignment, was run before the right-to-left transition animation finished. We could update FocusZone to dynamically check whether there's an animation and delay the check, but its simpler to just reduce the scope of the animation here so that the calculation still returns the correct column in the meantime.

Calendar and DatePicker components don't have this issue because they animate up and down.

#### Focus areas to test

(optional)
