### PR TITLE
feat(babel-make-styles): add config for evaluation rules

### DIFF
--- a/change/@fluentui-babel-make-styles-2dc14dcb-bf57-48ec-9ddd-cbd7f061ac8f.json
+++ b/change/@fluentui-babel-make-styles-2dc14dcb-bf57-48ec-9ddd-cbd7f061ac8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add config for rules evaluation",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/config-evaluation-rules/code.ts
+++ b/packages/babel-make-styles/__fixtures__/config-evaluation-rules/code.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+
+export const useStyles = makeStyles({
+  root: theme => {
+    // This assignment has no sense, but it will prevent us from evaluation in AST
+    // This fixture uses "sampleEvaluator.js" in plugin's config so input we should get a different color
+    const color = 'red';
+
+    return { color };
+  },
+});

--- a/packages/babel-make-styles/__fixtures__/config-evaluation-rules/options.json
+++ b/packages/babel-make-styles/__fixtures__/config-evaluation-rules/options.json
@@ -1,0 +1,7 @@
+{
+  "evaluationRules": [
+    {
+      "action": "@fluentui/babel-make-styles/__fixtures__/config-evaluation-rules/sampleEvaluator"
+    }
+  ]
+}

--- a/packages/babel-make-styles/__fixtures__/config-evaluation-rules/output.ts
+++ b/packages/babel-make-styles/__fixtures__/config-evaluation-rules/output.ts
@@ -1,0 +1,11 @@
+import { __styles } from '@fluentui/react-make-styles';
+export const useStyles = __styles(
+  {
+    root: {
+      sj55zd: 'f163i14w',
+    },
+  },
+  {
+    d: ['.f163i14w{color:blue;}'],
+  },
+);

--- a/packages/babel-make-styles/__fixtures__/config-evaluation-rules/sampleEvaluator.js
+++ b/packages/babel-make-styles/__fixtures__/config-evaluation-rules/sampleEvaluator.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @type {import("@linaria/babel-preset").Evaluator} */
+const sampleEvaluator = () => {
+  // Evaluators transform input code to something that will be evaluated by Node later. In evaluatePathsInVM() we expect
+  // that results will be available as "exports.__mkPreval", this evaluator mocks it
+  const result = `exports.__mkPreval = [{ color: 'blue' }]`;
+
+  return [result, null];
+};
+
+module.exports.default = sampleEvaluator;

--- a/packages/babel-make-styles/src/index.ts
+++ b/packages/babel-make-styles/src/index.ts
@@ -1,3 +1,5 @@
+export type { Evaluator, EvalRule } from '@linaria/babel-preset';
+
 export { configSchema } from './schema';
 
 export { plugin as default } from './plugin';

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -1,6 +1,7 @@
 import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
 import { Module } from '@linaria/babel-preset';
+import shakerEvaluator from '@linaria/shaker';
 import { resolveStyleRulesForSlots, CSSRulesByBucket, StyleBucketName, MakeStyles } from '@fluentui/make-styles';
 
 import { astify } from './utils/astify';
@@ -449,6 +450,13 @@ export const plugin = declare<Partial<BabelPluginOptions>, PluginObj<BabelPlugin
       { moduleSource: '@fluentui/react-components', importName: 'makeStyles' },
       { moduleSource: '@fluentui/react-make-styles', importName: 'makeStyles' },
     ],
+    evaluationRules: [
+      { action: shakerEvaluator },
+      {
+        test: /[/\\]node_modules[/\\]/,
+        action: 'ignore',
+      },
+    ],
 
     ...options,
   };
@@ -508,7 +516,7 @@ export const plugin = declare<Partial<BabelPluginOptions>, PluginObj<BabelPlugin
           );
 
           if (pathsToEvaluate.length > 0) {
-            evaluatePaths(path, state.file.opts.filename!, pathsToEvaluate, pluginOptions.babelOptions);
+            evaluatePaths(path, state.file.opts.filename!, pathsToEvaluate, pluginOptions);
           }
 
           state.styleNodes?.forEach(styleNode => {

--- a/packages/babel-make-styles/src/schema.ts
+++ b/packages/babel-make-styles/src/schema.ts
@@ -10,6 +10,7 @@ export const configSchema: JSONSchema7 = {
       type: 'array',
       items: {
         type: 'object',
+        required: ['moduleSource', 'importName'],
         properties: {
           moduleSource: {
             type: 'string',
@@ -28,6 +29,19 @@ export const configSchema: JSONSchema7 = {
         },
         presets: {
           type: 'array',
+        },
+      },
+    },
+    evaluationRules: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['action'],
+        properties: {
+          action: {
+            anyOf: [{}, { type: 'string' }, { const: 'ignore' }],
+          },
+          test: {},
         },
       },
     },

--- a/packages/babel-make-styles/src/types.ts
+++ b/packages/babel-make-styles/src/types.ts
@@ -1,4 +1,5 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
+import type { EvalRule } from '@linaria/babel-preset';
 
 export type BabelPluginOptions = {
   /** Defines set of modules and imports handled by a plugin. */
@@ -9,4 +10,7 @@ export type BabelPluginOptions = {
    * plugin when parsing and evaluating modules.
    */
   babelOptions?: Pick<TransformOptions, 'plugins' | 'presets'>;
+
+  /** The set of rules that defines how the matched files will be transformed during the evaluation. */
+  evaluationRules?: EvalRule[];
 };

--- a/packages/babel-make-styles/src/utils/evaluatePaths.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePaths.ts
@@ -1,4 +1,6 @@
-import { NodePath, TransformOptions, types as t } from '@babel/core';
+import { NodePath, types as t } from '@babel/core';
+
+import type { BabelPluginOptions } from '../types';
 import { evaluatePathsInVM } from './evaluatePathsInVM';
 
 /**
@@ -9,7 +11,7 @@ export function evaluatePaths(
   program: NodePath<t.Program>,
   filename: string,
   paths: NodePath<t.Expression | t.SpreadElement>[],
-  babelOptions: TransformOptions,
+  pluginOptions: Required<BabelPluginOptions>,
 ): void {
   const pathsToBeEvaluatedInVM: NodePath<t.Expression | t.SpreadElement>[] = [];
 
@@ -27,6 +29,6 @@ export function evaluatePaths(
   }
 
   if (pathsToBeEvaluatedInVM.length > 0) {
-    evaluatePathsInVM(program, filename, pathsToBeEvaluatedInVM, babelOptions);
+    evaluatePathsInVM(program, filename, pathsToBeEvaluatedInVM, pluginOptions);
   }
 }

--- a/packages/babel-make-styles/src/validateOptions.test.ts
+++ b/packages/babel-make-styles/src/validateOptions.test.ts
@@ -1,30 +1,71 @@
+import type { Evaluator } from '@linaria/babel-preset';
+
 import { validateOptions } from './validateOptions';
 import { BabelPluginOptions } from './types';
 
 describe('validateOptions', () => {
-  it('passes on valid options', () => {
-    const pluginOptionsA: BabelPluginOptions = {
-      modules: [{ moduleSource: 'react-make-styles', importName: 'makeStyles' }],
-      babelOptions: {
-        presets: ['@babel/preset'],
-        plugins: ['@babel/plugin'],
-      },
-    };
+  describe('modules', () => {
+    it('passes on valid options', () => {
+      const pluginOptions: BabelPluginOptions = {
+        modules: [{ moduleSource: 'react-make-styles', importName: 'makeStyles' }],
+      };
 
-    expect(() => validateOptions(pluginOptionsA)).not.toThrow();
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptions = { modules: {} };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/modules must be array"`,
+      );
+    });
   });
 
-  it('throws on wrong options', () => {
-    const pluginOptionsA = { modules: {} };
-    const pluginOptionsB = { babelOptions: [] };
+  describe('babelOptions', () => {
+    it('passes on valid options', () => {
+      const pluginOptions: BabelPluginOptions = {
+        babelOptions: {
+          presets: ['@babel/preset'],
+          plugins: ['@babel/plugin'],
+        },
+      };
 
-    // @ts-expect-error Invalid options are passed for testing purposes
-    expect(() => validateOptions(pluginOptionsA)).toThrowErrorMatchingInlineSnapshot(
-      `"Validation failed for passed config: data/modules must be array"`,
-    );
-    // @ts-expect-error Invalid options are passed for testing purposes
-    expect(() => validateOptions(pluginOptionsB)).toThrowErrorMatchingInlineSnapshot(
-      `"Validation failed for passed config: data/babelOptions must be object"`,
-    );
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptions = { babelOptions: [] };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptions)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/babelOptions must be object"`,
+      );
+    });
+  });
+
+  describe('evaluationRules', () => {
+    it('passes on valid options', () => {
+      const noopEvaluator: Evaluator = () => ['foo', null];
+      const pluginOptions: BabelPluginOptions = {
+        evaluationRules: [
+          { action: noopEvaluator },
+          { action: noopEvaluator, test: () => true },
+          { action: 'ignore', test: /foo/ },
+        ],
+      };
+
+      expect(() => validateOptions(pluginOptions)).not.toThrow();
+    });
+
+    it('throws on wrong options', () => {
+      const pluginOptionsA = { evaluationRules: {} };
+
+      // @ts-expect-error Invalid options are passed for testing purposes
+      expect(() => validateOptions(pluginOptionsA)).toThrowErrorMatchingInlineSnapshot(
+        `"Validation failed for passed config: data/evaluationRules must be array"`,
+      );
+    });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19403
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds support for configuring evaluation:
- adds new option for Babel plugin
- modifies schema & adds tests
- adds docs
