### PR TITLE
Use simple array for keytips to register instead of useConst

### DIFF
--- a/change/@fluentui-react-b94672dd-7637-41d5-8c90-9de94a86da10.json
+++ b/change/@fluentui-react-b94672dd-7637-41d5-8c90-9de94a86da10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use a simple array instead of a const for keytips to register",
+  "packageName": "@fluentui/react",
+  "email": "keyou@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/OverflowSet/OverflowButton.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowButton.tsx
@@ -58,7 +58,7 @@ const useKeytipRegistrations = (
 export const OverflowButton = (props: IOverflowSetProps) => {
   const keytipManager: KeytipManager = KeytipManager.getInstance();
   const { className, overflowItems, keytipSequences, itemSubMenuProvider, onRenderOverflowButton } = props;
-  const keytipsToRegister: IKeytipProps[] = [];
+
   const persistedKeytips = useConst<{ [uniqueID: string]: IKeytipProps }>({});
 
   // Gets the subMenu for an overflow item
@@ -76,8 +76,9 @@ export const OverflowButton = (props: IOverflowSetProps) => {
     [itemSubMenuProvider],
   );
 
-  const newOverflowItems = React.useMemo(() => {
-    let currentOverflowItems: IOverflowSetItemProps[] | undefined = [];
+  const { newOverflowItems, keytipsToRegister } = React.useMemo(() => {
+    const keytipsToRegister: IKeytipProps[] = [];
+    let newOverflowItems: IOverflowSetItemProps[] | undefined = [];
 
     if (keytipSequences) {
       overflowItems?.forEach(overflowItem => {
@@ -115,16 +116,16 @@ export const OverflowButton = (props: IOverflowSetProps) => {
               overflowSetSequence: keytipSequences,
             },
           };
-          currentOverflowItems?.push(newOverflowItem);
+          newOverflowItems?.push(newOverflowItem);
         } else {
           // Nothing to change, add overflowItem to list
-          currentOverflowItems?.push(overflowItem);
+          newOverflowItems?.push(overflowItem);
         }
       });
     } else {
-      currentOverflowItems = overflowItems!;
+      newOverflowItems = overflowItems!;
     }
-    return currentOverflowItems;
+    return { newOverflowItems, keytipsToRegister };
   }, [overflowItems, getSubMenuForItem, keytipManager, keytipSequences]);
 
   useKeytipRegistrations(persistedKeytips, keytipsToRegister, keytipManager);

--- a/packages/react/src/components/OverflowSet/OverflowButton.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowButton.tsx
@@ -76,8 +76,8 @@ export const OverflowButton = (props: IOverflowSetProps) => {
     [itemSubMenuProvider],
   );
 
-  const { newOverflowItems, keytipsToRegister } = React.useMemo(() => {
-    const keytipsToRegister: IKeytipProps[] = [];
+  const { modifiedOverflowItems, keytipsToRegister } = React.useMemo(() => {
+    const newKeytipsToRegister: IKeytipProps[] = [];
     let newOverflowItems: IOverflowSetItemProps[] | undefined = [];
 
     if (keytipSequences) {
@@ -106,7 +106,7 @@ export const OverflowButton = (props: IOverflowSetProps) => {
             persistedKeytip.onExecute = keytip.onExecute;
           }
 
-          keytipsToRegister.push(persistedKeytip);
+          newKeytipsToRegister.push(persistedKeytip);
 
           // Add the overflow sequence to this item
           const newOverflowItem = {
@@ -125,10 +125,10 @@ export const OverflowButton = (props: IOverflowSetProps) => {
     } else {
       newOverflowItems = overflowItems!;
     }
-    return { newOverflowItems, keytipsToRegister };
+    return { modifiedOverflowItems: newOverflowItems, keytipsToRegister: newKeytipsToRegister };
   }, [overflowItems, getSubMenuForItem, keytipManager, keytipSequences]);
 
   useKeytipRegistrations(persistedKeytips, keytipsToRegister, keytipManager);
 
-  return <div className={className}>{onRenderOverflowButton(newOverflowItems)}</div>;
+  return <div className={className}>{onRenderOverflowButton(modifiedOverflowItems)}</div>;
 };

--- a/packages/react/src/components/OverflowSet/OverflowButton.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowButton.tsx
@@ -123,7 +123,7 @@ export const OverflowButton = (props: IOverflowSetProps) => {
         }
       });
     } else {
-      newOverflowItems = overflowItems!;
+      newOverflowItems = overflowItems;
     }
     return { modifiedOverflowItems: newOverflowItems, keytipsToRegister: newKeytipsToRegister };
   }, [overflowItems, getSubMenuForItem, keytipManager, keytipSequences]);

--- a/packages/react/src/components/OverflowSet/OverflowButton.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowButton.tsx
@@ -125,7 +125,7 @@ export const OverflowButton = (props: IOverflowSetProps) => {
       currentOverflowItems = overflowItems!;
     }
     return currentOverflowItems;
-  }, [overflowItems, getSubMenuForItem, keytipManager, keytipSequences, keytipsToRegister]);
+  }, [overflowItems, getSubMenuForItem, keytipManager, keytipSequences]);
 
   useKeytipRegistrations(persistedKeytips, keytipsToRegister, keytipManager);
 

--- a/packages/react/src/components/OverflowSet/OverflowButton.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowButton.tsx
@@ -58,7 +58,7 @@ const useKeytipRegistrations = (
 export const OverflowButton = (props: IOverflowSetProps) => {
   const keytipManager: KeytipManager = KeytipManager.getInstance();
   const { className, overflowItems, keytipSequences, itemSubMenuProvider, onRenderOverflowButton } = props;
-  const keytipsToRegister = useConst<IKeytipProps[]>([]);
+  const keytipsToRegister: IKeytipProps[] = [];
   const persistedKeytips = useConst<{ [uniqueID: string]: IKeytipProps }>({});
 
   // Gets the subMenu for an overflow item


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

"keytipsToRegister" is basically a queue to go through every time the OverflowButton updates, which means we should use a simple array instead of a "preserved" constant which is what useConst does. Without this the registering was being over-done for keytips that didn't need to be re-registered

#### Focus areas to test

(optional)
