### PR TITLE
Fixed: On chart hover, chart title tooltip is showing

### DIFF
--- a/change/@fluentui-react-charting-daa11c69-e8c0-49a8-acc8-3f3ec9dfabdb.json
+++ b/change/@fluentui-react-charting-daa11c69-e8c0-49a8-acc8-3f3ec9dfabdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\\",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-daa11c69-e8c0-49a8-acc8-3f3ec9dfabdb.json
+++ b/change/@fluentui-react-charting-daa11c69-e8c0-49a8-acc8-3f3ec9dfabdb.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "\\",
+  "comment": "Title tag for svg removed, so tooltip will not be shown on chart hover",
   "packageName": "@fluentui/react-charting",
   "email": "v-scharde@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -39,9 +40,6 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -358,6 +356,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -366,9 +365,6 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -665,6 +661,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -673,9 +670,6 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -847,6 +841,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -855,9 +850,6 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1174,6 +1166,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1182,9 +1175,6 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1501,6 +1491,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1509,9 +1500,6 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 
@@ -1828,6 +1816,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="AreaChart"
       height={0}
       style={
         Object {
@@ -1836,9 +1825,6 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        AreaChart
-      </title>
       <g
         className=
 

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -241,8 +241,13 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
       >
         <FocusZone direction={focusDirection} {...svgFocusZoneProps}>
-          <svg width={svgDimensions.width} height={svgDimensions.height} style={{ display: 'block' }} {...svgProps}>
-            {this.props.chartTitle && <title>{this.props.chartTitle}</title>}
+          <svg
+            width={svgDimensions.width}
+            height={svgDimensions.height}
+            aria-label={this.props.chartTitle}
+            style={{ display: 'block' }}
+            {...svgProps}
+          >
             <g
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -99,11 +99,14 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     const outerRadius = Math.min(this.state._width!, this.state._height!) / 2;
     const chartData = data && data.chartData;
     return (
-      <div className={this._classNames.root} ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}>
+      <div
+        className={this._classNames.root}
+        aria-label={data?.chartTitle}
+        ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}
+      >
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
             <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
-              {data?.chartTitle && <title>{data?.chartTitle}</title>}
               <Pie
                 width={this.state._width!}
                 height={this.state._height!}

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
 <div
+  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -38,9 +39,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -360,6 +358,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1`] = `
 <div
+  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -396,9 +395,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -718,6 +714,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
 
 exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
 <div
+  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -754,9 +751,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -842,6 +836,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
 <div
+  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -878,9 +873,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >
@@ -1200,6 +1192,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
 <div
+  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -1236,9 +1229,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               overflow: visible;
             }
       >
-        <title>
-          Stacked Bar chart example
-        </title>
         <g
           transform="translate(0, 0)"
         >

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -39,9 +40,6 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -349,6 +347,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -357,9 +356,6 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -647,6 +643,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -655,9 +652,6 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -820,6 +814,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -828,9 +823,6 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1138,6 +1130,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1146,9 +1139,6 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1456,6 +1446,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1464,9 +1455,6 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 
@@ -1774,6 +1762,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
     onMouseDownCapture={[Function]}
   >
     <svg
+      aria-label="LineChart"
       height={0}
       style={
         Object {
@@ -1782,9 +1771,6 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
       }
       width={0}
     >
-      <title>
-        LineChart
-      </title>
       <g
         className=
 

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -235,8 +235,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>
-              {data!.chartTitle && <title>{data!.chartTitle}</title>}
+            <svg className={this._classNames.chart} aria-label={data?.chartTitle}>
               {bars}
             </svg>
           </div>

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -135,8 +135,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         </FocusZone>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div>
-            <svg className={this._classNames.chart}>
-              {data!.chartTitle && <title>{data!.chartTitle}</title>}
+            <svg className={this._classNames.chart} aria-label={data?.chartTitle}>
               <g>{bars[0]}</g>
               <Callout
                 gapSpace={15}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -93,9 +94,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -234,6 +232,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -241,9 +240,6 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout0"
@@ -453,6 +449,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -460,9 +457,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout20"
@@ -597,6 +591,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -604,9 +599,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout20"
@@ -820,6 +812,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -827,9 +820,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout5"
@@ -968,6 +958,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -975,9 +966,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout5"
@@ -1125,6 +1113,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -1132,9 +1121,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout15"
@@ -1273,6 +1259,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -1280,9 +1267,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout15"
@@ -1675,6 +1659,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
       >
         <div>
           <svg
+            aria-label="Monitored"
             className=
 
                 {
@@ -1682,9 +1667,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
-            <title>
-              Monitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout10"
@@ -1823,6 +1805,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
       >
         <div>
           <svg
+            aria-label="Unmonitored"
             className=
 
                 {
@@ -1830,9 +1813,6 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   width: 100%;
                 }
           >
-            <title>
-              Unmonitored
-            </title>
             <g
               aria-label="Multi stacked bar chart"
               aria-labelledby="callout10"

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -101,9 +102,6 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -272,6 +270,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -280,9 +279,6 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -437,6 +433,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -445,9 +442,6 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -616,6 +610,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -624,9 +619,6 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -765,6 +757,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -773,9 +766,6 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -944,6 +934,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -952,9 +943,6 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"
@@ -1093,6 +1081,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
   >
     <div>
       <svg
+        aria-label="Stacked bar chart 2nd example"
         className=
 
             {
@@ -1101,9 +1090,6 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
               width: 100%;
             }
       >
-        <title>
-          Stacked bar chart 2nd example
-        </title>
         <g>
           <g
             aria-label="Stacked bar chart"


### PR DESCRIPTION
…the chart

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Title stag removed from charting, which was used to denote about the chart.  Instead of that, ariaLabel used with SVG tag.
So with this changes, on chart focus, screen reader will announce chart title, but on hover tooltip wont show.

#### Focus areas to test

All Chart

**Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/130234805-decd02c0-dec8-432c-863c-f4d61b24e6ce.png)


**After changes:**
![image](https://user-images.githubusercontent.com/29042635/130234947-4970ffa3-4830-49f4-96ea-3ce8e1cea7b9.png)
