### PR TITLE
Charting: CherryPick #19356: Added Chart Title property for all charts #19356

### DIFF
--- a/change/@fluentui-react-examples-6ed3129e-a445-4057-aa96-249221b65b9c.json
+++ b/change/@fluentui-react-examples-6ed3129e-a445-4057-aa96-249221b65b9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for remaining charts, title will describe the chart",
+  "packageName": "@fluentui/react-examples",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-charting-f84a3e11-cd86-467e-8ee6-e3e7340e1535.json
+++ b/change/@uifabric-charting-f84a3e11-cd86-467e-8ee6-e3e7340e1535.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart title added for remaining charts, title will describe the chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -39,9 +40,6 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -366,6 +364,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -374,9 +373,6 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -681,6 +677,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -689,9 +686,6 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -863,6 +857,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -871,9 +866,6 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1198,6 +1190,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1206,9 +1199,6 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1533,6 +1523,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1541,9 +1532,6 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1868,6 +1856,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1876,9 +1865,6 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -241,8 +241,13 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
       >
         <FocusZone direction={focusDirection} {...svgFocusZoneProps}>
-          <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }} {...svgProps}>
-            {this.props.chartTitle && <title>{this.props.chartTitle}</title>}
+          <svg
+            width={svgDimensions.width}
+            height={svgDimensions.height}
+            aria-label={this.props.chartTitle}
+            style={{ display: 'block' }}
+            {...svgProps}
+          >
             <g
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -104,6 +104,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
             <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
+              {data?.chartTitle && <title>{data?.chartTitle}</title>}
               <Pie
                 width={this.state._width!}
                 height={this.state._height!}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -103,8 +103,11 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       <div className={this._classNames.root} ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}>
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
-            <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
-              {data?.chartTitle && <title>{data?.chartTitle}</title>}
+            <svg
+              className={this._classNames.chart}
+              aria-label={data?.chartTitle}
+              ref={(node: SVGElement | null) => this._setViewBox(node)}
+            >
               <Pie
                 width={this.state._width!}
                 height={this.state._height!}

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -38,6 +38,9 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -401,6 +404,9 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -764,6 +770,9 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -885,6 +894,9 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -1248,6 +1260,9 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               overflow: visible;
             }
       >
+        <title>
+          Stacked Bar chart example
+        </title>
         <g
           transform="translate(0, 0)"
         >

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -38,9 +39,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -396,6 +394,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -404,9 +403,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -762,6 +758,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -770,9 +767,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -886,6 +880,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -894,9 +889,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -1252,6 +1244,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -1260,9 +1253,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
@@ -10,6 +10,10 @@ import {
 
 export interface IGroupedVerticalBarChartProps extends ICartesianChartProps {
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+  /**
    * Data to render in the chart.
    */
   data: IGroupedVerticalBarChartData[];

--- a/packages/charting/src/components/HeatMapChart/HeatMapChart.types.ts
+++ b/packages/charting/src/components/HeatMapChart/HeatMapChart.types.ts
@@ -11,6 +11,10 @@ import {
 
 export interface IHeatMapChartProps extends Pick<ICartesianChartProps, Exclude<keyof ICartesianChartProps, 'styles'>> {
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+  /**
    * data to provide for Heat Map
    */
   data: IHeatMapChartData[];

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -39,9 +40,6 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -357,6 +355,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -365,9 +364,6 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -663,6 +659,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -671,9 +668,6 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -836,6 +830,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -844,9 +839,6 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1162,6 +1154,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1170,9 +1163,6 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1488,6 +1478,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1496,9 +1487,6 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1814,6 +1802,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1822,9 +1811,6 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 

--- a/packages/charting/src/components/PieChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/PieChart/Pie/Pie.tsx
@@ -33,7 +33,7 @@ export class Pie extends React.Component<IPieProps, {}> {
 
   public render(): JSX.Element {
     // const getClassNames = classNamesFunction<IPieProps, IPieStyles>();
-    const { pie, colors, data, width, height } = this.props;
+    const { pie, colors, data, width, height, chartTitle } = this.props;
 
     this.colors = scale.scaleOrdinal().range(colors!);
 
@@ -42,6 +42,7 @@ export class Pie extends React.Component<IPieProps, {}> {
 
     return (
       <svg width={width} height={height}>
+        {chartTitle && <title>{chartTitle}</title>}
         <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i))}</g>
       </svg>
     );

--- a/packages/charting/src/components/PieChart/Pie/Pie.types.ts
+++ b/packages/charting/src/components/PieChart/Pie/Pie.types.ts
@@ -27,6 +27,10 @@ export interface IPieProps {
    */
   colors?: string[];
   /**
+   * Title to apply to the whole chart.
+   */
+  chartTitle?: string;
+  /**
    * shape for pie.
    */
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/charting/src/components/PieChart/PieChart.base.tsx
+++ b/packages/charting/src/components/PieChart/PieChart.base.tsx
@@ -14,7 +14,7 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
   private _classNames: IProcessedStyleSet<IPieChartStyles>;
 
   public render(): JSX.Element {
-    const { data, width, height, colors } = this.props;
+    const { data, width, height, colors, chartTitle } = this.props;
 
     const { theme, className, styles } = this.props;
     this._classNames = getClassNames(styles!, {
@@ -29,7 +29,15 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
     return (
       <div className={this._classNames.root}>
         {this.props.chartTitle && <p className={this._classNames.chartTitle}>{this.props.chartTitle}</p>}
-        <Pie width={width!} height={height!} outerRadius={outerRadius} innerRadius={0} data={data!} colors={colors!} />
+        <Pie
+          width={width!}
+          height={height!}
+          outerRadius={outerRadius}
+          innerRadius={0}
+          data={data!}
+          colors={colors!}
+          chartTitle={chartTitle!}
+        />
       </div>
     );
   }

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -230,8 +230,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>
-              {data!.chartTitle && <title>{data!.chartTitle}</title>}
+            <svg className={this._classNames.chart} aria-label={data?.chartTitle}>
               {bars}
             </svg>
           </div>

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -135,8 +135,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>
-              {data!.chartTitle && <title>{data!.chartTitle}</title>}
+            <svg className={this._classNames.chart} aria-label={data?.chartTitle}>
               <g>{bars[0]}</g>
               <Callout
                 gapSpace={15}

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -93,9 +94,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -234,6 +232,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -241,9 +240,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -461,6 +457,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -468,9 +465,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout23"
@@ -605,6 +599,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -612,9 +607,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout23"
@@ -836,6 +828,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -843,9 +836,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
@@ -984,6 +974,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -991,9 +982,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout6"
@@ -1141,6 +1129,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -1148,9 +1137,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout17"
@@ -1289,6 +1275,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -1296,9 +1283,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout17"
@@ -1699,6 +1683,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -1706,9 +1691,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout11"
@@ -1847,6 +1829,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -1854,9 +1837,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout11"

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -101,9 +102,6 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -272,6 +270,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -280,9 +279,6 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -437,6 +433,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -445,9 +442,6 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -616,6 +610,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -624,9 +619,6 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -765,6 +757,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -773,9 +766,6 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -944,6 +934,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -952,9 +943,6 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -1093,6 +1081,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -1101,9 +1090,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
@@ -29,6 +29,11 @@ export interface IVerticalBarChartProps extends ICartesianChartProps {
   colors?: string[];
 
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+
+  /**
    * Legend text for the line datapoint in the chart
    */
   lineLegendText?: string;

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -51,6 +51,11 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
   colors?: string[];
 
   /**
+   * chart title for the chart
+   */
+  chartTitle?: string;
+
+  /**
    * To display multi stack callout or single callout
    * @default flase
    */

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx
@@ -12,10 +12,8 @@ export class DonutChartBasicExample extends React.Component<IDonutChartProps, {}
       { legend: 'second', data: 39000, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart basic example',
       chartData: points,
     };
     return (

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
@@ -24,10 +24,8 @@ export class DonutChartCustomAccessibilityExample extends React.Component<IDonut
       },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart custom accessibility example',
       chartData: points,
       chartTitleAccessibilityData: { ariaLabel: 'Bar chart depicting about Donut chart' },
     };

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.CustomCallout.Example.tsx
@@ -12,10 +12,8 @@ export class DonutChartCustomCalloutExample extends React.Component<IDonutChartP
       { legend: 'second', data: 39000, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
     ];
 
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart custom callout example',
       chartData: points,
     };
     return (

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.Dynamic.Example.tsx
@@ -37,10 +37,8 @@ export class DonutChartDynamicExample extends React.Component<IDonutChartProps, 
   }
 
   public render(): JSX.Element {
-    const chartTitle = 'Stacked Bar chart example';
-
     const data: IChartProps = {
-      chartTitle: chartTitle,
+      chartTitle: 'Donut chart dynamic example',
       chartData: this.state.dynamicData,
     };
     return (

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -124,6 +124,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart basic example"
             data={data}
             height={this.state.height}
             width={this.state.width}

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -153,6 +153,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart custom accessibility example"
             data={data}
             height={this.state.height}
             width={this.state.width}

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
@@ -108,6 +108,7 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<{}, IG
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            chartTitle="Grouped Vertical Bar chart styled example"
             data={data}
             width={this.state.width}
             height={this.state.height}

--- a/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
@@ -366,6 +366,7 @@ export class HeatMapChartCustomAccessibilityExample extends React.Component<{}, 
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>
           <HeatMapChart
+            chartTitle="Heat map chart custom accessibility example"
             data={HeatMapData}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisStringFormatter={(point: string) => ypointMapping[point as string]}

--- a/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
+++ b/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
@@ -305,6 +305,7 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>
           <HeatMapChart
+            chartTitle="Heat map chart basic example"
             data={HeatMapData}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisStringFormatter={(point: string) => ypointMapping[point as string]}

--- a/packages/react-examples/src/charting/PieChart/PieChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/PieChart/PieChart.Basic.Example.tsx
@@ -14,6 +14,6 @@ export class PieChartBasicExample extends React.Component<IPieChartProps, {}> {
       { y: 25, x: 'C' },
     ];
     const colors = [DefaultPalette.red, DefaultPalette.blue, DefaultPalette.green];
-    return <PieChart data={points} chartTitle="Pie Chart" colors={colors} />;
+    return <PieChart data={points} chartTitle="Pie Chart basic example" colors={colors} />;
   }
 }

--- a/packages/react-examples/src/charting/PieChart/PieChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/charting/PieChart/PieChart.Dynamic.Example.tsx
@@ -46,7 +46,7 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
   public render(): JSX.Element {
     return (
       <div>
-        <PieChart data={this.state.dynamicData} chartTitle="Pie Chart" colors={this.state.colors} />
+        <PieChart data={this.state.dynamicData} chartTitle="Pie Chart dynamic example" colors={this.state.colors} />
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
       </div>

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
@@ -61,6 +61,7 @@ export class VerticalBarChartTooltipExample extends React.Component<{}, IVertica
         </div>
         <div style={rootStyle}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart axis tooltip example "
             data={points}
             height={350}
             width={650}

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -159,11 +159,11 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
         />
         <div style={rootStyle}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart basic example "
             data={points}
             width={this.state.width}
             useSingleColor={this.state.useSingleColor}
             height={this.state.height}
-            chartLabel={'Basic Chart with Numeric Axes'}
             lineLegendText={'just line'}
             lineLegendColor={'brown'}
             {...(this.state.isCalloutselected && {

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx
@@ -65,6 +65,7 @@ export class VerticalBarChartCustomAccessibilityExample extends React.Component<
         />
         <div style={{ width: '800px', height: '400px' }}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart custom accessibility example "
             data={points}
             width={800}
             height={400}

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -44,9 +44,9 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
     return (
       <div style={{ width: '650px', height: '400px' }}>
         <VerticalBarChart
+          chartTitle="Vertical bar chart dynamic example "
           data={this.state.dynamicData}
           colors={this.state.colors}
-          chartLabel={'Chart with Dynamic Data'}
           hideLegend={true}
           hideTooltip={true}
           yMaxValue={50}

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Styled.Example.tsx
@@ -51,6 +51,7 @@ export class VerticalBarChartStyledExample extends React.Component<IVerticalBarC
         />
         <div style={{ width: '800px', height: '400px' }}>
           <VerticalBarChart
+            chartTitle="Vertical bar chart styled example "
             data={points}
             width={800}
             height={400}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
@@ -63,6 +63,7 @@ export class VerticalStackedBarChartTooltipExample extends React.Component<{}, I
         </div>
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart axis tooltip example"
             data={data}
             height={350}
             width={650}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -211,11 +211,11 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart basic example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
-            chartLabel="Card title"
             legendProps={{
               overflowProps: {
                 focusZoneProps: {

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
@@ -215,12 +215,12 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart callout example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
             yAxisTickCount={10}
-            chartLabel="Card title"
             isCalloutForStack={
               this.state.selectedCallout === 'MultiCallout' || this.state.selectedCallout === 'MultiCustomCallout'
             }

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -176,11 +176,11 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart custom accessibility example"
             barGapMax={this.state.barGapMax}
             data={data}
             height={this.state.height}
             width={this.state.width}
-            chartLabel="Card title"
             legendProps={{
               allowFocusOnLegends: true,
             }}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -153,6 +153,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
         </div>
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            chartTitle="Vertical stacked bar chart styled example"
             data={data}
             {...this.state}
             yAxisTickCount={10}


### PR DESCRIPTION
### Original description
Cherry pick of [#19356](https://github.com/microsoft/fluentui/pull/19356)

#### Description of changes

Previously chart title property was missed in other charts. Now chart title property is available for all charts, which will be used by the narrator to describe the chart.

#### Focus areas to test

All charts

**After Change**
![image](https://user-images.githubusercontent.com/29042635/130237077-f35acb4c-08a2-4522-b3c7-acffe238635e.png)


This PR containers changes from [19464 ](https://github.com/microsoft/fluentui/pull/19464
)PR.  As both are related to same issue. 