### PR TITLE
Charting: CherryPick #19436: Opacity of non selected legends removed, to pass the accessibility luminosity ratio. #19436

### DIFF
--- a/change/@uifabric-charting-27af0561-2974-46a8-983a-c5cd5cacbbf5.json
+++ b/change/@uifabric-charting-27af0561-2974-46a8-983a-c5cd5cacbbf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "opacity removed for unselected legends border, opacity was causing accessibility luminosity ratio issue",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -300,7 +300,6 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -618,7 +617,6 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1132,7 +1130,6 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1467,7 +1464,6 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1802,7 +1798,6 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2137,7 +2132,6 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -239,7 +239,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -328,7 +327,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -602,7 +600,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -691,7 +688,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1086,7 +1082,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1175,7 +1170,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1453,7 +1447,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1542,7 +1535,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -355,7 +355,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -444,7 +443,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -533,7 +531,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -906,7 +903,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -995,7 +991,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1084,7 +1079,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1708,7 +1702,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1797,7 +1790,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1886,7 +1878,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2276,7 +2267,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2365,7 +2355,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2454,7 +2443,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2844,7 +2832,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2933,7 +2920,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3022,7 +3008,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3412,7 +3397,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3501,7 +3485,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3590,7 +3573,6 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -285,7 +285,6 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -605,7 +604,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -694,7 +692,6 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1181,7 +1178,6 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1501,7 +1497,6 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -404,8 +404,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     legend: ILegend,
     color: string,
   ): React.ReactNode | string {
-    const { theme } = this.props;
-    const { palette } = theme!;
     const svgParentProps: React.SVGAttributes<SVGElement> = {
       className: classNames.shape,
     };
@@ -413,7 +411,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       fill: color,
       strokeWidth: 2,
       stroke: legend.color,
-      opacity: color === palette.white ? 0.6 : legend.opacity ? legend.opacity : '',
     };
     return (
       <Shape

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -52,7 +52,6 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       marginRight: '8px',
       border: '1px solid',
       borderColor: props.borderColor ? props.borderColor : theme?.semanticColors.buttonBorder,
-      opacity: props.colorOnSelectedState === palette.white ? '0.6' : props.opacity ? props.opacity : '',
       backgroundImage: props.stripePattern
         ? // eslint-disable-next-line @fluentui/max-len
           `repeating-linear-gradient(135deg, transparent, transparent 3px, ${props.colorOnSelectedState} 1px, ${props.colorOnSelectedState} 4px)`

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -291,7 +291,6 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -600,7 +599,6 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1096,7 +1094,6 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1422,7 +1419,6 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1748,7 +1744,6 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2074,7 +2069,6 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1486,7 +1486,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1575,7 +1574,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1296,7 +1296,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1385,7 +1384,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -281,7 +281,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -370,7 +369,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -459,7 +457,6 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -758,7 +755,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -847,7 +843,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -936,7 +931,6 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1412,7 +1406,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1501,7 +1494,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1590,7 +1582,6 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1906,7 +1897,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1995,7 +1985,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2084,7 +2073,6 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2400,7 +2388,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2489,7 +2476,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2578,7 +2564,6 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2894,7 +2879,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2983,7 +2967,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -3072,7 +3055,6 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -221,7 +221,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -310,7 +309,6 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -549,7 +547,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -638,7 +635,6 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     border: 1px solid;
                     height: 12px;
                     margin-right: 8px;
-                    opacity: ;
                     width: 12px;
                   }
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -994,7 +990,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1083,7 +1078,6 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1339,7 +1333,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1428,7 +1421,6 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1684,7 +1676,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -1773,7 +1764,6 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2029,7 +2019,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2118,7 +2107,6 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2374,7 +2362,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -2463,7 +2450,6 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           border: 1px solid;
                           height: 12px;
                           margin-right: 8px;
-                          opacity: ;
                           width: 12px;
                         }
                         @media screen and (-ms-high-contrast: active), (forced-colors: active){& {


### PR DESCRIPTION
### Original description
Cherry pick of [#19436](https://github.com/microsoft/fluentui/pull/19436)


#### Description of changes
Previously opacity=0.6 was added for non-selected legends, which was causing a luminosity ratio issue.
Now opacity removed, so whatever color user has passed that will directly use.
It's totally up to the user, legends color is passing the luminosity ratio or not. 
  
#### Focus areas to test
Legends

**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/129918518-f6acd7d1-0411-4fcc-91fd-6fc2da1c38f0.png)


**After Changes:**
![image](https://user-images.githubusercontent.com/29042635/129919110-8fcc95d3-5400-48c5-a2a3-16c0ef36ab40.png)