### PR TITLE
Generate *.page.json for react-components

### DIFF
--- a/apps/public-docsite-resources/just.config.ts
+++ b/apps/public-docsite-resources/just.config.ts
@@ -1,9 +1,12 @@
 import { preset, task, series } from '@fluentui/scripts';
-import { generatePageJsonFiles } from '@fluentui/api-docs';
 
 preset();
 
-task('generate-json', () => generatePageJsonFiles(require('./config/api-docs')));
+task('generate-json', () => {
+  // delay load in case it's not compiled yet
+  const { generatePageJsonFiles } = require('@fluentui/api-docs');
+  generatePageJsonFiles(require('./config/api-docs'));
+});
 
 // copied from scripts/just.config.js with addition of generate-json
 task('build', series('clean', 'copy', 'sass', 'generate-json', 'ts')).cached();

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,14 @@ jobs:
           yarn buildci --no-cache $(sinceArg)
         displayName: build, test, lint
 
+      # TEMPORARY for testing purposes
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: packages/react-components/dist/api
+          artifactName: page-json-converged
+          publishLocation: Container
+        displayName: 'Publish artifact: page-json-converged (API docs)'
+
       - template: .devops/templates/cleanup.yml
 
   - job: DeployE2E

--- a/change/@fluentui-api-docs-a00db916-4b31-4d6d-96f3-8fb6b7338505.json
+++ b/change/@fluentui-api-docs-a00db916-4b31-4d6d-96f3-8fb6b7338505.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new APIs for inferring page names by prefix",
+  "packageName": "@fluentui/api-docs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-d5f38007-8630-40be-8453-af12e9160417.json
+++ b/change/@fluentui-react-components-d5f38007-8630-40be-8453-af12e9160417.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Generate *.page.json for react-components",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-6a097635-ef54-4e05-989e-e55b66a36d91.json
+++ b/change/@fluentui-react-menu-6a097635-ef54-4e05-989e-e55b66a36d91.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unneeded export of UninitializedMenuListState",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-e5f0087b-7f98-4547-8ea2-8700f92fdb9d.json
+++ b/change/@fluentui-react-popover-e5f0087b-7f98-4547-8ea2-8700f92fdb9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add docCategory overrides",
+  "packageName": "@fluentui/react-popover",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-fe8f6c76-dd9a-4360-9597-f2c3579af7f1.json
+++ b/change/@fluentui-react-text-fe8f6c76-dd9a-4360-9597-f2c3579af7f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add docCategory overrides",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-d574a11d-d3e9-445d-8d79-373d0a0ba549.json
+++ b/change/@fluentui-react-tooltip-d574a11d-d3e9-445d-8d79-373d0a0ba549.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add docCategory overrides",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -12,6 +12,8 @@ module.exports = {
     test: ['build'],
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
+    // TODO: figure out how to actually integrate this
+    'generate-json': ['^build'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
   },
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components --min",
     "build:fluentui:docs": "gulp build:docs",
     "build:min": "yarn build --to @fluentui/react --to @fluentui/react-northstar --to @fluentui/react-components --min",
-    "buildci": "yarn prelint && lage build test lint type-check --verbose",
+    "buildci": "yarn prelint && lage build test lint type-check generate-json --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",
     "buildto:lerna": "node ./scripts/monorepo/buildTo.js",

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@microsoft/api-extractor-model": "7.13.3",
     "@microsoft/tsdoc": "0.13.2",
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "tslib": "^2.1.0"
   }
 }

--- a/packages/api-docs/src/pageJson.ts
+++ b/packages/api-docs/src/pageJson.ts
@@ -1,21 +1,33 @@
-import { ApiItem, ApiItemKind, ApiDocumentedItem, ApiModel } from '@microsoft/api-extractor-model';
+import {
+  ApiItem,
+  ApiItemKind,
+  ApiDocumentedItem,
+  ApiModel,
+  ApiInterface,
+  ApiEnum,
+  ApiClass,
+  ApiTypeAlias,
+} from '@microsoft/api-extractor-model';
 import { findInlineTagByName } from './rendering';
 import { ICollectedData } from './types-private';
-import { ITableJson, IPageJson, PageGroups } from './types';
+import { ITableJson, IPageJson, IPageJsonOptions } from './types';
 import { createTableJson } from './tableJson';
 
-const supportedApiItems = [ApiItemKind.Interface, ApiItemKind.Enum, ApiItemKind.Class, ApiItemKind.TypeAlias];
+// TODO: add consts (at least component consts)
+function isSupportedApiItem(item: ApiItem): item is ApiInterface | ApiEnum | ApiClass | ApiTypeAlias {
+  return [ApiItemKind.Interface, ApiItemKind.Enum, ApiItemKind.Class, ApiItemKind.TypeAlias].includes(item.kind);
+}
 
 /**
  * Given `apiModel` with API package info already loaded into it, generate page data for each
- * `docCategory` tag (page name) and the APIs within it.
+ * page name (docCategory tag, or possibly prefix or package name) and the APIs within it.
+ * Returns the pages and any warnings encountered.
  */
 export function generatePageJson(
   apiModel: ApiModel,
-  pageGroups: PageGroups = {},
-  fallbackGroup?: string,
-): Map<string, IPageJson> {
-  const collectedData = initPageData(apiModel, pageGroups, fallbackGroup);
+  options: IPageJsonOptions,
+): [pages: Map<string, IPageJson>, warnings: string[]] {
+  const collectedData = initPageData(apiModel, options);
 
   const result = new Map<string, IPageJson>();
   for (const [pageName, pageData] of collectedData.pagesByName.entries()) {
@@ -28,30 +40,30 @@ export function generatePageJson(
     });
   }
 
-  return result;
+  return [result, collectedData.warnings];
 }
 
 /**
  * Walk all the APIs from `apiModel.packages` and generate an empty page data object for each
- * `docCategory` tag (page name) encountered. The returned object contains a mapping from page name
- * (`docCategory`) to page data (`pagesByName`), and from API name to page data (`pagesByApi`).
- * The page data objects referenced in both maps are the same.
+ * page name (docCategory tag, or possibly prefix or package name) encountered.
+ * The returned object contains a mapping from page name to page data (`pagesByName`), and from
+ * API name to page data (`pagesByApi`). The page data objects referenced in both maps are the same.
  */
-function initPageData(apiModel: ApiModel, pageGroups: PageGroups, fallbackGroup?: string): ICollectedData {
+function initPageData(apiModel: ApiModel, options: IPageJsonOptions): ICollectedData {
   // Map the pages to groups all at once for convenience later
   const groupsByPage: { [pageName: string]: string } = {};
-  for (const [group, pageNames] of Object.entries(pageGroups)) {
+  for (const [group, pageNames] of Object.entries(options.pageGroups)) {
     for (const pageName of pageNames) {
       groupsByPage[pageName] = group;
     }
   }
 
-  const collectedData: ICollectedData = { apiModel, pagesByName: new Map(), pagesByApi: new Map() };
+  const collectedData: ICollectedData = { apiModel, pagesByName: new Map(), pagesByApi: new Map(), warnings: [] };
 
   // Generate empty page data objects for each docCategory
   for (const apiPackage of collectedData.apiModel.packages) {
     for (const entryPoint of apiPackage.entryPoints) {
-      initPageDataForItem(collectedData, entryPoint, groupsByPage, fallbackGroup);
+      initPageDataForItem(collectedData, options, entryPoint, groupsByPage);
     }
   }
   return collectedData;
@@ -59,37 +71,64 @@ function initPageData(apiModel: ApiModel, pageGroups: PageGroups, fallbackGroup?
 
 /**
  * Walk this API item and its members, adding an empty page data object to `collectedData.pagesByName`
- * for each new `docCategory` tag (page name) encountered. Also update `collectedData.pagesByApi` with
- * mappings for every API item encountered.
+ * for each new page name (docCategory tag, or possibly prefix or package name) encountered.
+ * Also update `collectedData.pagesByApi` with mappings for every API item encountered.
  */
 function initPageDataForItem(
   collectedData: ICollectedData,
+  options: IPageJsonOptions,
   apiItem: ApiItem,
   groupsByPage: { [pageName: string]: string },
-  fallbackGroup?: string,
 ): void {
-  if (supportedApiItems.includes(apiItem.kind) && apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment) {
-    const docCategoryTag = findInlineTagByName('@docCategory', apiItem.tsdocComment);
+  if (isSupportedApiItem(apiItem)) {
+    const packageName = apiItem.getAssociatedPackage()?.name || '';
 
-    if (docCategoryTag) {
-      const pageName = docCategoryTag.tagContent.trim();
+    // Figure out which page this API item goes under.
+    // Start by looking for an explicit @docCategory tag.
+    let pageName =
+      (apiItem instanceof ApiDocumentedItem &&
+        !!apiItem.tsdocComment &&
+        findInlineTagByName('@docCategory', apiItem.tsdocComment)?.tagContent.trim()) ||
+      undefined;
+
+    if (!pageName && options.inferDocCategoryByPrefix) {
+      // Or check if any page names are a prefix of this API item name
+      // (e.g. if apiItem is ButtonProps and one of the pageGroups includes Button)
+      pageName = Object.keys(groupsByPage).find(page => apiItem.name.startsWith(page));
+    }
+    if (!pageName && options.includeExtraItemsForPackages) {
+      // Or check if this item is from a package where including uncategorized items was requested
+      const unscopedPackageName = packageName.replace(/^@\w+\//, '');
+      pageName = options.includeExtraItemsForPackages.includes(unscopedPackageName) ? unscopedPackageName : undefined;
+    }
+
+    if (pageName) {
       let pageData = collectedData.pagesByName.get(pageName);
 
       if (!pageData) {
         pageData = {
           name: pageName,
           apiItems: [],
-          group: groupsByPage[pageName] || fallbackGroup,
+          group: groupsByPage[pageName] || options.fallbackGroup,
         };
         collectedData.pagesByName.set(pageName, pageData);
       }
-      collectedData.pagesByApi.set(apiItem.displayName, pageData);
+
+      if (collectedData.pagesByApi.has(apiItem.name)) {
+        collectedData.warnings.push(
+          `Found multiple exported API items with name "${apiItem.name}" (API names should be unique)`,
+        );
+      } else {
+        collectedData.pagesByApi.set(apiItem.name, pageData);
+      }
 
       pageData.apiItems.push(apiItem);
+    } else {
+      collectedData.warnings.push(`Couldn't find a page for API item "${apiItem.name}" from ${packageName}`);
     }
   }
 
   for (const memberApiItem of apiItem.members) {
-    initPageDataForItem(collectedData, memberApiItem, groupsByPage, fallbackGroup);
+    initPageDataForItem(collectedData, options, memberApiItem, groupsByPage);
   }
 }

--- a/packages/api-docs/src/types-private.ts
+++ b/packages/api-docs/src/types-private.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiModel } from '@microsoft/api-extractor-model';
  * A page and its associated API items.
  */
 export interface IPageData {
-  /** The name (`@docCategory` tag value) of the page */
+  /** The name (docCategory tag, or possibly prefix or package name) of the page */
   readonly name: string;
   readonly apiItems: ApiItem[];
   readonly group?: string;
@@ -15,7 +15,7 @@ export interface ICollectedData {
   // readonly fallbackGroup: string;
   readonly apiModel: ApiModel;
   /**
-   * Page data keyed by page name (`@docCategory` tag value).
+   * Page data keyed by page name (docCategory tag, or possibly prefix or package name).
    * Entries in this object are unique.
    */
   readonly pagesByName: Map<string, IPageData>;
@@ -24,4 +24,6 @@ export interface ICollectedData {
    * Entries are the same objects from `pagesByName`, but each page may appear multiple times.
    */
   readonly pagesByApi: Map<string, IPageData>;
+  /** List of warnings encountered */
+  readonly warnings: string[];
 }

--- a/packages/api-docs/src/types.ts
+++ b/packages/api-docs/src/types.ts
@@ -10,12 +10,30 @@ export interface IPageJsonOptions {
   /** If true, the generated files won't be pretty-formatted */
   min?: boolean;
   /**
-   * List of allowed page names (`@docCategory` tag values) grouped by any desired criteria,
-   * such as package name.
+   * List of allowed page names (`@docCategory` tag values, or component name prefixes if
+   * `inferDocCategoryByPrefix` is true) grouped by any desired criteria, such as package name.
    */
-  pageGroups?: PageGroups;
+  pageGroups: PageGroups;
   /**
-   * Group for any page names (`@docCategory` tag values) not listed in `pageGroups`.
+   * If true, interpret the list of page names from `pageGroups` as prefixes for type names,
+   * and group things matching that prefix onto a page. This is an alternative to specifying
+   * `@docCategory` everywhere (though if that's present, it will still be used as an override).
+   *
+   * Example: if this is true and one of the `pageGroups` includes "Button", `ButtonProps` will
+   * automatically go on the "Button" page.
+   */
+  inferDocCategoryByPrefix?: boolean;
+  /**
+   * For the given list of *unscoped* package names, group any uncategorized API items into a
+   * single page for that package.
+   */
+  includeExtraItemsForPackages?: string[];
+  /**
+   * If true, fail instead of warning about potential error conditions.
+   */
+  strict?: boolean;
+  /**
+   * Group for any page names not listed in `pageGroups`.
    * If unspecified, unlisted pages will go under the root.
    */
   fallbackGroup?: string;

--- a/packages/react-components/config/api-docs.js
+++ b/packages/react-components/config/api-docs.js
@@ -1,0 +1,59 @@
+// @ts-check
+
+// Config file for API doc JSON (*.page.json) generation
+
+const fs = require('fs');
+const path = require('path');
+const { findRepoDeps, findGitRoot } = require('@fluentui/scripts/monorepo');
+
+// note: react-components itself isn't included here because it only re-exports things
+const packagePaths = findRepoDeps({ cwd: path.resolve(__dirname, '..'), dev: false }).map(dep => dep.packagePath);
+const gitRoot = findGitRoot();
+
+const components = [
+  'Accordion',
+  'Avatar',
+  'Badge',
+  'CounterBadge',
+  'PresenceBadge',
+  'Button',
+  'CompoundButton',
+  'MenuButton',
+  'SplitButton',
+  'ToggleButton',
+  'Card',
+  // 'Checkbox',
+  'Divider',
+  'Image',
+  // 'Input',
+  'Label',
+  'Link',
+  'Menu',
+  'Popover',
+  'Portal',
+  'FluentProvider',
+  // 'Slider',
+  // 'Switch',
+  // 'Tabs',
+  'Text',
+  'Tooltip',
+];
+
+/** @type {import('@fluentui/api-docs').IPageJsonOptions} */
+module.exports = {
+  apiJsonPaths: packagePaths
+    .map(packagePath => path.join(gitRoot, packagePath, 'dist', path.basename(packagePath) + '.api.json'))
+    .filter(apiJsonPath => fs.existsSync(apiJsonPath)),
+  // TODO: figure out where these should actually go
+  outputRoot: path.resolve(__dirname, '../dist/api'),
+  inferDocCategoryByPrefix: true,
+  // include extra items for utility packages
+  includeExtraItemsForPackages: packagePaths
+    .map(packagePath => path.basename(packagePath))
+    .filter(unscopedPkg => !components.some(comp => unscopedPkg === `react-${comp.toLowerCase()}`)),
+  strict: true,
+  fallbackGroup: 'references',
+  pageGroups: {
+    'react-components': components,
+  },
+};

--- a/packages/react-components/just.config.ts
+++ b/packages/react-components/just.config.ts
@@ -1,3 +1,11 @@
-import { preset } from '@fluentui/scripts';
+import { preset, task } from '@fluentui/scripts';
 
 preset();
+
+// TODO: figure out where this should actually go
+// (for v8 it's in public-docsite-resources)
+task('generate-json', () => {
+  // delay load in case it's not compiled yet
+  const { generatePageJsonFiles } = require('@fluentui/api-docs');
+  generatePageJsonFiles(require('./config/api-docs'));
+});

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -17,6 +17,7 @@
     "chromatic": "npx chromatic@5.6.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "generate-json": "just-scripts generate-json",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",
@@ -28,6 +29,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@fluentui/api-docs": "^8.2.0",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-storybook-addon": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -328,9 +328,6 @@ export const renderMenuTrigger: (state: MenuTriggerState) => JSX.Element;
 // @public (undocumented)
 export type SelectableHandler = (e: React_2.MouseEvent | React_2.KeyboardEvent, name: string, value: string, checked: boolean) => void;
 
-// @public (undocumented)
-export type UninitializedMenuListState = Omit<MenuListState, 'setFocusByFirstCharacter' | 'toggleCheckbox' | 'selectRadio' | 'checkedValues'> & Partial<Pick<MenuListState, 'checkedValues'>>;
-
 // @public
 export const useCheckmarkStyles: (state: MenuItemSelectableState & Pick<MenuItemSlots, 'checkmark'>) => void;
 

--- a/packages/react-menu/src/components/MenuList/MenuList.types.ts
+++ b/packages/react-menu/src/components/MenuList/MenuList.types.ts
@@ -69,9 +69,3 @@ export type MenuListState = ComponentState<MenuListSlots> &
 export type MenuListContextValues = {
   menuList: MenuListContextValue;
 };
-
-export type UninitializedMenuListState = Omit<
-  MenuListState,
-  'setFocusByFirstCharacter' | 'toggleCheckbox' | 'selectRadio' | 'checkedValues'
-> &
-  Partial<Pick<MenuListState, 'checkedValues'>>;

--- a/packages/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuList.ts
@@ -9,7 +9,13 @@ import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabste
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { useMenuContext } from '../../contexts/menuContext';
 import { MenuContext } from '../../contexts/menuContext';
-import type { MenuListProps, MenuListState, UninitializedMenuListState } from './MenuList.types';
+import type { MenuListProps, MenuListState } from './MenuList.types';
+
+type UninitializedMenuListState = Omit<
+  MenuListState,
+  'setFocusByFirstCharacter' | 'toggleCheckbox' | 'selectRadio' | 'checkedValues'
+> &
+  Partial<Pick<MenuListState, 'checkedValues'>>;
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-menu/src/selectable/types.ts
+++ b/packages/react-menu/src/selectable/types.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * {@docCategory Menu}
+ */
 export type SelectableHandler = (
   e: React.MouseEvent | React.KeyboardEvent,
   name: string,

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -102,11 +102,13 @@ export type PopoverState = PopoverCommons &
 
 /**
  * Data attached to open/close events
+ * {@docCategory Popover}
  */
 export type OnOpenChangeData = { open: boolean };
 
 /**
  * The supported events that will trigger open/close of the menu
+ * {@docCategory Popover}
  */
 export type OpenPopoverEvents =
   | MouseEvent

--- a/packages/react-text/src/components/Body/Body.tsx
+++ b/packages/react-text/src/components/Body/Body.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Body typography variant
+ * {@docCategory Text}
  */
 export const Body: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Caption/Caption.tsx
+++ b/packages/react-text/src/components/Caption/Caption.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Caption typography variant
+ * {@docCategory Text}
  */
 export const Caption: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Display/Display.tsx
+++ b/packages/react-text/src/components/Display/Display.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Display typography variant
+ * {@docCategory Text}
  */
 export const Display: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Headline/Headline.tsx
+++ b/packages/react-text/src/components/Headline/Headline.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Headline typography variant
+ * {@docCategory Text}
  */
 export const Headline: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/LargeTitle/LargeTitle.tsx
+++ b/packages/react-text/src/components/LargeTitle/LargeTitle.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Large Title typography variant
+ * {@docCategory Text}
  */
 export const LargeTitle: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Subheadline/Subheadline.tsx
+++ b/packages/react-text/src/components/Subheadline/Subheadline.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Subheadline typography variant
+ * {@docCategory Text}
  */
 export const Subheadline: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Title1/Title1.tsx
+++ b/packages/react-text/src/components/Title1/Title1.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Title 1 typography variant
+ * {@docCategory Text}
  */
 export const Title1: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Title2/Title2.tsx
+++ b/packages/react-text/src/components/Title2/Title2.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Title 2 typography variant
+ * {@docCategory Text}
  */
 export const Title2: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-text/src/components/Title3/Title3.tsx
+++ b/packages/react-text/src/components/Title3/Title3.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
 
 /**
  * Text wrapper component for the Title 3 typography variant
+ * {@docCategory Text}
  */
 export const Title3: FunctionComponent<TextWrapperProps> = createWrapper({
   useStyles,

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -112,6 +112,7 @@ export type TooltipTriggerProps = {
 
 /**
  * Data for the Tooltip's onVisibleChange event.
+ * {@docCategory Tooltip}
  */
 export type OnVisibleChangeData = {
   visible: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Generate `*.page.json` files for `@fluentui/react-components`. These are currently only used to display API docs on the legacy doc site, but they may end up being used on the new website too.

The previous approach for generating these files involved having `{@docCategory Whatever}` tags in the doc comment for *every* item to be included. This has its pros and cons, a major con being that it's fully manual.

For generating these files in converged, I added a couple new features/options to api-docs:
- `inferDocCategoryByPrefix`: Use the list of component names in the config file to group types together. For example, any types starting with `Button` will be automatically grouped onto the `Button` page.
- `includeExtraItemsForPackages`: For this list of utility packages (in the config file), group all types from those packages into a single file even if they don't have a `docCategory` annotation.
- In both these cases, explicit `docCategory` annotations are still supported as a fallback: for example, to force a button-related interface that doesn't start with `Button` into that group

This approach still has some serious limitations (all of which we might be able to fix, but TBD how long it would take):
- Doesn't expand `extends` or union types (`&`). On the current website we work around this by displaying the original extends or union definition inline, but this isn't great.
- Doesn't include function components in the docs. Their props are included, just no entry for the component itself.
- Doesn't account for props added at the site of function component declaration (like by forwardRef)

The most relevant code for this PR (modifications to `packages/api-docs`) thankfully comes early on in the diff. The rest is adding some missing exported types, and modifying application of `{@docCategory}` tags in converged components: removing most of them, and adding a few new overrides for special cases.