### PR TITLE
Charting: CherryPick #19381: Chart data point element will not render when data value is zero #19381

### DIFF
--- a/change/@uifabric-charting-d0ef98be-f764-497d-ae39-d218851ed8b5.json
+++ b/change/@uifabric-charting-d0ef98be-f764-497d-ae39-d218851ed8b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chart element will not render when data value is zero",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -302,6 +302,9 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
         value = 1;
       }
       startingPoint.push(prevPosition);
+      if (value < 1) {
+        return <React.Fragment key={index}> </React.Fragment>;
+      }
       return (
         <rect
           key={index}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -106,6 +106,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           directionalHint={DirectionalHint.topRightEdge}
           id={this._calloutId}
           onDismiss={this._closeCallout}
+          preventDismissOnLostFocus={true}
           {...this.props.calloutProps!}
           {...this._getAccessibleDataObject(this.state.callOutAccessibilityData, 'text', false)}
         >
@@ -165,6 +166,10 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         shouldHighlight: shouldHighlight,
         href: href,
       });
+
+      if (value < 1) {
+        return <React.Fragment key={index}> </React.Fragment>;
+      }
 
       return (
         <g

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -248,6 +248,11 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         shouldHighlight: shouldHighlight,
         href: this.props.href!,
       });
+
+      if (value < 1) {
+        return <React.Fragment key={index}> </React.Fragment>;
+      }
+
       return (
         <g
           key={index}

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -468,6 +468,10 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
         legendColor: this.state.color,
         shouldHighlight: shouldHighlight,
       });
+      const barHeight: number = Math.max(yBarScale(point.y), 0);
+      if (barHeight < 1) {
+        return <React.Fragment key={point.x}> </React.Fragment>;
+      }
       return (
         <rect
           key={point.x}
@@ -476,7 +480,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
           data-is-focusable={!this.props.hideTooltip}
-          height={Math.max(yBarScale(point.y), 0)}
+          height={barHeight}
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!);
           }}
@@ -520,13 +524,17 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     const { xBarScale, yBarScale } = this._getScales(containerHeight, containerWidth, false);
     const colorScale = this._createColors();
     const bars = this._points.map((point: IVerticalBarChartDataPoint, index: number) => {
+      const barHeight: number = Math.max(yBarScale(point.y), 0);
+      if (barHeight < 1) {
+        return <React.Fragment key={point.x}> </React.Fragment>;
+      }
       return (
         <rect
           key={point.x}
           x={xBarScale(index)}
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
-          height={Math.max(yBarScale(point.y), 0)}
+          height={barHeight}
           aria-labelledby={`toolTip${this._calloutId}`}
           aria-label="Vertical bar chart"
           role="text"

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -97,66 +97,9 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -591,66 +534,9 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout14"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout14"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout14"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -1065,66 +951,9 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout5"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout5"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout5"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -1228,66 +1057,9 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout9"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={false}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout9"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={false}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout9"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={false}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -1722,66 +1494,9 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout19"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout19"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout19"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -2216,66 +1931,9 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout24"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout24"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout24"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>
@@ -2710,66 +2368,9 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
         transform="translate(40, 0)"
       />
       <g>
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout29"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#0078d4"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={56}
-          y={-24}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout29"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#002050"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={8.30769230769231}
-          y={20}
-        />
-        <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout29"
-          className=
-
-              {
-                opacity: ;
-              }
-          data-is-focusable={true}
-          fill="#00188f"
-          height={0}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          role="text"
-          width={32}
-          x={-63.23076923076923}
-          y={-2}
-        />
+         
+         
+         
       </g>
     </svg>
   </div>

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -748,7 +748,9 @@ export class VerticalStackedBarChartBase extends React.Component<
             />
           );
         }
-
+        if (barHeight < 1) {
+          return <React.Fragment key={index + indexNumber}> </React.Fragment>;
+        }
         return (
           <rect
             key={index + indexNumber + `${shouldFocusWholeStack}`}


### PR DESCRIPTION
### Original description
Cherry pick of [#19381](https://github.com/microsoft/fluentui/pull/19381)

#### Description of changes
If a data value is zero, then the chart element for that data point will not render. 
This is done because, Previously if the data point value was zero, that element was rendering but it was not visible because of 0 width. still, keyboard focus was showing the tooltip for that element. 
with new changes, as elements won't render, so the keyboard will focus on the visible elements only. 

#### Focus areas to test
Horizontal bar chart
Multistacked bar chart
Stacked bar chart
Vertical Bar chart
Vertical Stacked bar chart


**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/129189429-27e417ca-ace0-4d5c-a9ab-21575e7eaa49.png)


**After Changes:**

<img width="869" alt="Untitled" src="https://user-images.githubusercontent.com/29042635/129191045-12b063ea-ec9f-47d1-b9a1-77a13bf13d40.png">


(optional)
